### PR TITLE
⚡(front) add helper in yarn script to run easily linters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -300,7 +300,7 @@ jobs:
             - v3-front-dependencies-{{ checksum "package.json" }}
       - run:
           name: Lint code with prettier
-          command: yarn prettier --list-different "**/*.+(ts|tsx|json|js|jsx)" --ignore-path "../.prettierignore"
+          command: yarn prettier
 
   test-front:
     docker:

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -8,6 +8,10 @@
     "build-dev": "yarn copy-iframe-resizer; yarn build",
     "copy-iframe-resizer": "cp node_modules/iframe-resizer/js/iframeResizer.min.js ../backend/marsha/static/js",
     "lint": "tslint -c tslint.json '**/*.ts?(x)' -e 'node_modules/**/*'",
+    "lint-fix": "tslint --fix -c tslint.json '**/*.ts?(x)' -e 'node_modules/**/*'",
+    "prettier": "prettier --list-different '**/*.+(ts|tsx|json|js|jsx)' --ignore-path '../.prettierignore'",
+    "prettier-write": "prettier --write '**/*.+(ts|tsx|json|js|jsx)' --ignore-path '../.prettierignore'",
+    "lint-all": "yarn lint-fix && yarn prettier-fix",
     "test": "jest"
   },
   "repository": "git@github.com:openfun/marsha.git",


### PR DESCRIPTION
## Purpose

We use both tslint and prettier to manage our code styles. Prettier was
not configured in package.json. This PR add a prettier script and a more
general one to run both tslint and prettier at the same time. This
command can be used in a pre-commit hook for example.

## Proposal

add two new scripts in package definition:

- [x] script to run prettier
- [x] script to run at the same time tslint and prettier.


