### PR TITLE
✨(terraform) set up CORS on s3 & terraform for the destination bucket

### DIFF
--- a/terraform/cloudfront.tf
+++ b/terraform/cloudfront.tf
@@ -30,6 +30,7 @@ resource "aws_cloudfront_distribution" "marsha_cloudfront_distribution" {
 
     forwarded_values {
       query_string = false
+      headers = ["Access-Control-Request-Headers", "Access-Control-Request-Method", "Origin"]
 
       cookies {
         forward = "none"
@@ -53,6 +54,7 @@ resource "aws_cloudfront_distribution" "marsha_cloudfront_distribution" {
 
     forwarded_values {
       query_string = false
+      headers = ["Access-Control-Request-Headers", "Access-Control-Request-Method", "Origin"]
 
       cookies {
         forward = "none"
@@ -76,6 +78,7 @@ resource "aws_cloudfront_distribution" "marsha_cloudfront_distribution" {
 
     forwarded_values {
       query_string = false
+      headers = ["Access-Control-Request-Headers", "Access-Control-Request-Method", "Origin"]
 
       cookies {
         forward = "none"

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -21,6 +21,13 @@ resource "aws_s3_bucket" "marsha_destination" {
   bucket = "${terraform.workspace}-marsha-destination"
   acl    = "private"
 
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["GET"]
+    allowed_origins = ["*"]
+    max_age_seconds = 3600
+  }
+
   tags {
     Name        = "marsha-destination"
     Environment = "${terraform.workspace}"


### PR DESCRIPTION
## Purpose

We already allowed cross-origin POST requests on our source bucket to allow video uploads. Conversely, we need to allow cross-origin GET requests on the destination bucket to enable video playback.

## Proposal

Cloudfront needs to pass along CORS related headers to s3 as "Origin" is needed for s3 to send back any CORS headers at all and access control "Request-Headers" & "Request-Method" are necessary for preflight requests.