### PR TITLE
Improve the video upload UI

### DIFF
--- a/front/components/Button/Button.tsx
+++ b/front/components/Button/Button.tsx
@@ -1,0 +1,52 @@
+import styled from 'styled-components';
+
+import { styledComponentWithProps } from '../../utils/styledComponentsTs';
+import { colorName, colors } from '../../utils/theme/theme';
+
+export const Button = styledComponentWithProps<{ variant: colorName }>(
+  styled.button,
+)`
+  display: inline-block;
+  text-align: center;
+  white-space: nowrap;
+  vertical-align: middle;
+  user-select: none;
+  border: 1px solid transparent;
+  padding: 0.375rem 0.75rem;
+  font-size: 1rem;
+  line-height: 1.5;
+  border-radius: 0.25rem;
+  transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out,
+    border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+
+  ${props => `
+    color: white;
+    background-color: ${colors[props.variant].main};
+    border-color: ${colors[props.variant].main};
+  `};
+
+  &:hover,
+  &:focus {
+    text-decoration: none;
+  }
+
+  ${props => `
+    &:hover {
+      background-color: ${colors[props.variant].contrast};
+      border-color: ${colors[props.variant].contrast};
+    }
+  `};
+
+  &:focus, &.focus {
+    outline: 0;
+    box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25);
+  }
+
+  &.disabled, &:disabled {
+    opacity: 0.65;
+  }
+
+  &:not(:disabled):not(.disabled) {
+    cursor: pointer;
+  }
+`;

--- a/front/components/VideoForm/UploadingLoader.tsx
+++ b/front/components/VideoForm/UploadingLoader.tsx
@@ -1,0 +1,61 @@
+import * as React from 'react';
+import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
+import styled from 'styled-components';
+
+import { colors } from '../../utils/theme/theme';
+
+const messages = defineMessages({
+  uploading: {
+    defaultMessage: 'Uploading...',
+    description:
+      'Animated text loader displayed while the video is being uploaded.',
+    id: 'components.VideoForm.UploadingLoader.uploading',
+  },
+});
+
+const UploadingLoaderStyled = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+  align-items: center;
+  background: ${colors.mediumGray.contrast};
+`;
+
+const UploadingLoaderText = styled.div`
+  position: relative;
+  font-size: 2.5rem;
+  font-weight: 800;
+  color: white;
+
+  &:before {
+    content: attr(data-content);
+    position: absolute;
+    overflow: hidden;
+    color: ${colors.darkGray.main};
+    animation: filling 10s infinite;
+  }
+
+  @keyframes filling {
+    0% {
+      width: 0%;
+    }
+    50% {
+      width: 100%;
+    }
+    100% {
+      width: 0%;
+    }
+  }
+`;
+
+export const UploadingLoader = injectIntl(props => (
+  <UploadingLoaderStyled>
+    <UploadingLoaderText
+      data-content={props.intl.formatMessage(messages.uploading)}
+    >
+      <FormattedMessage {...messages.uploading} />
+    </UploadingLoaderText>
+  </UploadingLoaderStyled>
+));

--- a/front/components/VideoForm/VideoForm.spec.tsx
+++ b/front/components/VideoForm/VideoForm.spec.tsx
@@ -29,8 +29,6 @@ describe('VideoForm', () => {
     const wrapper = shallow(<VideoForm jwt={'some_token'} video={video} />);
 
     expect(wrapper.html()).toContain('Create a new video');
-    expect(wrapper.html()).toContain('<input type="text" name="title"/>');
-    expect(wrapper.html()).toContain('<textarea name="description">');
   });
 
   it('gets the policy from the API and uses it to upload the file', async () => {

--- a/front/components/VideoUploadField/DropzoneIcon.tsx
+++ b/front/components/VideoUploadField/DropzoneIcon.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import styled from 'styled-components';
+
+import { colors } from '../../utils/theme/theme';
+
+// Use a large "download" icon to make the dropzone stand out visually
+//
+//                      ||
+//                      ||
+//                    \\||//
+//                     \\//
+//                 ____________
+//
+export const DropzoneIcon = () => (
+  <DropzoneIconStyled
+    xmlns="http://www.w3.org/2000/svg"
+    preserveAspectRatio="none"
+    viewBox="0 0 8 8"
+  >
+    <path d="M3 0v3h-2l3 3 3-3h-2v-3h-2zm-3 7v1h8v-1h-8z" />
+  </DropzoneIconStyled>
+);
+const DropzoneIconStyled = styled.svg`
+  fill: ${colors.mediumGray.main};
+  width: 4rem;
+  height: 4rem;
+`;

--- a/front/components/VideoUploadField/DropzonePlaceholder.tsx
+++ b/front/components/VideoUploadField/DropzonePlaceholder.tsx
@@ -1,0 +1,72 @@
+import * as React from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+import styled from 'styled-components';
+
+import { colors } from '../../utils/theme/theme';
+import { Button } from '../Button/Button';
+import { DropzoneIcon } from './DropzoneIcon';
+
+const messages = defineMessages({
+  dropzoneButtonPick: {
+    defaultMessage: 'Select a video to upload',
+    description: `Video upload file dropzone: button to choose a video to upload,
+      has the drag text next to it (components.VideoForm.dropzoneDragText)`,
+    id: 'components.VideoForm.dropzoneButtonPick',
+  },
+  dropzoneDragText: {
+    defaultMessage: 'or drop it here',
+    description: `Video upload file dropzone: helptext on the dropzone,
+      goes along with the button (components.VideoForm.dropzoneButtonPick)`,
+    id: 'components.VideoForm.dropzoneDragText',
+  },
+});
+
+const DropzonePlaceholderStyled = styled.div`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-evenly;
+  flex-grow: 1;
+  align-items: center;
+  background-color: ${colors.lightGray.main};
+  padding-top: 2rem;
+  padding-bottom: 1rem;
+`;
+
+// Align the helptext vertically exactly with the button
+const DropzoneHelpText = styled.span`
+  padding: 0.375rem 0.75rem 0.375rem 0.375rem;
+  display: inline-block;
+  border: 1px solid transparent;
+  vertical-align: middle;
+`;
+
+// Make sure the dashbox background does not overlay the interactive UI
+const DropzoneTextBox = styled.div`
+  z-index: 1;
+`;
+
+const DropzoneDashBox = styled.div`
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  bottom: 0.5rem;
+  left: 0.5rem;
+  border: 3px dashed ${colors.mediumGray.main};
+  border-radius: 0.375rem;
+`;
+
+export const DropzonePlaceholder = () => (
+  <DropzonePlaceholderStyled>
+    <DropzoneDashBox />
+    <DropzoneIcon />
+    <DropzoneTextBox>
+      <Button variant="primary">
+        <FormattedMessage {...messages.dropzoneButtonPick} />
+      </Button>
+      <DropzoneHelpText>
+        <FormattedMessage {...messages.dropzoneDragText} />
+      </DropzoneHelpText>
+    </DropzoneTextBox>
+  </DropzonePlaceholderStyled>
+);

--- a/front/components/VideoUploadField/VideoUploadField.spec.tsx
+++ b/front/components/VideoUploadField/VideoUploadField.spec.tsx
@@ -2,40 +2,18 @@ import '../../testSetup';
 
 import { mount } from 'enzyme';
 import * as React from 'react';
-import { IntlProvider } from 'react-intl';
 
 import { VideoUploadField } from './VideoUploadField';
 
 test('VideoUploadField renders a Dropzone with the relevant messages', () => {
   const wrapper = mount(<VideoUploadField onContentUpdated={jest.fn()} />);
-
-  expect(wrapper.html()).toContain('dropzone');
-  expect(wrapper.text()).toContain('Pick a video to upload');
-  expect(wrapper.text()).not.toContain('Clear selected file');
+  expect(wrapper.text()).toContain('Select a video to upload');
 });
 
-test('VideoUploadField.onDrop() passes the file to the callback and updates the UI', () => {
+test('VideoUploadField.onDrop() passes the file to the callback', () => {
   const callback = jest.fn();
   const wrapper = mount(<VideoUploadField onContentUpdated={callback} />);
   const componentInstance = wrapper.instance() as VideoUploadField;
   componentInstance.onDrop(['file_1']);
-
   expect(callback).toHaveBeenCalledWith('file_1');
-  expect(wrapper.text()).not.toContain('Pick a video to upload');
-  expect(wrapper.text()).toContain('Clear selected file');
-  expect(wrapper.html()).toContain('aria-disabled="true"');
-});
-
-test('VideoUploadField.clearFile() calls the callback with undefined and resets the UI', () => {
-  const callback = jest.fn();
-  const wrapper = mount(<VideoUploadField onContentUpdated={callback} />);
-  const componentInstance = wrapper.instance() as VideoUploadField;
-  componentInstance.onDrop(['file_1']);
-  callback.mockReset();
-  componentInstance.clearFile();
-
-  expect(callback).toHaveBeenCalledWith(undefined);
-  expect(wrapper.text()).toContain('Pick a video to upload');
-  expect(wrapper.text()).not.toContain('Clear selected file');
-  expect(wrapper.html()).toContain('aria-disabled="false"');
 });

--- a/front/components/VideoUploadField/VideoUploadField.tsx
+++ b/front/components/VideoUploadField/VideoUploadField.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import Dropzone from 'react-dropzone';
-import { defineMessages, FormattedMessage } from 'react-intl';
+import styled from 'styled-components';
 
 import { Maybe } from '../../utils/types';
+import { DropzonePlaceholder } from './DropzonePlaceholder';
 
 export interface VideoUploadFieldProps {
   onContentUpdated: (fieldContent: Maybe<File>) => void;
@@ -12,30 +13,15 @@ interface VideoUploadFieldState {
   file: Maybe<File>;
 }
 
-const messages = defineMessages({
-  dropzoneButtonPick: {
-    defaultMessage: 'Pick a video to upload',
-    description:
-      'Video upload file dropzone: button to choose a video to upload',
-    id: 'components.VideoForm.dropzoneButtonPick',
-  },
-  dropzoneClear: {
-    defaultMessage: 'Clear selected file',
-    description:
-      'Video upload file dropzone: link to remove the currently selected video',
-    id: 'components.VideoForm.dropzoneClear',
-  },
-});
+const DropzoneStyled = styled(Dropzone)`
+  display: flex; /* For the dropzone contents */
+  flex-grow: 1;
+`;
 
 export class VideoUploadField extends React.Component<
   VideoUploadFieldProps,
   VideoUploadFieldState
 > {
-  clearFile() {
-    this.setState({ file: undefined });
-    this.props.onContentUpdated(undefined);
-  }
-
   onDrop(files: any) {
     this.setState({ file: files[0] });
     this.props.onContentUpdated(files[0]);
@@ -43,23 +29,12 @@ export class VideoUploadField extends React.Component<
 
   render() {
     return (
-      <div className="dropzone">
-        <Dropzone
-          onDrop={this.onDrop.bind(this)}
-          disabled={!!(this.state && this.state.file)}
-        >
-          {// Show either the 'upload' button or the 'clear' link
-          this.state && !!this.state.file ? (
-            <a onClick={this.clearFile.bind(this)}>
-              <FormattedMessage {...messages.dropzoneClear} />
-            </a>
-          ) : (
-            <button>
-              <FormattedMessage {...messages.dropzoneButtonPick} />
-            </button>
-          )}
-        </Dropzone>
-      </div>
+      <DropzoneStyled
+        onDrop={this.onDrop.bind(this)}
+        disabled={!!(this.state && this.state.file)}
+      >
+        <DropzonePlaceholder />
+      </DropzoneStyled>
     );
   }
 }


### PR DESCRIPTION
## Purpose

We have a working implementation of direct file upload to S3. However, is was lacking any styling and therefore difficult to understand and not esthetically pleasing.

## Proposal

- [x] Simplify the flow by uploading the file as soon as it is selected
- [x] Add styling/icons & a button to the drop zone to make it easy to understand & accessible
- [x] Make a loading state to show during file upload

---

<img width="533" alt="capture d ecran 2018-09-14 a 10 57 23" src="https://user-images.githubusercontent.com/1932937/45549868-82a7b900-b829-11e8-8ea1-bcdcf16fc010.png">

---

![capture d ecran 2018-09-14 a 10 56 12](https://user-images.githubusercontent.com/1932937/45550052-15485800-b82a-11e8-8dc5-4566f2be6981.jpg)

