### PR TITLE
✨(front) implement the instructor view wrapping <VideoPlayer />

### DIFF
--- a/src/frontend/components/AppRoutes/AppRoutes.tsx
+++ b/src/frontend/components/AppRoutes/AppRoutes.tsx
@@ -7,6 +7,7 @@ import {
   ErrorComponent,
   ROUTE as ERROR_ROUTE,
 } from '../ErrorComponent/ErrorComponent';
+import { InstructorWrapper } from '../InstructorWrapper/InstructorWrapper';
 import {
   RedirectOnLoad,
   ROUTE as HOME_ROUTE,
@@ -23,7 +24,11 @@ export const AppRoutes = () => {
           path={PLAYER_ROUTE()}
           render={() => (
             <AppDataContext.Consumer>
-              {({ video }) => <VideoPlayer video={video!} />}
+              {({ video }) => (
+                <InstructorWrapper>
+                  <VideoPlayer video={video!} />
+                </InstructorWrapper>
+              )}
             </AppDataContext.Consumer>
           )}
         />

--- a/src/frontend/components/InstructorView/InstructorView.spec.tsx
+++ b/src/frontend/components/InstructorView/InstructorView.spec.tsx
@@ -1,0 +1,33 @@
+import '../../testSetup';
+
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+import { InstructorControls, InstructorView, Preview } from './InstructorView';
+
+describe('<InstructorView />', () => {
+  it('renders the children inside a <Preview />', () => {
+    const wrapper = shallow(
+      <InstructorView>
+        <div className="some-child" />
+      </InstructorView>,
+    );
+
+    expect(
+      wrapper
+        .find(Preview)
+        .containsMatchingElement(<div className="some-child" />),
+    ).toBe(true);
+  });
+
+  it('renders the instructor controls', () => {
+    const controlsWrapper = shallow(
+      <InstructorView>
+        <div className="some-child" />
+      </InstructorView>,
+    ).find(InstructorControls);
+
+    expect(controlsWrapper.html()).toContain('Instructor Preview 👆');
+    expect(controlsWrapper.html()).toContain('Replace the video');
+  });
+});

--- a/src/frontend/components/InstructorView/InstructorView.tsx
+++ b/src/frontend/components/InstructorView/InstructorView.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+import styled from 'styled-components';
+
+import { colors } from '../../utils/theme/theme';
+import { Button } from '../Button/Button';
+import { ROUTE as FORM_ROUTE } from '../VideoForm/VideoForm';
+import { withLink } from '../withLink/withLink';
+
+const messages = defineMessages({
+  btnUpdateVideo: {
+    defaultMessage: 'Replace the video',
+    description: `Text for the button in the instructor view that allows the instructor to upload another
+      video to replace the one currently being shown.`,
+    id: 'components.InstructorView.btnUpdateVideo',
+  },
+  title: {
+    defaultMessage: 'Instructor Preview 👆',
+    description: `Title for the Instructor View. Describes the area appearing right above, which is a preview
+      of what the student will see there.`,
+    id: 'components.InstructorView.title',
+  },
+});
+
+export const Preview = styled.div`
+  transform: scale(0.85);
+`;
+
+const PreviewWrapper = styled.div`
+  background: ${colors.mediumGray.main};
+`;
+
+export const InstructorControls = styled.div`
+  display: flex;
+  height: 4rem;
+  padding: 1rem;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const BtnWithLink = withLink(Button);
+
+export const InstructorView = (props: { children: React.ReactNode }) => (
+  <React.Fragment>
+    <PreviewWrapper>
+      <Preview>{props.children}</Preview>
+    </PreviewWrapper>
+    <InstructorControls>
+      <FormattedMessage {...messages.title} />
+      <BtnWithLink to={FORM_ROUTE()} variant="primary">
+        <FormattedMessage {...messages.btnUpdateVideo} />
+      </BtnWithLink>
+    </InstructorControls>
+  </React.Fragment>
+);

--- a/src/frontend/components/InstructorWrapper/InstructorWrapper.spec.tsx
+++ b/src/frontend/components/InstructorWrapper/InstructorWrapper.spec.tsx
@@ -1,0 +1,64 @@
+import '../../testSetup';
+
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+// Mock the state context before we import InstructorWrapper. We'll be able to mutate the
+// context object to vary it for every test
+const context: {
+  state: string;
+} = { state: '' };
+jest.doMock('../App/App', () => {
+  return {
+    AppDataContext: {
+      Consumer: (props: any) => props.children(context),
+    },
+  };
+});
+
+import { appState } from '../../types/AppData';
+import { InstructorView } from '../InstructorView/InstructorView';
+import { InstructorWrapper } from './InstructorWrapper';
+
+describe('<InstructorWrapper />', () => {
+  it('wraps its children in an instructor view if the current user is an instructor', () => {
+    context.state = appState.INSTRUCTOR;
+    const wrapper = shallow(
+      <InstructorWrapper>
+        <div className="some-child" />
+      </InstructorWrapper>,
+    );
+
+    expect(
+      wrapper
+        .dive()
+        .find(InstructorView)
+        .exists(),
+    ).toBe(true);
+    expect(
+      wrapper
+        .dive()
+        .find(InstructorView)
+        .containsMatchingElement(<div className="some-child" />),
+    ).toBe(true);
+  });
+
+  it('just renders the children if the current user is not an instructor', () => {
+    context.state = appState.STUDENT;
+    const wrapper = shallow(
+      <InstructorWrapper>
+        <div className="some-child" />
+      </InstructorWrapper>,
+    );
+
+    expect(
+      wrapper
+        .dive()
+        .find(InstructorView)
+        .exists(),
+    ).not.toBe(true);
+    expect(
+      wrapper.dive().containsMatchingElement(<div className="some-child" />),
+    ).toBe(true);
+  });
+});

--- a/src/frontend/components/InstructorWrapper/InstructorWrapper.tsx
+++ b/src/frontend/components/InstructorWrapper/InstructorWrapper.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+
+import { appState } from '../../types/AppData';
+import { AppDataContext } from '../App/App';
+import { InstructorView } from '../InstructorView/InstructorView';
+
+export const InstructorWrapper = (props: { children: React.ReactNode }) => (
+  <AppDataContext.Consumer>
+    {({ state }) =>
+      state === appState.INSTRUCTOR ? (
+        <InstructorView>{props.children}</InstructorView>
+      ) : (
+        props.children
+      )
+    }
+  </AppDataContext.Consumer>
+);


### PR DESCRIPTION
## Purpose

We need to give instructors a way to change the video they uploaded for any given resource, that is the video that will be displayed in the corresponding location in the LMS.

## Proposal

To achieve this, we decided to implement a more generic `<InstructorView />` that we'll be able to use for other features later on.

We also used an `<InstructorWrapper />` that lets us automatically add the `<InstructorView />` on any view where it is needed, only when the current user is an instructor.

<img width="557" alt="capture d ecran 2018-11-19 a 18 31 54" src="https://user-images.githubusercontent.com/1932937/48724725-48dc9f80-ec2a-11e8-8f23-671e35640b75.png">