### PR TITLE
⚡️(settings) make AWS ssh key configurable

### DIFF
--- a/marsha/settings.py
+++ b/marsha/settings.py
@@ -155,8 +155,8 @@ class Base(Configuration):
     # Cloud Front key pair for signed urls
     CLOUDFRONT_URL = values.SecretValue()
     CLOUDFRONT_ACCESS_KEY_ID = values.Value(None)
-    CLOUDFRONT_PRIVATE_KEY_PATH = os.path.join(
-        BASE_DIR, "..", ".ssh", "cloudfront_private_key"
+    CLOUDFRONT_PRIVATE_KEY_PATH = values.Value(
+        os.path.join(BASE_DIR, "..", ".ssh", "cloudfront_private_key")
     )
     CLOUDFRONT_SIGNED_URLS_ACTIVE = True
     CLOUDFRONT_SIGNED_URLS_VALIDITY = 2 * 60 * 60  # 2 hours


### PR DESCRIPTION
## Purpose

To deploy Marsha, we need to make some settings more configurable. The location of the AWS private ssh key (required for cloudfront) is one of those.

## Proposal

Instead of hard-coding the location of AWS ssh private key, we've decided to make it overridable via an environment variable. Previous value make a great default, hence we've decided to keep it as is.