### PR TITLE
Activate cloudfront signed urls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,5 @@ dist
 node_modules
 package-lock.json
 
+# Ssh keys
+.ssh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       dockerfile: ./docker/images/dev/Dockerfile
     image: marsha:dev
     env_file: env.d/development
+    env_file: env.d/development_secret
     # Override production container command that runs gunicorn in favor of the
     # django development server (wrapped by dockerize to ensure the db is ready
     # to accept connections before running the development server)

--- a/docker/images/alpine/Dockerfile
+++ b/docker/images/alpine/Dockerfile
@@ -24,6 +24,7 @@ FROM base as back-builder
 # Pillow and psycopg2)
 RUN apk --no-cache add --update \
         gcc \
+        libffi-dev \
         musl-dev \
         postgresql-dev && \
     rm -rf /var/cache/apk/*

--- a/env.d/ci
+++ b/env.d/ci
@@ -11,3 +11,6 @@ POSTGRES_DB=marsha
 POSTGRES_USER=fun
 POSTGRES_PASSWORD=pass
 
+# AWS User
+DJANGO_AWS_ACCESS_KEY_ID=aws-access-key-id
+DJANGO_AWS_SECRET_ACCESS_KEY=aws-secret-access-key

--- a/env.d/ci
+++ b/env.d/ci
@@ -15,6 +15,5 @@ POSTGRES_PASSWORD=pass
 DJANGO_AWS_ACCESS_KEY_ID=aws-access-key-id
 DJANGO_AWS_SECRET_ACCESS_KEY=aws-secret-access-key
 
-# CloudFront User (has to be a root user, cannot be an IAM user)
-DJANGO_CLOUDFRONT_ACCESS_KEY_ID=cloudfront-access-key-id
+# AWS 
 DJANGO_CLOUDFRONT_URL=https://abc.cloudfront.net

--- a/env.d/ci
+++ b/env.d/ci
@@ -14,3 +14,7 @@ POSTGRES_PASSWORD=pass
 # AWS User
 DJANGO_AWS_ACCESS_KEY_ID=aws-access-key-id
 DJANGO_AWS_SECRET_ACCESS_KEY=aws-secret-access-key
+
+# CloudFront User (has to be a root user, cannot be an IAM user)
+DJANGO_CLOUDFRONT_ACCESS_KEY_ID=cloudfront-access-key-id
+DJANGO_CLOUDFRONT_URL=https://abc.cloudfront.net

--- a/env.d/test
+++ b/env.d/test
@@ -15,3 +15,6 @@ POSTGRES_PASSWORD=pass
 DJANGO_AWS_ACCESS_KEY_ID=aws-access-key-id
 DJANGO_AWS_SECRET_ACCESS_KEY=aws-secret-access-key
 
+# CloudFront User (has to be a root user, cannot be an IAM user)
+DJANGO_CLOUDFRONT_ACCESS_KEY_ID=cloudfront-access-key-id
+DJANGO_CLOUDFRONT_URL=https://abc.cloudfront.net

--- a/env.d/test
+++ b/env.d/test
@@ -11,4 +11,7 @@ POSTGRES_DB=marsha
 POSTGRES_USER=fun
 POSTGRES_PASSWORD=pass
 
+# AWS User
+DJANGO_AWS_ACCESS_KEY_ID=aws-access-key-id
+DJANGO_AWS_SECRET_ACCESS_KEY=aws-secret-access-key
 

--- a/env.d/test
+++ b/env.d/test
@@ -15,6 +15,5 @@ POSTGRES_PASSWORD=pass
 DJANGO_AWS_ACCESS_KEY_ID=aws-access-key-id
 DJANGO_AWS_SECRET_ACCESS_KEY=aws-secret-access-key
 
-# CloudFront User (has to be a root user, cannot be an IAM user)
-DJANGO_CLOUDFRONT_ACCESS_KEY_ID=cloudfront-access-key-id
+# AWS
 DJANGO_CLOUDFRONT_URL=https://abc.cloudfront.net

--- a/marsha/core/api.py
+++ b/marsha/core/api.py
@@ -8,7 +8,7 @@ from rest_framework.response import Response
 from .models import Video
 from .permissions import IsVideoTokenOrAdminUser
 from .serializers import VideoSerializer
-from .utils import get_s3_policy
+from .utils.aws_s3 import get_s3_policy
 
 
 class VideoViewSet(

--- a/marsha/core/serializers.py
+++ b/marsha/core/serializers.py
@@ -65,7 +65,7 @@ class VideoSerializer(serializers.ModelSerializer):
                     thumbnail_url, date_less_than=date_less_than
                 )
 
-            urls["mp4"][str(resolution)] = mp4_url
-            urls["thumbnails"][str(resolution)] = thumbnail_url
+            urls["mp4"][resolution] = mp4_url
+            urls["thumbnails"][resolution] = thumbnail_url
 
         return urls

--- a/marsha/core/serializers.py
+++ b/marsha/core/serializers.py
@@ -32,13 +32,15 @@ class VideoSerializer(serializers.ModelSerializer):
                 - jpeg thumbnails of the video in each resolution
 
         """
-        urls = {"mp4": {}, "jpeg": {}}
+        urls = {"mp4": {}, "thumbnails": {}}
 
         for resolution in settings.VIDEO_RESOLUTIONS:
             urls["mp4"][str(resolution)] = "{!s}/mp4/{!s}_{:d}.mp4".format(
                 obj.playlist.id, obj.id, resolution
             )
-            urls["jpeg"][str(resolution)] = "{!s}/jpeg/{!s}_{:d}.0000000.jpg".format(
+            urls["thumbnails"][
+                str(resolution)
+            ] = "{!s}/thumbnails/{!s}_{:d}.0000000.jpg".format(
                 obj.playlist.id, obj.id, resolution
             )
         return urls

--- a/marsha/core/tests/test_api_video.py
+++ b/marsha/core/tests/test_api_video.py
@@ -45,12 +45,14 @@ class VideoAPITest(TestCase):
         self.assertEqual(response.status_code, 200)
         content = json.loads(response.content)
 
-        jpeg_dict = {
-            "144": "{!s}/jpeg/{!s}_144.0000000.jpg".format(playlist.id, video.id),
-            "240": "{!s}/jpeg/{!s}_240.0000000.jpg".format(playlist.id, video.id),
-            "480": "{!s}/jpeg/{!s}_480.0000000.jpg".format(playlist.id, video.id),
-            "720": "{!s}/jpeg/{!s}_720.0000000.jpg".format(playlist.id, video.id),
-            "1080": "{!s}/jpeg/{!s}_1080.0000000.jpg".format(playlist.id, video.id),
+        thumbnails_dict = {
+            "144": "{!s}/thumbnails/{!s}_144.0000000.jpg".format(playlist.id, video.id),
+            "240": "{!s}/thumbnails/{!s}_240.0000000.jpg".format(playlist.id, video.id),
+            "480": "{!s}/thumbnails/{!s}_480.0000000.jpg".format(playlist.id, video.id),
+            "720": "{!s}/thumbnails/{!s}_720.0000000.jpg".format(playlist.id, video.id),
+            "1080": "{!s}/thumbnails/{!s}_1080.0000000.jpg".format(
+                playlist.id, video.id
+            ),
         }
         mp4_dict = {
             "144": "{!s}/mp4/{!s}_144.mp4".format(playlist.id, video.id),
@@ -65,7 +67,7 @@ class VideoAPITest(TestCase):
                 "description": video.description,
                 "id": str(video.id),
                 "title": video.title,
-                "urls": {"jpeg": jpeg_dict, "mp4": mp4_dict},
+                "urls": {"thumbnails": thumbnails_dict, "mp4": mp4_dict},
             },
         )
 

--- a/marsha/core/tests/test_api_video.py
+++ b/marsha/core/tests/test_api_video.py
@@ -10,7 +10,7 @@ from rest_framework_simplejwt.tokens import AccessToken
 
 from ..factories import UserFactory, VideoFactory
 from ..models import Video
-from ..utils import timezone
+from ..utils.aws_s3 import timezone
 
 
 # We don't enforce arguments documentation in tests

--- a/marsha/core/tests/test_api_video.py
+++ b/marsha/core/tests/test_api_video.py
@@ -343,17 +343,17 @@ class VideoAPITest(TestCase):
                     "Q4OGUtOWQ3MC02ZWM1OTlhNjc4MDYvYTJmMjdmZGUtOTczYS00ZTg5LThkY2EtY2M1OWUwMWQyNTV"
                     "jIn0sIHsiYWNsIjogInByaXZhdGUifSwgWyJzdGFydHMtd2l0aCIsICIkQ29udGVudC1UeXBlIiwg"
                     "InZpZGVvLyJdLCBbImNvbnRlbnQtbGVuZ3RoLXJhbmdlIiwgMCwgMTA3Mzc0MTgyNF0sIHsieC1hb"
-                    "XotY3JlZGVudGlhbCI6ICJBQ0NFU1NfS0VZX0lELzIwMTgwODA4L2V1LXdlc3QtMS9zMy9hd3M0X3"
-                    "JlcXVlc3QifSwgeyJ4LWFtei1hbGdvcml0aG0iOiAiQVdTNC1ITUFDLVNIQTI1NiJ9LCB7IngtYW1"
-                    "6LWRhdGUiOiAiMjAxODA4MDhUMDAwMDAwWiJ9XX0="
+                    "XotY3JlZGVudGlhbCI6ICJhd3MtYWNjZXNzLWtleS1pZC8yMDE4MDgwOC9ldS13ZXN0LTEvczMvYX"
+                    "dzNF9yZXF1ZXN0In0sIHsieC1hbXotYWxnb3JpdGhtIjogIkFXUzQtSE1BQy1TSEEyNTYifSwgeyJ"
+                    "4LWFtei1kYXRlIjogIjIwMTgwODA4VDAwMDAwMFoifV19"
                 ),
                 "s3_endpoint": "s3.eu-west-1.amazonaws.com",
                 "x_amz_algorithm": "AWS4-HMAC-SHA256",
-                "x_amz_credential": "ACCESS_KEY_ID/20180808/eu-west-1/s3/aws4_request",
+                "x_amz_credential": "aws-access-key-id/20180808/eu-west-1/s3/aws4_request",
                 "x_amz_date": "20180808T000000Z",
                 "x_amz_expires": 86400,
                 "x_amz_signature": (
-                    "8d7d40f125a70d6cc173130f5985be88291459928126638555694d2295882166"
+                    "ae5de31f8d6db6495e9b1ef0cbb06fa7506864cda0dcada97e2f6ef5cff24498"
                 ),
             },
         )

--- a/marsha/core/tests/test_api_video.py
+++ b/marsha/core/tests/test_api_video.py
@@ -115,7 +115,10 @@ class VideoAPITest(TestCase):
             content, {"detail": "You do not have permission to perform this action."}
         )
 
-    @override_settings(CLOUDFRONT_SIGNED_URLS_ACTIVE=True)
+    @override_settings(
+        CLOUDFRONT_SIGNED_URLS_ACTIVE=True,
+        CLOUDFRONT_ACCESS_KEY_ID="cloudfront-access-key-id",
+    )
     @mock.patch("builtins.open", new_callable=mock.mock_open, read_data=RSA_KEY_MOCK)
     def test_api_video_read_detail_token_user_signed_urls(self, mock_open):
         """Activating signed urls should add Cloudfront query string authentication parameters."""

--- a/marsha/core/tests/test_views_lti_video.py
+++ b/marsha/core/tests/test_views_lti_video.py
@@ -24,7 +24,7 @@ class ViewsTestCase(TestCase):
 
     @mock.patch.object(LTI, "verify", return_value=True)
     def test_views_video_lti_instructor(self, mock_initialize):
-        """."""
+        """Validate the context returned for an instructor request."""
         video = VideoFactory(
             lti_id="123",
             playlist__lti_id="abc",
@@ -52,11 +52,11 @@ class ViewsTestCase(TestCase):
         self.assertEqual(context["video"]["id"], str(video.id))
         self.assertEqual(context["video"]["title"], str(video.title))
         self.assertEqual(context["video"]["description"], str(video.description))
-        self.assertEqual(set(context["video"]["urls"].keys()), {"mp4", "jpeg"})
+        self.assertEqual(set(context["video"]["urls"].keys()), {"mp4", "thumbnails"})
 
     @mock.patch.object(LTI, "verify", return_value=True)
     def test_views_video_lti_student(self, mock_initialize):
-        """."""
+        """Validate the context returned for a student request."""
         video = VideoFactory(
             lti_id="123",
             playlist__lti_id="abc",
@@ -78,4 +78,4 @@ class ViewsTestCase(TestCase):
         self.assertEqual(context["video"]["id"], str(video.id))
         self.assertEqual(context["video"]["title"], str(video.title))
         self.assertEqual(context["video"]["description"], str(video.description))
-        self.assertEqual(set(context["video"]["urls"].keys()), {"mp4", "jpeg"})
+        self.assertEqual(set(context["video"]["urls"].keys()), {"mp4", "thumbnails"})

--- a/marsha/core/utils/aws_cloudfront.py
+++ b/marsha/core/utils/aws_cloudfront.py
@@ -6,7 +6,6 @@ https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloud
 """
 from django.conf import settings
 
-from botocore.signers import CloudFrontSigner
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding
@@ -41,6 +40,3 @@ def rsa_signer(message):
         raise MissingRSAKey()
 
     return private_key.sign(message, padding.PKCS1v15(), hashes.SHA1())
-
-
-cloudfront_signer = CloudFrontSigner(settings.CLOUDFRONT_ACCESS_KEY_ID, rsa_signer)

--- a/marsha/core/utils/aws_cloudfront.py
+++ b/marsha/core/utils/aws_cloudfront.py
@@ -1,0 +1,46 @@
+"""
+Utils to sign CloudFront urls and cookies.
+
+Following boto3's documentation to sign CloudFront urls
+https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloudfront.html
+"""
+from django.conf import settings
+
+from botocore.signers import CloudFrontSigner
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding
+
+
+class MissingRSAKey(Exception):
+    """Exception raised when an RSA key is missing."""
+
+    pass
+
+
+def rsa_signer(message):
+    """Sign a message with an rsa key pair found on the file system for CloudFront signed urls.
+
+    Parameters
+    ----------
+    message : Type[string]
+        the message for which we want to compute a signature
+
+    Returns
+    -------
+    string
+        The rsa signature
+
+    """
+    try:
+        with open(settings.CLOUDFRONT_PRIVATE_KEY_PATH, "rb") as key_file:
+            private_key = serialization.load_pem_private_key(
+                key_file.read(), password=None, backend=default_backend()
+            )
+    except FileNotFoundError:
+        raise MissingRSAKey()
+
+    return private_key.sign(message, padding.PKCS1v15(), hashes.SHA1())
+
+
+cloudfront_signer = CloudFrontSigner(settings.CLOUDFRONT_ACCESS_KEY_ID, rsa_signer)

--- a/marsha/core/utils/aws_s3.py
+++ b/marsha/core/utils/aws_s3.py
@@ -1,4 +1,4 @@
-"""Utils for the ``core`` app of the Marsha project."""
+"""Utils for direct upload to AWS S3."""
 from base64 import b64encode
 from datetime import timedelta
 import hashlib
@@ -8,7 +8,7 @@ import json
 from django.conf import settings
 from django.utils import timezone
 
-from .defaults import AWS_UPLOAD_EXPIRATION_DELAY, VIDEO_SOURCE_MAX_SIZE
+from ..defaults import AWS_UPLOAD_EXPIRATION_DELAY, VIDEO_SOURCE_MAX_SIZE
 
 
 def sign(key, message):

--- a/marsha/settings.py
+++ b/marsha/settings.py
@@ -159,6 +159,4 @@ class Development(Base):
 class Test(Base):
     """Test environment settings."""
 
-    AWS_ACCESS_KEY_ID = "ACCESS_KEY_ID"
-    AWS_SECRET_ACCESS_KEY = "SECRET_ACCESS_KEY"
     AWS_SOURCE_BUCKET_NAME = "test-marsha-source"

--- a/marsha/settings.py
+++ b/marsha/settings.py
@@ -126,11 +126,11 @@ class Base(Configuration):
     AWS_DEFAULT_REGION = values.Value("eu-west-1")
 
     # Cloud Front key pair for signed urls
-    CLOUDFRONT_ACCESS_KEY_ID = values.SecretValue()
+    CLOUDFRONT_URL = values.SecretValue()
+    CLOUDFRONT_ACCESS_KEY_ID = values.Value(None)
     CLOUDFRONT_PRIVATE_KEY_PATH = os.path.join(
         BASE_DIR, "..", ".ssh", "cloudfront_private_key"
     )
-    CLOUDFRONT_URL = values.SecretValue()
     CLOUDFRONT_SIGNED_URLS_ACTIVE = True
     CLOUDFRONT_SIGNED_URLS_VALIDITY = 2 * 60 * 60  # 2 hours
 

--- a/marsha/settings.py
+++ b/marsha/settings.py
@@ -125,6 +125,15 @@ class Base(Configuration):
     AWS_SECRET_ACCESS_KEY = values.SecretValue()
     AWS_DEFAULT_REGION = values.Value("eu-west-1")
 
+    # Cloud Front key pair for signed urls
+    CLOUDFRONT_ACCESS_KEY_ID = values.SecretValue()
+    CLOUDFRONT_PRIVATE_KEY_PATH = os.path.join(
+        BASE_DIR, "..", ".ssh", "cloudfront_private_key"
+    )
+    CLOUDFRONT_URL = values.SecretValue()
+    CLOUDFRONT_SIGNED_URLS_ACTIVE = True
+    CLOUDFRONT_SIGNED_URLS_VALIDITY = 2 * 60 * 60  # 2 hours
+
     # pylint: disable=invalid-name
     @property
     def SIMPLE_JWT(self):
@@ -160,3 +169,5 @@ class Test(Base):
     """Test environment settings."""
 
     AWS_SOURCE_BUCKET_NAME = "test-marsha-source"
+
+    CLOUDFRONT_SIGNED_URLS_ACTIVE = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,8 @@ requires-python = >=3.6
 zip_safe = True
 packages = find:
 install_requires =
+    boto3==1.8.6
+    cryptography==2.3.1
     django==2.0
     dj-database-url==0.5.0
     django-configurations==2.0


### PR DESCRIPTION
## Purpose

We want to allow making our videos private in AWS.
The backend must then compute CloudFront signed urls using the RSA private key of an AWS root account.

See AWS documentation for more information: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-signed-urls.html

## Proposal

- [x] starting by some refactorings to make place for signed urls (split utils between s3/cloudfront because they look similar and could be confusing, clarify settings between what comes from environment variables and what is committed in the Python code)
- [x] Allow activating signed urls via a setting. The computation of the signed urls is following boto3's documentation here: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloudfront.html
