### PR TITLE
🐛(terraform) change expected file name in lambda terraform file

### DIFF
--- a/src/aws/lambda.tf
+++ b/src/aws/lambda.tf
@@ -82,8 +82,8 @@ resource "aws_lambda_function" "marsha_update_state_lambda" {
   function_name    = "${terraform.workspace}-marsha-update-state"
   handler          = "index.handler"
   runtime          = "nodejs8.10"
-  filename         = "dist/marsha_update_state.zip"
-  source_code_hash = "${base64sha256(file("dist/marsha_update_state.zip"))}"
+  filename         = "dist/marsha_update-state.zip"
+  source_code_hash = "${base64sha256(file("dist/marsha_update-state.zip"))}"
   role             = "${aws_iam_role.lambda_invocation_role.arn}"
 
   environment {


### PR DESCRIPTION
## Purpose

`make lambda` generated zip file and the name used in terraform lambda config file are not
the same.

## Proposal

I changed the terraform config to use the goog file name