### PR TITLE
✨(front) update the AWS Policy type

### DIFF
--- a/front/types/AWSPolicy.ts
+++ b/front/types/AWSPolicy.ts
@@ -1,8 +1,12 @@
 export interface AWSPolicy {
   acl: string;
-  awsaccesskeyid: string;
+  bucket: string;
   key: string;
   policy: string;
-  signature: string;
-  url: string;
+  s3_endpoint: string;
+  x_amz_algorithm: string;
+  x_amz_credential: string;
+  x_amz_date: string;
+  x_amz_expires: string;
+  x_amz_signature: string;
 }


### PR DESCRIPTION
Update the AWS Policy type to reflect the actual shape of the object we expect to receive from the server as per #34.

Add in "acl" & "key" fields as they are required by the S3 API and implemented on the backend side.