### PR TITLE
Add Adaptive Bit Rate and encoding improvements

### DIFF
--- a/marsha/core/serializers.py
+++ b/marsha/core/serializers.py
@@ -204,16 +204,13 @@ class VideoSerializer(serializers.ModelSerializer):
                 resolution=resolution,
             )
 
-            # Sign the urls only if the functionality is activated
+            # Sign the urls of mp4 videos only if the functionality is activated
             if settings.CLOUDFRONT_SIGNED_URLS_ACTIVE:
                 cloudfront_signer = CloudFrontSigner(
                     settings.CLOUDFRONT_ACCESS_KEY_ID, cloudfront_utils.rsa_signer
                 )
                 mp4_url = cloudfront_signer.generate_presigned_url(
                     mp4_url, date_less_than=date_less_than
-                )
-                thumbnail_url = cloudfront_signer.generate_presigned_url(
-                    thumbnail_url, date_less_than=date_less_than
                 )
 
             urls["mp4"][resolution] = mp4_url

--- a/marsha/core/tests/test_api_video.py
+++ b/marsha/core/tests/test_api_video.py
@@ -99,7 +99,7 @@ class VideoAPITest(TestCase):
             for rate in [144, 240, 480, 720, 1080]
         }
 
-        mp4_template = "https://abc.cloudfront.net/{!s}/{!s}/videos/1533686400_{!s}.mp4"
+        mp4_template = "https://abc.cloudfront.net/{!s}/{!s}/mp4/1533686400_{!s}.mp4"
         mp4_dict = {
             str(rate): mp4_template.format(playlist.id, video.id, rate)
             for rate in [144, 240, 480, 720, 1080]
@@ -127,7 +127,26 @@ class VideoAPITest(TestCase):
                         "video": "a2f27fde-973a-4e89-8dca-cc59e01d255c",
                     }
                 ],
-                "urls": json.dumps({"mp4": mp4_dict, "thumbnails": thumbnails_dict}),
+                "urls": json.dumps(
+                    {
+                        "mp4": mp4_dict,
+                        "thumbnails": thumbnails_dict,
+                        "manifests": {
+                            "dash": (
+                                "https://abc.cloudfront.net/f76f6afd-7135-488e-9d70-6ec599a67806/"
+                                "a2f27fde-973a-4e89-8dca-cc59e01d255c/dash/1533686400.mpd"
+                            ),
+                            "hls": (
+                                "https://abc.cloudfront.net/f76f6afd-7135-488e-9d70-6ec599a67806/"
+                                "a2f27fde-973a-4e89-8dca-cc59e01d255c/hls/1533686400.m3u8"
+                            ),
+                        },
+                        "previews": (
+                            "https://abc.cloudfront.net/f76f6afd-7135-488e-9d70-6ec599a67806/"
+                            "a2f27fde-973a-4e89-8dca-cc59e01d255c/previews/1533686400_100.jpg"
+                        ),
+                    }
+                ),
             },
         )
 
@@ -242,12 +261,12 @@ class VideoAPITest(TestCase):
             json.loads(content["urls"])["mp4"]["144"],
             (
                 "https://abc.cloudfront.net/f76f6afd-7135-488e-9d70-6ec599a67806/"
-                "a2f27fde-973a-4e89-8dca-cc59e01d255c/videos/1533686400_144.mp4?"
-                "Expires=1533693600&Signature=SPadcxIoCVoLQbKk3hp2LdtgZY899OXJMjInxUiGnSVivMBKkXfT"
-                "yRn3wA9J~2mumU3PCZnIUguAKmvRUAgpbnSHj-f695OPiJtncPZufGmXCcnLcn7OhFy8SnqfOX9zK~K8m"
-                "A6AQKfI2TXKVl5wy6JTZYxGwkMpLM~CsGwJAWo-dxbIGPtRW9H2xKAEhC5glP5of4bjOQryvrzo1PGHJV"
-                "cUMcBL23eGSh9HAZHQFleI01ypQu75L~Z6BlbncjHO6tE0hKCqVU08rkdnoEDMRPRzMCVg~SdJvzZ7sth"
-                "8bu4iTv-v08pWDlSXhkmO-uBfKui0CI10eALwFLZ5cMpiRQ__&"
+                "a2f27fde-973a-4e89-8dca-cc59e01d255c/mp4/1533686400_144.mp4?"
+                "Expires=1533693600&Signature=DOsxZ8MeXL9FBqGs28V-oGDJ9jX9OPxDC-X2o~Hw7qN3UujzOG7"
+                "2WnangFhr4b1MqR5tmGL0BYFqfy1zEWYPdCDfVN79llcDod8J0MjL7CJx9iKVCdCTB8heAu6m~WiotZ5"
+                "cMeyAH48Zwdq2NdWiSlQkB0JrA-Pgie8m3zkyxGax8ZnzRp51hq5gjm-vqWMT-Bu7eIezidufWLgfk-1"
+                "vckzUgA5RMNgUaRE1YsUZh52RfsEYF5aC2gHJ2d1uG8WH-Ekn1v4OC6EexPCJUSr0B~AXKQWFeJRGxmc"
+                "XmRt6BWwPTONXZ5XwBBlZFwBAOx9oLrM5AkpYpzEUHx5vw1gTxg__&"
                 "Key-Pair-Id=cloudfront-access-key-id"
             ),
         )

--- a/marsha/core/tests/test_api_video.py
+++ b/marsha/core/tests/test_api_video.py
@@ -235,13 +235,7 @@ class VideoAPITest(TestCase):
             json.loads(content["urls"])["thumbnails"]["144"],
             (
                 "https://abc.cloudfront.net/f76f6afd-7135-488e-9d70-6ec599a67806/"
-                "a2f27fde-973a-4e89-8dca-cc59e01d255c/thumbnails/1533686400_144.0000000.jpg?"
-                "Expires=1533693600&Signature=MMm0VE8kDAOHrTJiVAa7cWQIn8sdF9lT6TOulfncbgf~AF3WgnLU"
-                "S2-OFvE0xbqi4MjxYBWZ1MkzZKDuRGTR6~YViYTz4WcomTPnVVc4euKM~HZYXxQDPKFVAcJ7hwsqhOEgn"
-                "X9npz-6uiXDgqjIlFbMcK~NkaZz3drwguWMdu6I5UUYFiLlwMpMjT0ecFtmTV9yDjIhan~k8HYWagjyAf"
-                "WtpfJsaSMlPJ2y4Gd4aaVYM16fspO6REZQzb4cC62aHB7ycpqUpmbThYH1saSuMtOcCemLcqzSVNNS7MX"
-                "YT-vNoSRbLNf5ydmtIGqvHv9YAJHQJKdBluwd~AUU3hmtPA__&"
-                "Key-Pair-Id=cloudfront-access-key-id"
+                "a2f27fde-973a-4e89-8dca-cc59e01d255c/thumbnails/1533686400_144.0000000.jpg"
             ),
         )
         self.assertEqual(

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -1,4 +1,4 @@
-# Create S3 Bucket for source videos
+# Create source S3 Bucket for uploaded videos to be converted
 resource "aws_s3_bucket" "marsha_source" {
   bucket = "${terraform.workspace}-marsha-source"
   acl    = "private"
@@ -16,7 +16,7 @@ resource "aws_s3_bucket" "marsha_source" {
   }
 }
 
-# Create S3 Bucket for converted videos
+# Create destination S3 Bucket for converted videos and images
 resource "aws_s3_bucket" "marsha_destination" {
   bucket = "${terraform.workspace}-marsha-destination"
   acl    = "private"

--- a/terraform/source/configure/media-convert.js
+++ b/terraform/source/configure/media-convert.js
@@ -15,6 +15,16 @@ const presets = [
   './presets/video_mp4_h264_480p_30fps_1200kbps.json',
   './presets/video_mp4_h264_720p_30fps_2400kbps.json',
   './presets/video_mp4_h264_1080p_30fps_5400kbps.json',
+  './presets/video_dash_h264_144p_30fps_300kbps.json',
+  './presets/video_dash_h264_240p_30fps_600kbps.json',
+  './presets/video_dash_h264_480p_30fps_1200kbps.json',
+  './presets/video_dash_h264_720p_30fps_2400kbps.json',
+  './presets/video_dash_h264_1080p_30fps_5400kbps.json',
+  './presets/video_hls_h264_144p_30fps_300kbps.json',
+  './presets/video_hls_h264_240p_30fps_600kbps.json',
+  './presets/video_hls_h264_480p_30fps_1200kbps.json',
+  './presets/video_hls_h264_720p_30fps_2400kbps.json',
+  './presets/video_hls_h264_1080p_30fps_5400kbps.json',
 ];
 
 let response;

--- a/terraform/source/configure/media-convert.spec.js
+++ b/terraform/source/configure/media-convert.spec.js
@@ -48,7 +48,7 @@ describe('Media Convert', () => {
     lambda
       .MediaConvertPresets(event)
       .then(data => {
-        expect(data).to.deep.equal({ Presets: Array.from(Array(11).keys()) });
+        expect(data).to.deep.equal({ Presets: Array.from(Array(21).keys()) });
         done();
       })
       .catch(err => done(err));
@@ -75,7 +75,7 @@ describe('Media Convert', () => {
     lambda
       .MediaConvertPresets(event)
       .then(data => {
-        expect(data).to.deep.equal({ Presets: Array.from(Array(11).keys()) });
+        expect(data).to.deep.equal({ Presets: Array.from(Array(21).keys()) });
         done();
       })
       .catch(err => done(err));

--- a/terraform/source/configure/presets/video_dash_h264_1080p_30fps_5400kbps.json
+++ b/terraform/source/configure/presets/video_dash_h264_1080p_30fps_5400kbps.json
@@ -1,0 +1,78 @@
+{
+  "Description": "Video, Dash, H264, 1920x1080p, 29.97fps, 5400kbps",
+  "Category": "DASH",
+  "Name": "marsha_video_dash_1080",
+  "Settings": {
+    "VideoDescription": {
+      "Width": 1920,
+      "Height": 1080,
+      "ScalingBehavior": "STRETCH_TO_OUTPUT",
+      "TimecodeInsertion": "DISABLED",
+      "AntiAlias": "ENABLED",
+      "Sharpness": 50,
+      "CodecSettings": {
+        "Codec": "H_264",
+        "H264Settings": {
+          "InterlaceMode": "PROGRESSIVE",
+          "NumberReferenceFrames": 3,
+          "Syntax": "DEFAULT",
+          "Softness": 0,
+          "FramerateDenominator": 1001,
+          "GopClosedCadence": 1,
+          "GopSize": 90,
+          "Slices": 1,
+          "GopBReference": "DISABLED",
+          "SlowPal": "DISABLED",
+          "SpatialAdaptiveQuantization": "ENABLED",
+          "TemporalAdaptiveQuantization": "ENABLED",
+          "FlickerAdaptiveQuantization": "DISABLED",
+          "EntropyEncoding": "CABAC",
+          "Bitrate": 5400000,
+          "FramerateControl": "SPECIFIED",
+          "RateControlMode": "CBR",
+          "CodecProfile": "MAIN",
+          "Telecine": "NONE",
+          "FramerateNumerator": 30000,
+          "MinIInterval": 0,
+          "AdaptiveQuantization": "HIGH",
+          "CodecLevel": "AUTO",
+          "FieldEncoding": "PAFF",
+          "SceneChangeDetect": "ENABLED",
+          "QualityTuningLevel": "SINGLE_PASS",
+          "FramerateConversionAlgorithm": "INTERPOLATE",
+          "UnregisteredSeiTimecode": "DISABLED",
+          "GopSizeUnits": "FRAMES",
+          "ParControl": "INITIALIZE_FROM_SOURCE",
+          "NumberBFramesBetweenReferenceFrames": 2,
+          "RepeatPps": "DISABLED"
+        }
+      },
+      "AfdSignaling": "NONE",
+      "DropFrameTimecode": "ENABLED",
+      "RespondToAfd": "NONE",
+      "ColorMetadata": "INSERT"
+    },
+    "AudioDescriptions": [
+      {
+        "AudioTypeControl": "FOLLOW_INPUT",
+        "CodecSettings": {
+          "Codec": "AAC",
+          "AacSettings": {
+            "AudioDescriptionBroadcasterMix": "NORMAL",
+            "Bitrate": 192000,
+            "RateControlMode": "CBR",
+            "CodecProfile": "LC",
+            "CodingMode": "CODING_MODE_2_0",
+            "RawFormat": "NONE",
+            "SampleRate": 48000,
+            "Specification": "MPEG4"
+          }
+        },
+        "LanguageCodeControl": "FOLLOW_INPUT"
+      }
+    ],
+    "ContainerSettings": {
+      "Container": "MPD"
+    }
+  }
+}

--- a/terraform/source/configure/presets/video_dash_h264_144p_30fps_300kbps.json
+++ b/terraform/source/configure/presets/video_dash_h264_144p_30fps_300kbps.json
@@ -1,0 +1,78 @@
+{
+  "Description": "Video, Dash, H264, 256x144p, 29.97fps, 300kbps",
+  "Category": "DASH",
+  "Name": "marsha_video_dash_144",
+  "Settings": {
+    "VideoDescription": {
+      "Width": 256,
+      "Height": 144,
+      "ScalingBehavior": "STRETCH_TO_OUTPUT",
+      "TimecodeInsertion": "DISABLED",
+      "AntiAlias": "ENABLED",
+      "Sharpness": 50,
+      "CodecSettings": {
+        "Codec": "H_264",
+        "H264Settings": {
+          "InterlaceMode": "PROGRESSIVE",
+          "NumberReferenceFrames": 3,
+          "Syntax": "DEFAULT",
+          "Softness": 0,
+          "FramerateDenominator": 1001,
+          "GopClosedCadence": 1,
+          "GopSize": 90,
+          "Slices": 1,
+          "GopBReference": "DISABLED",
+          "SlowPal": "DISABLED",
+          "SpatialAdaptiveQuantization": "ENABLED",
+          "TemporalAdaptiveQuantization": "ENABLED",
+          "FlickerAdaptiveQuantization": "DISABLED",
+          "EntropyEncoding": "CABAC",
+          "Bitrate": 300000,
+          "FramerateControl": "SPECIFIED",
+          "RateControlMode": "CBR",
+          "CodecProfile": "MAIN",
+          "Telecine": "NONE",
+          "FramerateNumerator": 30000,
+          "MinIInterval": 0,
+          "AdaptiveQuantization": "HIGH",
+          "CodecLevel": "AUTO",
+          "FieldEncoding": "PAFF",
+          "SceneChangeDetect": "ENABLED",
+          "QualityTuningLevel": "SINGLE_PASS",
+          "FramerateConversionAlgorithm": "INTERPOLATE",
+          "UnregisteredSeiTimecode": "DISABLED",
+          "GopSizeUnits": "FRAMES",
+          "ParControl": "INITIALIZE_FROM_SOURCE",
+          "NumberBFramesBetweenReferenceFrames": 2,
+          "RepeatPps": "DISABLED"
+        }
+      },
+      "AfdSignaling": "NONE",
+      "DropFrameTimecode": "ENABLED",
+      "RespondToAfd": "NONE",
+      "ColorMetadata": "INSERT"
+    },
+    "AudioDescriptions": [
+      {
+        "AudioTypeControl": "FOLLOW_INPUT",
+        "CodecSettings": {
+          "Codec": "AAC",
+          "AacSettings": {
+            "AudioDescriptionBroadcasterMix": "NORMAL",
+            "Bitrate": 64000,
+            "RateControlMode": "CBR",
+            "CodecProfile": "LC",
+            "CodingMode": "CODING_MODE_2_0",
+            "RawFormat": "NONE",
+            "SampleRate": 32000,
+            "Specification": "MPEG4"
+          }
+        },
+        "LanguageCodeControl": "FOLLOW_INPUT"
+      }
+    ],
+    "ContainerSettings": {
+      "Container": "MPD"
+    }
+  }
+}

--- a/terraform/source/configure/presets/video_dash_h264_240p_30fps_600kbps.json
+++ b/terraform/source/configure/presets/video_dash_h264_240p_30fps_600kbps.json
@@ -1,0 +1,78 @@
+{
+  "Description": "Video, Dash, H264, 426x240p, 29.97fps, 600kbps",
+  "Category": "DASH",
+  "Name": "marsha_video_dash_240",
+  "Settings": {
+    "VideoDescription": {
+      "Width": 426,
+      "Height": 240,
+      "ScalingBehavior": "STRETCH_TO_OUTPUT",
+      "TimecodeInsertion": "DISABLED",
+      "AntiAlias": "ENABLED",
+      "Sharpness": 50,
+      "CodecSettings": {
+        "Codec": "H_264",
+        "H264Settings": {
+          "InterlaceMode": "PROGRESSIVE",
+          "NumberReferenceFrames": 3,
+          "Syntax": "DEFAULT",
+          "Softness": 0,
+          "FramerateDenominator": 1001,
+          "GopClosedCadence": 1,
+          "GopSize": 90,
+          "Slices": 1,
+          "GopBReference": "DISABLED",
+          "SlowPal": "DISABLED",
+          "SpatialAdaptiveQuantization": "ENABLED",
+          "TemporalAdaptiveQuantization": "ENABLED",
+          "FlickerAdaptiveQuantization": "DISABLED",
+          "EntropyEncoding": "CABAC",
+          "Bitrate": 600000,
+          "FramerateControl": "SPECIFIED",
+          "RateControlMode": "CBR",
+          "CodecProfile": "MAIN",
+          "Telecine": "NONE",
+          "FramerateNumerator": 30000,
+          "MinIInterval": 0,
+          "AdaptiveQuantization": "HIGH",
+          "CodecLevel": "AUTO",
+          "FieldEncoding": "PAFF",
+          "SceneChangeDetect": "ENABLED",
+          "QualityTuningLevel": "SINGLE_PASS",
+          "FramerateConversionAlgorithm": "INTERPOLATE",
+          "UnregisteredSeiTimecode": "DISABLED",
+          "GopSizeUnits": "FRAMES",
+          "ParControl": "INITIALIZE_FROM_SOURCE",
+          "NumberBFramesBetweenReferenceFrames": 2,
+          "RepeatPps": "DISABLED"
+        }
+      },
+      "AfdSignaling": "NONE",
+      "DropFrameTimecode": "ENABLED",
+      "RespondToAfd": "NONE",
+      "ColorMetadata": "INSERT"
+    },
+    "AudioDescriptions": [
+      {
+        "AudioTypeControl": "FOLLOW_INPUT",
+        "CodecSettings": {
+          "Codec": "AAC",
+          "AacSettings": {
+            "AudioDescriptionBroadcasterMix": "NORMAL",
+            "Bitrate": 64000,
+            "RateControlMode": "CBR",
+            "CodecProfile": "LC",
+            "CodingMode": "CODING_MODE_2_0",
+            "RawFormat": "NONE",
+            "SampleRate": 32000,
+            "Specification": "MPEG4"
+          }
+        },
+        "LanguageCodeControl": "FOLLOW_INPUT"
+      }
+    ],
+    "ContainerSettings": {
+      "Container": "MPD"
+    }
+  }
+}

--- a/terraform/source/configure/presets/video_dash_h264_480p_30fps_1200kbps.json
+++ b/terraform/source/configure/presets/video_dash_h264_480p_30fps_1200kbps.json
@@ -1,0 +1,78 @@
+{
+  "Description": "Video, Dash, H264, 854x480p, 29.97fps, 1200kbps",
+  "Category": "DASH",
+  "Name": "marsha_video_dash_480",
+  "Settings": {
+    "VideoDescription": {
+      "Width": 854,
+      "Height": 480,
+      "ScalingBehavior": "STRETCH_TO_OUTPUT",
+      "TimecodeInsertion": "DISABLED",
+      "AntiAlias": "ENABLED",
+      "Sharpness": 50,
+      "CodecSettings": {
+        "Codec": "H_264",
+        "H264Settings": {
+          "InterlaceMode": "PROGRESSIVE",
+          "NumberReferenceFrames": 3,
+          "Syntax": "DEFAULT",
+          "Softness": 0,
+          "FramerateDenominator": 1001,
+          "GopClosedCadence": 1,
+          "GopSize": 90,
+          "Slices": 1,
+          "GopBReference": "DISABLED",
+          "SlowPal": "DISABLED",
+          "SpatialAdaptiveQuantization": "ENABLED",
+          "TemporalAdaptiveQuantization": "ENABLED",
+          "FlickerAdaptiveQuantization": "DISABLED",
+          "EntropyEncoding": "CABAC",
+          "Bitrate": 1200000,
+          "FramerateControl": "SPECIFIED",
+          "RateControlMode": "CBR",
+          "CodecProfile": "MAIN",
+          "Telecine": "NONE",
+          "FramerateNumerator": 30000,
+          "MinIInterval": 0,
+          "AdaptiveQuantization": "HIGH",
+          "CodecLevel": "AUTO",
+          "FieldEncoding": "PAFF",
+          "SceneChangeDetect": "ENABLED",
+          "QualityTuningLevel": "SINGLE_PASS",
+          "FramerateConversionAlgorithm": "INTERPOLATE",
+          "UnregisteredSeiTimecode": "DISABLED",
+          "GopSizeUnits": "FRAMES",
+          "ParControl": "INITIALIZE_FROM_SOURCE",
+          "NumberBFramesBetweenReferenceFrames": 2,
+          "RepeatPps": "DISABLED"
+        }
+      },
+      "AfdSignaling": "NONE",
+      "DropFrameTimecode": "ENABLED",
+      "RespondToAfd": "NONE",
+      "ColorMetadata": "INSERT"
+    },
+    "AudioDescriptions": [
+      {
+        "AudioTypeControl": "FOLLOW_INPUT",
+        "CodecSettings": {
+          "Codec": "AAC",
+          "AacSettings": {
+            "AudioDescriptionBroadcasterMix": "NORMAL",
+            "Bitrate": 80000,
+            "RateControlMode": "CBR",
+            "CodecProfile": "LC",
+            "CodingMode": "CODING_MODE_2_0",
+            "RawFormat": "NONE",
+            "SampleRate": 32000,
+            "Specification": "MPEG4"
+          }
+        },
+        "LanguageCodeControl": "FOLLOW_INPUT"
+      }
+    ],
+    "ContainerSettings": {
+      "Container": "MPD"
+    }
+  }
+}

--- a/terraform/source/configure/presets/video_dash_h264_720p_30fps_2400kbps.json
+++ b/terraform/source/configure/presets/video_dash_h264_720p_30fps_2400kbps.json
@@ -1,0 +1,78 @@
+{
+  "Description": "Video, Dash, H264, 1280x720p, 29.97fps, 2400kbps",
+  "Category": "DASH",
+  "Name": "marsha_video_dash_720",
+  "Settings": {
+    "VideoDescription": {
+      "Width": 1280,
+      "Height": 720,
+      "ScalingBehavior": "STRETCH_TO_OUTPUT",
+      "TimecodeInsertion": "DISABLED",
+      "AntiAlias": "ENABLED",
+      "Sharpness": 50,
+      "CodecSettings": {
+        "Codec": "H_264",
+        "H264Settings": {
+          "InterlaceMode": "PROGRESSIVE",
+          "NumberReferenceFrames": 3,
+          "Syntax": "DEFAULT",
+          "Softness": 0,
+          "FramerateDenominator": 1001,
+          "GopClosedCadence": 1,
+          "GopSize": 90,
+          "Slices": 1,
+          "GopBReference": "DISABLED",
+          "SlowPal": "DISABLED",
+          "SpatialAdaptiveQuantization": "ENABLED",
+          "TemporalAdaptiveQuantization": "ENABLED",
+          "FlickerAdaptiveQuantization": "DISABLED",
+          "EntropyEncoding": "CABAC",
+          "Bitrate": 2400000,
+          "FramerateControl": "SPECIFIED",
+          "RateControlMode": "CBR",
+          "CodecProfile": "MAIN",
+          "Telecine": "NONE",
+          "FramerateNumerator": 30000,
+          "MinIInterval": 0,
+          "AdaptiveQuantization": "HIGH",
+          "CodecLevel": "AUTO",
+          "FieldEncoding": "PAFF",
+          "SceneChangeDetect": "ENABLED",
+          "QualityTuningLevel": "SINGLE_PASS",
+          "FramerateConversionAlgorithm": "INTERPOLATE",
+          "UnregisteredSeiTimecode": "DISABLED",
+          "GopSizeUnits": "FRAMES",
+          "ParControl": "INITIALIZE_FROM_SOURCE",
+          "NumberBFramesBetweenReferenceFrames": 2,
+          "RepeatPps": "DISABLED"
+        }
+      },
+      "AfdSignaling": "NONE",
+      "DropFrameTimecode": "ENABLED",
+      "RespondToAfd": "NONE",
+      "ColorMetadata": "INSERT"
+    },
+    "AudioDescriptions": [
+      {
+        "AudioTypeControl": "FOLLOW_INPUT",
+        "CodecSettings": {
+          "Codec": "AAC",
+          "AacSettings": {
+            "AudioDescriptionBroadcasterMix": "NORMAL",
+            "Bitrate": 160000,
+            "RateControlMode": "CBR",
+            "CodecProfile": "LC",
+            "CodingMode": "CODING_MODE_2_0",
+            "RawFormat": "NONE",
+            "SampleRate": 48000,
+            "Specification": "MPEG4"
+          }
+        },
+        "LanguageCodeControl": "FOLLOW_INPUT"
+      }
+    ],
+    "ContainerSettings": {
+      "Container": "MPD"
+    }
+  }
+}

--- a/terraform/source/configure/presets/video_hls_h264_1080p_30fps_5400kbps.json
+++ b/terraform/source/configure/presets/video_hls_h264_1080p_30fps_5400kbps.json
@@ -1,0 +1,92 @@
+{
+  "Description": "Video, HLS, H264, 1920x1080p, 29.97fps, 5400kbps",
+  "Category": "HLS",
+  "Name": "marsha_video_hls_1080",
+  "Settings": {
+    "VideoDescription": {
+      "Width": 1920,
+      "Height": 1080,
+      "ScalingBehavior": "STRETCH_TO_OUTPUT",
+      "TimecodeInsertion": "DISABLED",
+      "AntiAlias": "ENABLED",
+      "Sharpness": 50,
+      "CodecSettings": {
+        "Codec": "H_264",
+        "H264Settings": {
+          "InterlaceMode": "PROGRESSIVE",
+          "NumberReferenceFrames": 3,
+          "Syntax": "DEFAULT",
+          "Softness": 0,
+          "FramerateDenominator": 1001,
+          "GopClosedCadence": 1,
+          "GopSize": 90,
+          "Slices": 1,
+          "GopBReference": "DISABLED",
+          "SlowPal": "DISABLED",
+          "SpatialAdaptiveQuantization": "ENABLED",
+          "TemporalAdaptiveQuantization": "ENABLED",
+          "FlickerAdaptiveQuantization": "DISABLED",
+          "EntropyEncoding": "CABAC",
+          "Bitrate": 5400000,
+          "FramerateControl": "SPECIFIED",
+          "RateControlMode": "CBR",
+          "CodecProfile": "MAIN",
+          "Telecine": "NONE",
+          "FramerateNumerator": 30000,
+          "MinIInterval": 0,
+          "AdaptiveQuantization": "HIGH",
+          "CodecLevel": "AUTO",
+          "FieldEncoding": "PAFF",
+          "SceneChangeDetect": "ENABLED",
+          "QualityTuningLevel": "SINGLE_PASS",
+          "FramerateConversionAlgorithm": "INTERPOLATE",
+          "UnregisteredSeiTimecode": "DISABLED",
+          "GopSizeUnits": "FRAMES",
+          "ParControl": "INITIALIZE_FROM_SOURCE",
+          "NumberBFramesBetweenReferenceFrames": 2,
+          "RepeatPps": "DISABLED"
+        }
+      },
+      "AfdSignaling": "NONE",
+      "DropFrameTimecode": "ENABLED",
+      "RespondToAfd": "NONE",
+      "ColorMetadata": "INSERT"
+    },
+    "AudioDescriptions": [
+      {
+        "AudioTypeControl": "FOLLOW_INPUT",
+        "CodecSettings": {
+          "Codec": "AAC",
+          "AacSettings": {
+            "AudioDescriptionBroadcasterMix": "NORMAL",
+            "Bitrate": 192000,
+            "RateControlMode": "CBR",
+            "CodecProfile": "LC",
+            "CodingMode": "CODING_MODE_2_0",
+            "RawFormat": "NONE",
+            "SampleRate": 48000,
+            "Specification": "MPEG4"
+          }
+        },
+        "LanguageCodeControl": "FOLLOW_INPUT"
+      }
+    ],
+    "ContainerSettings": {
+      "Container": "M3U8",
+      "M3u8Settings": {
+        "AudioFramesPerPes": 4,
+        "PcrControl": "PCR_EVERY_PES_PACKET",
+        "PmtPid": 480,
+        "PrivateMetadataPid": 503,
+        "ProgramNumber": 1,
+        "PatInterval": 0,
+        "PmtInterval": 0,
+        "Scte35Source": "NONE",
+        "NielsenId3": "NONE",
+        "TimedMetadata": "NONE",
+        "VideoPid": 481,
+        "AudioPids": [482, 483, 484, 485, 486, 487, 488, 489, 490, 491, 492]
+      }
+    }
+  }
+}

--- a/terraform/source/configure/presets/video_hls_h264_144p_30fps_300kbps.json
+++ b/terraform/source/configure/presets/video_hls_h264_144p_30fps_300kbps.json
@@ -1,0 +1,92 @@
+{
+  "Description": "Video, HLS, H264, 256x144p, 29.97fps, 300kbps",
+  "Category": "HLS",
+  "Name": "marsha_video_hls_144",
+  "Settings": {
+    "VideoDescription": {
+      "Width": 256,
+      "Height": 144,
+      "ScalingBehavior": "STRETCH_TO_OUTPUT",
+      "TimecodeInsertion": "DISABLED",
+      "AntiAlias": "ENABLED",
+      "Sharpness": 50,
+      "CodecSettings": {
+        "Codec": "H_264",
+        "H264Settings": {
+          "InterlaceMode": "PROGRESSIVE",
+          "NumberReferenceFrames": 3,
+          "Syntax": "DEFAULT",
+          "Softness": 0,
+          "FramerateDenominator": 1001,
+          "GopClosedCadence": 1,
+          "GopSize": 90,
+          "Slices": 1,
+          "GopBReference": "DISABLED",
+          "SlowPal": "DISABLED",
+          "SpatialAdaptiveQuantization": "ENABLED",
+          "TemporalAdaptiveQuantization": "ENABLED",
+          "FlickerAdaptiveQuantization": "DISABLED",
+          "EntropyEncoding": "CABAC",
+          "Bitrate": 300000,
+          "FramerateControl": "SPECIFIED",
+          "RateControlMode": "CBR",
+          "CodecProfile": "MAIN",
+          "Telecine": "NONE",
+          "FramerateNumerator": 30000,
+          "MinIInterval": 0,
+          "AdaptiveQuantization": "HIGH",
+          "CodecLevel": "AUTO",
+          "FieldEncoding": "PAFF",
+          "SceneChangeDetect": "ENABLED",
+          "QualityTuningLevel": "SINGLE_PASS",
+          "FramerateConversionAlgorithm": "INTERPOLATE",
+          "UnregisteredSeiTimecode": "DISABLED",
+          "GopSizeUnits": "FRAMES",
+          "ParControl": "INITIALIZE_FROM_SOURCE",
+          "NumberBFramesBetweenReferenceFrames": 2,
+          "RepeatPps": "DISABLED"
+        }
+      },
+      "AfdSignaling": "NONE",
+      "DropFrameTimecode": "ENABLED",
+      "RespondToAfd": "NONE",
+      "ColorMetadata": "INSERT"
+    },
+    "AudioDescriptions": [
+      {
+        "AudioTypeControl": "FOLLOW_INPUT",
+        "CodecSettings": {
+          "Codec": "AAC",
+          "AacSettings": {
+            "AudioDescriptionBroadcasterMix": "NORMAL",
+            "Bitrate": 64000,
+            "RateControlMode": "CBR",
+            "CodecProfile": "LC",
+            "CodingMode": "CODING_MODE_2_0",
+            "RawFormat": "NONE",
+            "SampleRate": 32000,
+            "Specification": "MPEG4"
+          }
+        },
+        "LanguageCodeControl": "FOLLOW_INPUT"
+      }
+    ],
+    "ContainerSettings": {
+      "Container": "M3U8",
+      "M3u8Settings": {
+        "AudioFramesPerPes": 4,
+        "PcrControl": "PCR_EVERY_PES_PACKET",
+        "PmtPid": 480,
+        "PrivateMetadataPid": 503,
+        "ProgramNumber": 1,
+        "PatInterval": 0,
+        "PmtInterval": 0,
+        "Scte35Source": "NONE",
+        "NielsenId3": "NONE",
+        "TimedMetadata": "NONE",
+        "VideoPid": 481,
+        "AudioPids": [482, 483, 484, 485, 486, 487, 488, 489, 490, 491, 492]
+      }
+    }
+  }
+}

--- a/terraform/source/configure/presets/video_hls_h264_240p_30fps_600kbps.json
+++ b/terraform/source/configure/presets/video_hls_h264_240p_30fps_600kbps.json
@@ -1,0 +1,92 @@
+{
+  "Description": "Video, HLS, H264, 426x240p, 29.97fps, 600kbps",
+  "Category": "HLS",
+  "Name": "marsha_video_hls_240",
+  "Settings": {
+    "VideoDescription": {
+      "Width": 426,
+      "Height": 240,
+      "ScalingBehavior": "STRETCH_TO_OUTPUT",
+      "TimecodeInsertion": "DISABLED",
+      "AntiAlias": "ENABLED",
+      "Sharpness": 50,
+      "CodecSettings": {
+        "Codec": "H_264",
+        "H264Settings": {
+          "InterlaceMode": "PROGRESSIVE",
+          "NumberReferenceFrames": 3,
+          "Syntax": "DEFAULT",
+          "Softness": 0,
+          "FramerateDenominator": 1001,
+          "GopClosedCadence": 1,
+          "GopSize": 90,
+          "Slices": 1,
+          "GopBReference": "DISABLED",
+          "SlowPal": "DISABLED",
+          "SpatialAdaptiveQuantization": "ENABLED",
+          "TemporalAdaptiveQuantization": "ENABLED",
+          "FlickerAdaptiveQuantization": "DISABLED",
+          "EntropyEncoding": "CABAC",
+          "Bitrate": 600000,
+          "FramerateControl": "SPECIFIED",
+          "RateControlMode": "CBR",
+          "CodecProfile": "MAIN",
+          "Telecine": "NONE",
+          "FramerateNumerator": 30000,
+          "MinIInterval": 0,
+          "AdaptiveQuantization": "HIGH",
+          "CodecLevel": "AUTO",
+          "FieldEncoding": "PAFF",
+          "SceneChangeDetect": "ENABLED",
+          "QualityTuningLevel": "SINGLE_PASS",
+          "FramerateConversionAlgorithm": "INTERPOLATE",
+          "UnregisteredSeiTimecode": "DISABLED",
+          "GopSizeUnits": "FRAMES",
+          "ParControl": "INITIALIZE_FROM_SOURCE",
+          "NumberBFramesBetweenReferenceFrames": 2,
+          "RepeatPps": "DISABLED"
+        }
+      },
+      "AfdSignaling": "NONE",
+      "DropFrameTimecode": "ENABLED",
+      "RespondToAfd": "NONE",
+      "ColorMetadata": "INSERT"
+    },
+    "AudioDescriptions": [
+      {
+        "AudioTypeControl": "FOLLOW_INPUT",
+        "CodecSettings": {
+          "Codec": "AAC",
+          "AacSettings": {
+            "AudioDescriptionBroadcasterMix": "NORMAL",
+            "Bitrate": 64000,
+            "RateControlMode": "CBR",
+            "CodecProfile": "LC",
+            "CodingMode": "CODING_MODE_2_0",
+            "RawFormat": "NONE",
+            "SampleRate": 32000,
+            "Specification": "MPEG4"
+          }
+        },
+        "LanguageCodeControl": "FOLLOW_INPUT"
+      }
+    ],
+    "ContainerSettings": {
+      "Container": "M3U8",
+      "M3u8Settings": {
+        "AudioFramesPerPes": 4,
+        "PcrControl": "PCR_EVERY_PES_PACKET",
+        "PmtPid": 480,
+        "PrivateMetadataPid": 503,
+        "ProgramNumber": 1,
+        "PatInterval": 0,
+        "PmtInterval": 0,
+        "Scte35Source": "NONE",
+        "NielsenId3": "NONE",
+        "TimedMetadata": "NONE",
+        "VideoPid": 481,
+        "AudioPids": [482, 483, 484, 485, 486, 487, 488, 489, 490, 491, 492]
+      }
+    }
+  }
+}

--- a/terraform/source/configure/presets/video_hls_h264_480p_30fps_1200kbps.json
+++ b/terraform/source/configure/presets/video_hls_h264_480p_30fps_1200kbps.json
@@ -1,0 +1,92 @@
+{
+  "Description": "Video, HLS, H264, 854x480p, 29.97fps, 1200kbps",
+  "Category": "HLS",
+  "Name": "marsha_video_hls_480",
+  "Settings": {
+    "VideoDescription": {
+      "Width": 854,
+      "Height": 480,
+      "ScalingBehavior": "STRETCH_TO_OUTPUT",
+      "TimecodeInsertion": "DISABLED",
+      "AntiAlias": "ENABLED",
+      "Sharpness": 50,
+      "CodecSettings": {
+        "Codec": "H_264",
+        "H264Settings": {
+          "InterlaceMode": "PROGRESSIVE",
+          "NumberReferenceFrames": 3,
+          "Syntax": "DEFAULT",
+          "Softness": 0,
+          "FramerateDenominator": 1001,
+          "GopClosedCadence": 1,
+          "GopSize": 90,
+          "Slices": 1,
+          "GopBReference": "DISABLED",
+          "SlowPal": "DISABLED",
+          "SpatialAdaptiveQuantization": "ENABLED",
+          "TemporalAdaptiveQuantization": "ENABLED",
+          "FlickerAdaptiveQuantization": "DISABLED",
+          "EntropyEncoding": "CABAC",
+          "Bitrate": 1200000,
+          "FramerateControl": "SPECIFIED",
+          "RateControlMode": "CBR",
+          "CodecProfile": "MAIN",
+          "Telecine": "NONE",
+          "FramerateNumerator": 30000,
+          "MinIInterval": 0,
+          "AdaptiveQuantization": "HIGH",
+          "CodecLevel": "AUTO",
+          "FieldEncoding": "PAFF",
+          "SceneChangeDetect": "ENABLED",
+          "QualityTuningLevel": "SINGLE_PASS",
+          "FramerateConversionAlgorithm": "INTERPOLATE",
+          "UnregisteredSeiTimecode": "DISABLED",
+          "GopSizeUnits": "FRAMES",
+          "ParControl": "INITIALIZE_FROM_SOURCE",
+          "NumberBFramesBetweenReferenceFrames": 2,
+          "RepeatPps": "DISABLED"
+        }
+      },
+      "AfdSignaling": "NONE",
+      "DropFrameTimecode": "ENABLED",
+      "RespondToAfd": "NONE",
+      "ColorMetadata": "INSERT"
+    },
+    "AudioDescriptions": [
+      {
+        "AudioTypeControl": "FOLLOW_INPUT",
+        "CodecSettings": {
+          "Codec": "AAC",
+          "AacSettings": {
+            "AudioDescriptionBroadcasterMix": "NORMAL",
+            "Bitrate": 80000,
+            "RateControlMode": "CBR",
+            "CodecProfile": "LC",
+            "CodingMode": "CODING_MODE_2_0",
+            "RawFormat": "NONE",
+            "SampleRate": 32000,
+            "Specification": "MPEG4"
+          }
+        },
+        "LanguageCodeControl": "FOLLOW_INPUT"
+      }
+    ],
+    "ContainerSettings": {
+      "Container": "M3U8",
+      "M3u8Settings": {
+        "AudioFramesPerPes": 4,
+        "PcrControl": "PCR_EVERY_PES_PACKET",
+        "PmtPid": 480,
+        "PrivateMetadataPid": 503,
+        "ProgramNumber": 1,
+        "PatInterval": 0,
+        "PmtInterval": 0,
+        "Scte35Source": "NONE",
+        "NielsenId3": "NONE",
+        "TimedMetadata": "NONE",
+        "VideoPid": 481,
+        "AudioPids": [482, 483, 484, 485, 486, 487, 488, 489, 490, 491, 492]
+      }
+    }
+  }
+}

--- a/terraform/source/configure/presets/video_hls_h264_720p_30fps_2400kbps.json
+++ b/terraform/source/configure/presets/video_hls_h264_720p_30fps_2400kbps.json
@@ -1,0 +1,92 @@
+{
+  "Description": "Video, HLS, H264, 1280x720p, 29.97fps, 2400kbps",
+  "Category": "HLS",
+  "Name": "marsha_video_hls_720",
+  "Settings": {
+    "VideoDescription": {
+      "Width": 1280,
+      "Height": 720,
+      "ScalingBehavior": "STRETCH_TO_OUTPUT",
+      "TimecodeInsertion": "DISABLED",
+      "AntiAlias": "ENABLED",
+      "Sharpness": 50,
+      "CodecSettings": {
+        "Codec": "H_264",
+        "H264Settings": {
+          "InterlaceMode": "PROGRESSIVE",
+          "NumberReferenceFrames": 3,
+          "Syntax": "DEFAULT",
+          "Softness": 0,
+          "FramerateDenominator": 1001,
+          "GopClosedCadence": 1,
+          "GopSize": 90,
+          "Slices": 1,
+          "GopBReference": "DISABLED",
+          "SlowPal": "DISABLED",
+          "SpatialAdaptiveQuantization": "ENABLED",
+          "TemporalAdaptiveQuantization": "ENABLED",
+          "FlickerAdaptiveQuantization": "DISABLED",
+          "EntropyEncoding": "CABAC",
+          "Bitrate": 2400000,
+          "FramerateControl": "SPECIFIED",
+          "RateControlMode": "CBR",
+          "CodecProfile": "MAIN",
+          "Telecine": "NONE",
+          "FramerateNumerator": 30000,
+          "MinIInterval": 0,
+          "AdaptiveQuantization": "HIGH",
+          "CodecLevel": "AUTO",
+          "FieldEncoding": "PAFF",
+          "SceneChangeDetect": "ENABLED",
+          "QualityTuningLevel": "SINGLE_PASS",
+          "FramerateConversionAlgorithm": "INTERPOLATE",
+          "UnregisteredSeiTimecode": "DISABLED",
+          "GopSizeUnits": "FRAMES",
+          "ParControl": "INITIALIZE_FROM_SOURCE",
+          "NumberBFramesBetweenReferenceFrames": 2,
+          "RepeatPps": "DISABLED"
+        }
+      },
+      "AfdSignaling": "NONE",
+      "DropFrameTimecode": "ENABLED",
+      "RespondToAfd": "NONE",
+      "ColorMetadata": "INSERT"
+    },
+    "AudioDescriptions": [
+      {
+        "AudioTypeControl": "FOLLOW_INPUT",
+        "CodecSettings": {
+          "Codec": "AAC",
+          "AacSettings": {
+            "AudioDescriptionBroadcasterMix": "NORMAL",
+            "Bitrate": 160000,
+            "RateControlMode": "CBR",
+            "CodecProfile": "LC",
+            "CodingMode": "CODING_MODE_2_0",
+            "RawFormat": "NONE",
+            "SampleRate": 48000,
+            "Specification": "MPEG4"
+          }
+        },
+        "LanguageCodeControl": "FOLLOW_INPUT"
+      }
+    ],
+    "ContainerSettings": {
+      "Container": "M3U8",
+      "M3u8Settings": {
+        "AudioFramesPerPes": 4,
+        "PcrControl": "PCR_EVERY_PES_PACKET",
+        "PmtPid": 480,
+        "PrivateMetadataPid": 503,
+        "ProgramNumber": 1,
+        "PatInterval": 0,
+        "PmtInterval": 0,
+        "Scte35Source": "NONE",
+        "NielsenId3": "NONE",
+        "TimedMetadata": "NONE",
+        "VideoPid": 481,
+        "AudioPids": [482, 483, 484, 485, 486, 487, 488, 489, 490, 491, 492]
+      }
+    }
+  }
+}

--- a/terraform/source/configure/presets/video_mp4_h264_1080p_30fps_5400kbps.json
+++ b/terraform/source/configure/presets/video_mp4_h264_1080p_30fps_5400kbps.json
@@ -67,12 +67,12 @@
           "Codec": "AAC",
           "AacSettings": {
             "AudioDescriptionBroadcasterMix": "NORMAL",
-            "Bitrate": 160000,
+            "Bitrate": 192000,
             "RateControlMode": "CBR",
             "CodecProfile": "LC",
             "CodingMode": "CODING_MODE_2_0",
             "RawFormat": "NONE",
-            "SampleRate": 44100,
+            "SampleRate": 48000,
             "Specification": "MPEG4"
           }
         },

--- a/terraform/source/configure/presets/video_mp4_h264_144p_30fps_300kbps.json
+++ b/terraform/source/configure/presets/video_mp4_h264_144p_30fps_300kbps.json
@@ -67,12 +67,12 @@
           "Codec": "AAC",
           "AacSettings": {
             "AudioDescriptionBroadcasterMix": "NORMAL",
-            "Bitrate": 160000,
+            "Bitrate": 64000,
             "RateControlMode": "CBR",
             "CodecProfile": "LC",
             "CodingMode": "CODING_MODE_2_0",
             "RawFormat": "NONE",
-            "SampleRate": 44100,
+            "SampleRate": 32000,
             "Specification": "MPEG4"
           }
         },

--- a/terraform/source/configure/presets/video_mp4_h264_240p_30fps_600kbps.json
+++ b/terraform/source/configure/presets/video_mp4_h264_240p_30fps_600kbps.json
@@ -67,12 +67,12 @@
           "Codec": "AAC",
           "AacSettings": {
             "AudioDescriptionBroadcasterMix": "NORMAL",
-            "Bitrate": 160000,
+            "Bitrate": 64000,
             "RateControlMode": "CBR",
             "CodecProfile": "LC",
             "CodingMode": "CODING_MODE_2_0",
             "RawFormat": "NONE",
-            "SampleRate": 44100,
+            "SampleRate": 32000,
             "Specification": "MPEG4"
           }
         },

--- a/terraform/source/configure/presets/video_mp4_h264_480p_30fps_1200kbps.json
+++ b/terraform/source/configure/presets/video_mp4_h264_480p_30fps_1200kbps.json
@@ -67,12 +67,12 @@
           "Codec": "AAC",
           "AacSettings": {
             "AudioDescriptionBroadcasterMix": "NORMAL",
-            "Bitrate": 160000,
+            "Bitrate": 80000,
             "RateControlMode": "CBR",
             "CodecProfile": "LC",
             "CodingMode": "CODING_MODE_2_0",
             "RawFormat": "NONE",
-            "SampleRate": 44100,
+            "SampleRate": 32000,
             "Specification": "MPEG4"
           }
         },

--- a/terraform/source/configure/presets/video_mp4_h264_720p_30fps_2400kbps.json
+++ b/terraform/source/configure/presets/video_mp4_h264_720p_30fps_2400kbps.json
@@ -72,7 +72,7 @@
             "CodecProfile": "LC",
             "CodingMode": "CODING_MODE_2_0",
             "RawFormat": "NONE",
-            "SampleRate": 44100,
+            "SampleRate": 48000,
             "Specification": "MPEG4"
           }
         },

--- a/terraform/source/encode/index.js
+++ b/terraform/source/encode/index.js
@@ -55,7 +55,10 @@ exports.handler = (event, context, callback) => {
             Type: 'FILE_GROUP_SETTINGS',
             FileGroupSettings: {
               Destination:
-                's3://' + process.env.S3_DESTINATION_BUCKET + '/' + objectKey,
+                's3://' +
+                process.env.S3_DESTINATION_BUCKET +
+                '/' +
+                objectKey.replace('/videos/', '/mp4/'),
             },
           },
           Outputs: [
@@ -82,6 +85,97 @@ exports.handler = (event, context, callback) => {
           ],
         },
         {
+          CustomName: 'Video DASH outputs',
+          Name: 'DASH ISO',
+          OutputGroupSettings: {
+            Type: 'DASH_ISO_GROUP_SETTINGS',
+            DashIsoGroupSettings: {
+              HbbtvCompliance: 'NONE',
+              SegmentLength: 30,
+              FragmentLength: 2,
+              SegmentControl: 'SEGMENTED_FILES',
+              Destination:
+                's3://' +
+                process.env.S3_DESTINATION_BUCKET +
+                '/' +
+                objectKey.replace('/videos/', '/dash/'),
+            },
+          },
+          Outputs: [
+            {
+              Preset: process.env.ENV_TYPE + '_marsha_video_dash_144',
+              NameModifier: '_144',
+            },
+            {
+              Preset: process.env.ENV_TYPE + '_marsha_video_dash_240',
+              NameModifier: '_240',
+            },
+            {
+              Preset: process.env.ENV_TYPE + '_marsha_video_dash_480',
+              NameModifier: '_480',
+            },
+            {
+              Preset: process.env.ENV_TYPE + '_marsha_video_dash_720',
+              NameModifier: '_720',
+            },
+            {
+              Preset: process.env.ENV_TYPE + '_marsha_video_dash_1080',
+              NameModifier: '_1080',
+            },
+          ],
+        },
+        {
+          CustomName: 'Video HLS outputs',
+          Name: 'Apple HLS',
+          OutputGroupSettings: {
+            Type: 'HLS_GROUP_SETTINGS',
+            HlsGroupSettings: {
+              ManifestDurationFormat: 'INTEGER',
+              SegmentLength: 10,
+              TimedMetadataId3Period: 6,
+              CaptionLanguageSetting: 'OMIT',
+              TimedMetadataId3Frame: 'PRIV',
+              CodecSpecification: 'RFC_4281',
+              OutputSelection: 'MANIFESTS_AND_SEGMENTS',
+              ProgramDateTimePeriod: 600,
+              MinSegmentLength: 0,
+              DirectoryStructure: 'SINGLE_DIRECTORY',
+              ProgramDateTime: 'EXCLUDE',
+              SegmentControl: 'SEGMENTED_FILES',
+              ManifestCompression: 'NONE',
+              ClientCache: 'ENABLED',
+              StreamInfResolution: 'INCLUDE',
+              Destination:
+                's3://' +
+                process.env.S3_DESTINATION_BUCKET +
+                '/' +
+                objectKey.replace('/videos/', '/hls/'),
+            },
+          },
+          Outputs: [
+            {
+              Preset: process.env.ENV_TYPE + '_marsha_video_hls_144',
+              NameModifier: '_144',
+            },
+            {
+              Preset: process.env.ENV_TYPE + '_marsha_video_hls_240',
+              NameModifier: '_240',
+            },
+            {
+              Preset: process.env.ENV_TYPE + '_marsha_video_hls_480',
+              NameModifier: '_480',
+            },
+            {
+              Preset: process.env.ENV_TYPE + '_marsha_video_hls_720',
+              NameModifier: '_720',
+            },
+            {
+              Preset: process.env.ENV_TYPE + '_marsha_video_hls_1080',
+              NameModifier: '_1080',
+            },
+          ],
+        },
+        {
           CustomName: 'Thumbnails outputs',
           Name: 'File Group',
           OutputGroupSettings: {
@@ -97,23 +191,23 @@ exports.handler = (event, context, callback) => {
           Outputs: [
             {
               Preset: process.env.ENV_TYPE + '_marsha_thumbnail_jpeg_144',
-              NameModifier: '_thumbnail_144',
+              NameModifier: '_144',
             },
             {
               Preset: process.env.ENV_TYPE + '_marsha_thumbnail_jpeg_240',
-              NameModifier: '_thumbnail_240',
+              NameModifier: '_240',
             },
             {
               Preset: process.env.ENV_TYPE + '_marsha_thumbnail_jpeg_480',
-              NameModifier: '_thumbnail_480',
+              NameModifier: '_480',
             },
             {
               Preset: process.env.ENV_TYPE + '_marsha_thumbnail_jpeg_720',
-              NameModifier: '_thumbnail_720',
+              NameModifier: '_720',
             },
             {
               Preset: process.env.ENV_TYPE + '_marsha_thumbnail_jpeg_1080',
-              NameModifier: '_thumbnail_1080',
+              NameModifier: '_1080',
             },
           ],
         },
@@ -133,7 +227,7 @@ exports.handler = (event, context, callback) => {
           Outputs: [
             {
               Preset: process.env.ENV_TYPE + '_marsha_preview_jpeg_100',
-              NameModifier: '_preview_100',
+              NameModifier: '_100',
             },
           ],
         },


### PR DESCRIPTION
## Purpose

The player we chose (https://github.com/sampotts/plyr) supports adaptive bitrate with HLS/DASH so it would be nice if our backend could support it as well.

## Proposal

- [x] add presets to encode our videos for DASH and HLS
- [x] update the video API endpoint to include urls for the DASH and HLS manifests
- [x] update CloudFront to only protect the mp4 and subtitle tracks urls (DASH, HLS and previews are harder to protect and can be left public as a first approach. Thumbnails should not be protected),
- [x] optimize audio encodings for better sound on high bitrate videos and minimal bandwidth consumption on low bitrate videos.

