### PR TITLE
🔧(front) add a simple mock for react-intl in our unit tests

### DIFF
--- a/__mocks__/react-intl.tsx
+++ b/__mocks__/react-intl.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import { FormattedMessage, Messages } from 'react-intl';
+
+const Intl: any = jest.genMockFromModule('react-intl');
+
+// Make a defineMessage implementation that just returns the messages (so they can be reused at the call site)
+Intl.defineMessages.mockImplementation((messages: Messages) => messages);
+
+// intl context that will be injected into components by injectIntl
+const intl = {
+  formatMessage: ({ defaultMessage }: { defaultMessage: string }) =>
+    defaultMessage,
+};
+
+// Patch injectIntl to do the context injecting
+Intl.injectIntl = (Node: any) => {
+  const renderWrapped: any = (props: any) => <Node {...props} intl={intl} />;
+  renderWrapped.displayName = Node.displayName || Node.name || 'Component';
+  return renderWrapped;
+};
+
+// Patch FormattedMessage to just spit out the default message
+Intl.FormattedMessage = (props: FormattedMessage.Props) => props.defaultMessage;
+
+module.exports = Intl;

--- a/front/components/ErrorComponent/ErrorComponent.spec.tsx
+++ b/front/components/ErrorComponent/ErrorComponent.spec.tsx
@@ -7,11 +7,7 @@ import { IntlProvider } from 'react-intl';
 import { ErrorComponent } from './ErrorComponent';
 
 test('ErrorComponent displays the content for 404 not found errors', () => {
-  const wrapper = render(
-    <IntlProvider locale="en">
-      <ErrorComponent code="not_found" />
-    </IntlProvider>,
-  );
+  const wrapper = render(<ErrorComponent code="not_found" />);
   expect(wrapper.text()).toContain(
     'The video you are looking for could not be found',
   );
@@ -21,11 +17,7 @@ test('ErrorComponent displays the content for 404 not found errors', () => {
 });
 
 test('ErrorComponent displays the content for lti related errors', () => {
-  const wrapper = render(
-    <IntlProvider locale="en">
-      <ErrorComponent code="lti" />
-    </IntlProvider>,
-  );
+  const wrapper = render(<ErrorComponent code="lti" />);
   expect(wrapper.text()).toContain('There was an error loading this video');
   expect(wrapper.text()).toContain(
     'We could not validate your access to this video',

--- a/front/components/VideoUploadField/VideoUploadField.spec.tsx
+++ b/front/components/VideoUploadField/VideoUploadField.spec.tsx
@@ -7,11 +7,7 @@ import { IntlProvider } from 'react-intl';
 import { VideoUploadField } from './VideoUploadField';
 
 test('VideoUploadField renders a Dropzone with the relevant messages', () => {
-  const wrapper = mount(
-    <IntlProvider locale="en">
-      <VideoUploadField onContentUpdated={jest.fn()} />
-    </IntlProvider>,
-  );
+  const wrapper = mount(<VideoUploadField onContentUpdated={jest.fn()} />);
 
   expect(wrapper.html()).toContain('dropzone');
   expect(wrapper.text()).toContain('Pick a video to upload');
@@ -20,12 +16,8 @@ test('VideoUploadField renders a Dropzone with the relevant messages', () => {
 
 test('VideoUploadField.onDrop() passes the file to the callback and updates the UI', () => {
   const callback = jest.fn();
-  const wrapper = mount(
-    <IntlProvider locale="en">
-      <VideoUploadField onContentUpdated={callback} />
-    </IntlProvider>,
-  );
-  const componentInstance = wrapper.childAt(0).instance() as VideoUploadField;
+  const wrapper = mount(<VideoUploadField onContentUpdated={callback} />);
+  const componentInstance = wrapper.instance() as VideoUploadField;
   componentInstance.onDrop(['file_1']);
 
   expect(callback).toHaveBeenCalledWith('file_1');
@@ -36,12 +28,8 @@ test('VideoUploadField.onDrop() passes the file to the callback and updates the 
 
 test('VideoUploadField.clearFile() calls the callback with undefined and resets the UI', () => {
   const callback = jest.fn();
-  const wrapper = mount(
-    <IntlProvider locale="en">
-      <VideoUploadField onContentUpdated={callback} />
-    </IntlProvider>,
-  );
-  const componentInstance = wrapper.childAt(0).instance() as VideoUploadField;
+  const wrapper = mount(<VideoUploadField onContentUpdated={callback} />);
+  const componentInstance = wrapper.instance() as VideoUploadField;
   componentInstance.onDrop(['file_1']);
   callback.mockReset();
   componentInstance.clearFile();


### PR DESCRIPTION
## Purpose

Wrapping all components we test that contain strings with an `IntlProvider` and having to account for it in our tests was getting old really quickly.

## Proposal

Write a simple manual mock of `react-intl` to allow us to stop using it in our tests. It still lets us test our strings as it hands back and prints default messages.