### PR TITLE
Fix the "urls" field type on serialized Videos

### DIFF
--- a/marsha/core/serializers.py
+++ b/marsha/core/serializers.py
@@ -194,7 +194,8 @@ class VideoSerializer(serializers.ModelSerializer):
 
         """
         if obj.uploaded_on is None or obj.state != READY:
-            return None
+            # Return JSON here to be consistent with the other possible return value below
+            return json.dumps(None)
 
         urls = {"mp4": {}, "thumbnails": {}}
         base = "{cloudfront:s}/{resource!s}".format(

--- a/marsha/core/tests/test_api_video.py
+++ b/marsha/core/tests/test_api_video.py
@@ -161,7 +161,7 @@ class VideoAPITest(TestCase):
 
     @override_settings(CLOUDFRONT_SIGNED_URLS_ACTIVE=False)
     def test_api_video_read_detail_token_user_no_active_stamp(self):
-        """A video with no active stamp should not fail and its "urls" should be set to `None`."""
+        """A video with no active stamp should not fail and its "urls" should be set to `null`."""
         video = VideoFactory(uploaded_on=None)
         jwt_token = AccessToken()
         jwt_token.payload["video_id"] = str(video.id)
@@ -183,13 +183,13 @@ class VideoAPITest(TestCase):
                 "active_stamp": None,
                 "state": "pending",
                 "subtitle_tracks": [],
-                "urls": None,
+                "urls": "null",
             },
         )
 
     @override_settings(CLOUDFRONT_SIGNED_URLS_ACTIVE=False)
     def test_api_video_read_detail_token_user_not_ready(self):
-        """A video that is not ready should have its "urls" set to `None`."""
+        """A video that is not ready should have its "urls" set to `null`."""
         for state, _ in STATE_CHOICES:
             if state == "ready":
                 continue
@@ -216,7 +216,7 @@ class VideoAPITest(TestCase):
                     "active_stamp": "1533686400",
                     "state": state,
                     "subtitle_tracks": [],
-                    "urls": None,
+                    "urls": "null",
                 },
             )
 

--- a/marsha/core/tests/test_views_lti_video.py
+++ b/marsha/core/tests/test_views_lti_video.py
@@ -52,7 +52,7 @@ class ViewsTestCase(TestCase):
         self.assertEqual(context["video"]["id"], str(video.id))
         self.assertEqual(context["video"]["title"], str(video.title))
         self.assertEqual(context["video"]["description"], str(video.description))
-        self.assertIsNone(context["video"]["urls"])
+        self.assertEqual(context["video"]["urls"], "null")
 
     @mock.patch.object(LTI, "verify", return_value=True)
     def test_views_video_lti_student(self, mock_initialize):
@@ -78,4 +78,4 @@ class ViewsTestCase(TestCase):
         self.assertEqual(context["video"]["id"], str(video.id))
         self.assertEqual(context["video"]["title"], str(video.title))
         self.assertEqual(context["video"]["description"], str(video.description))
-        self.assertIsNone(context["video"]["urls"])
+        self.assertEqual(context["video"]["urls"], "null")


### PR DESCRIPTION
## Purpose

The Video "urls" field as served by the LTI view is expected to be JSON. This enables the client to simply use JSON.parse and use the results.

## Proposal

Here the return value was JSON *when there was a value* and just "None" as a string otherwise.

Use json.dumps to serialize even the None value to the JSON "null".