### PR TITLE
Pin python dependencies version numbers

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,15 +27,15 @@ requires-python = >=3.6
 zip_safe = True
 packages = find:
 install_requires =
-    django>=2
-    dj-database-url
-    django-configurations
-    django-extensions
+    django==2.0
+    dj-database-url==0.5.0
+    django-configurations==2.0
+    django-extensions==2.1.0
     # django 2 support from version 1.21, but still alpha release
-    django-postgres-extra>=1.21a4
-    django-safedelete>=0.4
+    django-postgres-extra==1.21a12
+    django-safedelete==0.5.1
     # Warning from psycopg2 "The psycopg2 wheel package will be renamed from release 2.8" => psyopg2-binary
-    psycopg2-binary
+    psycopg2-binary==2.7.5
 
 [options.packages.find]
 exclude =
@@ -50,25 +50,25 @@ console_scripts =
 [options.extras_require]
 # flake8 is now at 3.5 and break with pycodestyle 2.4+, so both have their version pinned
 dev =
-    black
-    factory_boy
-    flake8==3.5
-    flake8-bugbear
-    flake8-comprehensions
-    flake8-formatter-abspath
-    flake8-imports
-    flake8-docstrings
-    flake8-pep3101
-    flake8-per-file-ignores
-    ipython
-    isort
-    pycodestyle<2.4
-    pylint
-    pylint-django
-    pytest
-    pytest-cov
-    pytest-mock
-    wheel
+    black==18.6b4
+    factory_boy==2.11.1
+    flake8==3.5.0
+    flake8-bugbear==18.2.0
+    flake8-comprehensions==1.4.1
+    flake8-formatter-abspath==1.0.1
+    flake8-imports==0.1.1
+    flake8-docstrings==1.3.0
+    flake8-pep3101==1.2.1
+    flake8-per-file-ignores==0.6
+    ipython==6.4.0
+    isort==4.3.4
+    pycodestyle==2.3.1
+    pylint==1.9.2
+    pylint-django==0.11.1
+    pytest==3.6.3
+    pytest-cov==2.5.1
+    pytest-mock==1.10.0
+    wheel==0.31.1
 
 [bdist_wheel]
 universal = 1


### PR DESCRIPTION
## Purpose

Auto-updating dependencies prevent different developers & the CI from having the same dependency versions. It can also trigger unrelated CI failures when pushing a new branch to the CI or fast-forwarding master to a validated branch.

## Proposal

Pin version numbers to avoid these issues.