### PR TITLE
✨(makefile) create a stop task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,3 +125,11 @@ bootstrap: env.d/development ## Prepare Docker images for the project
 .PHONY: run
 run: ## start the development server using Docker
 	@$(COMPOSE) up -d
+
+.PHONY: stop
+stop: ## stop the development server using Docker
+	@$(COMPOSE) stop
+
+.PHONY: down
+down: ## Stop and remove containers, networks, images, and volumes
+	@$(COMPOSE) down	


### PR DESCRIPTION
## Purpose

It is not possible to stop containers using make command. As it is possible to start them with make I think it should be great to stop them the same way.

## Proposal

Create a stop task to stop all running containers.

