### PR TITLE
Add environment variables for the confirm lambda

### DIFF
--- a/env.d/ci
+++ b/env.d/ci
@@ -17,3 +17,4 @@ DJANGO_AWS_SECRET_ACCESS_KEY=aws-secret-access-key
 
 # AWS 
 DJANGO_CLOUDFRONT_URL=https://abc.cloudfront.net
+DJANGO_UPLOAD_CONFIRM_SHARED_SECRET=dummy

--- a/env.d/test
+++ b/env.d/test
@@ -17,3 +17,4 @@ DJANGO_AWS_SECRET_ACCESS_KEY=aws-secret-access-key
 
 # AWS
 DJANGO_CLOUDFRONT_URL=https://abc.cloudfront.net
+DJANGO_UPLOAD_CONFIRM_SHARED_SECRET=dummy

--- a/marsha/settings.py
+++ b/marsha/settings.py
@@ -151,6 +151,7 @@ class Base(Configuration):
     AWS_ACCESS_KEY_ID = values.SecretValue()
     AWS_SECRET_ACCESS_KEY = values.SecretValue()
     AWS_DEFAULT_REGION = values.Value("eu-west-1")
+    UPLOAD_CONFIRM_SHARED_SECRET = values.SecretValue()
 
     # Cloud Front key pair for signed urls
     CLOUDFRONT_URL = values.SecretValue()

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -76,6 +76,15 @@ resource "aws_lambda_permission" "allow_bucket" {
 # Confirmation
 ################
 
+resource "random_string" "upload_confirm_secret" {
+  length = 32
+  special = true
+
+  keepers = {
+    stamp = "${var.deployment_stamp}"
+  }
+}
+
 resource "aws_lambda_function" "marsha_confirm_lambda" {
   function_name    = "${terraform.workspace}-marsha-confirm"
   handler          = "index.handler"
@@ -87,6 +96,8 @@ resource "aws_lambda_function" "marsha_confirm_lambda" {
   environment {
     variables = {
       ENV_TYPE = "${terraform.workspace}"
+      SHARED_SECRET = "${random_string.upload_confirm_secret.result}"
+      ENDPOINT = "${var.upload_confirm_endpoint}"
     }
   }
 }

--- a/terraform/output.tf
+++ b/terraform/output.tf
@@ -17,3 +17,7 @@ output "iam_access_key_id" {
 output "iam_secret_access_key" {
   value = "${aws_iam_access_key.marsha_access_key.secret}"
 }
+
+output "upload_confirm_secret" {
+  value = "${random_string.upload_confirm_secret.result}"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -14,3 +14,11 @@ variable "aws_region" {
   type    = "string"
   default = "eu-west-1"
 }
+
+variable "upload_confirm_endpoint" {
+  type    = "string"
+}
+
+variable "deployment_stamp" {
+  type    = "string"
+}


### PR DESCRIPTION
## Purpose

In order to implement the confirm lambda (that calls a Django route when processing of a video is complete), we need it to have access to the Django endpoint URL, and a shared secret to sign messages.

## Proposal

We can just pass the endpoint URL as an environment variable.

As for the shared secret, we're generating it from a deployment stamp (using terraform's random provider) and adding it to our outputs so it is not lost to us. It's the deployer's responsibility to pass it to Django as an environment variable.