### PR TITLE
Stop considering hostname from the LTI query

### DIFF
--- a/marsha/core/models/account.py
+++ b/marsha/core/models/account.py
@@ -15,7 +15,7 @@ from .base import BaseModel, NonDeletedUniqueIndex
 
 OAUTH_CONSUMER_KEY_CHARS = string.ascii_uppercase + string.digits
 OAUTH_CONSUMER_KEY_SIZE = 20
-SHARED_SECRET_CHARS = string.ascii_letters + string.digits + string.punctuation
+SHARED_SECRET_CHARS = string.ascii_letters + string.digits + "!#$%&*+-=?@^_"
 SHARED_SECRET_SIZE = 40
 
 ADMINISTRATOR, INSTRUCTOR, STUDENT = ("administrator", "instructor", "student")

--- a/marsha/core/tests/test_views_lti_video.py
+++ b/marsha/core/tests/test_views_lti_video.py
@@ -10,7 +10,7 @@ from django.test import TestCase
 from pylti.common import LTIException
 from rest_framework_simplejwt.tokens import AccessToken
 
-from ..factories import VideoFactory
+from ..factories import ConsumerSiteLTIPassportFactory, VideoFactory
 from ..lti import LTI
 
 
@@ -23,17 +23,19 @@ class ViewsTestCase(TestCase):
 
     @mock.patch.object(LTI, "verify", return_value=True)
     def test_views_video_lti_post_instructor(self, mock_initialize):
-        """Validate the format of the response returned by the view for a student request."""
+        """Validate the format of the response returned by the view for an instructor request."""
+        passport = ConsumerSiteLTIPassportFactory(oauth_consumer_key="ABC123")
         video = VideoFactory(
             lti_id="123",
             playlist__lti_id="abc",
-            playlist__consumer_site__name="example.com",
+            playlist__consumer_site=passport.consumer_site,
         )
         data = {
             "resource_link_id": "123",
             "roles": "instructor",
             "context_id": "abc",
             "tool_consumer_instance_guid": "example.com",
+            "oauth_consumer_key": "ABC123",
         }
         response = self.client.post("/lti-video/", data)
         self.assertEqual(response.status_code, 200)
@@ -73,16 +75,18 @@ class ViewsTestCase(TestCase):
     @mock.patch.object(LTI, "verify", return_value=True)
     def test_views_video_lti_post_student(self, mock_initialize):
         """Validate the format of the response returned by the view for a student request."""
+        passport = ConsumerSiteLTIPassportFactory(oauth_consumer_key="ABC123")
         video = VideoFactory(
             lti_id="123",
             playlist__lti_id="abc",
-            playlist__consumer_site__name="example.com",
+            playlist__consumer_site=passport.consumer_site,
         )
         data = {
             "resource_link_id": "123",
             "roles": "student",
             "context_id": "abc",
             "tool_consumer_instance_guid": "example.com",
+            "oauth_consumer_key": "ABC123",
         }
         response = self.client.post("/lti-video/", data)
         self.assertEqual(response.status_code, 200)
@@ -114,11 +118,13 @@ class ViewsTestCase(TestCase):
     @mock.patch.object(LTI, "verify", return_value=True)
     def test_views_video_lti_post_student_no_video(self, mock_initialize):
         """Validate the response returned for a student request when there is no video."""
+        ConsumerSiteLTIPassportFactory(oauth_consumer_key="ABC123")
         data = {
             "resource_link_id": "123",
             "roles": "student",
             "context_id": "abc",
             "tool_consumer_instance_guid": "example.com",
+            "oauth_consumer_key": "ABC123",
         }
         response = self.client.post("/lti-video/", data)
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
## Purpose

It seems that the Open edX LTI Xblock does not always send the hostname, for example when calling the LTI Xblock from the CMS. This causes Marsha to refuse the LTI connection because the passport can not be found.

## Proposal 

Since the consumer site is already defined by the passport, we can skip checking the hostname and rely on the consumer site linked to the passport (either directly or through a playlist depending on the type of passport) after we have retrieved and verified it. 

This method will also be used for other LMS like Moodle in order to stay coherent.