### PR TITLE
Add a higher-order component to route to a view

### DIFF
--- a/front/components/withLink/withLink.tsx
+++ b/front/components/withLink/withLink.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import { withRouter } from 'react-router';
+
+interface WithLinkprops {
+  to: string;
+}
+
+/** Wraps a component to allow it to link to a view using react-router.
+ * Uses react-router "history" to ensure the app state remains consistent.
+ * @param WrappedComponent the component to add a link to.
+ * @returns a wrapper which takes the same props as the Wrapped component, plus `to` as a link destination.
+ */
+export function withLink<P extends object>(
+  WrappedComponent: React.ComponentType<P & React.DOMAttributes<any>>,
+) {
+  return class extends React.Component<P & WithLinkprops> {
+    render() {
+      const InnerWrapper = withRouter(props => (
+        <WrappedComponent
+          {...this.props}
+          onClick={() => props.history.push(this.props.to)}
+        />
+      ));
+      return <InnerWrapper />;
+    }
+  };
+}


### PR DESCRIPTION
## Purpose

`react-router` does not provide any straightforward way to imperatively navigate to a route as needed.

This can be needed in some circumstances, most notably when we want to use something else than an <a> element as a link, and style it at the same time.

`react-router` & `styled-components` do not play nice together as we would end up with either dropped styles, an extra element in the DOM, or broken types.

We need this as we're using `Button`s as links to views in our incoming `Dashboard` component.

## Proposal

Take advantage of `withRouter` to write a more specialized HOC to enable us to add a link to any component.

With this helper, we can easily add a navigating onClick handler to any element, including a styled element.

NB: types may be imperfect as this was somewhat clunky to type, and tests are missing as they were too challenging to write in a reasonable amount of time.