### PR TITLE
♻️(front) update parseDataElements to load JSON directly

### DIFF
--- a/front/index.tsx
+++ b/front/index.tsx
@@ -10,8 +10,6 @@ const appData = parseDataElements(
   // Spread to pass an array instead of a NodeList
   [...document.querySelectorAll('.marsha-frontend-data')],
 );
-// urls are a JSON object. Parse it once here so we can use it as needed
-appData.video.urls = JSON.parse(appData.video.urls as any);
 export const AppDataContext = React.createContext(appData);
 
 // Wait for the DOM to load before we scour it for an element that requires React to render

--- a/front/utils/parseDataElements/parseDataElements.spec.ts
+++ b/front/utils/parseDataElements/parseDataElements.spec.ts
@@ -1,76 +1,80 @@
 import { keyFromAttr, parseDataElements } from './parseDataElements';
 
-test('keyFromAttr() drops "data-" from the attribute name and camel-cases it', () => {
-  expect(keyFromAttr('data-example')).toEqual('example');
-  expect(keyFromAttr('data-split-name')).toEqual('splitName');
-});
-
-test('parseDataElements() returns an object from the key/values of a data-element', () => {
-  // Build some bogus object with string values & lowecase string keys
-  const data: { [key: string]: string } = {
-    keyone: 'valueOne',
-    keytwo: 'valueTwo',
-  };
-  // Set up the element that contains our data as data-attributes
-  const dataElement = document.createElement('div');
-  Object.keys(data).forEach(key =>
-    dataElement.setAttribute(`data-${key}`, data[key]),
-  );
-  // The data is extracted from the data element
-  expect(parseDataElements([dataElement])).toEqual(data);
-});
-
-test('parseDataElements() merges data from two separate elements', () => {
-  // Build some bogus objects with string values & lowecase string keys
-  const dataX: { [key: string]: string } = {
-    keythree: 'valueThree',
-  };
-  const dataY: { [key: string]: string } = {
-    keyfour: 'valueFour',
-  };
-  // Set up the elements that contains our data as data-attributes
-  const dataElementX = document.createElement('div');
-  Object.keys(dataX).forEach(key =>
-    dataElementX.setAttribute(`data-${key}`, dataX[key]),
-  );
-  const dataElementY = document.createElement('div');
-  Object.keys(dataY).forEach(key =>
-    dataElementY.setAttribute(`data-${key}`, dataY[key]),
-  ); // The data is extracted from the data element
-  expect(parseDataElements([dataElementX, dataElementY])).toEqual({
-    ...dataX,
-    ...dataY,
+describe.only('utils/parseDataElements', () => {
+  describe('keyFromAttr()', () => {
+    it('drops "data-" from the attribute name and camel-cases it', () => {
+      expect(keyFromAttr('data-example')).toEqual('example');
+      expect(keyFromAttr('data-split-name')).toEqual('splitName');
+    });
   });
-});
 
-test('parseDataElements() creates a nested object when an element as an ID attribute', () => {
-  // Build some bogus objects with string values & lowecase string keys
-  const data: { [data: string]: string } = {
-    keyfive: 'valueFive',
-  };
-  // Make a standard AWS S3 policy for illustration purposes
-  const policy: { [key: string]: string } = {
-    acl: 'public-read',
-    awsaccesskeyid: 'MyAWSKey',
-    key: 'file_key_in_s3',
-    policy: 'base64_encoded_policy',
-    signature: 'the_policys_hmac_signature',
-    url: 'my_s3_buckets_url',
-  };
-  // Set up the element that contains our bogus data as data-attributes
-  const dataElement = document.createElement('div');
-  Object.keys(data).forEach(key =>
-    dataElement.setAttribute(`data-${key}`, data[key]),
-  );
-  // Set up the element that contains the policy as data-attributes
-  const policyElement = document.createElement('div');
-  policyElement.id = 'policy'; // triggers the creation of a nested object
-  Object.keys(policy).forEach(key =>
-    policyElement.setAttribute(`data-${key}`, policy[key]),
-  );
-  // The bogus data and policy are extracted from the data elements
-  expect(parseDataElements([dataElement, policyElement])).toEqual({
-    ...data,
-    policy,
+  describe('parseDataElements()', () => {
+    it('returns an object from the key/values of a data-element', () => {
+      // Build some bogus object with string values & lowecase string keys
+      const data: { [key: string]: string } = {
+        keyone: 'valueOne',
+        keytwo: 'valueTwo',
+      };
+      // Set up the element that contains our data as data-attributes
+      const dataElement = document.createElement('div');
+      Object.keys(data).forEach(key =>
+        dataElement.setAttribute(`data-${key}`, data[key]),
+      );
+      // The data is extracted from the data element
+      expect(parseDataElements([dataElement])).toEqual(data);
+    });
+
+    it('merges data from two separate elements', () => {
+      // Build some bogus objects with string values & lowecase string keys
+      const dataX: { [key: string]: string } = {
+        keythree: 'valueThree',
+      };
+      const dataY: { [key: string]: string } = {
+        keyfour: 'valueFour',
+      };
+      // Set up the elements that contains our data as data-attributes
+      const dataElementX = document.createElement('div');
+      Object.keys(dataX).forEach(key =>
+        dataElementX.setAttribute(`data-${key}`, dataX[key]),
+      );
+      const dataElementY = document.createElement('div');
+      Object.keys(dataY).forEach(key =>
+        dataElementY.setAttribute(`data-${key}`, dataY[key]),
+      ); // The data is extracted from the data element
+      expect(parseDataElements([dataElementX, dataElementY])).toEqual({
+        ...dataX,
+        ...dataY,
+      });
+    });
+
+    it('creates a nested object when an element as an ID attribute', () => {
+      // Build some bogus objects with string values & lowecase string keys
+      const data: { [data: string]: string } = {
+        keyfive: 'valueFive',
+      };
+      // Make a standard AWS S3 policy for illustration purposes
+      const policy: { [key: string]: string } = {
+        acl: 'public-read',
+        awsaccesskeyid: 'MyAWSKey',
+        key: 'file_key_in_s3',
+        policy: 'base64_encoded_policy',
+        signature: 'the_policys_hmac_signature',
+        url: 'my_s3_buckets_url',
+      };
+      // Set up the element that contains our bogus data as data-attributes
+      const dataElement = document.createElement('div');
+      Object.keys(data).forEach(key =>
+        dataElement.setAttribute(`data-${key}`, data[key]),
+      );
+      // Set up the element that contains the policy as data-attributes
+      const policyElement = document.createElement('div');
+      policyElement.id = 'policy'; // triggers the creation of a nested object
+      policyElement.setAttribute('data-policy', JSON.stringify(policy));
+      // The bogus data and policy are extracted from the data elements
+      expect(parseDataElements([dataElement, policyElement])).toEqual({
+        ...data,
+        policy,
+      });
+    });
   });
 });

--- a/front/utils/parseDataElements/parseDataElements.ts
+++ b/front/utils/parseDataElements/parseDataElements.ts
@@ -34,13 +34,13 @@ export const parseDataElements: (
         // Build the policy object using the element as data-{key}="value"
         .reduce((acc: any, key) => {
           if (element.id) {
-            // Use of ID denotes a nested object: merge on it, creating it if necessary
+            // Use of ID denotes a nested object
+            // Nested objects use straight JSON instead of a series of data-attributes
             return {
               ...acc,
-              [element.id]: {
-                ...(acc[element.id] ? acc[element.id] : {}),
-                [key.substr(5)]: element.getAttribute(key),
-              },
+              [element.id]: JSON.parse(
+                element.getAttribute(`data-${element.id}`)!,
+              ),
             };
           } else {
             // If there's no ID, just merge on the main accumulator


### PR DESCRIPTION
## Purpose

We recently updated the way the backend generates data elements in order to have consistent types & facilitate serialization and deserialization.

These changes result in nested objects being made of just an id and a data-{id} attribute containing a JSON with all the data.

## Proposal

Update parseDataElements to use JSON parse on such elements instead of iterating over attributes for nested objects.