### PR TITLE
Do not pass client jwt as video metadata

### DIFF
--- a/front/components/VideoForm/VideoForm.spec.tsx
+++ b/front/components/VideoForm/VideoForm.spec.tsx
@@ -72,7 +72,6 @@ describe('VideoForm', () => {
       ['Content-Type', 'video/mp4'],
       ['X-Amz-Credential', 'policy##x_amz_credential'],
       ['X-Amz-Algorithm', 'policy##x_amz_algorithm'],
-      ['X-Amz-Meta-Jwt', 'some_token'],
       ['X-Amz-Date', 'policy##x_amz_date'],
       ['Policy', 'policy##policy'],
       ['X-Amz-Signature', 'policy##x_amz_signature'],

--- a/front/components/VideoForm/VideoForm.tsx
+++ b/front/components/VideoForm/VideoForm.tsx
@@ -85,7 +85,6 @@ export class VideoForm extends React.Component<VideoFormProps, VideoFormState> {
   }
 
   async upload() {
-    const { jwt } = this.props;
     const { file, policy } = this.state;
 
     this.setState({ status: 'uploading' });
@@ -98,7 +97,6 @@ export class VideoForm extends React.Component<VideoFormProps, VideoFormState> {
       ['Content-Type', file!.type],
       ['X-Amz-Credential', policy.x_amz_credential],
       ['X-Amz-Algorithm', policy.x_amz_algorithm],
-      ['X-Amz-Meta-Jwt', jwt],
       ['X-Amz-Date', policy.x_amz_date],
       ['Policy', policy.policy],
       ['X-Amz-Signature', policy.x_amz_signature],

--- a/marsha/core/api.py
+++ b/marsha/core/api.py
@@ -99,7 +99,6 @@ class VideoViewSet(
             [
                 {"key": key},
                 ["starts-with", "$Content-Type", "video/"],
-                ["starts-with", "$x-amz-meta-jwt", ""],
                 ["content-length-range", 0, VIDEO_SOURCE_MAX_SIZE],
             ],
         )

--- a/marsha/core/tests/test_api_video.py
+++ b/marsha/core/tests/test_api_video.py
@@ -612,7 +612,6 @@ class VideoAPITest(TestCase):
                         )
                     },
                     ["starts-with", "$Content-Type", "video/"],
-                    ["starts-with", "$x-amz-meta-jwt", ""],
                     ["content-length-range", 0, 1073741824],
                 ],
             },
@@ -631,7 +630,7 @@ class VideoAPITest(TestCase):
                 "x_amz_date": "20180808T000000Z",
                 "x_amz_expires": 86400,
                 "x_amz_signature": (
-                    "293eff73208b628b06e4fc047af6782ef4228446c0843f65be63bd751c978b63"
+                    "7b4bb2a1d0620d1bcf5adeec87173cdfa048cdc45705f77370af017dd7772a6f"
                 ),
             },
         )


### PR DESCRIPTION
## Purpose

We planned on sending the client JWT as part of video metadata to enable our lambdas to use it to update the video on the API when upload & transcoding are finished.

## Proposal

This design was scrapped in favor of one where we actually use a shared secret to authenticate the lambdas with the backend server. We therefore should not send the client JWT to S3 anymore.