### PR TITLE
Complete AppData type with a Video record

### DIFF
--- a/front/types/AppData.ts
+++ b/front/types/AppData.ts
@@ -1,8 +1,10 @@
 import { AWSPolicy } from './AWSPolicy';
+import { Video } from './Video';
 
 export interface AppData {
   jwt: string;
   policy?: AWSPolicy;
   resourceLinkid: string;
-  state: string;
+  state: 'error' | 'instructor' | 'student';
+  video: Video;
 }

--- a/front/types/Video.ts
+++ b/front/types/Video.ts
@@ -1,0 +1,12 @@
+type sizes = '144' | '240' | '480' | '720' | '1080';
+
+export interface Video {
+  description: string;
+  id: string;
+  status: string;
+  title: string;
+  urls: {
+    jpeg: { [key in sizes]: string };
+    mp4: { [key in sizes]: string };
+  };
+}

--- a/marsha/core/templates/core/lti_video.html
+++ b/marsha/core/templates/core/lti_video.html
@@ -8,7 +8,7 @@
 
 <body>
   <div class="marsha-frontend-data" data-jwt="{{ jwt_token }}" data-resource-link-id="{{ resource_link_id }}" data-state="{{ state }}"></div>
-  <div class="marsha-frontend-data" id="policy" {% for key, value in policy.items %}data-{{ key }}="{{ value }}" {% endfor %}></div>
+  <div class="marsha-frontend-data" id="video" {% for key, value in video.items %}data-{{ key }}="{{ value }}" {% endfor %}></div>
 
   <div id="marsha-frontend-root">
 </body>

--- a/marsha/core/tests/test_templates_lti_video.py
+++ b/marsha/core/tests/test_templates_lti_video.py
@@ -15,12 +15,12 @@ class VideoLTITemplatesTestCase(TestCase):
         """The context should be rendered to html on the launch request page."""
         request = RequestFactory().get("/")
 
-        policy = {"a": 1, "b": 2}
+        video = {"a": 1, "b": 2}
         response = render(
             request,
             "core/lti_video.html",
             {
-                "policy": policy,
+                "video": video,
                 "state": "s",
                 "resource_link_id": "rli",
                 "jwt_token": "jwt",
@@ -36,6 +36,6 @@ class VideoLTITemplatesTestCase(TestCase):
         )
         self.assertContains(
             response,
-            '<div class="marsha-frontend-data" id="policy" data-a="1" data-b="2"></div>',
+            '<div class="marsha-frontend-data" id="video" data-a="1" data-b="2"></div>',
             html=True,
         )


### PR DESCRIPTION
The Video record information is available at load time as it comes from the HTML in the initial template provided from the server. We can therefore depend on it being present at all times (after load) and containing the necessary data.

On the other hand, upload policies are not part of the initial payload and need to be separately fetched later on. They thus cannot be part of AppData (and should be removed from our template data elements).