### PR TITLE
🐛(front) video is nullable in AppData interface

### DIFF
--- a/src/frontend/components/App/App.spec.tsx
+++ b/src/frontend/components/App/App.spec.tsx
@@ -23,7 +23,7 @@ describe('<App />', () => {
             if (updateVideo) {
               doUpdateVideo = updateVideo;
             }
-            getCurrentVideo = () => video;
+            getCurrentVideo = () => video!;
             return <div />;
           }}
         </AppDataContext.Consumer>

--- a/src/frontend/components/AppRoutes/AppRoutes.tsx
+++ b/src/frontend/components/AppRoutes/AppRoutes.tsx
@@ -23,7 +23,7 @@ export const AppRoutes = () => {
           path={PLAYER_ROUTE()}
           render={() => (
             <AppDataContext.Consumer>
-              {({ video }) => <VideoPlayer video={video} />}
+              {({ video }) => <VideoPlayer video={video!} />}
             </AppDataContext.Consumer>
           )}
         />
@@ -33,7 +33,7 @@ export const AppRoutes = () => {
           render={() => (
             <AppDataContext.Consumer>
               {({ jwt, updateVideo, video }) => (
-                <VideoForm jwt={jwt} updateVideo={updateVideo} video={video} />
+                <VideoForm jwt={jwt} updateVideo={updateVideo} video={video!} />
               )}
             </AppDataContext.Consumer>
           )}
@@ -48,7 +48,7 @@ export const AppRoutes = () => {
           path={DASHBOARD_ROUTE()}
           render={() => (
             <AppDataContext.Consumer>
-              {({ jwt, video }) => <Dashboard jwt={jwt} video={video} />}
+              {({ jwt, video }) => <Dashboard jwt={jwt} video={video!} />}
             </AppDataContext.Consumer>
           )}
         />

--- a/src/frontend/components/RedirectOnLoad/RedirectOnLoad.tsx
+++ b/src/frontend/components/RedirectOnLoad/RedirectOnLoad.tsx
@@ -23,12 +23,12 @@ export const RedirectOnLoad = () => {
           return <Redirect push to={ERROR_ROUTE('lti')} />;
         }
         // Everyone gets the video when it exists (so that instructors see the iframes like a student would by default)
-        else if (video.state === videoState.READY) {
+        else if (video && video.state === videoState.READY) {
           return <Redirect push to={PLAYER_ROUTE()} />;
         }
         // Only instructors are allowed to interact with a non-ready video
         else if (state === 'instructor') {
-          if (video.state === videoState.PENDING) {
+          if (video!.state === videoState.PENDING) {
             return <Redirect push to={FORM_ROUTE()} />;
           } else {
             return <Redirect push to={DASHBOARD_ROUTE()} />;

--- a/src/frontend/types/AppData.ts
+++ b/src/frontend/types/AppData.ts
@@ -1,3 +1,4 @@
+import { Nullable } from '../utils/types';
 import { AWSPolicy } from './AWSPolicy';
 import { Video } from './Video';
 
@@ -6,7 +7,7 @@ export interface AppData {
   policy?: AWSPolicy;
   resourceLinkid: string;
   state: 'error' | 'instructor' | 'student';
-  video: Video;
+  video: Nullable<Video>;
 
   updateVideo?: (video: Video) => void;
 }


### PR DESCRIPTION
## Purpose

When a student retrieves a video never created an exception is raised
and a white page display. 

## Proposal

To prevent this, video should be nullable in AppData interface and deal with this contraint in RedirectOnLoad component. In other component and usage of `AppData.video` I use the `!` notation because I am sure that video is not null.
