### PR TITLE
🔖(patch) bump release to 1.0.0-beta.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marsha",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.3",
   "description": "🐠 a FUN LTI video provider",
   "main": "front/index.tsx",
   "scripts": {

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 name = marsha
 description = A FUN video provider for Open edX
 long_description = file:README.rst
-version = 1.0.0-beta.2
+version = 1.0.0-beta.3
 author = Open FUN (France Universite Numerique)
 author_email = fun.dev@fun-mooc.fr
 license = MIT


### PR DESCRIPTION
This release fixes Marsha to make it work with Open edX (the LTI Xblock does not send its hostname on studio side and advanced settings don't accept all punctuation characters for the passport shared secret). 