### PR TITLE
Load javascript in the LTI Video view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,4 +121,5 @@ venv.bak/
 
 # Front
 node_modules
+marsha/static/js
 data/static/js

--- a/marsha/core/templates/core/lti_video.html
+++ b/marsha/core/templates/core/lti_video.html
@@ -1,9 +1,13 @@
+{% load staticfiles %}
+
 <html>
   <head>
+    <script src='{% static "js/index.js" %}'></script>
   </head>
   <body>
     <div data-resource-link-id="{{ resource_link_id }}" data-state="{{ state }}" data-jwt="{{ jwt_token }}"></div>
     <div {% for key, value in policy.items %}data-{{ key }}="{{ value }}" {% endfor %}></div>
 
+    <div id="marsha-frontend-root">
   </body>
 </html>

--- a/marsha/settings.py
+++ b/marsha/settings.py
@@ -29,6 +29,8 @@ class Base(Configuration):
 
     STATIC_URL = "/static/"
 
+    STATICFILES_DIRS = (os.path.join(BASE_DIR, "static"),)
+
     SECRET_KEY = values.SecretValue()
 
     DEBUG = values.BooleanValue(False)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
   entry: ['./front/index.tsx'],
   output: {
     filename: 'index.js',
-    path: __dirname + '/data/static/js',
+    path: __dirname + '/marsha/static/js',
   },
 
   // Enable sourcemaps for debugging webpack's output.


### PR DESCRIPTION
The LTI Video view will be displayed as a single-page javascript app. It therefore needs to load the result of the frontend build and provide a root for react to take charge of.

- [x] generate the JS bundle in the app's static folder so it gets picked up and served by Django during development
- [x] gitignore it (don't commit build results)
- [x] actually load the JS in the template