### PR TITLE
🐛(devtools) add an oauth_consumer_key field to the development view form

### DIFF
--- a/src/backend/marsha/core/templates/core/lti_development.html
+++ b/src/backend/marsha/core/templates/core/lti_development.html
@@ -48,6 +48,7 @@
       <input type="text" name="resource_link_id" value="example.com-df7" />
       <input type="text" name="context_id" value="course-v1:ufr+mathematics+0001" />
       <input type="text" name="roles" value="Instructor" />
+      <input type="text" name="oauth_consumer_key" placeholder="Consumer key" required />
       <input type="submit" />
     </form>
 
@@ -64,6 +65,7 @@
       <input type="text" name="resource_link_id" value="example.com-df7" />
       <input type="text" name="context_id" value="course-v1:ufr+mathematics+0001" />
       <input type="text" name="roles" value="Instructor" />
+      <input type="text" name="oauth_consumer_key" placeholder="Consumer key" required />
       <input type="submit" />
     </form>
   </section>


### PR DESCRIPTION
## Purpose

After changes in the way informations from the LTI request are collected and used, the Django backend is now using the consumer key to retrieve the passport, and, from there, the consumer site.

This means we cannot just bypass LTI checks in development and hand over a consumer site that will work out of the box. We need the LTI request to pass an oauth consumer key that matches to a real passport with a linked consumer site in the database.

## Proposal

Add an `oauth_consumer_key` field to our mock LTI forms in the development view.
