### PR TITLE
💄(front) make the video player responsive

### DIFF
--- a/front/components/VideoJsPlayer/VideoJsPlayer.tsx
+++ b/front/components/VideoJsPlayer/VideoJsPlayer.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react';
+import styled from 'styled-components';
 import videojs from 'video.js';
 import 'video.js/dist/video-js.min.css';
 
 import { Video, videoSize } from '../../types/Video';
 import { Nullable } from '../../utils/types';
+import './video.js.css';
 
 export interface VideoJsPlayerProps extends videojs.PlayerOptions {
   video: Video;
@@ -13,6 +15,12 @@ interface VideoJsPlayerState {
   player: videojs.Player;
   videoNode: Nullable<HTMLVideoElement>;
 }
+
+const VideoJsPlayerContainer = styled.div`
+  position: relative;
+  width: 100%;
+  height: 100%;
+`;
 
 export const ROUTE = () => '/player';
 
@@ -42,21 +50,23 @@ export class VideoJsPlayer extends React.Component<
     // Wrap the player in a div with a `data-vjs-player` attribute so videojs won't create an additional
     // wrapper in the DOM; see https://github.com/videojs/video.js/pull/3856
     return (
-      <div data-vjs-player>
-        <video
-          ref={node => (this.videoNodeRef = node)}
-          className="video-js"
-          controls={true}
-        >
-          {(Object.keys(video.urls.mp4) as videoSize[]).map(size => (
-            <source
-              src={video.urls.mp4[size]}
-              type="video/mp4"
-              key={video.urls.mp4[size]}
-            />
-          ))}
-        </video>
-      </div>
+      <VideoJsPlayerContainer>
+        <div data-vjs-player>
+          <video
+            ref={node => (this.videoNodeRef = node)}
+            className="video-js"
+            controls={true}
+          >
+            {(Object.keys(video.urls.mp4) as videoSize[]).map(size => (
+              <source
+                src={video.urls.mp4[size]}
+                type="video/mp4"
+                key={video.urls.mp4[size]}
+              />
+            ))}
+          </video>
+        </div>
+      </VideoJsPlayerContainer>
     );
   }
 }

--- a/front/components/VideoJsPlayer/video.js.css
+++ b/front/components/VideoJsPlayer/video.js.css
@@ -1,0 +1,20 @@
+/*
+  Adapt the video-js element to its container's size, ensuring it never overflows and keeps its aspect ratio
+  We can't use styled-components here as video.js will take over and replace our div
+*/
+.video-js {
+  position: absolute;
+  top: 0; right: 0; bottom: 0; left: 0;
+  max-width: 100%;
+  max-height: 100%;
+}
+
+/*
+  Fix centering for the play button shown on video load
+  Double up on the class to manage specificity of the original selector
+*/
+.vjs-big-play-button.vjs-big-play-button {
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}


### PR DESCRIPTION
## Purpose

Our `VideoJsPlayer` using base `video.js` styles is not responsive. It takes the size of the video and does not fill the given iframe.
Also, it does not place the "Play" button correctly.

## Proposal

Make our video.js player component responsive.

Simply use a relative wrapper + absolute content technique to make sure it fills the available space without overflowing or changing the video's aspect ratio.

NB: We're using our own `.css` file to override some styles in the base `video.js` `.css` file. In our opinion vendoring the `video.js` `.css` is not desirable, and we don't want to introduce a third way of styling things.

Stick to `styled-components` for everything else and basic `.css` files for `video.js` only.