### PR TITLE
Add endpoint for AWS to confirm file uploads

### DIFF
--- a/marsha/core/models/video.py
+++ b/marsha/core/models/video.py
@@ -12,6 +12,10 @@ from .account import INSTRUCTOR, ROLE_CHOICES
 from .base import BaseModel, NonDeletedUniqueIndex
 
 
+PENDING, ERROR, READY = "pending", "error", "ready"
+STATE_CHOICES = ((PENDING, _("pending")), (ERROR, _("error")), (READY, _("ready")))
+
+
 class Playlist(BaseModel):
     """Model representing a playlist which is a list of videos."""
 
@@ -120,9 +124,6 @@ class PlaylistAccess(BaseModel):
 
 class Video(BaseModel):
     """Model representing a video, created by an author."""
-
-    PENDING, ERROR, READY = "pending", "error", "ready"
-    STATE_CHOICES = ((PENDING, _("pending")), (ERROR, _("error")), (READY, _("ready")))
 
     title = models.CharField(
         max_length=255, verbose_name=_("title"), help_text=_("title of the video")
@@ -238,9 +239,6 @@ class Video(BaseModel):
 
 class BaseTrack(BaseModel):
     """Base model for different kinds of tracks tied to a video."""
-
-    PENDING, ERROR, READY = "pending", "error", "ready"
-    STATE_CHOICES = ((PENDING, _("pending")), (ERROR, _("error")), (READY, _("ready")))
 
     video = models.ForeignKey(
         to="Video",

--- a/marsha/core/models/video.py
+++ b/marsha/core/models/video.py
@@ -232,7 +232,7 @@ class Video(BaseModel):
 
         """
         stamp = stamp or to_timestamp(self.uploaded_on)
-        return "{resource!s}/videos/{video!s}/{stamp:s}".format(
+        return "{resource!s}/video/{video!s}/{stamp:s}".format(
             resource=self.resource_id, video=self.id, stamp=stamp
         )
 
@@ -331,7 +331,7 @@ class SubtitleTrack(BaseTrack):
 
         """
         stamp = stamp or to_timestamp(self.uploaded_on)
-        return "{resource!s}/subtitles/{subtitle!s}/{stamp:s}_{language:s}{cc:s}".format(
+        return "{resource!s}/subtitletrack/{subtitle!s}/{stamp:s}_{language:s}{cc:s}".format(
             resource=self.video.resource_id,
             subtitle=self.id,
             stamp=stamp,

--- a/marsha/core/serializers.py
+++ b/marsha/core/serializers.py
@@ -9,7 +9,7 @@ from botocore.signers import CloudFrontSigner
 from rest_framework import serializers
 from rest_framework_simplejwt.models import TokenUser
 
-from .models import SubtitleTrack, Video
+from .models import ERROR, READY, STATE_CHOICES, SubtitleTrack, Video
 from .utils import cloudfront_utils, time_utils
 
 
@@ -109,7 +109,7 @@ class SubtitleTrackSerializer(serializers.ModelSerializer):
             None if the subtitle track is still not uploaded to S3 with success.
 
         """
-        if obj.uploaded_on and obj.state == SubtitleTrack.READY:
+        if obj.uploaded_on and obj.state == READY:
 
             base = "{cloudfront:s}/{resource!s}".format(
                 cloudfront=settings.CLOUDFRONT_URL, resource=obj.video.resource_id
@@ -177,7 +177,7 @@ class VideoSerializer(serializers.ModelSerializer):
             None if the video is still not uploaded to S3 with success
 
         """
-        if obj.uploaded_on is None or obj.state != Video.READY:
+        if obj.uploaded_on is None or obj.state != READY:
             return None
 
         urls = {"mp4": {}, "thumbnails": {}}

--- a/marsha/core/serializers.py
+++ b/marsha/core/serializers.py
@@ -150,9 +150,11 @@ class VideoSerializer(serializers.ModelSerializer):
             "subtitle_tracks",
             "urls",
         )
-        read_only_fields = ("id", "urls")
+        read_only_fields = ("id", "active_stamp", "state", "urls")
 
-    active_stamp = TimestampField(source="uploaded_on", required=False, allow_null=True)
+    active_stamp = TimestampField(
+        source="uploaded_on", required=False, allow_null=True, read_only=True
+    )
     subtitle_tracks = SubtitleTrackSerializer(
         source="subtitletracks", many=True, read_only=True
     )

--- a/marsha/core/tests/test_api_subtitle_track.py
+++ b/marsha/core/tests/test_api_subtitle_track.py
@@ -1,4 +1,5 @@
 """Tests for the SubtitleTrack API of the Marsha project."""
+from base64 import b64decode
 from datetime import datetime
 import json
 from unittest import mock
@@ -565,33 +566,46 @@ class SubtitleTrackAPITest(TestCase):
         self.assertEqual(response.status_code, 200)
         content = json.loads(response.content)
 
+        policy = content.pop("policy")
+        self.assertEqual(
+            json.loads(b64decode(policy)),
+            {
+                "expiration": "2018-08-09T00:00:00.000Z",
+                "conditions": [
+                    {"acl": "private"},
+                    {"bucket": "test-marsha-source"},
+                    {
+                        "x-amz-credential": "aws-access-key-id/20180808/eu-west-1/s3/aws4_request"
+                    },
+                    {"x-amz-algorithm": "AWS4-HMAC-SHA256"},
+                    {"x-amz-date": "20180808T000000Z"},
+                    {
+                        "key": (
+                            "b8d40ed7-95b8-4848-98c9-50728dfee25d/subtitletrack/"
+                            "5c019027-1e1f-4d8c-9f83-c5e20edaad2b/1533686400_fr_cc"
+                        )
+                    },
+                    ["content-length-range", 0, 1048576],
+                ],
+            },
+        )
         self.assertEqual(
             content,
             {
                 "acl": "private",
                 "bucket": "test-marsha-source",
                 "stamp": "1533686400",
-                "key": "{!s}/subtitles/{!s}/1533686400_fr_cc".format(
+                "key": "{!s}/subtitletrack/{!s}/1533686400_fr_cc".format(
                     subtitle_track.video.resource_id, subtitle_track.id
                 ),
                 "max_file_size": 1048576,
-                "policy": (
-                    "eyJleHBpcmF0aW9uIjogIjIwMTgtMDgtMDlUMDA6MDA6MDAuMDAwWiIsICJjb25kaXRpb25zIjog"
-                    "W3siYWNsIjogInByaXZhdGUifSwgeyJidWNrZXQiOiAidGVzdC1tYXJzaGEtc291cmNlIn0sIHsi"
-                    "eC1hbXotY3JlZGVudGlhbCI6ICJhd3MtYWNjZXNzLWtleS1pZC8yMDE4MDgwOC9ldS13ZXN0LTEv"
-                    "czMvYXdzNF9yZXF1ZXN0In0sIHsieC1hbXotYWxnb3JpdGhtIjogIkFXUzQtSE1BQy1TSEEyNTYi"
-                    "fSwgeyJ4LWFtei1kYXRlIjogIjIwMTgwODA4VDAwMDAwMFoifSwgeyJrZXkiOiAiYjhkNDBlZDct"
-                    "OTViOC00ODQ4LTk4YzktNTA3MjhkZmVlMjVkL3N1YnRpdGxlcy81YzAxOTAyNy0xZTFmLTRkOGMt"
-                    "OWY4My1jNWUyMGVkYWFkMmIvMTUzMzY4NjQwMF9mcl9jYyJ9LCBbImNvbnRlbnQtbGVuZ3RoLXJh"
-                    "bmdlIiwgMCwgMTA0ODU3Nl1dfQ=="
-                ),
                 "s3_endpoint": "s3.eu-west-1.amazonaws.com",
                 "x_amz_algorithm": "AWS4-HMAC-SHA256",
                 "x_amz_credential": "aws-access-key-id/20180808/eu-west-1/s3/aws4_request",
                 "x_amz_date": "20180808T000000Z",
                 "x_amz_expires": 86400,
                 "x_amz_signature": (
-                    "0e4b8bbcad3d4c8b1ac57c9ef87b9ef16c35c3789040074e6f3c6517aa6cdfb7"
+                    "22e5e75aee4104c3382b584f83adb19a872a12f58f09bc19fbe909b357e28efd"
                 ),
             },
         )

--- a/marsha/core/tests/test_api_subtitle_track.py
+++ b/marsha/core/tests/test_api_subtitle_track.py
@@ -10,7 +10,7 @@ from rest_framework_simplejwt.tokens import AccessToken
 
 from ..api import timezone
 from ..factories import SubtitleTrackFactory, UserFactory, VideoFactory
-from ..models import SubtitleTrack
+from ..models import STATE_CHOICES, SubtitleTrack
 from .test_api_video import RSA_KEY_MOCK
 
 
@@ -103,7 +103,7 @@ class SubtitleTrackAPITest(TestCase):
     @override_settings(CLOUDFRONT_SIGNED_URLS_ACTIVE=False)
     def test_api_subtitle_track_read_detail_token_user_not_ready(self):
         """A subtitle_track that is not ready should have its "url" field set to `None`."""
-        for state, _ in SubtitleTrack.STATE_CHOICES:
+        for state, _ in STATE_CHOICES:
             if state == "ready":
                 continue
 

--- a/marsha/core/tests/test_api_upload_confirm.py
+++ b/marsha/core/tests/test_api_upload_confirm.py
@@ -1,0 +1,88 @@
+"""Tests for the upload confirmation API of the Marsha project."""
+from datetime import datetime
+import json
+from uuid import uuid4
+
+from django.test import TestCase
+
+import pytz
+
+from ..factories import SubtitleTrackFactory, VideoFactory
+
+
+# We don't enforce arguments documentation in tests
+# pylint: disable=missing-param-doc,missing-type-doc,unused-argument
+
+
+class UploadConfirmAPITest(TestCase):
+    """Test the API that allows to confirm uploads of video and subtitle track objects."""
+
+    def test_api_upload_confirm_video(self):
+        """Confirming the successful upload of a video."""
+        video = VideoFactory()
+        data = {
+            "key": "{!s}/video/{!s}/1533686400".format(video.resource_id, video.id),
+            "state": "ready",
+            "signature": "123abc",
+        }
+
+        response = self.client.post("/api/upload-confirm", data)
+        video.refresh_from_db()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(json.loads(response.content), {"success": True})
+        self.assertEqual(video.uploaded_on, datetime(2018, 8, 8, tzinfo=pytz.utc))
+        self.assertEqual(video.state, "ready")
+
+    def test_api_upload_confirm_subtitle_track(self):
+        """Confirming the successful upload of a subtitle track."""
+        subtitle_track = SubtitleTrackFactory()
+        data = {
+            "key": "{!s}/subtitletrack/{!s}/1533686400_fr_cc".format(
+                subtitle_track.video.resource_id, subtitle_track.id
+            ),
+            "state": "ready",
+            "signature": "123abc",
+        }
+
+        response = self.client.post("/api/upload-confirm", data)
+        subtitle_track.refresh_from_db()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(json.loads(response.content), {"success": True})
+        self.assertEqual(
+            subtitle_track.uploaded_on, datetime(2018, 8, 8, tzinfo=pytz.utc)
+        )
+        self.assertEqual(subtitle_track.state, "ready")
+
+    def test_api_upload_confirm_unknown_video(self):
+        """Trying to confirm a video that does not exist should return a 404."""
+        data = {
+            "key": "{!s}/video/{!s}/1533686400".format(uuid4(), uuid4()),
+            "state": "ready",
+            "signature": "123abc",
+        }
+
+        response = self.client.post("/api/upload-confirm", data)
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(json.loads(response.content), {"success": False})
+
+    def test_api_upload_confirm_invalid_data(self):
+        """Trying to confirm an upload with invalid data (invalid state) should return a 400."""
+        video = VideoFactory()
+        data = {
+            "key": "{!s}/video/{!s}/1533686400".format(video.resource_id, video.id),
+            "state": "reedo",
+            "signature": "123abc",
+        }
+
+        response = self.client.post("/api/upload-confirm", data)
+        video.refresh_from_db()
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            json.loads(response.content), {"state": ['"reedo" is not a valid choice.']}
+        )
+        self.assertIsNone(video.uploaded_on)
+        self.assertEqual(video.state, "pending")

--- a/marsha/core/tests/test_api_video.py
+++ b/marsha/core/tests/test_api_video.py
@@ -10,7 +10,7 @@ from rest_framework_simplejwt.tokens import AccessToken
 
 from ..api import timezone
 from ..factories import SubtitleTrackFactory, UserFactory, VideoFactory
-from ..models import Video
+from ..models import STATE_CHOICES, Video
 
 
 RSA_KEY_MOCK = b"""
@@ -189,7 +189,7 @@ class VideoAPITest(TestCase):
     @override_settings(CLOUDFRONT_SIGNED_URLS_ACTIVE=False)
     def test_api_video_read_detail_token_user_not_ready(self):
         """A video that is not ready should have its "urls" set to `None`."""
-        for state, _ in Video.STATE_CHOICES:
+        for state, _ in STATE_CHOICES:
             if state == "ready":
                 continue
 

--- a/marsha/core/tests/test_api_video.py
+++ b/marsha/core/tests/test_api_video.py
@@ -1,4 +1,5 @@
 """Tests for the Video API of the Marsha project."""
+from base64 import b64decode
 from datetime import datetime
 import json
 from unittest import mock
@@ -599,34 +600,46 @@ class VideoAPITest(TestCase):
         self.assertEqual(response.status_code, 200)
         content = json.loads(response.content)
 
+        policy = content.pop("policy")
+        self.assertEqual(
+            json.loads(b64decode(policy)),
+            {
+                "expiration": "2018-08-09T00:00:00.000Z",
+                "conditions": [
+                    {"acl": "private"},
+                    {"bucket": "test-marsha-source"},
+                    {
+                        "x-amz-credential": "aws-access-key-id/20180808/eu-west-1/s3/aws4_request"
+                    },
+                    {"x-amz-algorithm": "AWS4-HMAC-SHA256"},
+                    {"x-amz-date": "20180808T000000Z"},
+                    {
+                        "key": (
+                            "a2f27fde-973a-4e89-8dca-cc59e01d255c/video/"
+                            "27a23f52-3379-46a2-94fa-697b59cfe3c7/1533686400"
+                        )
+                    },
+                    ["starts-with", "$Content-Type", "video/"],
+                    ["starts-with", "$x-amz-meta-jwt", ""],
+                    ["content-length-range", 0, 1073741824],
+                ],
+            },
+        )
         self.assertEqual(
             content,
             {
                 "acl": "private",
                 "bucket": "test-marsha-source",
                 "stamp": "1533686400",
-                "key": "{!s}/videos/{!s}/1533686400".format(
-                    video.resource_id, video.id
-                ),
+                "key": "{!s}/video/{!s}/1533686400".format(video.resource_id, video.id),
                 "max_file_size": 1073741824,
-                "policy": (
-                    "eyJleHBpcmF0aW9uIjogIjIwMTgtMDgtMDlUMDA6MDA6MDAuMDAwWiIsICJjb25kaXRpb25zIjog"
-                    "W3siYWNsIjogInByaXZhdGUifSwgeyJidWNrZXQiOiAidGVzdC1tYXJzaGEtc291cmNlIn0sIHsi"
-                    "eC1hbXotY3JlZGVudGlhbCI6ICJhd3MtYWNjZXNzLWtleS1pZC8yMDE4MDgwOC9ldS13ZXN0LTEv"
-                    "czMvYXdzNF9yZXF1ZXN0In0sIHsieC1hbXotYWxnb3JpdGhtIjogIkFXUzQtSE1BQy1TSEEyNTYi"
-                    "fSwgeyJ4LWFtei1kYXRlIjogIjIwMTgwODA4VDAwMDAwMFoifSwgeyJrZXkiOiAiYTJmMjdmZGUt"
-                    "OTczYS00ZTg5LThkY2EtY2M1OWUwMWQyNTVjL3ZpZGVvcy8yN2EyM2Y1Mi0zMzc5LTQ2YTItOTRm"
-                    "YS02OTdiNTljZmUzYzcvMTUzMzY4NjQwMCJ9LCBbInN0YXJ0cy13aXRoIiwgIiRDb250ZW50LVR5"
-                    "cGUiLCAidmlkZW8vIl0sIFsic3RhcnRzLXdpdGgiLCAiJHgtYW16LW1ldGEtand0IiwgIiJdLCBb"
-                    "ImNvbnRlbnQtbGVuZ3RoLXJhbmdlIiwgMCwgMTA3Mzc0MTgyNF1dfQ=="
-                ),
                 "s3_endpoint": "s3.eu-west-1.amazonaws.com",
                 "x_amz_algorithm": "AWS4-HMAC-SHA256",
                 "x_amz_credential": "aws-access-key-id/20180808/eu-west-1/s3/aws4_request",
                 "x_amz_date": "20180808T000000Z",
                 "x_amz_expires": 86400,
                 "x_amz_signature": (
-                    "13c35c0bb9afd9dc7cc61a7e3a279f829421945864aeb6486f7d286a68de0b00"
+                    "293eff73208b628b06e4fc047af6782ef4228446c0843f65be63bd751c978b63"
                 ),
             },
         )

--- a/marsha/core/tests/test_serializers_upload_confirm.py
+++ b/marsha/core/tests/test_serializers_upload_confirm.py
@@ -1,0 +1,117 @@
+"""Tests for the UploadConfirmSerializer serializer of the Marsha project."""
+from datetime import datetime
+import random
+from uuid import uuid4
+
+from django.test import TestCase
+
+import pytz
+
+from ..serializers import UploadConfirmSerializer
+
+
+# We don't enforce arguments documentation in tests
+# pylint: disable=missing-param-doc,missing-type-doc,unused-argument
+
+
+class UploadConfirmSerializerTest(TestCase):
+    """Test the serializer that receives upload confirmations."""
+
+    def test_serializers_upload_confirm_valid_data(self):
+        """The serializer should return the validated data."""
+        valid_keys = (
+            "{!s}/video/{!s}/0123456789".format(uuid4(), uuid4()),
+            "{!s}/subtitletrack/{!s}/0123456789".format(uuid4(), uuid4()),
+            "{!s}/subtitletrack/{!s}/0123456789_fr".format(uuid4(), uuid4()),
+            "{!s}/subtitletrack/{!s}/0123456789_fr_cc".format(uuid4(), uuid4()),
+        )
+        for key in valid_keys:
+            state = random.choice(("ready", "error"))
+            valid_data = {"key": key, "state": state, "signature": "123abc"}
+            serializer = UploadConfirmSerializer(data=valid_data)
+            self.assertTrue(serializer.is_valid())
+            self.assertEqual(
+                dict(serializer.validated_data),
+                {"key": key, "state": state, "signature": "123abc"},
+            )
+
+    def test_serializers_upload_confirm_missing_field(self):
+        """All fields in the serializer are required."""
+        valid_data = {
+            "key": "{!s}/video/{!s}/0123456789".format(uuid4(), uuid4()),
+            "state": random.choice(("ready", "error")),
+            "signature": "123abc",
+        }
+        for field in valid_data:
+            invalid_data = valid_data.copy()
+            invalid_data.pop(field, None)
+            serializer = UploadConfirmSerializer(data=invalid_data)
+            self.assertFalse(serializer.is_valid())
+            self.assertEqual(serializer.errors[field][0], "This field is required.")
+
+    def test_serializers_upload_confirm_invalid_key(self):
+        """The serializer should not be valid if the key is not of a valid format."""
+        invalid_uuids = (
+            "a2f27fdz-973a-4e89-8dca-cc59e01d255c",
+            "a2f27fde9-73a-4e89-8dca-cc59e01d255c",
+            "a2f27fde-973a4-e89-8dca-cc59e01d255c",
+            "a2f27fde-973a-4e89-8dc-ccc59e01d255c",
+            "a2f27fde-973a-4e89-8dca-cc59e01d255",
+            "a2f27fde973a4e898dcacc59e01d255c",
+        )
+        invalid_keys = (
+            ["{!s}/video/{!s}/0123456789".format(u, uuid4()) for u in invalid_uuids]
+            + ["{!s}/video/{!s}/0123456789".format(uuid4(), u) for u in invalid_uuids]
+            + [
+                "{!s}/pideos/{!s}/0123456789".format(uuid4(), uuid4()),
+                "{!s}/video/{!s}/012345678a".format(uuid4(), uuid4()),
+                "{!s}/subtitle/{!s}/0123456789_f1".format(uuid4(), uuid4()),
+                "{!s}/subtitle/{!s}/0123456789_fr_cf".format(uuid4(), uuid4()),
+            ]
+        )
+        for key in invalid_keys:
+            invalid_data = {"key": key, "state": "ready", "signature": "123abc"}
+            serializer = UploadConfirmSerializer(data=invalid_data)
+            self.assertFalse(serializer.is_valid())
+            self.assertEqual(
+                serializer.errors["key"][0],
+                "This value does not match the required pattern.",
+            )
+
+    def test_serializers_upload_confirm_invalid_state(self):
+        """The serializer should not be valid if the state is not of a valid value."""
+        invalid_states = {
+            "pending": '"pending" is not a valid choice.',
+            "reedy": '"reedy" is not a valid choice.',
+        }
+        for state, message in invalid_states.items():
+            invalid_data = {
+                "key": "{!s}/video/{!s}/0123456789".format(uuid4(), uuid4()),
+                "state": state,
+                "signature": "123abc",
+            }
+            serializer = UploadConfirmSerializer(data=invalid_data)
+            self.assertFalse(serializer.is_valid())
+            self.assertEqual(serializer.errors["state"][0], message)
+
+    def test_serializers_upload_confirm_key_elements(self):
+        """The serializer has a method that helps to extract key elements."""
+        resource_id, object_id = uuid4(), uuid4()
+        valid_data = {
+            "key": "{!s}/video/{!s}/1533686400".format(resource_id, object_id),
+            "state": "ready",
+            "signature": "123abc",
+        }
+        serializer = UploadConfirmSerializer(data=valid_data)
+
+        self.assertTrue(serializer.is_valid())
+        self.assertEqual(
+            serializer.get_key_elements(),
+            {
+                "model_name": "video",
+                "object_id": str(object_id),
+                "resource_id": str(resource_id),
+                "stamp": "1533686400",
+                "uploaded_on": datetime(2018, 8, 8, tzinfo=pytz.utc),
+            },
+        )

--- a/marsha/urls.py
+++ b/marsha/urls.py
@@ -6,7 +6,7 @@ from django.urls import include, path
 from rest_framework.routers import DefaultRouter
 
 from marsha.core.admin import admin_site
-from marsha.core.api import SubtitleTrackViewSet, VideoViewSet
+from marsha.core.api import SubtitleTrackViewSet, VideoViewSet, upload_confirm
 from marsha.core.views import LTIDevelopmentView, VideoLTIView
 
 
@@ -16,7 +16,8 @@ router.register(r"subtitle-tracks", SubtitleTrackViewSet, base_name="subtitle_tr
 
 urlpatterns = [
     path(f"{admin_site.name}/", admin_site.urls),
-    path("lti-video/", VideoLTIView.as_view(), name="lti-video"),
+    path("lti-video/", VideoLTIView.as_view(), name="lti_video"),
+    path("api/upload-confirm", upload_confirm, name="upload_confirm"),
     path("api/", include(router.urls)),
 ]
 

--- a/terraform/source/encode/index.js
+++ b/terraform/source/encode/index.js
@@ -58,7 +58,7 @@ exports.handler = (event, context, callback) => {
                 's3://' +
                 process.env.S3_DESTINATION_BUCKET +
                 '/' +
-                objectKey.replace(/\/videos\/.*\//, '/mp4/'),
+                objectKey.replace(/\/video\/.*\//, '/mp4/'),
             },
           },
           Outputs: [
@@ -98,7 +98,7 @@ exports.handler = (event, context, callback) => {
                 's3://' +
                 process.env.S3_DESTINATION_BUCKET +
                 '/' +
-                objectKey.replace(/\/videos\/.*\//, '/dash/'),
+                objectKey.replace(/\/video\/.*\//, '/dash/'),
             },
           },
           Outputs: [
@@ -149,7 +149,7 @@ exports.handler = (event, context, callback) => {
                 's3://' +
                 process.env.S3_DESTINATION_BUCKET +
                 '/' +
-                objectKey.replace(/\/videos\/.*\//, '/hls/'),
+                objectKey.replace(/\/video\/.*\//, '/hls/'),
             },
           },
           Outputs: [
@@ -185,7 +185,7 @@ exports.handler = (event, context, callback) => {
                 's3://' +
                 process.env.S3_DESTINATION_BUCKET +
                 '/' +
-                objectKey.replace(/\/videos\/.*\//, '/thumbnails/'),
+                objectKey.replace(/\/video\/.*\//, '/thumbnails/'),
             },
           },
           Outputs: [
@@ -221,7 +221,7 @@ exports.handler = (event, context, callback) => {
                 's3://' +
                 process.env.S3_DESTINATION_BUCKET +
                 '/' +
-                objectKey.replace(/\/videos\/.*\//, '/previews/'),
+                objectKey.replace(/\/video\/.*\//, '/previews/'),
             },
           },
           Outputs: [


### PR DESCRIPTION
## Purpose 

AWS needs to confirm the state of uploads (+processing) it has received.

## Proposal

I added a separate endpoint to handle all upload confirms after making the necessary refactorings.

The pros of this approach:
- simplicity in AWS because it does not need to know about the Marsha objects. AWS only knows S3 object keys and confirms the state of the upload of an object key. The intelligence to know to which object and which version the key belongs is kept in Django in a DRY way with the rest of the code.
- security as we could make the state and stamp fields readonly on the main API. Authentication for this endpoint is specific to AWS and based on signed urls.

The cons of this approach:
- The API scheme for this endpoint is not in line with the other endpoints (/api/{object_type}/{object_id})