### PR TITLE
Add a component to show upload state

### DIFF
--- a/front/components/Loader/Loader.spec.tsx
+++ b/front/components/Loader/Loader.spec.tsx
@@ -1,0 +1,12 @@
+import '../../testSetup';
+
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+import { Loader } from './Loader';
+
+describe('<Loader />', () => {
+  it('renders', () => {
+    expect(shallow(<Loader />).html()).toContain('div');
+  });
+});

--- a/front/components/Loader/Loader.tsx
+++ b/front/components/Loader/Loader.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import styled from 'styled-components';
 
 import { colors } from '../../utils/theme/theme';
@@ -24,6 +25,7 @@ const LoaderStyled = styled.div`
   }
 `;
 
+/** Component. Displays a rotating CSS loader. */
 export const Loader = () => (
   <LoaderStyled aria-busy="true" aria-live="polite" />
 );

--- a/front/components/UploadStatusList/UploadStatus.spec.tsx
+++ b/front/components/UploadStatusList/UploadStatus.spec.tsx
@@ -1,0 +1,40 @@
+import '../../testSetup';
+
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+import { colors } from '../../utils/theme/theme';
+import { Loader } from '../Loader/Loader';
+import { statusIconKey, UploadStatus } from './UploadStatus';
+
+describe('<UploadStatus />', () => {
+  it('renders with children', () => {
+    expect(
+      shallow(<UploadStatus>Some child content</UploadStatus>).html(),
+    ).toContain('Some child content');
+  });
+
+  it('displays the status icon depending on the props', () => {
+    expect(
+      shallow(<UploadStatus statusIcon={statusIconKey.TICK} />).html(),
+    ).toContain('✓');
+
+    expect(
+      shallow(
+        <UploadStatus statusIcon={statusIconKey.LOADER} />,
+      ).containsMatchingElement(<Loader />),
+    ).toBeTruthy();
+  });
+
+  it('displays in primary color when isHighlighted is true', () => {
+    expect(shallow(<UploadStatus />)).not.toHaveStyleRule(
+      'color',
+      colors.primary.main,
+    );
+
+    expect(shallow(<UploadStatus isHighlighted={true} />)).toHaveStyleRule(
+      'color',
+      colors.primary.main,
+    );
+  });
+});

--- a/front/components/UploadStatusList/UploadStatus.tsx
+++ b/front/components/UploadStatusList/UploadStatus.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react';
+import styled from 'styled-components';
+
+import { styledComponentWithProps } from '../../utils/styledComponentsTs';
+import { colors } from '../../utils/theme/theme';
+import { Loader } from '../Loader/Loader';
+
+export const UploadStatusStyled = styledComponentWithProps<{
+  isHighlighted?: boolean;
+}>(styled.li)`
+  flex-grow: 1;
+  text-align: center;
+
+  ${({ isHighlighted }) =>
+    isHighlighted
+      ? `
+    color: ${colors.primary.main};
+    font-weight: 700;
+  `
+      : `
+    color: ${colors.mediumTextGray.main};
+  `}
+`;
+
+/** Available icon names for statusIcon on the UploadStatus component. */
+export enum statusIconKey {
+  LOADER = 'loader',
+  TICK = 'tick',
+}
+
+/** Props shape for the UploadStatus component. */
+export interface UploadStatusProps {
+  isHighlighted?: boolean;
+  statusIcon?: statusIconKey;
+}
+
+/** Component. Displays one word status information along with an optional icon.
+ * @param isHighlighted Whether to highlight this status by changing its color.
+ * @param statusIcon The key for an icon to display along with the status.
+ */
+export class UploadStatus extends React.Component<UploadStatusProps> {
+  render() {
+    const { children, statusIcon, isHighlighted } = this.props;
+
+    let icon;
+    switch (statusIcon) {
+      case statusIconKey.LOADER:
+        icon = <Loader />;
+        break;
+
+      case statusIconKey.TICK:
+        icon = '✓';
+        break;
+    }
+
+    return (
+      <UploadStatusStyled isHighlighted={isHighlighted}>
+        {children}
+        {icon}
+      </UploadStatusStyled>
+    );
+  }
+}

--- a/front/components/UploadStatusList/UploadStatusList.spec.tsx
+++ b/front/components/UploadStatusList/UploadStatusList.spec.tsx
@@ -1,0 +1,97 @@
+import '../../testSetup';
+
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+import { videoState } from '../../types/Video';
+import { statusIconKey, UploadStatus } from './UploadStatus';
+import { UploadStatusList } from './UploadStatusList';
+
+const { ERROR, PENDING, PROCESSING, READY, UPLOADING } = videoState;
+
+describe('<UploadStatusList />', () => {
+  it('renders the status list for PENDING', () => {
+    const wrapper = shallow(<UploadStatusList state={PENDING} />);
+    const items = wrapper.find(UploadStatus);
+
+    expect(items.at(0).html()).toContain('Uploading');
+    expect(items.at(0).prop('isHighlighted')).not.toBeTruthy();
+    expect(items.at(0).prop('statusIcon')).not.toBeDefined();
+
+    expect(items.at(1).html()).toContain('Processing');
+    expect(items.at(1).prop('isHighlighted')).not.toBeTruthy();
+    expect(items.at(1).prop('statusIcon')).not.toBeDefined();
+
+    expect(items.at(2).html()).toContain('Ready');
+    expect(items.at(2).prop('isHighlighted')).not.toBeTruthy();
+    expect(items.at(2).prop('statusIcon')).not.toBeDefined();
+  });
+
+  it('renders the status list for UPLOADING', () => {
+    const wrapper = shallow(<UploadStatusList state={UPLOADING} />);
+    const items = wrapper.find(UploadStatus);
+
+    expect(items.at(0).html()).toContain('Uploading');
+    expect(items.at(0).prop('isHighlighted')).toBeTruthy();
+    expect(items.at(0).prop('statusIcon')).toEqual(statusIconKey.LOADER);
+
+    expect(items.at(1).html()).toContain('Processing');
+    expect(items.at(1).prop('isHighlighted')).not.toBeTruthy();
+    expect(items.at(1).prop('statusIcon')).not.toBeDefined();
+
+    expect(items.at(2).html()).toContain('Ready');
+    expect(items.at(2).prop('isHighlighted')).not.toBeTruthy();
+    expect(items.at(2).prop('statusIcon')).not.toBeDefined();
+  });
+
+  it('renders the status list for PROCESSING', () => {
+    const wrapper = shallow(<UploadStatusList state={PROCESSING} />);
+    const items = wrapper.find(UploadStatus);
+
+    expect(items.at(0).html()).toContain('Uploaded');
+    expect(items.at(0).prop('isHighlighted')).not.toBeTruthy();
+    expect(items.at(0).prop('statusIcon')).toEqual(statusIconKey.TICK);
+
+    expect(items.at(1).html()).toContain('Processing');
+    expect(items.at(1).prop('isHighlighted')).toBeTruthy();
+    expect(items.at(1).prop('statusIcon')).toEqual(statusIconKey.LOADER);
+
+    expect(items.at(2).html()).toContain('Ready');
+    expect(items.at(2).prop('isHighlighted')).not.toBeTruthy();
+    expect(items.at(2).prop('statusIcon')).not.toBeDefined();
+  });
+
+  it('renders the status list for READY', () => {
+    const wrapper = shallow(<UploadStatusList state={READY} />);
+    const items = wrapper.find(UploadStatus);
+
+    expect(items.at(0).html()).toContain('Uploaded');
+    expect(items.at(0).prop('isHighlighted')).not.toBeTruthy();
+    expect(items.at(0).prop('statusIcon')).toEqual(statusIconKey.TICK);
+
+    expect(items.at(1).html()).toContain('Processed');
+    expect(items.at(1).prop('isHighlighted')).not.toBeTruthy();
+    expect(items.at(1).prop('statusIcon')).toEqual(statusIconKey.TICK);
+
+    expect(items.at(2).html()).toContain('Ready');
+    expect(items.at(2).prop('isHighlighted')).toBeTruthy();
+    expect(items.at(2).prop('statusIcon')).toEqual(statusIconKey.TICK);
+  });
+
+  it('renders the status list for ERROR', () => {
+    const wrapper = shallow(<UploadStatusList state={ERROR} />);
+    const items = wrapper.find(UploadStatus);
+
+    expect(items.at(0).html()).toContain('Uploading');
+    expect(items.at(0).prop('isHighlighted')).not.toBeTruthy();
+    expect(items.at(0).prop('statusIcon')).not.toBeDefined();
+
+    expect(items.at(1).html()).toContain('Processing');
+    expect(items.at(1).prop('isHighlighted')).not.toBeTruthy();
+    expect(items.at(1).prop('statusIcon')).not.toBeDefined();
+
+    expect(items.at(2).html()).toContain('Ready');
+    expect(items.at(2).prop('isHighlighted')).not.toBeTruthy();
+    expect(items.at(2).prop('statusIcon')).not.toBeDefined();
+  });
+});

--- a/front/components/UploadStatusList/UploadStatusList.tsx
+++ b/front/components/UploadStatusList/UploadStatusList.tsx
@@ -1,0 +1,104 @@
+import * as React from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+import styled from 'styled-components';
+
+import { videoState } from '../../types/Video';
+import { colors } from '../../utils/theme/theme';
+import { statusIconKey, UploadStatus } from './UploadStatus';
+
+const { PROCESSING, READY, UPLOADING } = videoState;
+
+const messages = defineMessages({
+  statusProcessed: {
+    defaultMessage: 'Processed',
+    description: 'Status information for a video/audio/subtitle track',
+    id: 'components.UploadStatusList.statusProcessed',
+  },
+  statusProcessing: {
+    defaultMessage: 'Processing',
+    description: 'Status information for a video/audio/subtitle track',
+    id: 'components.UploadStatusList.statusProcessing',
+  },
+  statusReady: {
+    defaultMessage: 'Ready',
+    description: 'Status information for a video/audio/subtitle track',
+    id: 'components.UploadStatusList.statusReady',
+  },
+  statusUploaded: {
+    defaultMessage: 'Uploaded',
+    description: 'Status information for a video/audio/subtitle track',
+    id: 'components.UploadStatusList.statusUploaded',
+  },
+  statusUploading: {
+    defaultMessage: 'Uploading',
+    description: 'Status information for a video/audio/subtitle track',
+    id: 'components.UploadStatusList.statusUploading',
+  },
+});
+
+const UploadStatusListStyled = styled.ul`
+  display: flex;
+  justify-items: justified;
+  margin: 0;
+  padding: 1rem 0;
+  list-style-type: none;
+  background: ${colors.mediumGray.main};
+`;
+
+/** Props shape for the UploadStatusList component. */
+export interface UploadStatusListProps {
+  state: videoState;
+}
+
+/** Component. Displays the list of statuses for an upload, showing (and/or highlighting)
+ * the relevant one, along with relevant status icon(s).
+ * @param state The current state of the video/track upload.
+ */
+export class UploadStatusList extends React.Component<UploadStatusListProps> {
+  render() {
+    const { state } = this.props;
+
+    return (
+      <UploadStatusListStyled>
+        <UploadStatus
+          isHighlighted={state === UPLOADING}
+          statusIcon={
+            state === UPLOADING
+              ? statusIconKey.LOADER
+              : [PROCESSING, READY].includes(state)
+                ? statusIconKey.TICK
+                : undefined
+          }
+        >
+          <FormattedMessage
+            {...([PROCESSING, READY].includes(state)
+              ? messages.statusUploaded
+              : messages.statusUploading)}
+          />
+        </UploadStatus>
+        <UploadStatus
+          isHighlighted={state === PROCESSING}
+          statusIcon={
+            state === PROCESSING
+              ? statusIconKey.LOADER
+              : state === READY
+                ? statusIconKey.TICK
+                : undefined
+          }
+        >
+          <FormattedMessage
+            {...(state === READY
+              ? messages.statusProcessed
+              : messages.statusProcessing)}
+          />
+        </UploadStatus>
+        <UploadStatus
+          isHighlighted={state === READY}
+          statusIcon={state === READY ? statusIconKey.TICK : undefined}
+        >
+          <FormattedMessage {...messages.statusReady} />
+        </UploadStatus>
+      </UploadStatusListStyled>
+    );
+  }
+}

--- a/front/testSetup.ts
+++ b/front/testSetup.ts
@@ -3,6 +3,9 @@ import Adapter from 'enzyme-adapter-react-16';
 
 Enzyme.configure({ adapter: new Adapter() });
 
+// Jest helpers for styled-components
+import 'jest-styled-components';
+
 // Utility function to allow flushing of all outstanding (completed) promises
 // Use it like this :
 //    const asyncValue = someFunction();

--- a/front/types/Video.ts
+++ b/front/types/Video.ts
@@ -1,11 +1,28 @@
+/** Possible sizes for a video file or stream. Used as keys in lists of files. */
 export type videoSize = '144' | '240' | '480' | '720' | '1080';
 
+/** Possible states for a video.
+ *
+ * NB: PENDING, PROCESSING, READY and ERROR are the actual possible values
+ * for the state field on a video record.
+ *
+ * UPLOADING does not exist as a video state on the backend side, as during
+ * upload the model value for the state is still PENDING. However, here
+ * on the frontend, they are two different states as far as the user is concerned.
+ *
+ * We add it in to make it easier to work with those states. It should not actually be
+ * applied on any Video but will be used as a stand-in wherever we're passing
+ * video state without the full video and need to represent this state.
+ */
 export enum videoState {
   ERROR = 'error',
   PENDING = 'pending',
+  PROCESSING = 'processing',
   READY = 'ready',
+  UPLOADING = 'uploading',
 }
 
+/** A Video record as it exists on the backend. */
 export interface Video {
   description: string;
   id: string;

--- a/front/utils/theme/theme.ts
+++ b/front/utils/theme/theme.ts
@@ -1,4 +1,9 @@
-export type colorName = 'darkGray' | 'lightGray' | 'mediumGray' | 'primary';
+export type colorName =
+  | 'darkGray'
+  | 'lightGray'
+  | 'mediumGray'
+  | 'mediumTextGray'
+  | 'primary';
 
 export interface Color {
   contrast: string;
@@ -17,6 +22,10 @@ export const colors: { [clr in colorName]: Color } = {
   mediumGray: {
     contrast: '#dee2e6',
     main: '#ced4da',
+  },
+  mediumTextGray: {
+    contrast: '#949ca4',
+    main: '#6e7881',
   },
   primary: {
     contrast: '#0069d9',

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "enzyme-adapter-react-16": "1.2.0",
     "fetch-mock": "6.5.2",
     "jest": "23.4.2",
+    "jest-styled-components": "6.2.1",
     "prettier": "1.14.0",
     "source-map-loader": "0.2.3",
     "style-loader": "0.22.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1771,6 +1771,15 @@ css-what@2.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.0.tgz#9467d032c38cfaefb9f2d79501253062f87fa1bd"
 
+css@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/css/-/css-2.2.4.tgz#c646755c73971f2bba6a601e2cf2fd71b1298929"
+  dependencies:
+    inherits "^2.0.3"
+    source-map "^0.6.1"
+    source-map-resolve "^0.5.2"
+    urix "^0.1.0"
+
 cssesc@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-0.1.0.tgz#c814903e45623371a0477b40109aaafbeeaddbb4"
@@ -3384,6 +3393,12 @@ jest-snapshot@^23.4.2:
     natural-compare "^1.4.0"
     pretty-format "^23.2.0"
     semver "^5.5.0"
+
+jest-styled-components@6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/jest-styled-components/-/jest-styled-components-6.2.1.tgz#63d28c6bf637977509f0e6a57bff0a10f44a48e3"
+  dependencies:
+    css "^2.2.4"
 
 jest-util@^23.4.0:
   version "23.4.0"
@@ -5107,7 +5122,7 @@ source-map-loader@0.2.3:
     loader-utils "~0.2.2"
     source-map "~0.6.1"
 
-source-map-resolve@^0.5.0:
+source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.2.tgz#72e2cc34095543e43b2c62b2c4c10d4a9054f259"
   dependencies:


### PR DESCRIPTION
## Purpose

In our dashboard (or elsewhere, later on), we'll need to display the status of an upload along our pipeline, from the initial PENDING to READY or error through all our steps.

## Proposal

- [x] build a component to show the current state and where it's located in the pipeline through a single property
- [x] fix the `<Loader />` component (used by `<UploadStateList />`


NB: actual dashboard to follow in a subsequent PR