### PR TITLE
🔧(tslint) update tslint rules for prettier & style consistency

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -8,6 +8,8 @@
     "member-access": [true, "no-public"],
     "no-console": [true, "log", "error"],
     "no-empty": false,
+    "object-literal-key-quotes": [true, "as-needed"],
+    "one-line": false,
     "quotemark": [true, "single", "avoid-escape", "jsx-double"]
   },
   "rulesDirectory": []


### PR DESCRIPTION
`tslint` recently changed the default (or added a default) for property names in objects. This clashes with the standard way to write JS and with what prettier is enforcing. Change it to only allow quotes when they are strictly necessary.

Also remove the one-line rule for if/else clauses, which makes no sense when writing branching logic with comments that can't be coerced easily into a switch.

The rules on `tslint`'s website for reference:
https://palantir.github.io/tslint/rules/object-literal-key-quotes/
https://palantir.github.io/tslint/rules/one-line/