### PR TITLE
🐛(app) update default cloudfront private key path

### DIFF
--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -163,7 +163,7 @@ class Base(Configuration):
     CLOUDFRONT_URL = values.SecretValue()
     CLOUDFRONT_ACCESS_KEY_ID = values.Value(None)
     CLOUDFRONT_PRIVATE_KEY_PATH = values.Value(
-        os.path.join(BASE_DIR, "..", ".ssh", "cloudfront_private_key")
+        os.path.join(BASE_DIR, "..", "..", "..", ".ssh", "cloudfront_private_key")
     )
     CLOUDFRONT_SIGNED_URLS_ACTIVE = True
     CLOUDFRONT_SIGNED_URLS_VALIDITY = 2 * 60 * 60  # 2 hours


### PR DESCRIPTION
## Purpose

The default cloudfront private key path is not the good one since backend application has moved is `src/backend/marsha`. When you retrieve a video, it fails with this error : `MissingRSAKey at /lti-video/`

## Proposal

fix the default value with the good path but I don't know if I did it well or not

