### PR TITLE
Add a policy to allow lambdas to read source s3 bucket

### DIFF
--- a/terraform/roles.tf
+++ b/terraform/roles.tf
@@ -102,6 +102,34 @@ resource "aws_iam_role_policy_attachment" "lambda_pass_role_policy_attachment" {
   policy_arn = "${aws_iam_policy.lambda_pass_role_policy.arn}"
 }
 
+resource "aws_iam_policy" "lambda_readonly_s3_source_objects" {
+  name        = "${terraform.workspace}-marsha-lambda-readonly-s3-source-objects-policy"
+  path        = "/"
+  description = "IAM policy to read s3 source bucket objects"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+      {
+          "Effect": "Allow",
+          "Action": [
+              "s3:GetObject",
+              "s3:GetObjectTagging",
+              "s3:GetObjectVersion"
+          ],
+          "Resource": "${aws_s3_bucket.marsha_source.arn}/*"
+      }
+  ]
+}
+  EOF
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_readonly_s3_source_policy_attachment" {
+  role       = "${aws_iam_role.lambda_invocation_role.name}"
+  policy_arn = "${aws_iam_policy.lambda_readonly_s3_source_objects.arn}"
+}
+
 # Media Convert role
 #####################
 


### PR DESCRIPTION
## Purpose 
Our lambdas (only `encode` at first but maybe others later on) need to be able to read metadata on existing objects in the relevant S3 source bucket.

## Proposal
There is no specific permission for metadata, so we need to give them read access to those objects. The way to do that is to target the marsha_source by its arn and then select all objects inside it.