### PR TITLE
Add a development view to simplify LTI based work

### DIFF
--- a/marsha/core/templates/core/lti_development.html
+++ b/marsha/core/templates/core/lti_development.html
@@ -1,0 +1,72 @@
+<html>
+
+<head>
+  <style>
+    * {
+      font-family: Helvetica, sans-serif;
+    }
+
+    body {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      margin: 0;
+      padding: 1rem;
+    }
+
+    section {
+      flex-basis: 50%;
+      text-align: center;
+    }
+
+    section:last-of-type {
+      display: flex;
+      justify-content: center;
+      flex-direction: column;
+    }
+
+    section p {
+      max-width: 40rem;
+    }
+
+    section iframe {
+      width: 533px;
+      height: 300px;
+      resize: both;
+      overflow: auto;
+      border: 1px solid lightslategray;
+    }
+  </style>
+</head>
+
+<body>
+  <section>
+    <h2>Iframe LTI setup</h2>
+    <p>Open the `/lti-video/` view in the iframe below, with a POST request. Simulates
+      execution in real conditions, except this is not a cross-origin call.</p>
+    <form action="/lti-video/" method="post" target="lti_iframe">
+      <input type="text" name="resource_link_id" value="example.com-df7" />
+      <input type="text" name="context_id" value="course-v1:ufr+mathematics+0001" />
+      <input type="text" name="roles" value="Instructor" />
+      <input type="submit" />
+    </form>
+
+    <iframe name="lti_iframe" srcdoc="<body style='position: absolute; display: flex; justify-content: center; align-items: center; width: 100%; height: 100%; margin: 0;'><h2 style='font-family: Helvetica, sans-serif;'>Fill the form above to load the LTI view</h2></body>"
+      frameborder="0" allowfullscreen allow="fullscreen *" webkitallowfullscreen mozallowfullscreen>
+    </iframe>
+  </section>
+
+  <section>
+    <h2>New page LTI setup</h2>
+    <p style="margin-top: 0;">Open the `/lti-video/` view in a regular full-screen page, with a POST
+      request.</p>
+    <form action="/lti-video/" method="post">
+      <input type="text" name="resource_link_id" value="example.com-df7" />
+      <input type="text" name="context_id" value="course-v1:ufr+mathematics+0001" />
+      <input type="text" name="roles" value="Instructor" />
+      <input type="submit" />
+    </form>
+  </section>
+</body>
+
+</html>

--- a/marsha/core/views.py
+++ b/marsha/core/views.py
@@ -3,7 +3,7 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.clickjacking import xframe_options_exempt
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View
-from django.views.generic.base import TemplateResponseMixin
+from django.views.generic.base import TemplateResponseMixin, TemplateView
 
 from pylti.common import LTIException
 from rest_framework_simplejwt.tokens import AccessToken
@@ -90,3 +90,13 @@ class VideoLTIView(TemplateResponseMixin, View):
 
         """
         return self.render_to_response(self.get_context_data())
+
+
+class LTIDevelopmentView(TemplateView):
+    """A development view with iframe POST / plain POST helpers.
+
+    Not available outside of DEBUG = true environments.
+
+    """
+
+    template_name = "core/lti_development.html"

--- a/marsha/urls.py
+++ b/marsha/urls.py
@@ -1,12 +1,13 @@
 """Marsha URLs configuration."""
 
+from django.conf import settings
 from django.urls import include, path
 
 from rest_framework.routers import DefaultRouter
 
 from marsha.core.admin import admin_site
 from marsha.core.api import SubtitleTrackViewSet, VideoViewSet
-from marsha.core.views import VideoLTIView
+from marsha.core.views import LTIDevelopmentView, VideoLTIView
 
 
 router = DefaultRouter()
@@ -18,3 +19,8 @@ urlpatterns = [
     path("lti-video/", VideoLTIView.as_view(), name="lti-video"),
     path("api/", include(router.urls)),
 ]
+
+if settings.DEBUG:
+    urlpatterns += [
+        path("development/", LTIDevelopmentView.as_view(), name="lti-development-view")
+    ]


### PR DESCRIPTION
## Purpose

LTI providers need to respond to a POST request on a route with a specific set of parameters. We also intend it to be used through an iframe.

## Proposal

We therefore need a development view to be able to make multiple POST requests hassle-free during development. Developing in an iframe is also more comfortable as it mimicks the environment the real app will run in.