### PR TITLE
♻️ (front) use an Enum for app state name

### DIFF
--- a/src/frontend/components/RedirectOnLoad/RedirectOnLoad.spec.tsx
+++ b/src/frontend/components/RedirectOnLoad/RedirectOnLoad.spec.tsx
@@ -18,6 +18,7 @@ jest.doMock('../App/App', () => {
 });
 
 import { Nullable } from 'utils/types';
+import { appState } from '../../types/AppData';
 import { videoState } from '../../types/Video';
 import { ROUTE as DASHBOARD_ROUTE } from '../Dashboard/Dashboard';
 import { ROUTE as ERROR_ROUTE } from '../ErrorComponent/ErrorComponent';
@@ -27,7 +28,7 @@ import { RedirectOnLoad } from './RedirectOnLoad';
 
 describe('<RedirectOnLoad />', () => {
   it('redirects to the error view on LTI error', () => {
-    context.state = 'error';
+    context.state = appState.ERROR;
     const wrapper = shallow(<RedirectOnLoad />).dive();
 
     expect(wrapper.name()).toEqual('Redirect');
@@ -36,7 +37,7 @@ describe('<RedirectOnLoad />', () => {
   });
 
   it('redirects instructors to the player when the video is ready', () => {
-    context.state = 'instructor';
+    context.state = appState.INSTRUCTOR;
     context.video = { state: videoState.READY };
     const wrapper = shallow(<RedirectOnLoad />).dive();
 
@@ -46,7 +47,7 @@ describe('<RedirectOnLoad />', () => {
   });
 
   it('redirects students to /player when the video is ready', () => {
-    context.state = 'student';
+    context.state = appState.STUDENT;
     context.video = { state: videoState.READY };
     const wrapper = shallow(<RedirectOnLoad />).dive();
 
@@ -56,7 +57,7 @@ describe('<RedirectOnLoad />', () => {
   });
 
   it('redirects instructors to /form when there is no video yet', () => {
-    context.state = 'instructor';
+    context.state = appState.INSTRUCTOR;
     context.video = { state: videoState.PENDING };
     const wrapper = shallow(<RedirectOnLoad />).dive();
 
@@ -66,7 +67,7 @@ describe('<RedirectOnLoad />', () => {
   });
 
   it('redirects instructors to /dashboard when there is a video undergoing processing', () => {
-    context.state = 'instructor';
+    context.state = appState.INSTRUCTOR;
     context.video = { state: videoState.PROCESSING };
     const wrapper = shallow(<RedirectOnLoad />).dive();
 
@@ -76,7 +77,7 @@ describe('<RedirectOnLoad />', () => {
   });
 
   it('redirects students to the error view when the video is not ready', () => {
-    context.state = 'student';
+    context.state = appState.STUDENT;
     context.video = { state: 'not_ready' };
     const wrapper = shallow(<RedirectOnLoad />).dive();
 
@@ -86,7 +87,7 @@ describe('<RedirectOnLoad />', () => {
   });
 
   it('redirects students to the error view when the video is null', () => {
-    context.state = 'student';
+    context.state = appState.STUDENT;
     context.video = null;
     const wrapper = shallow(<RedirectOnLoad />).dive();
 

--- a/src/frontend/components/RedirectOnLoad/RedirectOnLoad.tsx
+++ b/src/frontend/components/RedirectOnLoad/RedirectOnLoad.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Redirect } from 'react-router-dom';
 
+import { appState } from '../../types/AppData';
 import { videoState } from '../../types/Video';
 import { AppDataContext } from '../App/App';
 import { ROUTE as DASHBOARD_ROUTE } from '../Dashboard/Dashboard';
@@ -19,7 +20,7 @@ export const RedirectOnLoad = () => {
         const { state, video } = appData;
 
         // Get LTI errors out of the way
-        if (state === 'error') {
+        if (state === appState.ERROR) {
           return <Redirect push to={ERROR_ROUTE('lti')} />;
         }
         // Everyone gets the video when it exists (so that instructors see the iframes like a student would by default)
@@ -27,7 +28,7 @@ export const RedirectOnLoad = () => {
           return <Redirect push to={PLAYER_ROUTE()} />;
         }
         // Only instructors are allowed to interact with a non-ready video
-        else if (state === 'instructor') {
+        else if (state === appState.INSTRUCTOR) {
           if (video!.state === videoState.PENDING) {
             return <Redirect push to={FORM_ROUTE()} />;
           } else {

--- a/src/frontend/types/AppData.ts
+++ b/src/frontend/types/AppData.ts
@@ -2,11 +2,17 @@ import { Nullable } from '../utils/types';
 import { AWSPolicy } from './AWSPolicy';
 import { Video } from './Video';
 
+export enum appState {
+  ERROR = 'error',
+  INSTRUCTOR = 'instructor',
+  STUDENT = 'student',
+}
+
 export interface AppData {
   jwt: string;
   policy?: AWSPolicy;
   resourceLinkid: string;
-  state: 'error' | 'instructor' | 'student';
+  state: appState;
   video: Nullable<Video>;
 
   updateVideo?: (video: Video) => void;


### PR DESCRIPTION
## Purpose

to reflect changes made in our code base, an enum is used to represent
all the state the app can have. This will avoid typo and mistake.

## Proposal

use an enum to represent all the app state. We will have a single source of truth for those values.

