### PR TITLE
Add a component to handle file upload

### DIFF
--- a/front/components/VideoUploadField/VideoUploadField.spec.tsx
+++ b/front/components/VideoUploadField/VideoUploadField.spec.tsx
@@ -1,0 +1,53 @@
+import '../../testSetup';
+
+import { mount } from 'enzyme';
+import * as React from 'react';
+import { IntlProvider } from 'react-intl';
+
+import { VideoUploadField } from './VideoUploadField';
+
+test('VideoUploadField renders a Dropzone with the relevant messages', () => {
+  const wrapper = mount(
+    <IntlProvider locale="en">
+      <VideoUploadField onContentUpdated={jest.fn()} />
+    </IntlProvider>,
+  );
+
+  expect(wrapper.html()).toContain('dropzone');
+  expect(wrapper.text()).toContain('Pick a video to upload');
+  expect(wrapper.text()).not.toContain('Clear selected file');
+});
+
+test('VideoUploadField.onDrop() passes the file to the callback and updates the UI', () => {
+  const callback = jest.fn();
+  const wrapper = mount(
+    <IntlProvider locale="en">
+      <VideoUploadField onContentUpdated={callback} />
+    </IntlProvider>,
+  );
+  const componentInstance = wrapper.childAt(0).instance() as VideoUploadField;
+  componentInstance.onDrop(['file_1']);
+
+  expect(callback).toHaveBeenCalledWith('file_1');
+  expect(wrapper.text()).not.toContain('Pick a video to upload');
+  expect(wrapper.text()).toContain('Clear selected file');
+  expect(wrapper.html()).toContain('aria-disabled="true"');
+});
+
+test('VideoUploadField.clearFile() calls the callback with undefined and resets the UI', () => {
+  const callback = jest.fn();
+  const wrapper = mount(
+    <IntlProvider locale="en">
+      <VideoUploadField onContentUpdated={callback} />
+    </IntlProvider>,
+  );
+  const componentInstance = wrapper.childAt(0).instance() as VideoUploadField;
+  componentInstance.onDrop(['file_1']);
+  callback.mockReset();
+  componentInstance.clearFile();
+
+  expect(callback).toHaveBeenCalledWith(undefined);
+  expect(wrapper.text()).toContain('Pick a video to upload');
+  expect(wrapper.text()).not.toContain('Clear selected file');
+  expect(wrapper.html()).toContain('aria-disabled="false"');
+});

--- a/front/components/VideoUploadField/VideoUploadField.tsx
+++ b/front/components/VideoUploadField/VideoUploadField.tsx
@@ -1,0 +1,65 @@
+import * as React from 'react';
+import Dropzone from 'react-dropzone';
+import { defineMessages, FormattedMessage } from 'react-intl';
+
+import { Maybe } from '../../utils/types';
+
+export interface VideoUploadFieldProps {
+  onContentUpdated: (fieldContent: Maybe<File>) => void;
+}
+
+interface VideoUploadFieldState {
+  file: Maybe<File>;
+}
+
+const messages = defineMessages({
+  dropzoneButtonPick: {
+    defaultMessage: 'Pick a video to upload',
+    description:
+      'Video upload file dropzone: button to choose a video to upload',
+    id: 'components.VideoForm.dropzoneButtonPick',
+  },
+  dropzoneClear: {
+    defaultMessage: 'Clear selected file',
+    description:
+      'Video upload file dropzone: link to remove the currently selected video',
+    id: 'components.VideoForm.dropzoneClear',
+  },
+});
+
+export class VideoUploadField extends React.Component<
+  VideoUploadFieldProps,
+  VideoUploadFieldState
+> {
+  clearFile() {
+    this.setState({ file: undefined });
+    this.props.onContentUpdated(undefined);
+  }
+
+  onDrop(files: any) {
+    this.setState({ file: files[0] });
+    this.props.onContentUpdated(files[0]);
+  }
+
+  render() {
+    return (
+      <div className="dropzone">
+        <Dropzone
+          onDrop={this.onDrop.bind(this)}
+          disabled={!!(this.state && this.state.file)}
+        >
+          {// Show either the 'upload' button or the 'clear' link
+          this.state && !!this.state.file ? (
+            <a onClick={this.clearFile.bind(this)}>
+              <FormattedMessage {...messages.dropzoneClear} />
+            </a>
+          ) : (
+            <button>
+              <FormattedMessage {...messages.dropzoneButtonPick} />
+            </button>
+          )}
+        </Dropzone>
+      </div>
+    );
+  }
+}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@types/jest": "23.3.1",
     "@types/react": "16.4.7",
     "@types/react-dom": "16.0.6",
+    "@types/react-dropzone": "4.2.1",
     "@types/react-intl": "2.3.9",
     "@types/video.js": "7.2.0",
     "babel-jest": "23.4.2",
@@ -43,6 +44,7 @@
   "dependencies": {
     "react": "16.4.2",
     "react-dom": "16.4.2",
+    "react-dropzone": "4.3.0",
     "react-intl": "2.4.0",
     "video.js": "7.1.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -546,6 +546,12 @@
     "@types/node" "*"
     "@types/react" "*"
 
+"@types/react-dropzone@4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@types/react-dropzone/-/react-dropzone-4.2.1.tgz#4a973b63a8a227e263ff4eece053f643220f28fc"
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-intl@2.3.9":
   version "2.3.9"
   resolved "https://registry.yarnpkg.com/@types/react-intl/-/react-intl-2.3.9.tgz#47dfc2c4ff82c938ffb0ecaa1bc9f2f449f191cc"
@@ -933,6 +939,12 @@ asynckit@^0.4.0:
 atob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.1.tgz#ae2d5a729477f289d60dd7f96a6314a22dd6c22a"
+
+attr-accept@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/attr-accept/-/attr-accept-1.1.3.tgz#48230c79f93790ef2775fcec4f0db0f5db41ca52"
+  dependencies:
+    core-js "^2.5.0"
 
 aws-sign2@~0.7.0:
   version "0.7.0"
@@ -4443,7 +4455,7 @@ prompts@^0.1.9:
     kleur "^2.0.1"
     sisteransi "^0.1.1"
 
-prop-types@^15.6.0, prop-types@^15.6.2:
+prop-types@^15.5.7, prop-types@^15.6.0, prop-types@^15.6.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
   dependencies:
@@ -4566,6 +4578,13 @@ react-dom@16.4.2:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.0"
+
+react-dropzone@4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/react-dropzone/-/react-dropzone-4.3.0.tgz#facdd7db16509772633c9f5200621ac01aa6706f"
+  dependencies:
+    attr-accept "^1.1.3"
+    prop-types "^15.5.7"
 
 react-intl@2.4.0:
   version "2.4.0"


### PR DESCRIPTION
## Purpose

The purpose of this component is to let us handle file uploads (almost) as easily as another field by encapsulating the file adding/changing/removing logic.
It will help us keep the Video Form component simpler and lighter by delegating this separate function.

## Proposal

Use `react-dropzone` & component state to make a simple "video upload field"