### PR TITLE
Enforce presence of all authors in CONTRIBUTORS.md

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,10 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Check presence of all commit authors in CONTRIBUTORS.md file
+          command: |
+            for contributor in $(git log --pretty="format:%ae" 33587e4faee29ef55d0c8e8dd96eaa4989ea714a.. | sort | uniq ); do grep $contributor CONTRIBUTORS.md; done
+      - run:
           name: Check absence of fixup commits
           command: |
             ! git log | grep 'fixup!'

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,8 +1,8 @@
-Marsha contributors (sorted alphabetically)
-============================================
+# Marsha contributors (sorted alphabetically)
+# Please make sure you insert here the email with which your git is configured
 
-* [Stéphane Angel](https://github.com/twidi)
-* [Mehdi Benadda](https://github.com/mbenadda)
-* [Julien Maupetit](https://github.com/jmaupetit)
-* [Richard Moch](https://github.com/rmoch)
-* [Samuel Paccoud](https://github.com/sampaccoud)
+- [Stéphane Angel](https://github.com/twidi) <s.angel@twidi.com>
+- [Mehdi Benadda](https://github.com/mbenadda) <me@mbenadda.com>
+- [Julien Maupetit](https://github.com/jmaupetit) <julien@maupetit.net>
+- [Richard Moch](https://github.com/rmoch) <richard.moch@gmail.com>
+- [Samuel Paccoud](https://github.com/sampaccoud) <samuel.paccoud@fun-mooc.fr>


### PR DESCRIPTION
## Purpose

In Github issue #91, @xanderyzwich suggested we should add a tool to our build to make sure our list of contributors in CONTRIBUTORS.md is always up-to-date. 

## Proposal

This is a tentative to add such a check via a command line run in CircleCI that fails if the author of one of the commit contained in a PR is not included in the CONTRIBUTORS.md file.

My proposal requires adding the contributors' emails to the CONTRIBUTORS.md files.

Fixes #91
