### PR TITLE
Add JWT token for authentication after LTI launch request

### DIFF
--- a/env.d/ci
+++ b/env.d/ci
@@ -3,6 +3,7 @@ DATABASE_URL=postgresql://fun:pass@db/marsha
 DJANGO_SETTINGS_MODULE=marsha.settings
 DJANGO_CONFIGURATION=Test
 DJANGO_SECRET_KEY=ThisIsAnExampleKeyForTestPurposeOnly
+DJANGO_JWT_SIGNING_KEY=ThisIsAnExampleKeyForDevPurposeOnly
 
 # Database
 POSTGRES_HOST=db

--- a/env.d/development
+++ b/env.d/development
@@ -3,6 +3,7 @@ DATABASE_URL=postgresql://fun:pass@db/marsha
 DJANGO_SETTINGS_MODULE=marsha.settings
 DJANGO_CONFIGURATION=Development
 DJANGO_SECRET_KEY=ThisIsAnExampleKeyForDevPurposeOnly
+DJANGO_JWT_SIGNING_KEY=ThisIsAnExampleKeyForDevPurposeOnly
 
 # Database
 POSTGRES_HOST=db

--- a/env.d/test
+++ b/env.d/test
@@ -3,6 +3,7 @@ DATABASE_URL=postgresql://fun:pass@db/marsha
 DJANGO_SETTINGS_MODULE=marsha.settings
 DJANGO_CONFIGURATION=Test
 DJANGO_SECRET_KEY=ThisIsAnExampleKeyForTestPurposeOnly
+DJANGO_JWT_SIGNING_KEY=ThisIsAnExampleKeyForDevPurposeOnly
 
 # Database
 POSTGRES_HOST=db

--- a/marsha/core/templates/core/lti_video.html
+++ b/marsha/core/templates/core/lti_video.html
@@ -2,6 +2,8 @@
   <head>
   </head>
   <body>
-    <div data-state="{{ state }}" {% for key, value in policy.items %} data-{{ key }}="{{ value }}"{% endfor %}></div>
+    <div data-resource-link-id="{{ resource_link_id }}" data-state="{{ state }}" data-jwt="{{ jwt_token }}"></div>
+    <div {% for key, value in policy.items %}data-{{ key }}="{{ value }}" {% endfor %}></div>
+
   </body>
 </html>

--- a/marsha/core/tests/test_templates_lti_video.py
+++ b/marsha/core/tests/test_templates_lti_video.py
@@ -1,0 +1,34 @@
+"""Test the LTI interconnection with Open edX."""
+
+from django.shortcuts import render
+from django.test import RequestFactory, TestCase
+
+
+# We don't enforce arguments documentation in tests
+# pylint: disable=missing-param-doc,missing-type-doc,unused-argument
+
+
+class VideoLTITemplatesTestCase(TestCase):
+    """Test the LTI provider endpoint to upload and view videos."""
+
+    def test_lti_video_launch_request_render_context(self):
+        """The context should be rendered to html on the launch request page."""
+        request = RequestFactory().get("/")
+
+        policy = {"a": 1, "b": 2}
+        response = render(
+            request,
+            "core/lti_video.html",
+            {
+                "policy": policy,
+                "state": "s",
+                "resource_link_id": "rli",
+                "jwt_token": "jwt",
+            },
+        )
+        self.assertContains(
+            response,
+            '<div data-resource-link-id="rli" data-state="s" data-jwt="jwt"></div>',
+            html=True,
+        )
+        self.assertContains(response, '<div data-a="1" data-b="2"></div>', html=True)

--- a/marsha/core/tests/test_views_lti_video.py
+++ b/marsha/core/tests/test_views_lti_video.py
@@ -1,0 +1,54 @@
+"""Test the LTI interconnection with Open edX."""
+from datetime import datetime
+from unittest import mock
+
+from django.test import RequestFactory, TestCase
+
+from ..lti import LTI
+from ..views import VideoLTIView
+
+
+# We don't enforce arguments documentation in tests
+# pylint: disable=missing-param-doc,missing-type-doc,unused-argument
+
+
+class ViewsTestCase(TestCase):
+    """Test the views in the ``core`` app of the Marsha project."""
+
+    def setUp(self):
+        """Override the setUp method to instanciate and serve a request factory."""
+        super().setUp()
+        self.factory = RequestFactory()
+
+    @mock.patch.object(LTI, "verify", return_value=True)
+    def test_views_video_lti_instructor(self, mock_initialize):
+        """."""
+        view = VideoLTIView()
+        view.request = self.factory.post(
+            "/", {"resource_link_id": "123", "roles": "instructor"}
+        )
+        with mock.patch(
+            "rest_framework_simplejwt.tokens.aware_utcnow",
+            return_value=datetime(2015, 5, 5),
+        ):
+            context = view.get_context_data()
+        self.assertEqual(
+            context,
+            {
+                "jwt_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ0b2tlbl90eXBlIjoiYWNjZXNz"
+                "IiwiZXhwIjoxNDMwODcwNDAwLCJqdGkiOiIxMjMifQ.mePJBhus9BIP9NrspCeVvxuu3EItD23YKlO"
+                "ZRmBSpew",
+                "state": "instructor",
+                "resource_link_id": "123",
+            },
+        )
+
+    @mock.patch.object(LTI, "verify", return_value=True)
+    def test_views_video_lti_student(self, mock_initialize):
+        """."""
+        view = VideoLTIView()
+        view.request = self.factory.post(
+            "/", {"resource_link_id": "123", "roles": "student"}
+        )
+        context = view.get_context_data()
+        self.assertEqual(context, {"state": "student", "resource_link_id": "123"})

--- a/marsha/core/views.py
+++ b/marsha/core/views.py
@@ -1,29 +1,69 @@
 """Views of the ``core`` app of the Marsha project."""
-from django.shortcuts import render
+from django.views.generic import TemplateView
 
 from pylti.common import LTIException
+from rest_framework_simplejwt.tokens import AccessToken
 
 from .lti import LTI
 from .models.account import INSTRUCTOR, STUDENT
 
 
-def video_lti_view(request):
+class VideoLTIView(TemplateView):
     """View called by an LTI launch request.
 
-    Arguments:
-        request(django.http.request.HttpRequest): Http request for the view
-
-    Returns:
-        HttpResponse(django.http.response.HttpResponse): Http response to the LTI launch request.
-            It is designed to work as a React single page application.
+    It is designed to work as a React single page application.
 
     """
-    lti = LTI(request)
-    try:
-        lti.initialize_session()
-    except LTIException:
-        context = {"state": "error"}
-    else:
-        context = {"state": INSTRUCTOR if lti.is_instructor else STUDENT}
 
-    return render(request, "core/lti_video.html", context)
+    template_name = "core/lti_video.html"
+
+    def get_context_data(self, **kwargs):
+        """
+        Populate the context with data retrieved from the LTI launch request.
+
+        Parameters
+        ----------
+        kwargs : dictionary
+            passed on to the parent's method
+
+        Returns
+        -------
+        dictionary
+            context for template rendering:
+
+            For all roles
+            +++++++++++++
+
+            - resource-link-id: resource targetted by the LTI launch request.
+            - state: state of the LTI launch request. Can be one of `student`, `instructor` or
+                `error`.
+
+            For instructors only
+            ++++++++++++++++++++
+
+            - jwt_token: a short-lived JWT token linked to the `resource_link_id` that will be used
+                as authentication to request an upload policy.
+
+        """
+        context = super().get_context_data(**kwargs)
+
+        lti = LTI(self.request)
+        try:
+            lti.verify()
+        except LTIException:
+            return {"state": "error"}
+
+        if lti.is_instructor:
+            # Create a short-lived JWT token for the "resource_link_id"
+            jwt_token = AccessToken()
+            jwt_token.payload["jti"] = lti.resource_link_id
+
+            # Evaluating the token as a string computes it from its payload
+            context = {"state": INSTRUCTOR, "jwt_token": str(jwt_token)}
+
+        else:
+            context = {"state": STUDENT}
+
+        context["resource_link_id"] = lti.resource_link_id
+
+        return context

--- a/marsha/settings.py
+++ b/marsha/settings.py
@@ -5,6 +5,7 @@ config from the environment
 
 """
 
+from datetime import timedelta
 import os
 
 from django.utils.translation import gettext_lazy as _
@@ -92,6 +93,8 @@ class Base(Configuration):
         {"NAME": "django.contrib.auth.password_validation.NumericPasswordValidator"},
     ]
 
+    JWT_SIGNING_KEY = values.SecretValue()
+
     # Internationalization
     # https://docs.djangoproject.com/en/2.0/topics/i18n/
 
@@ -106,6 +109,20 @@ class Base(Configuration):
     USE_L10N = True
 
     USE_TZ = True
+
+    # pylint: disable=invalid-name
+    @property
+    def SIMPLE_JWT(self):
+        """Define settings for `djangorestframework_simplejwt`.
+
+        The JWT_SIGNING_KEY must be evaluated late as the jwt library check for string type.
+        """
+        return {
+            "ACCESS_TOKEN_LIFETIME": timedelta(days=1),
+            "ALGORITHM": "HS256",
+            "SIGNING_KEY": str(self.JWT_SIGNING_KEY),
+            "AUTH_TOKEN_CLASSES": ("rest_framework_simplejwt.tokens.AccessToken",),
+        }
 
 
 class Development(Base):

--- a/marsha/urls.py
+++ b/marsha/urls.py
@@ -5,10 +5,10 @@ from typing import Iterable
 from django.urls import path
 
 from marsha.core.admin import admin_site
-from marsha.core.views import video_lti_view
+from marsha.core.views import VideoLTIView
 
 
 urlpatterns: Iterable[path] = [
     path(f"{admin_site.name}/", admin_site.urls),
-    path("lti-video/", video_lti_view, name="lti-video"),
+    path("lti-video/", VideoLTIView.as_view(), name="lti-video"),
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,8 @@ install_requires =
     django-extensions==2.1.0
     # django 2 support from version 1.21, but still alpha release
     django-postgres-extra==1.21a12
+    djangorestframework==3.8
+    djangorestframework_simplejwt==3.2
     django-safedelete==0.5.1
     # Warning from psycopg2 "The psycopg2 wheel package will be renamed from release 2.8" => psyopg2-binary
     psycopg2-binary==2.7.5


### PR DESCRIPTION
## Purpose

After an LTI launch request, the frontend application will make requests to the server's API and should be authenticated to related to the LTI launch request.

## Proposal

We chose to use short-lived JWT tokens linked to the resource_link_id (instead of a JWT token linked to a user) because it can carry its own payload without resorting to a session or an object in database. Thus, the video instance will only be created by AWS after the video encoding has completed.

In fact, the previous PR was storing everything in the session but it was not viable because the same browser will initiate several LTI launch request with Marsha if there are several video xblocks on a page in Open edx... The session cookie is unique for a given browser and would be over-written...