### PR TITLE
Make lambdas production ready

### DIFF
--- a/docs/env.md
+++ b/docs/env.md
@@ -270,6 +270,14 @@ Example: `https://example.com/api/update-state`.
 - Required: Yes
 - Default: None
 
+#### TF_VAR_update_state_disable_ssl_validation
+
+Whether SSL certificate validation in requests made by the AWS lambdas should be disabled. This allows Django to run on a domain with a self-signed or otherwise invalid certificate in non-production environments.
+
+- Type: boolean
+- Required: No
+- Default: false
+
 ## 3. Environment to create the state bucket in AWS
 
 Specified in `{REPO_ROOT}/src/aws/env.d/state_bucket`.

--- a/docs/env.md
+++ b/docs/env.md
@@ -99,7 +99,7 @@ Secrets used to sign messages sent to the Django backend from AWS lambdas (like 
 
 Note: should include the value from `TF_VAR_update_state_secret` in `src/aws` for any stack deployed to AWS which should communicate with the Django backend.
 
-- Type: comma-separated list of strings
+- Type: comma-separated list of strings <br> ⚠️ *ITEMS MUST NOT INCLUDE ANY COMMAS* as commas are used to separated items.
 - Required: Yes
 - Default: None
 
@@ -256,7 +256,7 @@ Secret used to sign messages exchanged between the Django backend & AWS lambdas.
 
 Note: should be included in the list of values declared in `DJANGO_UPDATE_STATE_SHARED_SECRETS` for the Django backend deployment with which our deployment's lambdas will communicate.
 
-- Type: string
+- Type: string <br> ⚠️ *MUST NOT INCLUDE ANY COMMAS* as the corresponding Django setting is a comma-separated list.
 - Required: Yes
 - Default: None
 

--- a/src/aws/env.d/development.dist
+++ b/src/aws/env.d/development.dist
@@ -7,5 +7,6 @@ AWS_SECRET_ACCESS_KEY=YourAwsSecretAccessKey
 # Terraform variables
 TF_VAR_cloudfront_trusted_signer_id=888888888888
 TF_VAR_aws_region=eu-west-1
+TF_VAR_update_state_disable_ssl_validation=false
 TF_VAR_update_state_secret=YourUpdateStateSecret
 TF_VAR_update_state_endpoint=https://example.com/update-state

--- a/src/aws/lambda-encode/src/updateState.js
+++ b/src/aws/lambda-encode/src/updateState.js
@@ -7,6 +7,7 @@ const request = require('request-promise-native');
 const crypto = require('crypto');
 
 const { ENDPOINT, SHARED_SECRET } = process.env;
+const DISABLE_SSL_VALIDATION = JSON.parse(process.env.DISABLE_SSL_VALIDATION);
 
 module.exports = async (key, state) => {
   const hmac = crypto.createHmac('sha256', SHARED_SECRET);
@@ -25,6 +26,7 @@ module.exports = async (key, state) => {
     body,
     json: true,
     method: 'POST',
+    strictSSL: DISABLE_SSL_VALIDATION ? false : true,
     uri: ENDPOINT,
   });
 

--- a/src/aws/lambda-encode/src/updateState.js
+++ b/src/aws/lambda-encode/src/updateState.js
@@ -1,4 +1,4 @@
-// DUPLICATE CODE: terraform/source/update_state/src/updateState
+// DUPLICATE CODE: src/aws/lambda-update-state/src/updateState
 /**
  * Post an update to the state of an object to any endpoint, using hmac with a shared secret
  * to sign the object key and provide authorization for the request.
@@ -13,12 +13,16 @@ module.exports = async (key, state) => {
   hmac.update(key);
   const signature = hmac.digest('hex');
 
+  const body = {
+    key,
+    signature,
+    state,
+  };
+
+  console.log(`Updating state: POST ${ENDPOINT} \n ${JSON.stringify(body)}`);
+
   await request({
-    body: {
-      key,
-      signature,
-      state,
-    },
+    body,
     json: true,
     method: 'POST',
     uri: ENDPOINT,

--- a/src/aws/lambda-encode/src/updateState.spec.js
+++ b/src/aws/lambda-encode/src/updateState.spec.js
@@ -7,13 +7,28 @@ const requestStub = jest.fn();
 jest.doMock('request-promise-native', () => requestStub);
 
 // Don't pollute tests with logs intended for CloudWatch
-jest.spyOn(console, 'log').mockReset();
+const mockConsoleLog = jest.spyOn(console, 'log');
 
 const updateState = require('./updateState');
 
 describe('lambda/update_state/src/updateState()', () => {
+  beforeEach(mockConsoleLog.mockReset);
+
   it('calculates the signature and posts the new state to the server', async () => {
     await updateState('successful object key', 'ready');
+
+    const anteLogArgument = mockConsoleLog.mock.calls[0][0];
+    expect(anteLogArgument).toContain(`Updating state: POST ${endpoint}`);
+    expect(anteLogArgument).toContain('successful object key');
+    expect(anteLogArgument).toContain(
+      'c39021355124558ee9300e4874c357c68dad40374b299eab747d5449b7572308',
+    );
+    expect(anteLogArgument).toContain('ready');
+
+    const postLogArgument = mockConsoleLog.mock.calls[1][0];
+    expect(postLogArgument).toEqual(
+      `Updated successful object key. New state is (ready).`,
+    );
 
     expect(requestStub).toHaveBeenCalledWith({
       body: {
@@ -33,8 +48,16 @@ describe('lambda/update_state/src/updateState()', () => {
       () => new Promise((resolve, reject) => reject('Failed!')),
     );
 
-    await expect(
-      updateState('successful object key', 'COMPLETE'),
-    ).rejects.toEqual('Failed!');
+    await expect(updateState('failed object key', 'ready')).rejects.toEqual(
+      'Failed!',
+    );
+
+    const anteLogArgument = mockConsoleLog.mock.calls[0][0];
+    expect(anteLogArgument).toContain(`Updating state: POST ${endpoint}`);
+    expect(anteLogArgument).toContain('failed object key');
+    expect(anteLogArgument).toContain(
+      '59e04fa0b3b72bb529d88d40d96bd6c306d8d7a6963d9ae9b912da5fdba6f25f',
+    );
+    expect(anteLogArgument).toContain('ready');
   });
 });

--- a/src/aws/lambda-update-state/src/updateState.js
+++ b/src/aws/lambda-update-state/src/updateState.js
@@ -1,4 +1,4 @@
-// DUPLICATE CODE: terraform/source/encode/src/updateState
+// DUPLICATE CODE: src/aws/lambda-encode/src/updateState
 /**
  * Post an update to the state of an object to any endpoint, using hmac with a shared secret
  * to sign the object key and provide authorization for the request.
@@ -13,12 +13,16 @@ module.exports = async (key, state) => {
   hmac.update(key);
   const signature = hmac.digest('hex');
 
+  const body = {
+    key,
+    signature,
+    state,
+  };
+
+  console.log(`Updating state: POST ${ENDPOINT} \n ${JSON.stringify(body)}`);
+
   await request({
-    body: {
-      key,
-      signature,
-      state,
-    },
+    body,
     json: true,
     method: 'POST',
     uri: ENDPOINT,

--- a/src/aws/lambda-update-state/src/updateState.js
+++ b/src/aws/lambda-update-state/src/updateState.js
@@ -7,6 +7,7 @@ const request = require('request-promise-native');
 const crypto = require('crypto');
 
 const { ENDPOINT, SHARED_SECRET } = process.env;
+const DISABLE_SSL_VALIDATION = JSON.parse(process.env.DISABLE_SSL_VALIDATION)
 
 module.exports = async (key, state) => {
   const hmac = crypto.createHmac('sha256', SHARED_SECRET);
@@ -25,6 +26,7 @@ module.exports = async (key, state) => {
     body,
     json: true,
     method: 'POST',
+    strictSSL: DISABLE_SSL_VALIDATION ? false : true,
     uri: ENDPOINT,
   });
 

--- a/src/aws/lambda-update-state/src/updateState.spec.js
+++ b/src/aws/lambda-update-state/src/updateState.spec.js
@@ -7,13 +7,28 @@ const requestStub = jest.fn();
 jest.doMock('request-promise-native', () => requestStub);
 
 // Don't pollute tests with logs intended for CloudWatch
-jest.spyOn(console, 'log').mockReset();
+const mockConsoleLog = jest.spyOn(console, 'log');
 
 const updateState = require('./updateState');
 
-describe('src/updateState()', () => {
+describe('lambda/update_state/src/updateState()', () => {
+  beforeEach(mockConsoleLog.mockReset);
+
   it('calculates the signature and posts the new state to the server', async () => {
     await updateState('successful object key', 'ready');
+
+    const anteLogArgument = mockConsoleLog.mock.calls[0][0];
+    expect(anteLogArgument).toContain(`Updating state: POST ${endpoint}`);
+    expect(anteLogArgument).toContain('successful object key');
+    expect(anteLogArgument).toContain(
+      'c39021355124558ee9300e4874c357c68dad40374b299eab747d5449b7572308',
+    );
+    expect(anteLogArgument).toContain('ready');
+
+    const postLogArgument = mockConsoleLog.mock.calls[1][0];
+    expect(postLogArgument).toEqual(
+      `Updated successful object key. New state is (ready).`,
+    );
 
     expect(requestStub).toHaveBeenCalledWith({
       body: {
@@ -33,8 +48,16 @@ describe('src/updateState()', () => {
       () => new Promise((resolve, reject) => reject('Failed!')),
     );
 
-    await expect(
-      updateState('successful object key', 'COMPLETE'),
-    ).rejects.toEqual('Failed!');
+    await expect(updateState('failed object key', 'ready')).rejects.toEqual(
+      'Failed!',
+    );
+
+    const anteLogArgument = mockConsoleLog.mock.calls[0][0];
+    expect(anteLogArgument).toContain(`Updating state: POST ${endpoint}`);
+    expect(anteLogArgument).toContain('failed object key');
+    expect(anteLogArgument).toContain(
+      '59e04fa0b3b72bb529d88d40d96bd6c306d8d7a6963d9ae9b912da5fdba6f25f',
+    );
+    expect(anteLogArgument).toContain('ready');
   });
 });

--- a/src/aws/lambda.tf
+++ b/src/aws/lambda.tf
@@ -57,6 +57,7 @@ resource "aws_lambda_function" "marsha_encode_lambda" {
 
   environment {
     variables = {
+      DISABLE_SSL_VALIDATION = "${var.update_state_disable_ssl_validation}"
       ENDPOINT = "${var.update_state_endpoint}"
       ENV_TYPE = "${terraform.workspace}"
       MEDIA_CONVERT_ROLE      = "${aws_iam_role.media_convert_role.arn}"
@@ -88,6 +89,7 @@ resource "aws_lambda_function" "marsha_update_state_lambda" {
 
   environment {
     variables = {
+      DISABLE_SSL_VALIDATION = "${var.update_state_disable_ssl_validation}"
       ENDPOINT = "${var.update_state_endpoint}"
       ENV_TYPE = "${terraform.workspace}"
       SHARED_SECRET = "${var.update_state_secret}"

--- a/src/aws/variables.tf
+++ b/src/aws/variables.tf
@@ -1,3 +1,9 @@
+
+variable "aws_region" {
+  type    = "string"
+  default = "eu-west-1"
+}
+
 variable "cloudfront_price_class" {
   type = "map"
 
@@ -10,9 +16,9 @@ variable "cloudfront_trusted_signer_id" {
   type = "string"
 }
 
-variable "aws_region" {
+variable "update_state_disable_ssl_validation" {
   type    = "string"
-  default = "eu-west-1"
+  default = "false"
 }
 
 variable "update_state_endpoint" {


### PR DESCRIPTION
## Purpose

We encountered several issues in our lambdas while deploying Marsha on different environments beyond developer machines.

This PR aims to fix those issues as we move forward with marsha deployments.

## Proposal

- [x] add more logging to lambda state update requests to the Django backend;
- [x] improve docs on the lambda-Django shared secret env variables;
- [x] add an env variable to disable SSL validation in lambdas.
