### PR TITLE
Fix the update-state request serializer

### DIFF
--- a/src/backend/marsha/core/serializers.py
+++ b/src/backend/marsha/core/serializers.py
@@ -16,10 +16,11 @@ from .utils import cloudfront_utils, time_utils
 
 UUID_REGEX = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
 # This regex matches keys in AWS for videos or timed text tracks
+TIMED_TEXT_EXTENSIONS = "|".join(m[0] for m in TimedTextTrack.MODE_CHOICES)
 KEY_PATTERN = (
-    "^(?P<resource_id>{uuid:s})/(?P<model_name>video|timedtexttrack)/(?P<object_id>{uuid:s})/"
-    "(?P<stamp>[0-9]{{10}})(_[a-z]{{2}}(_cc)?)?$".format(uuid=UUID_REGEX)
-)
+    "^(?P<resource_id>{uuid:s})/(?P<model_name>video|timedtexttrack)/(?P<object_id>"
+    "{uuid:s})/(?P<stamp>[0-9]{{10}})(_[a-z]{{2}}_({tt_ex}))?$"
+).format(uuid=UUID_REGEX, tt_ex=TIMED_TEXT_EXTENSIONS)
 KEY_REGEX = re.compile(KEY_PATTERN)
 
 

--- a/src/backend/marsha/core/tests/test_serializers_upload_confirm.py
+++ b/src/backend/marsha/core/tests/test_serializers_upload_confirm.py
@@ -7,6 +7,7 @@ from django.test import TestCase
 
 import pytz
 
+from ..models.video import TimedTextTrack
 from ..serializers import UpdateStateSerializer
 
 
@@ -19,12 +20,15 @@ class UpdateStateSerializerTest(TestCase):
 
     def test_serializers_update_state_valid_data(self):
         """The serializer should return the validated data."""
-        valid_keys = (
+        valid_keys = [
             "{!s}/video/{!s}/0123456789".format(uuid4(), uuid4()),
-            "{!s}/timedtexttrack/{!s}/0123456789".format(uuid4(), uuid4()),
-            "{!s}/timedtexttrack/{!s}/0123456789_fr".format(uuid4(), uuid4()),
-            "{!s}/timedtexttrack/{!s}/0123456789_fr_cc".format(uuid4(), uuid4()),
-        )
+            *[
+                "{!s}/timedtexttrack/{!s}/0123456789_fr_{!s}".format(
+                    uuid4(), uuid4(), mode
+                )
+                for mode, _ in TimedTextTrack.MODE_CHOICES
+            ],
+        ]
         for key in valid_keys:
             state = random.choice(("ready", "error"))
             valid_data = {"key": key, "state": state, "signature": "123abc"}


### PR DESCRIPTION
## Purpose

The update state request serializer uses a regex to validate s3 object keys. It had not been updated to account for changes in the way timedtext files are stored in s3.

## Proposal

Update the regexp to make the "mode" part of the object key mandatory and accept all valid modes (`"st"`, `"ts"`, `"cc"`) to fix the issue.
