### PR TITLE
Revert "add a policy to allow lambdas to read source s3 buckets"

### DIFF
--- a/terraform/roles.tf
+++ b/terraform/roles.tf
@@ -102,34 +102,6 @@ resource "aws_iam_role_policy_attachment" "lambda_pass_role_policy_attachment" {
   policy_arn = "${aws_iam_policy.lambda_pass_role_policy.arn}"
 }
 
-resource "aws_iam_policy" "lambda_readonly_s3_source_objects" {
-  name        = "${terraform.workspace}-marsha-lambda-readonly-s3-source-objects-policy"
-  path        = "/"
-  description = "IAM policy to read s3 source bucket objects"
-
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-      {
-          "Effect": "Allow",
-          "Action": [
-              "s3:GetObject",
-              "s3:GetObjectTagging",
-              "s3:GetObjectVersion"
-          ],
-          "Resource": "${aws_s3_bucket.marsha_source.arn}/*"
-      }
-  ]
-}
-  EOF
-}
-
-resource "aws_iam_role_policy_attachment" "lambda_readonly_s3_source_policy_attachment" {
-  role       = "${aws_iam_role.lambda_invocation_role.name}"
-  policy_arn = "${aws_iam_policy.lambda_readonly_s3_source_objects.arn}"
-}
-
 # Media Convert role
 #####################
 


### PR DESCRIPTION
This reverts commit 11a46d4e5d21540c2b9b3ca9302073eed73ce7ed.

## Purpose

We decided not to use metadata to transmit a JWT to the lambda and instead share a proper secret between the lambda and the Django backend.

It is therefore not necessary for lambdas to have read access on our source s3 buckets.

## Proposal

We should not grant privileges that are not actually required. We can just revert that permission.