### PR TITLE
Add media convert preset to capture previews

### DIFF
--- a/terraform/roles.tf
+++ b/terraform/roles.tf
@@ -61,6 +61,7 @@ resource "aws_iam_policy" "lambda_media_convert_policy" {
       "Action": [
         "mediaconvert:CreateJob",
         "mediaconvert:CreatePreset",
+        "mediaconvert:GetPreset",
         "mediaconvert:UpdatePreset",
         "mediaconvert:DescribeEndpoints"
       ],

--- a/terraform/source/configure/media-convert.js
+++ b/terraform/source/configure/media-convert.js
@@ -4,16 +4,17 @@ const fs = require('fs');
 const AWS = require('aws-sdk');
 
 const presets = [
-  './presets/jpeg_144p.json',
-  './presets/jpeg_240p.json',
-  './presets/jpeg_480p.json',
-  './presets/jpeg_720p.json',
-  './presets/jpeg_1080p.json',
-  './presets/mp4_h264_144p_30fps_300kbps.json',
-  './presets/mp4_h264_240p_30fps_600kbps.json',
-  './presets/mp4_h264_480p_30fps_1200kbps.json',
-  './presets/mp4_h264_720p_30fps_2400kbps.json',
-  './presets/mp4_h264_1080p_30fps_5400kbps.json',
+  './presets/thumbnail_jpeg_144p.json',
+  './presets/thumbnail_jpeg_240p.json',
+  './presets/thumbnail_jpeg_480p.json',
+  './presets/thumbnail_jpeg_720p.json',
+  './presets/thumbnail_jpeg_1080p.json',
+  './presets/preview_jpeg_100p.json',
+  './presets/video_mp4_h264_144p_30fps_300kbps.json',
+  './presets/video_mp4_h264_240p_30fps_600kbps.json',
+  './presets/video_mp4_h264_480p_30fps_1200kbps.json',
+  './presets/video_mp4_h264_720p_30fps_2400kbps.json',
+  './presets/video_mp4_h264_1080p_30fps_5400kbps.json',
 ];
 
 let response;

--- a/terraform/source/configure/media-convert.js
+++ b/terraform/source/configure/media-convert.js
@@ -38,12 +38,25 @@ let createPreset = (preset, url) => {
   });
   return new Promise((resolve, reject) => {
     let params = JSON.parse(fs.readFileSync(preset, 'utf8'));
-    // TODO: update does not work
-    mediaconvert.createPreset(params, (error, data) => {
-      if (error) reject(error);
-      else {
-        console.log('created preset: ', data.Preset.Name);
-        resolve(data);
+    mediaconvert.getPreset({ Name: params.Name }, function(error, data) {
+      if (error) {
+        // the preset does not exist, let's create it
+        mediaconvert.createPreset(params, (error, data) => {
+          if (error) reject(error);
+          else {
+            console.log('created preset: ', data.Preset.Name);
+            resolve(data);
+          }
+        });
+      } else {
+        // the preset exists, let's update it
+        mediaconvert.updatePreset(params, (error, data) => {
+          if (error) reject(error);
+          else {
+            console.log('updated existing preset: ', data.Preset.Name);
+            resolve(data);
+          }
+        });
       }
     });
   });

--- a/terraform/source/configure/media-convert.spec.js
+++ b/terraform/source/configure/media-convert.spec.js
@@ -32,10 +32,41 @@ describe('Media Convert', () => {
       EndPoint: 'https://test.mediaconvert.eu-west-1.amazonaws.com',
     };
 
-    // Mock the function that create presets and return a different name
-    // for the preset time it is called
+    // Mock the function that gets presets to fake all new presets
+    AWS.mock('MediaConvert', 'getPreset', (params, callback) =>
+      callback('Preset does not exist'),
+    );
+
+    // Mock the function that creates presets and return a different name
+    // for the preset each time it is called
     let callCount = 0;
     AWS.mock('MediaConvert', 'createPreset', (params, callback) =>
+      callback(null, { Preset: { Name: callCount++ } }),
+    );
+
+    lambda
+      .MediaConvertPresets(event)
+      .then(data => {
+        expect(data).to.deep.equal({ Presets: Array.from(Array(11).keys()) });
+        done();
+      })
+      .catch(err => done(err));
+  });
+
+  it('should update existing presets', done => {
+    const event = {
+      EndPoint: 'https://test.mediaconvert.eu-west-1.amazonaws.com',
+    };
+
+    // Mock the function that gets presets to fake all existing presets
+    AWS.mock('MediaConvert', 'getPreset', (params, callback) =>
+      callback(null, {}),
+    );
+
+    // Mock the function that updates presets and return a different name
+    // for the preset each time it is called
+    let callCount = 0;
+    AWS.mock('MediaConvert', 'updatePreset', (params, callback) =>
       callback(null, { Preset: { Name: callCount++ } }),
     );
 

--- a/terraform/source/configure/media-convert.spec.js
+++ b/terraform/source/configure/media-convert.spec.js
@@ -42,7 +42,7 @@ describe('Media Convert', () => {
     lambda
       .MediaConvertPresets(event)
       .then(data => {
-        expect(data).to.deep.equal({ Presets: Array.from(Array(10).keys()) });
+        expect(data).to.deep.equal({ Presets: Array.from(Array(11).keys()) });
         done();
       })
       .catch(err => done(err));

--- a/terraform/source/configure/presets/preview_jpeg_100p.json
+++ b/terraform/source/configure/presets/preview_jpeg_100p.json
@@ -1,7 +1,7 @@
 {
-  "Description": "Frame capture, JPEG, 854x480p",
+  "Description": "Frame capture, JPEG, 1/1, 178x100p",
   "Category": "JPEG",
-  "Name": "marsha_jpeg_480",
+  "Name": "marsha_preview_jpeg_100",
   "Settings": {
     "ContainerSettings": {
       "Container": "RAW"
@@ -13,19 +13,19 @@
         "Codec": "FRAME_CAPTURE",
         "FrameCaptureSettings": {
           "FramerateNumerator": 1,
-          "FramerateDenominator": 10,
-          "MaxCaptures": 1000,
+          "FramerateDenominator": 1,
+          "MaxCaptures": 10000,
           "Quality": 80
         }
       },
       "ColorMetadata": "INSERT",
       "DropFrameTimecode": "ENABLED",
-      "Height": 480,
+      "Height": 100,
       "RespondToAfd": "NONE",
       "ScalingBehavior": "DEFAULT",
       "Sharpness": 50,
       "TimecodeInsertion": "DISABLED",
-      "Width": 854
+      "Width": 178
     }
   }
 }

--- a/terraform/source/configure/presets/thumbnail_jpeg_1080p.json
+++ b/terraform/source/configure/presets/thumbnail_jpeg_1080p.json
@@ -1,0 +1,31 @@
+{
+  "Description": "Frame capture, JPEG, 1/10, 1920x1080p",
+  "Category": "JPEG",
+  "Name": "marsha_thumbnail_jpeg_1080",
+  "Settings": {
+    "ContainerSettings": {
+      "Container": "RAW"
+    },
+    "VideoDescription": {
+      "AfdSignaling": "NONE",
+      "AntiAlias": "ENABLED",
+      "CodecSettings": {
+        "Codec": "FRAME_CAPTURE",
+        "FrameCaptureSettings": {
+          "FramerateNumerator": 1,
+          "FramerateDenominator": 10,
+          "MaxCaptures": 1,
+          "Quality": 80
+        }
+      },
+      "ColorMetadata": "INSERT",
+      "DropFrameTimecode": "ENABLED",
+      "Height": 1080,
+      "RespondToAfd": "NONE",
+      "ScalingBehavior": "DEFAULT",
+      "Sharpness": 50,
+      "TimecodeInsertion": "DISABLED",
+      "Width": 1920
+    }
+  }
+}

--- a/terraform/source/configure/presets/thumbnail_jpeg_144p.json
+++ b/terraform/source/configure/presets/thumbnail_jpeg_144p.json
@@ -1,7 +1,7 @@
 {
-  "Description": "Frame capture, JPEG, 256x144p",
+  "Description": "Frame capture, JPEG, 1/10, 256x144p",
   "Category": "JPEG",
-  "Name": "marsha_jpeg_144",
+  "Name": "marsha_thumbnail_jpeg_144",
   "Settings": {
     "ContainerSettings": {
       "Container": "RAW"
@@ -14,7 +14,7 @@
         "FrameCaptureSettings": {
           "FramerateNumerator": 1,
           "FramerateDenominator": 10,
-          "MaxCaptures": 1000,
+          "MaxCaptures": 1,
           "Quality": 80
         }
       },

--- a/terraform/source/configure/presets/thumbnail_jpeg_240p.json
+++ b/terraform/source/configure/presets/thumbnail_jpeg_240p.json
@@ -1,7 +1,7 @@
 {
-  "Description": "Frame capture, JPEG, 426x240p",
+  "Description": "Frame capture, JPEG, 1/10, 426x240p",
   "Category": "JPEG",
-  "Name": "marsha_jpeg_240",
+  "Name": "marsha_thumbnail_jpeg_240",
   "Settings": {
     "ContainerSettings": {
       "Container": "RAW"
@@ -14,7 +14,7 @@
         "FrameCaptureSettings": {
           "FramerateNumerator": 1,
           "FramerateDenominator": 10,
-          "MaxCaptures": 1000,
+          "MaxCaptures": 1,
           "Quality": 80
         }
       },

--- a/terraform/source/configure/presets/thumbnail_jpeg_480p.json
+++ b/terraform/source/configure/presets/thumbnail_jpeg_480p.json
@@ -1,7 +1,7 @@
 {
-  "Description": "Frame capture, JPEG, 1920x1080p",
+  "Description": "Frame capture, JPEG, 1/10, 854x480p",
   "Category": "JPEG",
-  "Name": "marsha_jpeg_1080",
+  "Name": "marsha_thumbnail_jpeg_480",
   "Settings": {
     "ContainerSettings": {
       "Container": "RAW"
@@ -14,18 +14,18 @@
         "FrameCaptureSettings": {
           "FramerateNumerator": 1,
           "FramerateDenominator": 10,
-          "MaxCaptures": 1000,
+          "MaxCaptures": 1,
           "Quality": 80
         }
       },
       "ColorMetadata": "INSERT",
       "DropFrameTimecode": "ENABLED",
-      "Height": 1080,
+      "Height": 480,
       "RespondToAfd": "NONE",
       "ScalingBehavior": "DEFAULT",
       "Sharpness": 50,
       "TimecodeInsertion": "DISABLED",
-      "Width": 1920
+      "Width": 854
     }
   }
 }

--- a/terraform/source/configure/presets/thumbnail_jpeg_720p.json
+++ b/terraform/source/configure/presets/thumbnail_jpeg_720p.json
@@ -1,7 +1,7 @@
 {
-  "Description": "Frame capture, JPEG, 1280x720p",
+  "Description": "Frame capture, JPEG, 1/10, 1280x720p",
   "Category": "JPEG",
-  "Name": "marsha_jpeg_720",
+  "Name": "marsha_thumbnail_jpeg_720",
   "Settings": {
     "ContainerSettings": {
       "Container": "RAW"
@@ -14,7 +14,7 @@
         "FrameCaptureSettings": {
           "FramerateNumerator": 1,
           "FramerateDenominator": 10,
-          "MaxCaptures": 1000,
+          "MaxCaptures": 1,
           "Quality": 80
         }
       },

--- a/terraform/source/configure/presets/video_mp4_h264_1080p_30fps_5400kbps.json
+++ b/terraform/source/configure/presets/video_mp4_h264_1080p_30fps_5400kbps.json
@@ -1,11 +1,11 @@
 {
-  "Description": "Video, H264, 256x144p, 29.97fps, 300kbps",
+  "Description": "Video, H264, 1920x1080p, 29.97fps, 5400kbps",
   "Category": "MP4",
-  "Name": "marsha_mp4_144",
+  "Name": "marsha_video_mp4_1080",
   "Settings": {
     "VideoDescription": {
-      "Width": 256,
-      "Height": 144,
+      "Width": 1920,
+      "Height": 1080,
       "ScalingBehavior": "STRETCH_TO_OUTPUT",
       "VideoPreprocessors": {
         "Deinterlacer": {
@@ -34,7 +34,7 @@
           "TemporalAdaptiveQuantization": "ENABLED",
           "FlickerAdaptiveQuantization": "DISABLED",
           "EntropyEncoding": "CABAC",
-          "Bitrate": 300000,
+          "Bitrate": 5400000,
           "FramerateControl": "SPECIFIED",
           "RateControlMode": "CBR",
           "CodecProfile": "MAIN",

--- a/terraform/source/configure/presets/video_mp4_h264_144p_30fps_300kbps.json
+++ b/terraform/source/configure/presets/video_mp4_h264_144p_30fps_300kbps.json
@@ -1,11 +1,11 @@
 {
-  "Description": "Video, H264, 426x240p, 29.97fps, 600kbps",
+  "Description": "Video, H264, 256x144p, 29.97fps, 300kbps",
   "Category": "MP4",
-  "Name": "marsha_mp4_240",
+  "Name": "marsha_video_mp4_144",
   "Settings": {
     "VideoDescription": {
-      "Width": 426,
-      "Height": 240,
+      "Width": 256,
+      "Height": 144,
       "ScalingBehavior": "STRETCH_TO_OUTPUT",
       "VideoPreprocessors": {
         "Deinterlacer": {
@@ -34,7 +34,7 @@
           "TemporalAdaptiveQuantization": "ENABLED",
           "FlickerAdaptiveQuantization": "DISABLED",
           "EntropyEncoding": "CABAC",
-          "Bitrate": 600000,
+          "Bitrate": 300000,
           "FramerateControl": "SPECIFIED",
           "RateControlMode": "CBR",
           "CodecProfile": "MAIN",

--- a/terraform/source/configure/presets/video_mp4_h264_240p_30fps_600kbps.json
+++ b/terraform/source/configure/presets/video_mp4_h264_240p_30fps_600kbps.json
@@ -1,11 +1,11 @@
 {
-  "Description": "Video, H264, 854x480p, 29.97fps, 1200kbps",
+  "Description": "Video, H264, 426x240p, 29.97fps, 600kbps",
   "Category": "MP4",
-  "Name": "marsha_mp4_480",
+  "Name": "marsha_video_mp4_240",
   "Settings": {
     "VideoDescription": {
-      "Width": 854,
-      "Height": 480,
+      "Width": 426,
+      "Height": 240,
       "ScalingBehavior": "STRETCH_TO_OUTPUT",
       "VideoPreprocessors": {
         "Deinterlacer": {
@@ -34,7 +34,7 @@
           "TemporalAdaptiveQuantization": "ENABLED",
           "FlickerAdaptiveQuantization": "DISABLED",
           "EntropyEncoding": "CABAC",
-          "Bitrate": 1200000,
+          "Bitrate": 600000,
           "FramerateControl": "SPECIFIED",
           "RateControlMode": "CBR",
           "CodecProfile": "MAIN",

--- a/terraform/source/configure/presets/video_mp4_h264_480p_30fps_1200kbps.json
+++ b/terraform/source/configure/presets/video_mp4_h264_480p_30fps_1200kbps.json
@@ -1,11 +1,11 @@
 {
-  "Description": "Video, H264, 1280x720p, 29.97fps, 2400kbps",
+  "Description": "Video, H264, 854x480p, 29.97fps, 1200kbps",
   "Category": "MP4",
-  "Name": "marsha_mp4_720",
+  "Name": "marsha_video_mp4_480",
   "Settings": {
     "VideoDescription": {
-      "Width": 1280,
-      "Height": 720,
+      "Width": 854,
+      "Height": 480,
       "ScalingBehavior": "STRETCH_TO_OUTPUT",
       "VideoPreprocessors": {
         "Deinterlacer": {
@@ -34,7 +34,7 @@
           "TemporalAdaptiveQuantization": "ENABLED",
           "FlickerAdaptiveQuantization": "DISABLED",
           "EntropyEncoding": "CABAC",
-          "Bitrate": 2400000,
+          "Bitrate": 1200000,
           "FramerateControl": "SPECIFIED",
           "RateControlMode": "CBR",
           "CodecProfile": "MAIN",

--- a/terraform/source/configure/presets/video_mp4_h264_720p_30fps_2400kbps.json
+++ b/terraform/source/configure/presets/video_mp4_h264_720p_30fps_2400kbps.json
@@ -1,11 +1,11 @@
 {
-  "Description": "Video, H264, 1920x1080p, 29.97fps, 5400kbps",
+  "Description": "Video, H264, 1280x720p, 29.97fps, 2400kbps",
   "Category": "MP4",
-  "Name": "marsha_mp4_1080",
+  "Name": "marsha_video_mp4_720",
   "Settings": {
     "VideoDescription": {
-      "Width": 1920,
-      "Height": 1080,
+      "Width": 1280,
+      "Height": 720,
       "ScalingBehavior": "STRETCH_TO_OUTPUT",
       "VideoPreprocessors": {
         "Deinterlacer": {
@@ -34,7 +34,7 @@
           "TemporalAdaptiveQuantization": "ENABLED",
           "FlickerAdaptiveQuantization": "DISABLED",
           "EntropyEncoding": "CABAC",
-          "Bitrate": 5400000,
+          "Bitrate": 2400000,
           "FramerateControl": "SPECIFIED",
           "RateControlMode": "CBR",
           "CodecProfile": "MAIN",

--- a/terraform/source/encode/index.js
+++ b/terraform/source/encode/index.js
@@ -61,29 +61,29 @@ exports.handler = (event, context, callback) => {
           },
           Outputs: [
             {
-              Preset: 'marsha_mp4_144',
+              Preset: 'marsha_video_mp4_144',
               NameModifier: '_144',
             },
             {
-              Preset: 'marsha_mp4_240',
+              Preset: 'marsha_video_mp4_240',
               NameModifier: '_240',
             },
             {
-              Preset: 'marsha_mp4_480',
+              Preset: 'marsha_video_mp4_480',
               NameModifier: '_480',
             },
             {
-              Preset: 'marsha_mp4_720',
+              Preset: 'marsha_video_mp4_720',
               NameModifier: '_720',
             },
             {
-              Preset: 'marsha_mp4_1080',
+              Preset: 'marsha_video_mp4_1080',
               NameModifier: '_1080',
             },
           ],
         },
         {
-          CustomName: 'Frame Capture outputs',
+          CustomName: 'Thumbnails outputs',
           Name: 'File Group',
           OutputGroupSettings: {
             Type: 'FILE_GROUP_SETTINGS',
@@ -93,29 +93,50 @@ exports.handler = (event, context, callback) => {
                 process.env.S3_DESTINATION_BUCKET +
                 '/' +
                 objectKey.split('/')[0] +
-                '/jpeg/',
+                '/thumbnails/',
             },
           },
           Outputs: [
             {
-              Preset: 'marsha_jpeg_144',
-              NameModifier: '_144',
+              Preset: 'marsha_thumbnail_jpeg_144',
+              NameModifier: '_thumbnail_144',
             },
             {
-              Preset: 'marsha_jpeg_240',
-              NameModifier: '_240',
+              Preset: 'marsha_thumbnail_jpeg_240',
+              NameModifier: '_thumbnail_240',
             },
             {
-              Preset: 'marsha_jpeg_480',
-              NameModifier: '_480',
+              Preset: 'marsha_thumbnail_jpeg_480',
+              NameModifier: '_thumbnail_480',
             },
             {
-              Preset: 'marsha_jpeg_720',
-              NameModifier: '_720',
+              Preset: 'marsha_thumbnail_jpeg_720',
+              NameModifier: '_thumbnail_720',
             },
             {
-              Preset: 'marsha_jpeg_1080',
-              NameModifier: '_1080',
+              Preset: 'marsha_thumbnail_jpeg_1080',
+              NameModifier: '_thumbnail_1080',
+            },
+          ],
+        },
+        {
+          CustomName: 'Previews outputs',
+          Name: 'File Group',
+          OutputGroupSettings: {
+            Type: 'FILE_GROUP_SETTINGS',
+            FileGroupSettings: {
+              Destination:
+                's3://' +
+                process.env.S3_DESTINATION_BUCKET +
+                '/' +
+                objectKey.split('/')[0] +
+                '/previews/',
+            },
+          },
+          Outputs: [
+            {
+              Preset: 'marsha_preview_jpeg_100',
+              NameModifier: '_preview_100',
             },
           ],
         },
@@ -130,8 +151,5 @@ exports.handler = (event, context, callback) => {
       console.log(JSON.stringify(data, null, 2));
       callback(null, { Job: data.Job.Id });
     })
-    .catch(err => {
-      error.handler(event, err);
-      callback(err);
-    });
+    .catch(error => callback(error));
 };


### PR DESCRIPTION
## Purpose

Displaying a thumbnail to display as a placeholder for the video and displaying small preview captures at each second of the video are two different things.

For thumbnails, we only sample one image in each resolution.
For previews, we sample one image per second on the whole video but in a size of  100 pixels.

## Proposal

- [x] Fix updating a preset in AWS media convert through the node.js SDK
- [x] Improve preset names to differentiate usage: video, thumbnail, preview
- [x] Add a preset for preview frame captures 

