### PR TITLE
Improve lambdas build and bundling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,31 +12,23 @@ generate-version-file: &generate-version-file
         "$CIRCLE_PROJECT_REPONAME" \
         "$CIRCLE_BUILD_URL" > version.json
 
-
 version: 2
 jobs:
-
   # Git jobs
   # Check that the git history is clean and complies with our expectations
   lint-git:
-
     machine: true
-
     working_directory: ~/marsha
-
     steps:
       - checkout
-
       - run:
           name: Check absence of fixup commits
           command: |
             ! git log | grep 'fixup!'
-
       - run:
           name: Install gitlint
           command: |
             pip install gitlint
-
       - run:
           name: lint commit messages added to master
           command: |
@@ -46,21 +38,16 @@ jobs:
   # Build job
   # Build the Docker image ready for production
   build:
-
     # We use the machine executor, i.e. a VM, not a container
     machine:
       # Cache docker layers so that we strongly speed up this job execution
       docker_layer_caching: true
-
     working_directory: ~/marsha
-
     steps:
       # Checkout repository sources
       - checkout
-
       # Generate a version.json file describing app release
       - <<: *generate-version-file
-
       # Each image is tagged with the current git commit sha1 to avoid
       # collisions in parallel builds.
       - run:
@@ -69,11 +56,9 @@ jobs:
             docker build \
               -t marsha:${CIRCLE_SHA1} \
               .
-
       - run:
           name: Check built image availability
           command: docker images "marsha:${CIRCLE_SHA1}*"
-
       # Since we cannot rely on CircleCI's Docker layers cache (for obscure
       # reasons some subsequent jobs will benefit from a previous job cache and
       # some others won't), we choose to save built docker images in cached
@@ -85,7 +70,6 @@ jobs:
             docker save \
               -o docker/images/marsha.tar \
               marsha:${CIRCLE_SHA1}
-
       - save_cache:
           paths:
             - ~/marsha/docker/images/
@@ -94,31 +78,23 @@ jobs:
   # Build dev job
   # Build the Docker image ready for development
   build-dev:
-
     machine:
       docker_layer_caching: true
-
     working_directory: ~/marsha
-
     steps:
       - checkout
-
       - restore_cache:
           keys:
             - docker-debian-images-{{ .Revision }}
-
       - run:
           name: Load images to docker engine
           command: |
             docker load < docker/images/marsha.tar
-
       - run:
           name: List available images
           command: docker images "marsha:${CIRCLE_SHA1}*"
-
       # Generate a version.json file describing app release
       - <<: *generate-version-file
-
       # Development image build, it uses the dev Dockerfile file
       - run:
           name: Build development image
@@ -128,11 +104,9 @@ jobs:
               -f docker/images/dev/Dockerfile \
               --build-arg BASE_TAG=${CIRCLE_SHA1} \
               .
-
       - run:
           name: Check built image availability
           command: docker images "marsha:${CIRCLE_SHA1}*"
-
       - run:
           name: Store docker image in cache
           command: |
@@ -140,30 +114,23 @@ jobs:
               -o docker/images/dev/marsha.tar \
               marsha:${CIRCLE_SHA1} \
               marsha:${CIRCLE_SHA1}-dev
-
       - save_cache:
           paths:
             - ~/marsha/docker/images/dev/
           key: docker-debian-images-dev-{{ .Revision }}
 
   lint-isort:
-
     machine: true
-
     working_directory: ~/marsha
-
     steps:
       - checkout
-
       - restore_cache:
           keys:
             - docker-debian-images-dev-{{ .Revision }}
-
       - run:
           name: Load images to docker engine
           command: |
             docker load < docker/images/dev/marsha.tar
-
       - run:
           name: Lint code with isort
           command: |
@@ -175,23 +142,17 @@ jobs:
                 isort --recursive --check-only .
 
   lint-flake8:
-
     machine: true
-
     working_directory: ~/marsha
-
     steps:
       - checkout
-
       - restore_cache:
           keys:
             - docker-debian-images-dev-{{ .Revision }}
-
       - run:
           name: Load images to docker engine
           command: |
             docker load < docker/images/dev/marsha.tar
-
       - run:
           name: Lint code with flake8
           command: |
@@ -203,23 +164,17 @@ jobs:
                 flake8
 
   lint-pylint:
-
     machine: true
-
     working_directory: ~/marsha
-
     steps:
       - checkout
-
       - restore_cache:
           keys:
             - docker-debian-images-dev-{{ .Revision }}
-
       - run:
           name: Load images to docker engine
           command: |
             docker load < docker/images/dev/marsha.tar
-
       - run:
           name: Lint code with pylint
           command: |
@@ -231,23 +186,17 @@ jobs:
                 pylint marsha
 
   lint-black:
-
     machine: true
-
     working_directory: ~/marsha
-
     steps:
       - checkout
-
       - restore_cache:
           keys:
             - docker-debian-images-dev-{{ .Revision }}
-
       - run:
           name: Load images to docker engine
           command: |
             docker load < docker/images/dev/marsha.tar
-
       - run:
           name: Lint code with black
           command: |
@@ -259,23 +208,17 @@ jobs:
                 black marsha --check
 
   test-back:
-
     machine: true
-
     working_directory: ~/marsha
-
     steps:
       - checkout
-
       - restore_cache:
           keys:
             - docker-debian-images-dev-{{ .Revision }}
-
       - run:
           name: Load images to docker engine
           command: |
             docker load < docker/images/dev/marsha.tar
-
       # Run back-end (Django) test suite
       #
       # Nota bene: to run the django test suite, we need to ensure that the
@@ -305,8 +248,8 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-          - v3-front-dependencies-{{ checksum "package.json" }}
-          - v3-front-dependencies-
+            - v3-front-dependencies-{{ checksum "package.json" }}
+            - v3-front-dependencies-
       # If the yarn.lock file is not up-to-date with the package.json file,
       # using the --frozen-lockfile should fail.
       - run:
@@ -328,7 +271,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-          - v3-front-dependencies-{{ checksum "package.json" }}
+            - v3-front-dependencies-{{ checksum "package.json" }}
       - run:
           name: Lint code with tslint
           command: yarn lint
@@ -341,7 +284,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-          - v3-front-dependencies-{{ checksum "package.json" }}
+            - v3-front-dependencies-{{ checksum "package.json" }}
       - run:
           name: Lint code with prettier
           command: yarn prettier --list-different "**/*.+(ts|tsx|json|js|jsx)"
@@ -354,7 +297,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-          - v3-front-dependencies-{{ checksum "package.json" }}
+            - v3-front-dependencies-{{ checksum "package.json" }}
       - run:
           name: Run tests
           command: yarn test
@@ -369,8 +312,8 @@ jobs:
           path: ~/marsha
       - restore_cache:
           keys:
-          - v3-lambdas-configure-dependencies-{{ checksum "package.json" }}
-          - v3-lambdas-configure-dependencies-
+            - v3-lambdas-configure-dependencies-{{ checksum "package.json" }}
+            - v3-lambdas-configure-dependencies-
       - run:
           name: Install configure lambda dependencies
           command: yarn install --ignore-engines --frozen-lockfile
@@ -391,8 +334,8 @@ jobs:
           path: ~/marsha
       - restore_cache:
           keys:
-          - v3-lambdas-confirm-dependencies-{{ checksum "package.json" }}
-          - v3-lambdas-confirm-dependencies-
+            - v3-lambdas-confirm-dependencies-{{ checksum "package.json" }}
+            - v3-lambdas-confirm-dependencies-
       - run:
           name: Install confirm lambda dependencies
           command: yarn install --ignore-engines --frozen-lockfile
@@ -406,18 +349,13 @@ jobs:
 
   # ---- Alpine jobs ----
   build-alpine:
-
     machine:
       docker_layer_caching: true
-
     working_directory: ~/marsha
-
     steps:
       - checkout
-
       # Generate a version.json file describing app release
       - <<: *generate-version-file
-
       - run:
           name: Build alpine production image
           command: |
@@ -425,7 +363,6 @@ jobs:
               -t marsha:${CIRCLE_SHA1}-alpine \
               -f docker/images/alpine/Dockerfile \
               .
-
       - run:
           name: Build alpine development image
           command: |
@@ -434,11 +371,9 @@ jobs:
               -f docker/images/alpine/dev/Dockerfile \
               --build-arg BASE_TAG=${CIRCLE_SHA1}-alpine \
               .
-
       - run:
           name: List available images
           command: docker images marsha
-
       - run:
           name: Store docker image in cache
           command: |
@@ -446,30 +381,23 @@ jobs:
               -o docker/images/alpine/marsha.tar \
               marsha:${CIRCLE_SHA1}-alpine \
               marsha:${CIRCLE_SHA1}-alpine-dev
-
       - save_cache:
           paths:
             - ~/marsha/docker/images/
           key: docker-alpine-images-dev-{{ .Revision }}
 
   test-alpine:
-
     machine: true
-
     working_directory: ~/marsha
-
     steps:
       - checkout
-
       - restore_cache:
           keys:
             - docker-alpine-images-dev-{{ .Revision }}
-
       - run:
           name: Load images to docker engine
           command: |
             docker load < docker/images/alpine/marsha.tar
-
       - run:
           name: Run tests
           command: |
@@ -484,25 +412,18 @@ jobs:
                   -timeout 60s \
                     python manage.py test
 
-
   # ---- DockerHub publication job ----
   hub:
-
     machine: true
-
     working_directory: ~/marsha
-
     steps:
       - checkout
-
       - restore_cache:
           keys:
             - docker-debian-images-dev-{{ .Revision }}
-
       - restore_cache:
           keys:
             - docker-alpine-images-dev-{{ .Revision }}
-
       # Load all built images in all flavors
       - run:
           name: Load images to docker engine
@@ -519,7 +440,8 @@ jobs:
       #   - DOCKER_PASS
       - run:
           name: Login to DockerHub
-          command: echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
+          command:
+            echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
 
       # Tag docker images with the same pattern used in Git (Semantic Versioning)
       #
@@ -556,13 +478,11 @@ jobs:
             docker push fundocker/marsha:${DOCKER_TAG}-alpine
             docker push fundocker/marsha:${DOCKER_TAG}-alpine-dev
 
-
 workflows:
   version: 2
 
   marsha:
     jobs:
-
       # Git jobs
       #
       # Check validity of git history

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -325,6 +325,28 @@ jobs:
             - ./node_modules
           key: v3-lambdas-configure-dependencies-{{ checksum "package.json" }}
 
+  test-lambda-encode:
+    docker:
+      - image: circleci/node:8.11.3
+    working_directory: ~/marsha/terraform/source/encode
+    steps:
+      - checkout:
+          path: ~/marsha
+      - restore_cache:
+          keys:
+            - v3-lambdas-encode-dependencies-{{ checksum "package.json" }}
+            - v3-lambdas-encode-dependencies-
+      - run:
+          name: Install encode lambda dependencies
+          command: yarn install --ignore-engines --frozen-lockfile
+      - run:
+          name: Run encode lambda tests
+          command: yarn test
+      - save_cache:
+          paths:
+            - ./node_modules
+          key: v3-lambdas-encode-dependencies-{{ checksum "package.json" }}
+
   test-lambda-confirm:
     docker:
       - image: circleci/node:8.11.3
@@ -519,6 +541,10 @@ workflows:
 
       # Lambda related jobs
       - test-lambda-configure:
+          filters:
+            tags:
+              only: /.*/
+      - test-lambda-encode:
           filters:
             tags:
               only: /.*/

--- a/.gitignore
+++ b/.gitignore
@@ -135,7 +135,6 @@ marsha/static/js
 # Lambda build
 dist
 node_modules
-package-lock.json
 
 # Ssh keys
 .ssh

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -53,13 +53,22 @@ lambda: ## Zip and copy source files to dist/
 lambda:
 	@echo "Zip and copy source files to dist/"
 	@rm -rf dist && mkdir dist
-	@find ./source -maxdepth 2  -name "node_modules" -exec rm -rf "{}" \;
-	@cd ./source/configure && npm install --production && zip -q -r9 ../../dist/marsha_configure.zip *;
-	@cd ./source/encode && npm install --production && zip -q -r9 ../../dist/marsha_encode.zip *;
-	@cd ./source/update_state && npm install --production && zip -q -r9 ../../dist/marsha_update_state.zip *;
+	@for lambda in configure encode update_state ; do \
+		cd ./source/$$lambda ; \
+		rm -rf node_modules ; \
+		yarn install --frozen-lockfile --production=true ; \
+		zip -q -r9 ../../dist/marsha_$$lambda.zip *; \
+		cd - ; \
+	done
 
 .PHONY: test
 test: ## test all lambda packages
 test:
 	@echo "Test all lambda packages"
-	@cd ./source/configure && npm install && npm test;
+	@for lambda in configure encode update_state ; do \
+		cd ./source/$$lambda ; \
+		rm -rf node_modules ; \
+		yarn install --frozen-lockfile ; \
+		yarn test; \
+		cd - ; \
+	done

--- a/terraform/source/encode/yarn.lock
+++ b/terraform/source/encode/yarn.lock
@@ -26,7 +26,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/jest@^23.3.5":
+"@types/jest@23.3.5":
   version "23.3.5"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.5.tgz#870a1434208b60603745bfd214fc3fc675142364"
 
@@ -34,7 +34,7 @@
   version "10.11.6"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.11.6.tgz#ce5690df6cd917a9178439a1013e39a7e565c46e"
 
-"@types/request-promise-native@^1.0.15":
+"@types/request-promise-native@1.0.15":
   version "1.0.15"
   resolved "https://registry.yarnpkg.com/@types/request-promise-native/-/request-promise-native-1.0.15.tgz#5b3369fc6aaf9e7fef7b6b688aef4c5759623e16"
   dependencies:
@@ -1780,7 +1780,7 @@ jest-worker@^23.2.0:
   dependencies:
     merge-stream "^1.0.1"
 
-jest@^23.6.0:
+jest@23.6.0:
   version "23.6.0"
   resolved "https://registry.yarnpkg.com/jest/-/jest-23.6.0.tgz#ad5835e923ebf6e19e7a1d7529a432edfee7813d"
   dependencies:
@@ -2554,7 +2554,7 @@ request-promise-core@1.1.1:
   dependencies:
     lodash "^4.13.1"
 
-request-promise-native@^1.0.5:
+request-promise-native@1.0.5, request-promise-native@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/request-promise-native/-/request-promise-native-1.0.5.tgz#5281770f68e0c9719e5163fd3fab482215f4fda5"
   dependencies:
@@ -2562,7 +2562,7 @@ request-promise-native@^1.0.5:
     stealthy-require "^1.1.0"
     tough-cookie ">=2.3.3"
 
-request@^2.87.0, request@^2.88.0:
+request@2.88.0, request@^2.87.0:
   version "2.88.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
   dependencies:


### PR DESCRIPTION
## Purpose

As we worked on #92, we noticed there was no test job for the encode lambda, and also deploying the lambdas generated unnecessarily large packages and useless `package-lock.json` files.

## Proposal

- [x] Stop using NPM at all
- [x] Improve `make lambda` task
- [x] Add a CI job to run encode lambda tests