### PR TITLE
Fix & test docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,12 @@ jobs:
       - run:
           name: Check built image availability
           command: docker images "marsha:${CIRCLE_SHA1}*"
+      - run:
+          name: Test running production image
+          command: ./docker/tests/run.sh marsha ${CIRCLE_SHA1}
+      - run:
+          name: Test statics location in production image
+          command: ./docker/tests/statics.sh marsha ${CIRCLE_SHA1}
       # Since we cannot rely on CircleCI's Docker layers cache (for obscure
       # reasons some subsequent jobs will benefit from a previous job cache and
       # some others won't), we choose to save built docker images in cached
@@ -241,7 +247,7 @@ jobs:
                 dockerize \
                   -wait tcp://db:5432 \
                   -timeout 60s \
-                    python src/backend/manage.py test
+                    python manage.py test
 
   # ---- Front-end jobs ----
   build-front:
@@ -405,6 +411,12 @@ jobs:
           name: List available images
           command: docker images marsha
       - run:
+          name: Test running alpine production image
+          command: ./docker/tests/run.sh marsha ${CIRCLE_SHA1}-alpine
+      - run:
+          name: Test statics location in alpine production image
+          command: ./docker/tests/statics.sh marsha ${CIRCLE_SHA1}-alpine
+      - run:
           name: Store docker image in cache
           command: |
             docker save \
@@ -440,7 +452,7 @@ jobs:
                 dockerize \
                   -wait tcp://db:5432 \
                   -timeout 60s \
-                    python src/backend/manage.py test
+                    python manage.py test
 
   # ---- DockerHub publication job ----
   hub:
@@ -470,8 +482,7 @@ jobs:
       #   - DOCKER_PASS
       - run:
           name: Login to DockerHub
-          command:
-            echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
+          command: echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
 
       # Tag docker images with the same pattern used in Git (Semantic Versioning)
       #

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,7 @@ jobs:
               -f docker/compose/ci/docker-compose.yml \
               --project-directory . \
               run --rm --no-deps app \
-                isort --recursive --check-only src/backend/marsha
+                isort --recursive --check-only marsha
 
   lint-flake8:
     machine: true
@@ -165,7 +165,7 @@ jobs:
               -f docker/compose/ci/docker-compose.yml \
               --project-directory . \
               run --rm --no-deps app \
-                flake8 src/backend/marsha
+                flake8 marsha
 
   lint-pylint:
     machine: true
@@ -187,7 +187,7 @@ jobs:
               -f docker/compose/ci/docker-compose.yml \
               --project-directory . \
               run --rm --no-deps app \
-                pylint --rcfile=src/backend/pylintrc src/backend/marsha
+                pylint --rcfile=pylintrc marsha
 
   lint-black:
     machine: true
@@ -209,7 +209,7 @@ jobs:
               -f docker/compose/ci/docker-compose.yml \
               --project-directory . \
               run --rm --no-deps app \
-                black src/backend/marsha/ --check
+                black marsha/ --check
 
   test-back:
     machine: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,9 +50,9 @@ COPY --from=back-builder /install /usr/local
 COPY . /app/
 
 # Copy front-end dependencies
-COPY --from=front-builder /app/marsha/static /app/marsha/static
+COPY --from=front-builder /app/marsha/static /app/src/backend/marsha/static
 
-WORKDIR /app
+WORKDIR /app/src/backend
 
 # Gunicorn
 RUN mkdir -p /usr/local/etc/gunicorn

--- a/Makefile
+++ b/Makefile
@@ -40,53 +40,53 @@ lint: lint-isort lint-black lint-flake8 lint-pylint
 .PHONY: check-black
 check-black:  ## Run the black tool in check mode only (won't modify files)
 	@echo "$(BOLD)Checking black$(RESET)"
-	@$(COMPOSE_TEST_RUN_APP) black --check src/backend/marsha/ 2>&1
+	@$(COMPOSE_TEST_RUN_APP) black --check marsha/ 2>&1
 
 .PHONY: lint-black
 lint-black:  ## Run the black tool and update files that need to
 	@echo "$(BOLD)Running black$(RESET)"
-	@$(COMPOSE_TEST_RUN_APP) black src/backend/marsha/
+	@$(COMPOSE_TEST_RUN_APP) black marsha/
 
 .PHONY: lint-flake8
 lint-flake8:  ## Run the flake8 tool
 	@echo "$(BOLD)Running flake8$(RESET)"
-	@$(COMPOSE_TEST_RUN_APP) flake8 src/backend/marsha --format=abspath
+	@$(COMPOSE_TEST_RUN_APP) flake8 marsha --format=abspath
 
 .PHONY: lint-pylint
 lint-pylint:  ## Run the pylint tool
 	@echo "$(BOLD)Running pylint$(RESET)"
-	@$(COMPOSE_TEST_RUN_APP) pylint --rcfile=src/backend/pylintrc src/backend/marsha
+	@$(COMPOSE_TEST_RUN_APP) pylint --rcfile=pylintrc marsha
 
 .PHONY: lint-isort
 lint-isort:  ## automatically re-arrange python imports in code base
 	@echo "$(BOLD)Running isort$(RESET)"
-	@$(COMPOSE_TEST_RUN_APP) isort src/backend/marsha --recursive --atomic
+	@$(COMPOSE_TEST_RUN_APP) isort marsha --recursive --atomic
 
 .PHONY: check-django
 check-django:  ## Run the Django "check" command
 	@echo "$(BOLD)Checking django$(RESET)"
-	@$(COMPOSE_TEST_RUN_APP) python src/backend/manage.py check
+	@$(COMPOSE_TEST_RUN_APP) python manage.py check
 
 .PHONY: check-migrations
 check-migrations:  ## Check that all needed migrations exist
 	@echo "$(BOLD)Checking migrations$(RESET)"
-	@$(COMPOSE_TEST_RUN_APP) python src/backend/manage.py makemigrations --check --dry-run
+	@$(COMPOSE_TEST_RUN_APP) python manage.py makemigrations --check --dry-run
 
 .PHONY: migrate
 migrate:  ## Run django migration for the marsha project.
 	@echo "$(BOLD)Running migrations$(RESET)"
-	@$(COMPOSE_RUN_APP) python src/backend/manage.py migrate
+	@$(COMPOSE_RUN_APP) python manage.py migrate
 
 superuser: ## create a Django superuser
 	@echo "$(BOLD)Creating a Django superuser$(RESET)"
-	@$(COMPOSE_RUN_APP) python src/backend/manage.py createsuperuser
+	@$(COMPOSE_RUN_APP) python manage.py createsuperuser
 .PHONY: superuser
 
 .PHONY: test
 test:  ## Run django tests for the marsha project.
 	@echo "$(BOLD)Running tests$(RESET)"
 	# we use a test-runner that does not run the django check command as its done in another job
-	@$(COMPOSE_TEST_RUN_APP) python src/backend/manage.py test src/backend --testrunner marsha.test_runner.NoCheckDiscoverRunner
+	@$(COMPOSE_TEST_RUN_APP) python manage.py test --testrunner marsha.test_runner.NoCheckDiscoverRunner
 
 
 ##############################################
@@ -132,4 +132,4 @@ stop: ## stop the development server using Docker
 
 .PHONY: down
 down: ## Stop and remove containers, networks, images, and volumes
-	@$(COMPOSE) down	
+	@$(COMPOSE) down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: postgres:10.3
     env_file: env.d/development
     ports:
-        - "5452:5432"
+      - "5452:5432"
 
   # We use our production image as a basis for the development image, hence, we
   # define a "base" service upon which the "app" service depends to force
@@ -28,9 +28,9 @@ services:
     # django development server (wrapped by dockerize to ensure the db is ready
     # to accept connections before running the development server)
     command: >
-      dockerize -wait tcp://db:5432 -timeout 60s python ./src/backend/manage.py runserver 0.0.0.0:8000
+      dockerize -wait tcp://db:5432 -timeout 60s python manage.py runserver 0.0.0.0:8000
     ports:
-        - "8060:8000"
+      - "8060:8000"
     volumes:
       - .:/app
       - ./data/static:/data/static

--- a/docker/images/alpine/Dockerfile
+++ b/docker/images/alpine/Dockerfile
@@ -23,10 +23,10 @@ FROM base as back-builder
 # Install development libraries required for compiled python dependencies (lxml,
 # Pillow and psycopg2)
 RUN apk --no-cache add --update \
-        gcc \
-        libffi-dev \
-        musl-dev \
-        postgresql-dev && \
+    gcc \
+    libffi-dev \
+    musl-dev \
+    postgresql-dev && \
     rm -rf /var/cache/apk/*
 
 WORKDIR /install
@@ -34,7 +34,7 @@ WORKDIR /install
 COPY src/backend/setup.cfg /setup.cfg
 
 RUN python -c "import configparser; c = configparser.ConfigParser(); c.read('/setup.cfg'); \
-               print(c['options']['install_requires'])" | xargs pip install --prefix=/install
+    print(c['options']['install_requires'])" | xargs pip install --prefix=/install
 
 # ---- final application image ----
 FROM base
@@ -45,14 +45,14 @@ COPY --from=back-builder /install /usr/local
 # Install only (linked) libraries required for compiled python dependencies
 # (lxml, Pillow and psycopg2)
 RUN apk --no-cache add --update \
-        gcc \
-        postgresql && \
+    gcc \
+    postgresql && \
     rm -rf /var/cache/apk/*
 
 # Copy marsha application (see .dockerignore)
 COPY . /app/
 
-WORKDIR /app
+WORKDIR /app/src/backend
 
 # Gunicorn
 RUN mkdir -p /usr/local/etc/gunicorn

--- a/docker/images/alpine/Dockerfile
+++ b/docker/images/alpine/Dockerfile
@@ -36,6 +36,16 @@ COPY src/backend/setup.cfg /setup.cfg
 RUN python -c "import configparser; c = configparser.ConfigParser(); c.read('/setup.cfg'); \
     print(c['options']['install_requires'])" | xargs pip install --prefix=/install
 
+# ---- front-end builder image ----
+FROM node:9 as front-builder
+
+WORKDIR /app
+
+COPY ./src/frontend /app/
+
+RUN yarn install && \
+    yarn build -o marsha/static/js/index.js
+
 # ---- final application image ----
 FROM base
 
@@ -51,6 +61,9 @@ RUN apk --no-cache add --update \
 
 # Copy marsha application (see .dockerignore)
 COPY . /app/
+
+# Copy front-end dependencies
+COPY --from=front-builder /app/marsha/static /app/src/backend/marsha/static
 
 WORKDIR /app/src/backend
 

--- a/docker/images/alpine/dev/Dockerfile
+++ b/docker/images/alpine/dev/Dockerfile
@@ -15,19 +15,18 @@ RUN mkdir -p /data/{media,static}
 
 # Install curl
 RUN apk --no-cache add --update \
-        curl \
-        vim \
-        musl-dev  # required for Sphinx
+    curl \
+    vim \
+    musl-dev  # required for Sphinx
 
 # Install development dependencies
-RUN python -c "import configparser; c = configparser.ConfigParser(); c.read('src/backend/setup.cfg'); \
-               print(c['options.extras_require']['dev'])" | xargs pip install
+RUN pip install .[dev]
 
 # Install dockerize. It is used to ensure that the database service is accepting
 # connections before trying to access it from the main application.
 ENV DOCKERIZE_VERSION v0.6.1
 RUN curl -L \
-         --output dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-         https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
+    --output dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
     tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
     rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz

--- a/docker/images/dev/Dockerfile
+++ b/docker/images/dev/Dockerfile
@@ -13,18 +13,17 @@ USER root:root
 # Install vim
 RUN apt-get update && \
     apt-get install -y \
-        vim && \
+    vim && \
     rm -rf /var/lib/apt/lists/*
 
 # Install development dependencies
-RUN python -c "import configparser; c = configparser.ConfigParser(); c.read('src/backend/setup.cfg'); \
-               print(c['options.extras_require']['dev'])" | xargs pip install
+RUN pip install .[dev]
 
 # Install dockerize. It is used to ensure that the database service is accepting
 # connections before trying to access it from the main application.
 ENV DOCKERIZE_VERSION v0.6.1
 RUN curl -L \
-         --output dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-         https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
+    --output dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
     tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
     rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz

--- a/docker/tests/run.sh
+++ b/docker/tests/run.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# Test that the container can be running with the default command
+#
+# If the command fails this script will return a non-zero exit code (it should
+# be the gunicorn process exit code). Else, if it must send a kill signal after
+# 5 seconds, it will return a zero exit code, because it means that gunicorn has
+# booted with no errors and was running.
+
+MARSHA_IMAGE_NAME="${1:-marsha}"
+MARSHA_IMAGE_TAG="${2:-latest}"
+
+echo "Running image ${MARSHA_IMAGE_NAME}:${MARSHA_IMAGE_TAG}..."
+
+timeout --preserve-status -k 5s 5s \
+    docker run --rm --env-file=env.d/development.dist "${MARSHA_IMAGE_NAME}:${MARSHA_IMAGE_TAG}"
+
+exit_code=$?
+expected=137
+
+if [[ $exit_code -ne $expected ]]; then
+    echo "Test run: FAILED (exit code: $exit_code)"
+    exit $exit_code
+else
+    echo "Test run: SUCCEED"
+    exit 0
+fi

--- a/docker/tests/statics.sh
+++ b/docker/tests/statics.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# Ensure front-end build is bundled in the image
+#
+
+MARSHA_IMAGE_NAME="${1:-marsha}"
+MARSHA_IMAGE_TAG="${2:-latest}"
+
+echo "Test statics for image ${MARSHA_IMAGE_NAME}:${MARSHA_IMAGE_TAG}..."
+
+expected_statics_path="/app/src/backend/marsha/static/js/index.js"
+
+docker run --rm --env-file=env.d/development.dist "${MARSHA_IMAGE_NAME}:${MARSHA_IMAGE_TAG}" ls $expected_statics_path
+
+exit_code=$?
+expected=0
+
+if [[ $exit_code -ne $expected ]]; then
+    echo "Test statics: FAILED (exit code: $exit_code)"
+    exit $exit_code
+else
+    echo "Test statics: SUCCEED"
+    exit 0
+fi

--- a/src/backend/marsha/README.md
+++ b/src/backend/marsha/README.md
@@ -1,1 +1,0 @@
-../docs/README.md


### PR DESCRIPTION
## Purpose

Docker image default `CMD` (running `gunicorn`) is broken as the WSGI script moved to `src/backend/marsha`. Moreover, the front-end build cannot be collected.

## Proposal

- [x] Move the `WORKDIR` to the Django project root, _i.e._ `/app/src/backend`
- [x] Fix front-end build target path
- [x] Add functional docker tests

