### PR TITLE
💄(front) add some basic styling to error pages

### DIFF
--- a/front/components/ErrorComponent/ErrorComponent.tsx
+++ b/front/components/ErrorComponent/ErrorComponent.tsx
@@ -1,10 +1,31 @@
 import * as React from 'react';
-
 import { defineMessages, FormattedMessage } from 'react-intl';
+import styled from 'styled-components';
+
+import { H2 } from '../Headings/Headings';
 
 export interface ErrorComponentProps {
   code: 'lti' | 'notFound' | 'policy' | 'upload';
 }
+
+const ErrorComponentStyled = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  padding: 0 2rem;
+`;
+
+const ErrorContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-evenly;
+  align-items: center;
+  flex-grow: 1;
+  padding-top: 4rem;
+  padding-bottom: 6rem;
+  text-align: center;
+`;
 
 const messages = {
   lti: defineMessages({
@@ -66,13 +87,15 @@ export const ROUTE = (code?: ErrorComponentProps['code']) =>
 
 export const ErrorComponent = (props: ErrorComponentProps) => {
   return (
-    <div className="error-component">
-      <h2>
-        <FormattedMessage {...messages[props.code].title} />
-      </h2>
-      <p>
-        <FormattedMessage {...messages[props.code].text} />
-      </p>
-    </div>
+    <ErrorComponentStyled>
+      <ErrorContent>
+        <H2>
+          <FormattedMessage {...messages[props.code].title} />
+        </H2>
+        <p>
+          <FormattedMessage {...messages[props.code].text} />
+        </p>
+      </ErrorContent>
+    </ErrorComponentStyled>
   );
 };

--- a/front/components/Headings/Headings.tsx
+++ b/front/components/Headings/Headings.tsx
@@ -1,0 +1,45 @@
+import styled from 'styled-components';
+
+import { colors } from '../../utils/theme/theme';
+
+const headingsStyle = `
+  margin-bottom: 0.5rem;
+  font-family: inherit;
+  font-weight: 500;
+  line-height: 1.2;
+  color: inherit;
+`;
+
+export const H1 = styled.h1`
+  font-size: 2.5rem;
+  ${headingsStyle};
+`;
+
+export const H2 = styled.h2`
+  font-size: 2rem;
+  ${headingsStyle};
+`;
+
+export const H3 = styled.h3`
+  font-size: 1.75rem;
+  ${headingsStyle};
+`;
+
+export const H4 = styled.h4`
+  font-size: 1.5rem;
+  ${headingsStyle};
+`;
+
+export const H5 = styled.h5`
+  font-size: 1.25rem;
+  ${headingsStyle};
+`;
+
+export const H6 = styled.h6`
+  font-size: 1rem;
+  ${headingsStyle};
+`;
+
+export const IframeHeading = styled(H2)`
+  padding: 0.5rem 0;
+`;


### PR DESCRIPTION
## Purpose

For now we use the same ErrorComponent with the same layout to display all our errors. Hopefully users don't see it too often, but we still need to style it.

## Proposal

Add some basic styling to center the content & use proper typography.

As we're using a specific H2, write similar styled components for other heading levels.