### PR TITLE
📝 (adr) Add base for ADR documents

### DIFF
--- a/docs/adr/README.rst
+++ b/docs/adr/README.rst
@@ -1,0 +1,1 @@
+index.rst

--- a/docs/adr/index.rst
+++ b/docs/adr/index.rst
@@ -1,0 +1,30 @@
+ADR - Architecture Decision Records
+===================================
+
+Purpose
+-------
+
+These are the architectural decisions that are taken while developing Marsha.
+
+The format is based on Michael `Nygard's article on the subject <http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions>`_.
+
+The following is a list of these records
+
+
+Proposed
+--------
+
+
+Accepted
+--------
+
+
+
+Deprecated
+----------
+
+
+
+Superseded
+----------
+


### PR DESCRIPTION
This commits creates the `docs/adr` directory with an `index.rst` file
which will contains the list of all ADR docs

`index.rst` can be used for a doc website.
`README.rst` is a symbolic link to `index.rst`, just to be rendered on
Github