### PR TITLE
Use MemoryRouter instead of HashRouter for frontend routing

### DIFF
--- a/front/components/AppRoutes/AppRoutes.tsx
+++ b/front/components/AppRoutes/AppRoutes.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { HashRouter, Route, Switch } from 'react-router-dom';
+import { MemoryRouter, Route, Switch } from 'react-router-dom';
 
 import { AppDataContext } from '../..';
 import {
@@ -18,7 +18,7 @@ import {
 
 export const AppRoutes = () => {
   return (
-    <HashRouter>
+    <MemoryRouter>
       <Switch>
         <Route
           exact
@@ -45,6 +45,6 @@ export const AppRoutes = () => {
         />
         <Route path={HOME_ROUTE()} component={RedirectOnLoad} />
       </Switch>
-    </HashRouter>
+    </MemoryRouter>
   );
 };


### PR DESCRIPTION
## Purpose

We used HashRouter to manage our frontend routing. This allowed us to have a proper history (even though hidden away by the iframe) as we move around the app.

It is however not ideal with LTI. In some situations we need to reload the iframe, which does not work if we navigater in the browser's history as it then sends a GET with the new URL instead of POSTing the original one with its params.

## Proposal

Using MemoryRouter solves the issue as it does not touch the browser's history at all. We therefore remain on the same URL and can reload our POST request with its params.