### PR TITLE
✨(front) use frontend URL fragments from variables

### DIFF
--- a/front/components/AppRoutes/AppRoutes.tsx
+++ b/front/components/AppRoutes/AppRoutes.tsx
@@ -2,10 +2,19 @@ import React from 'react';
 import { HashRouter, Route, Switch } from 'react-router-dom';
 
 import { AppDataContext } from '../..';
-import { ErrorComponent } from '../ErrorComponent/ErrorComponent';
-import { RedirectOnLoad } from '../RedirectOnLoad/RedirectOnLoad';
-import { VideoForm } from '../VideoForm/VideoForm';
-import { VideoJsPlayer } from '../VideoJsPlayer/VideoJsPlayer';
+import {
+  ErrorComponent,
+  ROUTE as ERROR_ROUTE,
+} from '../ErrorComponent/ErrorComponent';
+import {
+  RedirectOnLoad,
+  ROUTE as HOME_ROUTE,
+} from '../RedirectOnLoad/RedirectOnLoad';
+import { ROUTE as FORM_ROUTE, VideoForm } from '../VideoForm/VideoForm';
+import {
+  ROUTE as PLAYER_ROUTE,
+  VideoJsPlayer,
+} from '../VideoJsPlayer/VideoJsPlayer';
 
 export const AppRoutes = () => {
   return (
@@ -13,7 +22,7 @@ export const AppRoutes = () => {
       <Switch>
         <Route
           exact
-          path="/player"
+          path={PLAYER_ROUTE()}
           render={() => (
             <AppDataContext.Consumer>
               {({ video }) => <VideoJsPlayer video={video} />}
@@ -22,7 +31,7 @@ export const AppRoutes = () => {
         />
         <Route
           exact
-          path="/form"
+          path={FORM_ROUTE()}
           render={() => (
             <AppDataContext.Consumer>
               {({ jwt, video }) => <VideoForm jwt={jwt} video={video} />}
@@ -31,10 +40,10 @@ export const AppRoutes = () => {
         />
         <Route
           exact
-          path="/errors/:code"
+          path={ERROR_ROUTE()}
           render={({ match }) => <ErrorComponent code={match.params.code} />}
         />
-        <Route path="/" component={RedirectOnLoad} />
+        <Route path={HOME_ROUTE()} component={RedirectOnLoad} />
       </Switch>
     </HashRouter>
   );

--- a/front/components/ErrorComponent/ErrorComponent.tsx
+++ b/front/components/ErrorComponent/ErrorComponent.tsx
@@ -61,6 +61,9 @@ const messages = {
   }),
 };
 
+export const ROUTE = (code?: ErrorComponentProps['code']) =>
+  code ? `/errors/${code}` : '/errors/:code';
+
 export const ErrorComponent = (props: ErrorComponentProps) => {
   return (
     <div className="error-component">

--- a/front/components/RedirectOnLoad/RedirectOnLoad.spec.tsx
+++ b/front/components/RedirectOnLoad/RedirectOnLoad.spec.tsx
@@ -14,26 +14,29 @@ jest.doMock('../..', () => {
   };
 });
 
+import { ROUTE as ERROR_ROUTE } from '../ErrorComponent/ErrorComponent';
+import { ROUTE as FORM_ROUTE } from '../VideoForm/VideoForm';
+import { ROUTE as PLAYER_ROUTE } from '../VideoJsPlayer/VideoJsPlayer';
 import { RedirectOnLoad } from './RedirectOnLoad';
 
 describe('<RedirectOnLoad />', () => {
-  it('redirects to /errors/lti on LTI error', () => {
+  it('redirects to the error view on LTI error', () => {
     context.state = 'error';
     const wrapper = shallow(<RedirectOnLoad />).dive();
 
     expect(wrapper.name()).toEqual('Redirect');
     expect(wrapper.prop('push')).toBeTruthy();
-    expect(wrapper.prop('to')).toEqual('/errors/lti');
+    expect(wrapper.prop('to')).toEqual(ERROR_ROUTE('lti'));
   });
 
-  it('redirects instructors to /player when the video is ready', () => {
+  it('redirects instructors to the player when the video is ready', () => {
     context.state = 'instructor';
     context.video = { status: 'ready' };
     const wrapper = shallow(<RedirectOnLoad />).dive();
 
     expect(wrapper.name()).toEqual('Redirect');
     expect(wrapper.prop('push')).toBeTruthy();
-    expect(wrapper.prop('to')).toEqual('/player');
+    expect(wrapper.prop('to')).toEqual(PLAYER_ROUTE());
   });
 
   it('redirects students to /player when the video is ready', () => {
@@ -43,7 +46,7 @@ describe('<RedirectOnLoad />', () => {
 
     expect(wrapper.name()).toEqual('Redirect');
     expect(wrapper.prop('push')).toBeTruthy();
-    expect(wrapper.prop('to')).toEqual('/player');
+    expect(wrapper.prop('to')).toEqual(PLAYER_ROUTE());
   });
 
   it('redirects instructors to /form when the video is not ready', () => {
@@ -53,16 +56,16 @@ describe('<RedirectOnLoad />', () => {
 
     expect(wrapper.name()).toEqual('Redirect');
     expect(wrapper.prop('push')).toBeTruthy();
-    expect(wrapper.prop('to')).toEqual('/form');
+    expect(wrapper.prop('to')).toEqual(FORM_ROUTE());
   });
 
-  it('redirects students to /errors/notFound when the video is not ready', () => {
+  it('redirects students to the error view when the video is not ready', () => {
     context.state = 'student';
     context.video = { status: 'not_ready' };
     const wrapper = shallow(<RedirectOnLoad />).dive();
 
     expect(wrapper.name()).toEqual('Redirect');
     expect(wrapper.prop('push')).toBeTruthy();
-    expect(wrapper.prop('to')).toEqual('/errors/notFound');
+    expect(wrapper.prop('to')).toEqual(ERROR_ROUTE('notFound'));
   });
 });

--- a/front/components/RedirectOnLoad/RedirectOnLoad.tsx
+++ b/front/components/RedirectOnLoad/RedirectOnLoad.tsx
@@ -2,6 +2,11 @@ import * as React from 'react';
 import { Redirect } from 'react-router-dom';
 
 import { AppDataContext } from '../..';
+import { ROUTE as ERROR_ROUTE } from '../ErrorComponent/ErrorComponent';
+import { ROUTE as FORM_ROUTE } from '../VideoForm/VideoForm';
+import { ROUTE as PLAYER_ROUTE } from '../VideoJsPlayer/VideoJsPlayer';
+
+export const ROUTE = () => '/';
 
 // RedirectOnLoad assesses the initial state of the application using appData and determines the proper
 // route to load in the Router
@@ -13,20 +18,20 @@ export const RedirectOnLoad = () => {
 
         // Get LTI errors out of the way
         if (state === 'error') {
-          return <Redirect push to="/errors/lti" />;
+          return <Redirect push to={ERROR_ROUTE('lti')} />;
         }
         // Everyone gets the video when it exists (so that instructors see the iframes like a student would by default)
         else if (video.status === 'ready') {
-          return <Redirect push to="/player" />;
+          return <Redirect push to={PLAYER_ROUTE()} />;
         }
         // Only instructors are allowed to interact with a non-ready video
         else if (state === 'instructor') {
-          return <Redirect push to="/form" />;
+          return <Redirect push to={FORM_ROUTE()} />;
         }
         // For safety default to the 404 view: this is for students, and any other role we add later on and don't add
         // a special clause for, when the video is not ready.
         else {
-          return <Redirect push to="/errors/notFound" />;
+          return <Redirect push to={ERROR_ROUTE('notFound')} />;
         }
       }}
     </AppDataContext.Consumer>

--- a/front/components/VideoForm/VideoForm.tsx
+++ b/front/components/VideoForm/VideoForm.tsx
@@ -7,6 +7,8 @@ import { AWSPolicy } from '../../types/AWSPolicy';
 import { Video } from '../../types/Video';
 import { makeFormData } from '../../utils/makeFormData/makeFormData';
 import { Maybe } from '../../utils/types';
+import { ROUTE as ERROR_ROUTE } from '../ErrorComponent/ErrorComponent';
+import { ROUTE as PLAYER_ROUTE } from '../VideoJsPlayer/VideoJsPlayer';
 import { VideoUploadField } from '../VideoUploadField/VideoUploadField';
 
 export interface VideoFormProps {
@@ -33,6 +35,8 @@ const messages = defineMessages({
     id: 'components.VideoForm.title',
   },
 });
+
+export const ROUTE = () => '/form';
 
 export class VideoForm extends React.Component<VideoFormProps, VideoFormState> {
   async componentDidMount() {
@@ -92,13 +96,13 @@ export class VideoForm extends React.Component<VideoFormProps, VideoFormState> {
 
     switch (status) {
       case 'success':
-        return <Redirect push to="/player" />;
+        return <Redirect push to={PLAYER_ROUTE()} />;
 
       case 'policy_error':
-        return <Redirect push to="/errors/policy" />;
+        return <Redirect push to={ERROR_ROUTE('policy')} />;
 
       case 'upload_error':
-        return <Redirect push to="/errors/upload" />;
+        return <Redirect push to={ERROR_ROUTE('upload')} />;
 
       default:
         return (

--- a/front/components/VideoJsPlayer/VideoJsPlayer.tsx
+++ b/front/components/VideoJsPlayer/VideoJsPlayer.tsx
@@ -14,6 +14,8 @@ interface VideoJsPlayerState {
   videoNode: Nullable<HTMLVideoElement>;
 }
 
+export const ROUTE = () => '/player';
+
 export class VideoJsPlayer extends React.Component<
   VideoJsPlayerProps,
   VideoJsPlayerState


### PR DESCRIPTION
## Purpose

Using strings directly wherever we define a route or link/redirect to them can cause issues when some of the URL fragments change or when we decide to translate them.

Closes #42 

## Proposal

Using functions returning strings instead gives us a simple API that manages these issues and will enable us to add a helper to build URL localization later on if we need to.