### PR TITLE
♻️(front) rename Video property from "status" to "state"

### DIFF
--- a/front/components/RedirectOnLoad/RedirectOnLoad.spec.tsx
+++ b/front/components/RedirectOnLoad/RedirectOnLoad.spec.tsx
@@ -31,7 +31,7 @@ describe('<RedirectOnLoad />', () => {
 
   it('redirects instructors to the player when the video is ready', () => {
     context.state = 'instructor';
-    context.video = { status: 'ready' };
+    context.video = { state: 'ready' };
     const wrapper = shallow(<RedirectOnLoad />).dive();
 
     expect(wrapper.name()).toEqual('Redirect');
@@ -41,7 +41,7 @@ describe('<RedirectOnLoad />', () => {
 
   it('redirects students to /player when the video is ready', () => {
     context.state = 'student';
-    context.video = { status: 'ready' };
+    context.video = { state: 'ready' };
     const wrapper = shallow(<RedirectOnLoad />).dive();
 
     expect(wrapper.name()).toEqual('Redirect');

--- a/front/components/RedirectOnLoad/RedirectOnLoad.tsx
+++ b/front/components/RedirectOnLoad/RedirectOnLoad.tsx
@@ -21,7 +21,7 @@ export const RedirectOnLoad = () => {
           return <Redirect push to={ERROR_ROUTE('lti')} />;
         }
         // Everyone gets the video when it exists (so that instructors see the iframes like a student would by default)
-        else if (video.status === 'ready') {
+        else if (video.state === 'ready') {
           return <Redirect push to={PLAYER_ROUTE()} />;
         }
         // Only instructors are allowed to interact with a non-ready video

--- a/front/components/VideoForm/VideoForm.spec.tsx
+++ b/front/components/VideoForm/VideoForm.spec.tsx
@@ -18,7 +18,7 @@ describe('VideoForm', () => {
   const video = {
     description: '',
     id: 'ab42',
-    status: 'no_ready',
+    state: 'pending',
     title: '',
   } as Video;
 

--- a/front/components/VideoPlayer/VideoPlayer.spec.tsx
+++ b/front/components/VideoPlayer/VideoPlayer.spec.tsx
@@ -11,7 +11,7 @@ describe('VideoPlayer', () => {
   const video = {
     description: 'Some description',
     id: 'video-id',
-    status: 'ready',
+    state: 'ready',
     title: 'Some title',
     urls: {
       mp4: {

--- a/front/index.tsx
+++ b/front/index.tsx
@@ -10,8 +10,6 @@ const appData = parseDataElements(
   // Spread to pass an array instead of a NodeList
   [...document.querySelectorAll('.marsha-frontend-data')],
 );
-// urls are a JSON object. Parse it once here so we can use it as needed
-appData.video.urls = JSON.parse(appData.video.urls as any);
 export const AppDataContext = React.createContext(appData);
 
 // Wait for the DOM to load before we scour it for an element that requires React to render

--- a/front/types/Video.ts
+++ b/front/types/Video.ts
@@ -3,7 +3,7 @@ export type videoSize = '144' | '240' | '480' | '720' | '1080';
 export interface Video {
   description: string;
   id: string;
-  status: string;
+  state: string;
   title: string;
   urls: {
     mp4: { [key in videoSize]: string };

--- a/front/utils/parseDataElements/parseDataElements.spec.ts
+++ b/front/utils/parseDataElements/parseDataElements.spec.ts
@@ -1,76 +1,80 @@
 import { keyFromAttr, parseDataElements } from './parseDataElements';
 
-test('keyFromAttr() drops "data-" from the attribute name and camel-cases it', () => {
-  expect(keyFromAttr('data-example')).toEqual('example');
-  expect(keyFromAttr('data-split-name')).toEqual('splitName');
-});
-
-test('parseDataElements() returns an object from the key/values of a data-element', () => {
-  // Build some bogus object with string values & lowecase string keys
-  const data: { [key: string]: string } = {
-    keyone: 'valueOne',
-    keytwo: 'valueTwo',
-  };
-  // Set up the element that contains our data as data-attributes
-  const dataElement = document.createElement('div');
-  Object.keys(data).forEach(key =>
-    dataElement.setAttribute(`data-${key}`, data[key]),
-  );
-  // The data is extracted from the data element
-  expect(parseDataElements([dataElement])).toEqual(data);
-});
-
-test('parseDataElements() merges data from two separate elements', () => {
-  // Build some bogus objects with string values & lowecase string keys
-  const dataX: { [key: string]: string } = {
-    keythree: 'valueThree',
-  };
-  const dataY: { [key: string]: string } = {
-    keyfour: 'valueFour',
-  };
-  // Set up the elements that contains our data as data-attributes
-  const dataElementX = document.createElement('div');
-  Object.keys(dataX).forEach(key =>
-    dataElementX.setAttribute(`data-${key}`, dataX[key]),
-  );
-  const dataElementY = document.createElement('div');
-  Object.keys(dataY).forEach(key =>
-    dataElementY.setAttribute(`data-${key}`, dataY[key]),
-  ); // The data is extracted from the data element
-  expect(parseDataElements([dataElementX, dataElementY])).toEqual({
-    ...dataX,
-    ...dataY,
+describe.only('utils/parseDataElements', () => {
+  describe('keyFromAttr()', () => {
+    it('drops "data-" from the attribute name and camel-cases it', () => {
+      expect(keyFromAttr('data-example')).toEqual('example');
+      expect(keyFromAttr('data-split-name')).toEqual('splitName');
+    });
   });
-});
 
-test('parseDataElements() creates a nested object when an element as an ID attribute', () => {
-  // Build some bogus objects with string values & lowecase string keys
-  const data: { [data: string]: string } = {
-    keyfive: 'valueFive',
-  };
-  // Make a standard AWS S3 policy for illustration purposes
-  const policy: { [key: string]: string } = {
-    acl: 'public-read',
-    awsaccesskeyid: 'MyAWSKey',
-    key: 'file_key_in_s3',
-    policy: 'base64_encoded_policy',
-    signature: 'the_policys_hmac_signature',
-    url: 'my_s3_buckets_url',
-  };
-  // Set up the element that contains our bogus data as data-attributes
-  const dataElement = document.createElement('div');
-  Object.keys(data).forEach(key =>
-    dataElement.setAttribute(`data-${key}`, data[key]),
-  );
-  // Set up the element that contains the policy as data-attributes
-  const policyElement = document.createElement('div');
-  policyElement.id = 'policy'; // triggers the creation of a nested object
-  Object.keys(policy).forEach(key =>
-    policyElement.setAttribute(`data-${key}`, policy[key]),
-  );
-  // The bogus data and policy are extracted from the data elements
-  expect(parseDataElements([dataElement, policyElement])).toEqual({
-    ...data,
-    policy,
+  describe('parseDataElements()', () => {
+    it('returns an object from the key/values of a data-element', () => {
+      // Build some bogus object with string values & lowecase string keys
+      const data: { [key: string]: string } = {
+        keyone: 'valueOne',
+        keytwo: 'valueTwo',
+      };
+      // Set up the element that contains our data as data-attributes
+      const dataElement = document.createElement('div');
+      Object.keys(data).forEach(key =>
+        dataElement.setAttribute(`data-${key}`, data[key]),
+      );
+      // The data is extracted from the data element
+      expect(parseDataElements([dataElement])).toEqual(data);
+    });
+
+    it('merges data from two separate elements', () => {
+      // Build some bogus objects with string values & lowecase string keys
+      const dataX: { [key: string]: string } = {
+        keythree: 'valueThree',
+      };
+      const dataY: { [key: string]: string } = {
+        keyfour: 'valueFour',
+      };
+      // Set up the elements that contains our data as data-attributes
+      const dataElementX = document.createElement('div');
+      Object.keys(dataX).forEach(key =>
+        dataElementX.setAttribute(`data-${key}`, dataX[key]),
+      );
+      const dataElementY = document.createElement('div');
+      Object.keys(dataY).forEach(key =>
+        dataElementY.setAttribute(`data-${key}`, dataY[key]),
+      ); // The data is extracted from the data element
+      expect(parseDataElements([dataElementX, dataElementY])).toEqual({
+        ...dataX,
+        ...dataY,
+      });
+    });
+
+    it('creates a nested object when an element as an ID attribute', () => {
+      // Build some bogus objects with string values & lowecase string keys
+      const data: { [data: string]: string } = {
+        keyfive: 'valueFive',
+      };
+      // Make a standard AWS S3 policy for illustration purposes
+      const policy: { [key: string]: string } = {
+        acl: 'public-read',
+        awsaccesskeyid: 'MyAWSKey',
+        key: 'file_key_in_s3',
+        policy: 'base64_encoded_policy',
+        signature: 'the_policys_hmac_signature',
+        url: 'my_s3_buckets_url',
+      };
+      // Set up the element that contains our bogus data as data-attributes
+      const dataElement = document.createElement('div');
+      Object.keys(data).forEach(key =>
+        dataElement.setAttribute(`data-${key}`, data[key]),
+      );
+      // Set up the element that contains the policy as data-attributes
+      const policyElement = document.createElement('div');
+      policyElement.id = 'policy'; // triggers the creation of a nested object
+      policyElement.setAttribute('data-policy', JSON.stringify(policy));
+      // The bogus data and policy are extracted from the data elements
+      expect(parseDataElements([dataElement, policyElement])).toEqual({
+        ...data,
+        policy,
+      });
+    });
   });
 });

--- a/front/utils/parseDataElements/parseDataElements.ts
+++ b/front/utils/parseDataElements/parseDataElements.ts
@@ -34,13 +34,13 @@ export const parseDataElements: (
         // Build the policy object using the element as data-{key}="value"
         .reduce((acc: any, key) => {
           if (element.id) {
-            // Use of ID denotes a nested object: merge on it, creating it if necessary
+            // Use of ID denotes a nested object
+            // Nested objects use straight JSON instead of a series of data-attributes
             return {
               ...acc,
-              [element.id]: {
-                ...(acc[element.id] ? acc[element.id] : {}),
-                [key.substr(5)]: element.getAttribute(key),
-              },
+              [element.id]: JSON.parse(
+                element.getAttribute(`data-${element.id}`)!,
+              ),
             };
           } else {
             // If there's no ID, just merge on the main accumulator


### PR DESCRIPTION
## Purpose

We implemented our Video type in the frontend before this property was available on the backend and we provisionally named it "status". It's actually named "state" on the backend.

## Proposal

Just rename it on the type and at all use sites to conform to the actual shape of a Video object.