### PR TITLE
🔧(settings) add production(-derived) configurations

### DIFF
--- a/marsha/settings.py
+++ b/marsha/settings.py
@@ -218,3 +218,27 @@ class Test(Base):
     AWS_SOURCE_BUCKET_NAME = "test-marsha-source"
 
     CLOUDFRONT_SIGNED_URLS_ACTIVE = False
+
+
+class Production(Base):
+    """Production environment settings.
+
+    You must define the DJANGO_ALLOWED_HOSTS environment variable in Production
+    configuration (and derived configurations):
+
+    DJANGO_ALLOWED_HOSTS="foo.com,foo.fr"
+    """
+
+    ALLOWED_HOSTS = values.ListValue(None)
+
+
+class Staging(Production):
+    """Staging environment settings."""
+
+    pass
+
+
+class PreProduction(Production):
+    """Pre-production environment settings."""
+
+    pass


### PR DESCRIPTION
## Purpose

At the time of writing, available configurations for Marsha are: `Development` and `Test`. Some more configurations are missing to push the project to production.

## Proposal

The following missing configurations have been added to deploy marsha:

- `Production`
- `Staging`
- `PreProduction`

The two later ones derive from the `Production` configuration.

Fix #94 