### PR TITLE
Add CORS rules for the source bucket

### DIFF
--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -3,6 +3,13 @@ resource "aws_s3_bucket" "marsha_source" {
   bucket = "${terraform.workspace}-marsha-source"
   acl    = "private"
 
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["POST"]
+    allowed_origins = ["*"]
+    max_age_seconds = 3600
+  }
+
   tags {
     Name        = "marsha-source"
     Environment = "${terraform.workspace}"


### PR DESCRIPTION
## Purpose 

The source bucket is expected to receive direct browser uploads from our users. In order to do that, it needs to return the correct cross origin headers.

## Proposal

Just open POST requests as all operations are locked down and need signed policies to be performed.