### PR TITLE
Pass jwt as s3 file metadata

### DIFF
--- a/front/components/VideoForm/VideoForm.spec.tsx
+++ b/front/components/VideoForm/VideoForm.spec.tsx
@@ -74,6 +74,7 @@ describe('VideoForm', () => {
       ['Content-Type', 'video/mp4'],
       ['X-Amz-Credential', 'policy##x_amz_credential'],
       ['X-Amz-Algorithm', 'policy##x_amz_algorithm'],
+      ['X-Amz-Meta-Jwt', 'some_token'],
       ['X-Amz-Date', 'policy##x_amz_date'],
       ['Policy', 'policy##policy'],
       ['X-Amz-Signature', 'policy##x_amz_signature'],

--- a/front/components/VideoForm/VideoForm.tsx
+++ b/front/components/VideoForm/VideoForm.tsx
@@ -63,6 +63,7 @@ export class VideoForm extends React.Component<VideoFormProps, VideoFormState> {
   }
 
   async upload() {
+    const { jwt } = this.props;
     const { file, policy } = this.state;
 
     // Use FormData to meet the requirement of a multi-part POST request for s3
@@ -73,6 +74,7 @@ export class VideoForm extends React.Component<VideoFormProps, VideoFormState> {
       ['Content-Type', file!.type],
       ['X-Amz-Credential', policy.x_amz_credential],
       ['X-Amz-Algorithm', policy.x_amz_algorithm],
+      ['X-Amz-Meta-Jwt', jwt],
       ['X-Amz-Date', policy.x_amz_date],
       ['Policy', policy.policy],
       ['X-Amz-Signature', policy.x_amz_signature],

--- a/marsha/core/tests/test_api_video.py
+++ b/marsha/core/tests/test_api_video.py
@@ -431,7 +431,8 @@ class VideoAPITest(TestCase):
                     "InZpZGVvLyJdLCBbImNvbnRlbnQtbGVuZ3RoLXJhbmdlIiwgMCwgMTA3Mzc0MTgyNF0sIHsieC1hb"
                     "XotY3JlZGVudGlhbCI6ICJhd3MtYWNjZXNzLWtleS1pZC8yMDE4MDgwOC9ldS13ZXN0LTEvczMvYX"
                     "dzNF9yZXF1ZXN0In0sIHsieC1hbXotYWxnb3JpdGhtIjogIkFXUzQtSE1BQy1TSEEyNTYifSwgeyJ"
-                    "4LWFtei1kYXRlIjogIjIwMTgwODA4VDAwMDAwMFoifV19"
+                    "4LWFtei1kYXRlIjogIjIwMTgwODA4VDAwMDAwMFoifSwgWyJzdGFydHMtd2l0aCIsICIkeC1hbXot"
+                    "bWV0YS1qd3QiLCAiIl1dfQ=="
                 ),
                 "s3_endpoint": "s3.eu-west-1.amazonaws.com",
                 "x_amz_algorithm": "AWS4-HMAC-SHA256",
@@ -439,7 +440,7 @@ class VideoAPITest(TestCase):
                 "x_amz_date": "20180808T000000Z",
                 "x_amz_expires": 86400,
                 "x_amz_signature": (
-                    "ae5de31f8d6db6495e9b1ef0cbb06fa7506864cda0dcada97e2f6ef5cff24498"
+                    "434a8c9d285b6b287647adc527676beaee0943d36aa2bc3fad3657f53f8b0d09"
                 ),
             },
         )

--- a/marsha/core/utils/aws_s3.py
+++ b/marsha/core/utils/aws_s3.py
@@ -100,6 +100,7 @@ def get_s3_policy(bucket, key):
             {"x-amz-credential": x_amz_credential},
             {"x-amz-algorithm": x_amz_algorithm},
             {"x-amz-date": x_amz_date},
+            ["starts-with", "$x-amz-meta-jwt", ""],
         ],
     }
 


### PR DESCRIPTION
## Purpose

We need to update the video status from a lambda once it has finished processing in our mediaconvert pipelines. To enable the lambda to do this update, we need to pass it the JWT that allows the video record to be updated in our django app.

## Proposal

The simplest way to do that is to just add it as metadata that will automatically be available in the relevant lambda(s).