### PR TITLE
✨(front) add error codes & related strings to ErrorComponent

### DIFF
--- a/front/components/ErrorComponent/ErrorComponent.spec.tsx
+++ b/front/components/ErrorComponent/ErrorComponent.spec.tsx
@@ -7,7 +7,7 @@ import { IntlProvider } from 'react-intl';
 import { ErrorComponent } from './ErrorComponent';
 
 test('ErrorComponent displays the content for 404 not found errors', () => {
-  const wrapper = render(<ErrorComponent code="not_found" />);
+  const wrapper = render(<ErrorComponent code="notFound" />);
   expect(wrapper.text()).toContain(
     'The video you are looking for could not be found',
   );

--- a/front/components/ErrorComponent/ErrorComponent.tsx
+++ b/front/components/ErrorComponent/ErrorComponent.tsx
@@ -3,58 +3,73 @@ import * as React from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 
 export interface ErrorComponentProps {
-  code: 'lti' | 'not_found';
+  code: 'lti' | 'notFound' | 'policy' | 'upload';
 }
 
-const messages = defineMessages({
-  ltiText: {
-    defaultMessage: `We could not validate your access to this video. Please contact your instructor.
+const messages = {
+  lti: defineMessages({
+    text: {
+      defaultMessage: `We could not validate your access to this video. Please contact your instructor.
       If you are the instructor, please check your settings.`,
-    description: '',
-    id: 'components.ErrorComponent.ltiText',
-  },
-  ltiTitle: {
-    defaultMessage: 'There was an error loading this video',
-    description: 'Title for the LTI error page',
-    id: 'components.ErrorComponent.ltiTitle',
-  },
-  notFoundText: {
-    defaultMessage: `This video does not exist or has not been published yet.
+      description: 'Helpful text for the LTI error page',
+      id: 'components.ErrorComponent.lti.text',
+    },
+    title: {
+      defaultMessage: 'There was an error loading this video',
+      description: 'Title for the LTI error page',
+      id: 'components.ErrorComponent.lti.title',
+    },
+  }),
+  notFound: defineMessages({
+    text: {
+      defaultMessage: `This video does not exist or has not been published yet.
       If you are an instructor, please make sure you are properly authenticated.`,
-    description: 'Helpful text for the 404 Not Found error page',
-    id: 'components.ErrorComponent.notFoundText',
-  },
-  notFoundTitle: {
-    defaultMessage: 'The video you are looking for could not be found',
-    description: 'Title for the 404 Not Found error page',
-    id: 'components.ErrorComponent.notFoundTitle',
-  },
-});
+      description: 'Helpful text for the 404 Not Found error page',
+      id: 'components.ErrorComponent.notFound.text',
+    },
+    title: {
+      defaultMessage: 'The video you are looking for could not be found',
+      description: 'Title for the 404 Not Found error page',
+      id: 'components.ErrorComponent.notFound.title',
+    },
+  }),
+  policy: defineMessages({
+    text: {
+      defaultMessage:
+        'We could not make sure you are allowed to upload a video file. Please check your settings and/or try again.',
+      description: 'Title for the upload permission error page',
+      id: 'components.ErrorComponent.policy.text',
+    },
+    title: {
+      defaultMessage: 'Failed to authenticate your permission to upload',
+      description: 'Helpful text for the upload permission error page',
+      id: 'components.ErrorComponent.policy.title',
+    },
+  }),
+  upload: defineMessages({
+    text: {
+      defaultMessage:
+        'You can try again later. You may want to check your Internet connection quality.',
+      description: 'Helpful text for the Upload error page',
+      id: 'components.ErrorComponent.upload.text',
+    },
+    title: {
+      defaultMessage: 'Failed to upload your video file',
+      description: 'Title for the video upload error page',
+      id: 'components.ErrorComponent.upload.title',
+    },
+  }),
+};
 
 export const ErrorComponent = (props: ErrorComponentProps) => {
-  switch (props.code) {
-    case 'not_found':
-      return (
-        <div className="error-component">
-          <h2>
-            <FormattedMessage {...messages.notFoundTitle} />
-          </h2>
-          <p>
-            <FormattedMessage {...messages.notFoundText} />
-          </p>
-        </div>
-      );
-
-    case 'lti':
-      return (
-        <div className="error-component">
-          <h2>
-            <FormattedMessage {...messages.ltiTitle} />
-          </h2>
-          <p>
-            <FormattedMessage {...messages.ltiText} />
-          </p>
-        </div>
-      );
-  }
+  return (
+    <div className="error-component">
+      <h2>
+        <FormattedMessage {...messages[props.code].title} />
+      </h2>
+      <p>
+        <FormattedMessage {...messages[props.code].text} />
+      </p>
+    </div>
+  );
 };

--- a/front/components/RedirectOnLoad/RedirectOnLoad.spec.tsx
+++ b/front/components/RedirectOnLoad/RedirectOnLoad.spec.tsx
@@ -56,13 +56,13 @@ describe('<RedirectOnLoad />', () => {
     expect(wrapper.prop('to')).toEqual('/form');
   });
 
-  it('redirects students to /errors/not_found when the video is not ready', () => {
+  it('redirects students to /errors/notFound when the video is not ready', () => {
     context.state = 'student';
     context.video = { status: 'not_ready' };
     const wrapper = shallow(<RedirectOnLoad />).dive();
 
     expect(wrapper.name()).toEqual('Redirect');
     expect(wrapper.prop('push')).toBeTruthy();
-    expect(wrapper.prop('to')).toEqual('/errors/not_found');
+    expect(wrapper.prop('to')).toEqual('/errors/notFound');
   });
 });

--- a/front/components/RedirectOnLoad/RedirectOnLoad.tsx
+++ b/front/components/RedirectOnLoad/RedirectOnLoad.tsx
@@ -26,7 +26,7 @@ export const RedirectOnLoad = () => {
         // For safety default to the 404 view: this is for students, and any other role we add later on and don't add
         // a special clause for, when the video is not ready.
         else {
-          return <Redirect push to="/errors/not_found" />;
+          return <Redirect push to="/errors/notFound" />;
         }
       }}
     </AppDataContext.Consumer>


### PR DESCRIPTION
## Purpose

We recently added two possible error codes from the video upload form, that redirect to `ErrorComponent`.

Note: we can't make the URLs + codes into variables until we have full coverage of the possible values in `ErrorComponent`, otherwise the compiler complains of undefined behavior 😅

This is a pretty cool consequence of doing our routing this way instead of delegating to a more complicated router.

## Proposal 

Add relevant help text and error code handling into `ErrorComponent`.

These are not necessarily the final implementation of the `ErrorComponent`, or of handlers for these particular errors. I just thought it best to start from something and make it better later on rather than just drop or throw errors and go 🤷‍♂️