### PR TITLE
Simulate an LTI launch request to test our LTI verification

### DIFF
--- a/src/backend/marsha/core/tests/test_lti.py
+++ b/src/backend/marsha/core/tests/test_lti.py
@@ -1,11 +1,13 @@
 """Test the LTI interconnection with Open edX."""
 import random
 from unittest import mock
+from urllib.parse import unquote
 
 from django.test import RequestFactory, TestCase
 from django.utils import timezone
 
 import oauth2
+from oauthlib import oauth1
 from pylti.common import LTIException, LTIOAuthServer
 
 from ..factories import (
@@ -28,6 +30,59 @@ class VideoLTITestCase(TestCase):
         """Override the setUp method to instanciate and serve a request factory."""
         super().setUp()
         self.factory = RequestFactory()
+
+    def test_lti_request_body(self):
+        """Simulate an LTI launch request with oauth in the body.
+
+        This test uses the oauthlib library to simulate an LTI launch request and make sure
+        that our LTI verification works.
+        """
+        passport = ConsumerSiteLTIPassportFactory(consumer_site__name="testserver")
+        lti_parameters = {
+            "resource_link_id": "df7",
+            "context_id": "course-v1:ufr+mathematics+0001",
+            "roles": "Instructor",
+        }
+        url = "http://testserver/lti-video/"
+        client = oauth1.Client(
+            client_key=passport.oauth_consumer_key, client_secret=passport.shared_secret
+        )
+        # Compute Authorization header which looks like:
+        # Authorization: OAuth oauth_nonce="80966668944732164491378916897",
+        # oauth_timestamp="1378916897", oauth_version="1.0", oauth_signature_method="HMAC-SHA1",
+        # oauth_consumer_key="", oauth_signature="frVp4JuvT1mVXlxktiAUjQ7%2F1cw%3D"
+        _uri, headers, _body = client.sign(
+            url,
+            http_method="POST",
+            body=lti_parameters,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+
+        # Parse headers to pass to template as part of context:
+        oauth_dict = {
+            k: v
+            for k, v in [
+                param.strip().replace('"', "").split("=")
+                for param in headers["Authorization"].split(",")
+            ]
+        }
+        signature = oauth_dict["oauth_signature"]
+        oauth_dict["oauth_signature"] = unquote(signature)
+        oauth_dict["oauth_nonce"] = oauth_dict.pop("OAuth oauth_nonce")
+
+        lti_parameters.update(oauth_dict)
+        request = self.factory.post(url, lti_parameters)
+        lti = LTI(request)
+        self.assertEqual(lti.verify(), passport.consumer_site)
+
+        # If we alter the signature (e.g. add "a" to it), the verification should fail
+        oauth_dict["oauth_signature"] = "{:s}a".format(signature)
+
+        lti_parameters.update(oauth_dict)
+        request = self.factory.post(url, lti_parameters)
+        lti = LTI(request)
+        with self.assertRaises(LTIException):
+            lti.verify()
 
     def test_lti_video_instructor(self):
         """The instructor role should be identified even when a synonym is used."""

--- a/src/backend/marsha/core/tests/test_lti.py
+++ b/src/backend/marsha/core/tests/test_lti.py
@@ -124,7 +124,7 @@ class VideoLTITestCase(TestCase):
     @mock.patch.object(LTIOAuthServer, "verify_request", return_value=True)
     def test_lti_passport_consumer_site(self, mock_verify):
         """Authenticating an LTI launch request with a passport related to a consumer site."""
-        ConsumerSiteLTIPassportFactory(
+        passport = ConsumerSiteLTIPassportFactory(
             oauth_consumer_key="ABC123",
             shared_secret="#Y5$",
             consumer_site__name="example.com",
@@ -137,13 +137,13 @@ class VideoLTITestCase(TestCase):
         }
         request = self.factory.post("/", data)
         lti = LTI(request)
-        self.assertTrue(lti.verify())
+        self.assertEqual(lti.verify(), passport.consumer_site)
         self.assertEqual(mock_verify.call_count, 1)
 
     @mock.patch.object(LTIOAuthServer, "verify_request", return_value=True)
     def test_lti_passport_playlist(self, mock_verify):
         """Authenticating an LTI launch request with a passport related to a playlist."""
-        PlaylistLTIPassportFactory(
+        passport = PlaylistLTIPassportFactory(
             oauth_consumer_key="ABC123",
             shared_secret="#Y5$",
             playlist__consumer_site__name="example.com",
@@ -156,7 +156,7 @@ class VideoLTITestCase(TestCase):
         }
         request = self.factory.post("/", data)
         lti = LTI(request)
-        self.assertTrue(lti.verify())
+        self.assertEqual(lti.verify(), passport.playlist.consumer_site)
         self.assertEqual(mock_verify.call_count, 1)
 
     @mock.patch.object(LTIOAuthServer, "verify_request", side_effect=oauth2.Error)

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -39,7 +39,7 @@ install_requires =
     gunicorn==19.8.1
     # Warning from psycopg2 "The psycopg2 wheel package will be renamed from release 2.8" => psyopg2-binary
     psycopg2-binary==2.7.5
-    pylti
+    PyLTI==0.7.0
     sentry-sdk==0.4.0
 packages = find:
 package_dir =
@@ -71,6 +71,7 @@ dev =
     flake8-per-file-ignores==0.6
     ipython==6.4.0
     isort==4.3.4
+    oauthlib==2.1.0
     pycodestyle==2.3.1
     pylint==1.9.2
     pylint-django==0.11.1


### PR DESCRIPTION
## Purpose

Our LTI functionality is quite well tested but it assumes that the pylti library is working. As we want to remove this dependency, we start by adding tests that involve the whole LTI process without mocking.

## Proposal

We use oauthlib, an alternative oauth1 library, to calculate our signatures for the test because marsha uses oauth2 behind pylti so we should test it with another implementation. 

- [x] Add a test simulating an LTI launch request with oauth in request body