### PR TITLE
Allow configuring logging via an environment variable

### DIFF
--- a/marsha/settings.py
+++ b/marsha/settings.py
@@ -149,6 +149,9 @@ class Base(Configuration):
 
     VIDEO_RESOLUTIONS = [144, 240, 480, 720, 1080]
 
+    # Logging
+    LOGGING = values.DictValue({"version": 1})
+
     # AWS
     AWS_ACCESS_KEY_ID = values.SecretValue()
     AWS_SECRET_ACCESS_KEY = values.SecretValue()


### PR DESCRIPTION
## Purpose

We should be able to configure logging via an environment variable.

## Proposal

We assign a django-configuration's DictValue to the LOGGING setting.
The string passed as environment variable will be evaluated using ast.literal_eval() and can thus be formatted as Python dictionary.
