### PR TITLE
Make configuration independant by workspace

### DIFF
--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -8,6 +8,12 @@ resource "aws_lambda_function" "marsha_configure_lambda" {
   filename         = "dist/marsha_configure.zip"
   source_code_hash = "${base64sha256(file("dist/marsha_configure.zip"))}"
   role             = "${aws_iam_role.lambda_invocation_role.arn}"
+
+  environment {
+    variables = {
+      ENV_TYPE = "${terraform.workspace}"
+    }
+  }
 }
 
 # Call the configuration lambda to create a Media Convert endpoint
@@ -47,6 +53,7 @@ resource "aws_lambda_function" "marsha_encode_lambda" {
 
   environment {
     variables = {
+      ENV_TYPE = "${terraform.workspace}"
       S3_DESTINATION_BUCKET   = "${aws_s3_bucket.marsha_destination.id}"
       MEDIA_CONVERT_ROLE      = "${aws_iam_role.media_convert_role.arn}"
       MEDIA_CONVERT_END_POINT = "${data.aws_lambda_invocation.configure_lambda_endpoint.result_map["EndpointUrl"]}"
@@ -72,6 +79,12 @@ resource "aws_lambda_function" "marsha_confirm_lambda" {
   filename         = "dist/marsha_confirm.zip"
   source_code_hash = "${base64sha256(file("dist/marsha_confirm.zip"))}"
   role             = "${aws_iam_role.lambda_invocation_role.arn}"
+
+  environment {
+    variables = {
+      ENV_TYPE = "${terraform.workspace}"
+    }
+  }
 }
 
 resource "aws_lambda_permission" "allow_cloudwatch" {

--- a/terraform/roles.tf
+++ b/terraform/roles.tf
@@ -2,7 +2,7 @@
 #########################
 
 resource "aws_iam_role" "lambda_invocation_role" {
-  name = "lambda-invocation-role"
+  name = "${terraform.workspace}-marsha-lambda-invocation-role"
 
   assume_role_policy = <<EOF
 {
@@ -21,7 +21,7 @@ EOF
 }
 
 resource "aws_iam_policy" "lambda_logging_policy" {
-  name        = "lambda-logging-policy"
+  name        = "${terraform.workspace}-marsha-lambda-logging-policy"
   path        = "/"
   description = "IAM policy for logging from a lambda"
 
@@ -49,7 +49,7 @@ resource "aws_iam_role_policy_attachment" "lambda_logging_policy_attachment" {
 }
 
 resource "aws_iam_policy" "lambda_media_convert_policy" {
-  name        = "lambda-media-convert-policy"
+  name        = "${terraform.workspace}-marsha-lambda-media-convert-policy"
   path        = "/"
   description = "IAM policy for configuring media convert from a lambda"
 
@@ -79,7 +79,7 @@ resource "aws_iam_role_policy_attachment" "lambda_media_convert_policy_attachmen
 }
 
 resource "aws_iam_policy" "lambda_pass_role_policy" {
-  name        = "lambda-pass-role-policy"
+  name        = "${terraform.workspace}-marsha-lambda-pass-role-policy"
   path        = "/"
   description = "IAM policy for passing a role from a lambda"
 
@@ -106,7 +106,7 @@ resource "aws_iam_role_policy_attachment" "lambda_pass_role_policy_attachment" {
 #####################
 
 resource "aws_iam_role" "media_convert_role" {
-  name = "media-convert-role"
+  name = "${terraform.workspace}-marsha-media-convert-role"
 
   assume_role_policy = <<EOF
 {
@@ -125,7 +125,7 @@ EOF
 }
 
 resource "aws_iam_policy" "media_convert_s3_policy" {
-  name        = "media-convert-s3-policy"
+  name        = "${terraform.workspace}-marsha-media-convert-s3-policy"
   path        = "/"
   description = "IAM policy for accessing S3 from Media Convert"
 
@@ -157,7 +157,7 @@ resource "aws_iam_role_policy_attachment" "media_convert_s3_policy_attachment" {
 ###################
 
 resource "aws_iam_role" "event_rule_role" {
-  name = "event-rule-role"
+  name = "${terraform.workspace}-marsha-event-rule-role"
 
   assume_role_policy = <<EOF
 {
@@ -176,7 +176,7 @@ EOF
 }
 
 resource "aws_iam_policy" "event_rule_lambda_invoke_policy" {
-  name        = "event-lambda-invoke-policy"
+  name        = "${terraform.workspace}-marsha-event-lambda-invoke-policy"
   path        = "/"
   description = "IAM policy for invoking a lambda from an event rule"
 

--- a/terraform/source/configure/media-convert.js
+++ b/terraform/source/configure/media-convert.js
@@ -38,6 +38,10 @@ let createPreset = (preset, url) => {
   });
   return new Promise((resolve, reject) => {
     let params = JSON.parse(fs.readFileSync(preset, 'utf8'));
+
+    // Supplement the preset name with the environment
+    params.Name = process.env.ENV_TYPE + '_' + params.Name;
+
     mediaconvert.getPreset({ Name: params.Name }, function(error, data) {
       if (error) {
         // the preset does not exist, let's create it
@@ -63,6 +67,12 @@ let createPreset = (preset, url) => {
 };
 
 let createPresets = event => {
+  if (!process.env.ENV_TYPE) {
+    const message = 'You must set the ENV_TYPE environment variable.';
+    console.log(message);
+    throw message;
+  }
+
   return new Promise((resolve, reject) => {
     let promises = [];
     let url = event.EndPoint;

--- a/terraform/source/configure/media-convert.spec.js
+++ b/terraform/source/configure/media-convert.spec.js
@@ -28,6 +28,7 @@ describe('Media Convert', () => {
   });
 
   it('should return data when creating presets', done => {
+    process.env.ENV_TYPE = 'test';
     const event = {
       EndPoint: 'https://test.mediaconvert.eu-west-1.amazonaws.com',
     };
@@ -54,6 +55,7 @@ describe('Media Convert', () => {
   });
 
   it('should update existing presets', done => {
+    process.env.ENV_TYPE = 'test';
     const event = {
       EndPoint: 'https://test.mediaconvert.eu-west-1.amazonaws.com',
     };

--- a/terraform/source/encode/index.js
+++ b/terraform/source/encode/index.js
@@ -61,23 +61,23 @@ exports.handler = (event, context, callback) => {
           },
           Outputs: [
             {
-              Preset: 'marsha_video_mp4_144',
+              Preset: process.env.ENV_TYPE + '_marsha_video_mp4_144',
               NameModifier: '_144',
             },
             {
-              Preset: 'marsha_video_mp4_240',
+              Preset: process.env.ENV_TYPE + '_marsha_video_mp4_240',
               NameModifier: '_240',
             },
             {
-              Preset: 'marsha_video_mp4_480',
+              Preset: process.env.ENV_TYPE + '_marsha_video_mp4_480',
               NameModifier: '_480',
             },
             {
-              Preset: 'marsha_video_mp4_720',
+              Preset: process.env.ENV_TYPE + '_marsha_video_mp4_720',
               NameModifier: '_720',
             },
             {
-              Preset: 'marsha_video_mp4_1080',
+              Preset: process.env.ENV_TYPE + '_marsha_video_mp4_1080',
               NameModifier: '_1080',
             },
           ],
@@ -98,23 +98,23 @@ exports.handler = (event, context, callback) => {
           },
           Outputs: [
             {
-              Preset: 'marsha_thumbnail_jpeg_144',
+              Preset: process.env.ENV_TYPE + '_marsha_thumbnail_jpeg_144',
               NameModifier: '_thumbnail_144',
             },
             {
-              Preset: 'marsha_thumbnail_jpeg_240',
+              Preset: process.env.ENV_TYPE + '_marsha_thumbnail_jpeg_240',
               NameModifier: '_thumbnail_240',
             },
             {
-              Preset: 'marsha_thumbnail_jpeg_480',
+              Preset: process.env.ENV_TYPE + '_marsha_thumbnail_jpeg_480',
               NameModifier: '_thumbnail_480',
             },
             {
-              Preset: 'marsha_thumbnail_jpeg_720',
+              Preset: process.env.ENV_TYPE + '_marsha_thumbnail_jpeg_720',
               NameModifier: '_thumbnail_720',
             },
             {
-              Preset: 'marsha_thumbnail_jpeg_1080',
+              Preset: process.env.ENV_TYPE + '_marsha_thumbnail_jpeg_1080',
               NameModifier: '_thumbnail_1080',
             },
           ],
@@ -135,7 +135,7 @@ exports.handler = (event, context, callback) => {
           },
           Outputs: [
             {
-              Preset: 'marsha_preview_jpeg_100',
+              Preset: process.env.ENV_TYPE + '_marsha_preview_jpeg_100',
               NameModifier: '_preview_100',
             },
           ],


### PR DESCRIPTION
## Purpose

We want to be able to deploy several independant pipelines, one per environment. When I tried to do it I faced 2 issues:
- presets could not be differentiated by environment
- roles and policies were clashing because their name did not differentiate their environment

## Proposal

- [x] allow defining media convert presets per environment
- [x] fix clashing names for roles and policies