### PR TITLE
✨(backend) integrate sentry

### DIFF
--- a/marsha/settings.py
+++ b/marsha/settings.py
@@ -11,6 +11,8 @@ import os
 from django.utils.translation import gettext_lazy as _
 
 from configurations import Configuration, values
+import sentry_sdk
+from sentry_sdk.integrations.django import DjangoIntegration
 
 
 class Base(Configuration):
@@ -176,6 +178,25 @@ class Base(Configuration):
             "USER_ID_CLAIM": "video_id",
             "AUTH_TOKEN_CLASSES": ("rest_framework_simplejwt.tokens.AccessToken",),
         }
+
+    @classmethod
+    def post_setup(cls):
+        """Post setup configuration.
+
+        This is the place where you can configure settings that require other
+        settings to be loaded.
+        """
+        super().post_setup()
+
+        # The DJANGO_SENTRY_DSN environment variable should be set to activate
+        # sentry for an environment
+        sentry_dsn = values.Value(None, environ_name="SENTRY_DSN")
+        if sentry_dsn is not None:
+            sentry_sdk.init(
+                dsn=sentry_dsn,
+                environment=cls.__name__.lower(),
+                integrations=[DjangoIntegration()],
+            )
 
 
 class Development(Base):

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,6 +42,7 @@ install_requires =
     # Warning from psycopg2 "The psycopg2 wheel package will be renamed from release 2.8" => psyopg2-binary
     psycopg2-binary==2.7.5
     pylti
+    sentry-sdk==0.4.0
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
## Purpose

[Sentry](https://sentry.io) is a great tool to track and report application errors. Looks like a requirement for any Django project.

## Proposal

This work integrates Sentry to Marsha. To activate it, you should create a sentry project and set the `DJANGO_SENTRY_DSN` environment variable to point to your project's DSN.

Fix #93