### PR TITLE
Implement adaptive bitrate client-side

### DIFF
--- a/__mocks__/shaka-player.ts
+++ b/__mocks__/shaka-player.ts
@@ -1,0 +1,1 @@
+export default jest.genMockFromModule('shaka-player');

--- a/front/components/RedirectOnLoad/RedirectOnLoad.tsx
+++ b/front/components/RedirectOnLoad/RedirectOnLoad.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Redirect } from 'react-router-dom';
 
 import { AppDataContext } from '../..';
+import { videoState } from '../../types/Video';
 import { ROUTE as ERROR_ROUTE } from '../ErrorComponent/ErrorComponent';
 import { ROUTE as FORM_ROUTE } from '../VideoForm/VideoForm';
 import { ROUTE as PLAYER_ROUTE } from '../VideoPlayer/VideoPlayer';
@@ -21,7 +22,7 @@ export const RedirectOnLoad = () => {
           return <Redirect push to={ERROR_ROUTE('lti')} />;
         }
         // Everyone gets the video when it exists (so that instructors see the iframes like a student would by default)
-        else if (video.state === 'ready') {
+        else if (video.state === videoState.READY) {
           return <Redirect push to={PLAYER_ROUTE()} />;
         }
         // Only instructors are allowed to interact with a non-ready video

--- a/front/components/VideoPlayer/VideoPlayer.spec.tsx
+++ b/front/components/VideoPlayer/VideoPlayer.spec.tsx
@@ -3,9 +3,15 @@ import '../../testSetup';
 import { mount, shallow } from 'enzyme';
 import Plyr from 'plyr';
 import * as React from 'react';
+import shaka from 'shaka-player';
 
 import { Video } from '../../types/Video';
 import { VideoPlayer } from './VideoPlayer';
+
+const mockShakaPlayer: jest.Mocked<typeof shaka.Player> = shaka.Player as any;
+const mockShakaPolyfill: jest.Mocked<
+  typeof shaka.polyfill
+> = shaka.polyfill as any;
 
 describe('VideoPlayer', () => {
   const video = {
@@ -14,6 +20,10 @@ describe('VideoPlayer', () => {
     state: 'ready',
     title: 'Some title',
     urls: {
+      manifests: {
+        dash: 'https://example.com/dash.mpd',
+        hls: 'https://example.com/hls.m3u8',
+      },
       mp4: {
         144: 'https://example.com/144p.mp4',
         1080: 'https://example.com/1080p.mp4',
@@ -21,9 +31,14 @@ describe('VideoPlayer', () => {
     },
   } as Video;
 
+  beforeEach(() => jest.clearAllMocks());
+
   it('renders the video element with all the relevant sources', () => {
     const wrapper = shallow(<VideoPlayer video={video} />);
 
+    expect(wrapper.html()).toContain(
+      '<source src="https://example.com/hls.m3u8" type="application/vnd.apple.mpegURL"/>',
+    );
     expect(wrapper.html()).toContain(
       '<source size="144" src="https://example.com/144p.mp4" type="video/mp4"/>',
     );
@@ -43,5 +58,31 @@ describe('VideoPlayer', () => {
     ).instance() as VideoPlayer;
     instance.componentWillUnmount();
     expect(instance.state.player!.destroy).toHaveBeenCalled();
+  });
+
+  describe('in an EME enabled environment', () => {
+    beforeEach(() => mockShakaPlayer.isBrowserSupported.mockReturnValue(true));
+
+    it('instantiates shaka Player and loads our dash manifest', () => {
+      mount(<VideoPlayer video={video} />);
+
+      expect(mockShakaPlayer.prototype.constructor).toHaveBeenCalledWith(
+        expect.any(HTMLMediaElement),
+      );
+      expect(mockShakaPolyfill.installAll).toHaveBeenCalled();
+      expect(mockShakaPlayer.prototype.configure).toHaveBeenCalled();
+      expect(mockShakaPlayer.prototype.load).toHaveBeenCalledWith(
+        'https://example.com/dash.mpd',
+      );
+    });
+  });
+
+  describe('in an environment without EME', () => {
+    beforeEach(() => mockShakaPlayer.isBrowserSupported.mockReturnValue(true));
+
+    it('never instantiates shaka', () => {
+      expect(mockShakaPlayer.prototype.constructor).not.toHaveBeenCalled();
+      expect(mockShakaPlayer.prototype.load).not.toHaveBeenCalled();
+    });
   });
 });

--- a/front/components/VideoPlayer/VideoPlayer.tsx
+++ b/front/components/VideoPlayer/VideoPlayer.tsx
@@ -1,6 +1,7 @@
 import Plyr from 'plyr';
 import 'plyr/dist/plyr.css';
 import * as React from 'react';
+import shaka from 'shaka-player';
 
 import { Video, videoSize } from '../../types/Video';
 import { Maybe, Nullable } from '../../utils/types';
@@ -29,8 +30,28 @@ export class VideoPlayer extends React.Component<
   }
 
   componentDidMount() {
+    const { video } = this.props;
+
     // Instantiate Plyr and keep the instance in state
     this.setState({ player: new Plyr(this.videoNodeRef!) });
+
+    // Use Shaka Player to stream using DASH ISO if the browser supports it
+    // Otherwise we'll fall back to HLS/MP4 as described in the <sources> of the <video> element
+    if (shaka.Player.isBrowserSupported()) {
+      // Install any necessary polyfills from the shaka package
+      shaka.polyfill.installAll();
+      // Instantiate the player, passing our <video> element
+      const shakaInstance = new shaka.Player(this.videoNodeRef!);
+      shakaInstance.configure({
+        abr: {
+          // Set a more sensible default bandwidth
+          // This lets us start with 480p instead of 144p with the default value
+          defaultBandwidthEstimate: 1600000,
+        },
+      });
+      // Pass our DASH manifest to Shaka
+      shakaInstance.load(video.urls.manifests.dash);
+    }
   }
 
   componentWillUnmount() {
@@ -42,8 +63,14 @@ export class VideoPlayer extends React.Component<
 
   render() {
     const { video } = this.props;
+
     return (
       <video ref={node => (this.videoNodeRef = node)} crossOrigin="anonymous">
+        <source
+          src={video.urls.manifests.hls}
+          size="auto"
+          type="application/vnd.apple.mpegURL"
+        />
         {(Object.keys(video.urls.mp4) as videoSize[]).map(size => (
           <source
             key={video.urls.mp4[size]}

--- a/front/types/Video.ts
+++ b/front/types/Video.ts
@@ -1,11 +1,21 @@
 export type videoSize = '144' | '240' | '480' | '720' | '1080';
 
+export enum videoState {
+  ERROR = 'error',
+  PENDING = 'pending',
+  READY = 'ready',
+}
+
 export interface Video {
   description: string;
   id: string;
-  state: string;
+  state: videoState;
   title: string;
   urls: {
+    manifests: {
+      dash: string;
+      hls: string;
+    };
     mp4: { [key in videoSize]: string };
     thumbnails: { [key in videoSize]: string };
   };

--- a/front/types/libs/shaka-player/index.d.ts
+++ b/front/types/libs/shaka-player/index.d.ts
@@ -1,0 +1,97 @@
+/* tslint:disable:no-namespace unified-signatures, variable-name */
+// Type definitions for shaka-player 2.5.0-beta
+// Project: https://github.com/google/shaka-player
+// Definitions by: Mehdi Benadda https://github.com/mbenadda
+
+// shaka is imported through a module loader
+export = shaka;
+
+declare namespace shaka {
+  class Player {
+    /** STATIC FIELDS */
+
+    /** A version number taken from git at compile time. */
+    static version: string;
+
+    /** STATIC METHODS */
+
+    /** Whether the browser provides basic support. If this returns false, Shaka Player cannot be used at all.
+     * In this case, do not construct a Player instance and do not use the library.
+     * @returns the result of the browser support check.
+     */
+    static isBrowserSupported(): boolean;
+
+    /** Probes the browser to determine what features are supported. This makes a number of requests to EME/MSE/etc
+     * which may result in user prompts. This should only be used for diagnostics.
+     * NOTE: This may show a request to the user for permission.
+     * @returns a promise for the results of the support diagnostics.
+     */
+    // FIXME: shakaExtern reference
+    static probeSupport(): Promise<any>;
+
+    /** Registers a plugin callback that will be called with support().
+     * The callback should return the value that will be stored in the return value from support().
+     * @param name The name of the plugin for which support is checked.
+     * @param callback The actual support check, returning the result of its tests.
+     */
+    static registerSupportPlugin(name: string, callback: () => unknown): void;
+
+    /** INSTANCE METHODS */
+
+    /** Instantiate a new player
+     * @param video The video element on which to attach the player. If provided, this is equivalent to calling
+     * attach(video, true) immediately after construction.
+     * @param opt_dependencyInjector Optional callback which is called to inject mocks into the Player. Used
+     * for testing.
+     * @returns a new player instance.
+     */
+    constructor(
+      video?: HTMLMediaElement,
+      opt_dependencyInjector?: (this: shaka.Player) => void,
+    );
+
+    /** Configure the Player instance. The config object passed in need not be complete. It will be merged
+     * with the existing Player configuration.
+     *
+     * Config keys and types will be checked. If any problems with the config object are found, errors will be
+     * reported through logs and this returns false. If there are errors, valid config objects are still set.
+     * @param config PlayerConfiguration object with the correct shape.
+     * @returns whether the configuration object was 100% valid.
+     */
+    // FIXME: shakaExtern reference
+    configure(config: any): boolean;
+    /** Configure the Player instance. The config object passed in need not be complete. It will be merged
+     * with the existing Player configuration.
+     *
+     * Config keys and types will be checked. If any problems with the config object are found, errors will be
+     * reported through logs and this returns false. If there are errors, valid config objects are still set.
+     * @param configKey A property name from the Configuration object.
+     * @param value The value to assign to this property.
+     * @returns whether the configuration object was 100% valid.
+     */
+    // FIXME: shakaExtern reference (configKey should be keyof PlayerConfiguration)
+    // FIXME: shakaExtern reference (should support only sensible types on value through typeof)
+    configure(configKey: string, value: any): boolean;
+
+    /** Load a manifest.
+     * @param manifestUri The URI for the manifest.
+     * @param opt_startTime Optional start time, in seconds, to begin playback. Defaults to 0 for VOD and
+     * to the live edge for live. Set a positive number to start with a certain offset from the beginning. Set a
+     * negative number to start with a certain offset from the end. This is intended for use with live streams,
+     * to start at a fixed offset from the live edge.
+     * @param opt_manifestParserFactory Optional manifest parser factory to override auto-detection or
+     * use an unregistered parser.
+     */
+    // FIXME: precise the return value
+    load(
+      manifestUri: string,
+      opt_startTime?: number,
+      opt_manifestParserFactory?: any,
+    ): Promise<any>;
+  }
+
+  namespace polyfill {
+    /** Install all polyfills. */
+    const installAll: () => void;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "react-dropzone": "4.3.0",
     "react-intl": "2.4.0",
     "react-router-dom": "4.3.1",
+    "shaka-player": "2.5.0-beta",
     "styled-components": "3.4.5",
     "styled-reboot": "3.0.0"
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
     "module": "es6",
     "moduleResolution": "node",
     "paths": {
-      "plyr": ["front/types/libs/plyr"]
+      "plyr": ["front/types/libs/plyr"],
+      "shaka-player": ["front/types/libs/shaka-player"]
     },
     "strict": true,
     "sourceMap": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5038,6 +5038,10 @@ sha.js@^2.4.0, sha.js@^2.4.8:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
+shaka-player@2.5.0-beta:
+  version "2.5.0-beta"
+  resolved "https://registry.yarnpkg.com/shaka-player/-/shaka-player-2.5.0-beta.tgz#3ee56c88178422883d39e1463508933e07b2c2a0"
+
 shebang-command@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"


### PR DESCRIPTION
## Purpose

Enable adaptive bitrate streaming for all supported clients.

## Proposal

- Add `shaka-player` to allow DASH ISO playback in browsers (HLS is natively supported on iPhones, which are the only relevant clients for this format)
- update our `VideoPlayer` to load `shaka-player` and set the HLS manifest source