### PR TITLE
Fix an issue with VideoPlayer when the video is first ready

### DIFF
--- a/src/frontend/components/AppRoutes/AppRoutes.tsx
+++ b/src/frontend/components/AppRoutes/AppRoutes.tsx
@@ -48,7 +48,9 @@ export const AppRoutes = () => {
           path={DASHBOARD_ROUTE()}
           render={() => (
             <AppDataContext.Consumer>
-              {({ jwt, video }) => <Dashboard jwt={jwt} video={video!} />}
+              {({ jwt, updateVideo, video }) => (
+                <Dashboard jwt={jwt} updateVideo={updateVideo} video={video!} />
+              )}
             </AppDataContext.Consumer>
           )}
         />

--- a/src/frontend/components/Dashboard/Dashboard.spec.tsx
+++ b/src/frontend/components/Dashboard/Dashboard.spec.tsx
@@ -17,9 +17,14 @@ describe('<Dashboard />', () => {
     // Create a mock video with the initial state (PROCESSING)
     const mockVideo: any = { id: 'dd44', state: videoState.PROCESSING };
     fetchMock.mock('/api/videos/dd44/', mockVideo);
+    const mockUpdateVideo = jest.fn();
 
     const wrapper = shallow(
-      <Dashboard jwt={'cool_token_m8'} video={mockVideo} />,
+      <Dashboard
+        jwt={'cool_token_m8'}
+        updateVideo={mockUpdateVideo}
+        video={mockVideo}
+      />,
     );
 
     // Dashboard shows the video as PROCESSING
@@ -53,6 +58,10 @@ describe('<Dashboard />', () => {
     expect(wrapper.find(UploadStatusList).prop('state')).toEqual(
       videoState.READY,
     );
+    expect(mockUpdateVideo).toHaveBeenCalledWith({
+      id: 'dd44',
+      state: 'ready',
+    });
 
     // Unmount Dashboard to get rid of its interval
     wrapper.unmount();

--- a/src/frontend/components/Dashboard/Dashboard.tsx
+++ b/src/frontend/components/Dashboard/Dashboard.tsx
@@ -61,6 +61,7 @@ const DashboardInnerContainer = styled.div`
 export interface DashboardProps {
   isUploading?: boolean;
   jwt: string;
+  updateVideo?: (video: Video) => void;
   video: Video;
 }
 
@@ -75,6 +76,7 @@ interface DashboardState {
  * Will also be used to manage related tracks such as subtitles when they are available.
  * @param isUploading Whether the relevant video file is currently being uploaded.
  * @param jwt The token that will be used to fetch the video record from the server to update it.
+ * @param updateVideo Callback to update the video in App state.
  * @param video The video object from AppData. We need it to populate the component before polling starts.
  */
 export class Dashboard extends React.Component<DashboardProps, DashboardState> {
@@ -115,6 +117,12 @@ export class Dashboard extends React.Component<DashboardProps, DashboardState> {
       ) {
         // Disregard the server-provided video.
         return;
+      }
+      // When the video is ready, we need to update the App state so VideoForm has access to the URLs when it loads
+      else if (incomingVideo.state === videoState.READY) {
+        if (this.props.updateVideo) {
+          this.props.updateVideo(incomingVideo);
+        }
       }
       this.setState({ video: incomingVideo });
     } catch (error) {


### PR DESCRIPTION
## Purpose

When the upload is ready at the end of processing, the instructor can click on a "Watch Video" button to go to the player.

This is broken right now as the video object `<VideoPlayer />` receives from the App state is not up-to-date.

## Proposal

Add a call to App's `updateVideo` in `<Dashboard />` polling to ensure App state contains the most up-to-date video, including the URLs.
