### PR TITLE
Update lambdas to manage timed text

### DIFF
--- a/src/aws/lambda-encode/index.js
+++ b/src/aws/lambda-encode/index.js
@@ -1,16 +1,13 @@
 'use strict';
 
-const AWS = require('aws-sdk');
-
+const encodeVideo = require('./src/encodeVideo');
 const updateState = require('./src/updateState');
 
 exports.handler = async (event, context, callback) => {
   console.log('Received event:', JSON.stringify(event, null, 2));
 
-  const envType = process.env.ENV_TYPE;
   const objectKey = event.Records[0].s3.object.key;
   const sourceBucket = event.Records[0].s3.bucket.name;
-  const destinationBucket = process.env.S3_DESTINATION_BUCKET;
 
   if (objectKey.split('/').length != 4) {
     let error =
@@ -22,127 +19,8 @@ exports.handler = async (event, context, callback) => {
     return;
   }
 
-  let params = {
-    Role: process.env.MEDIA_CONVERT_ROLE,
-    UserMetadata: {
-      Bucket: sourceBucket,
-      ObjectKey: objectKey,
-    },
-    Settings: {
-      AdAvailOffset: 0,
-      Inputs: [
-        {
-          FilterEnable: 'AUTO',
-          PsiControl: 'USE_PSI',
-          FilterStrength: 0,
-          DeblockFilter: 'DISABLED',
-          DenoiseFilter: 'DISABLED',
-          TimecodeSource: 'EMBEDDED',
-          VideoSelector: {
-            ColorSpace: 'FOLLOW',
-          },
-          AudioSelectors: {
-            'Audio Selector 1': {
-              Offset: 0,
-              DefaultSelection: 'DEFAULT',
-              ProgramSelection: 1,
-            },
-          },
-          FileInput: `s3://${sourceBucket}/${objectKey}`,
-        },
-      ],
-      OutputGroups: [
-        {
-          CustomName: 'Video MP4 outputs',
-          Name: 'File Group',
-          OutputGroupSettings: {
-            Type: 'FILE_GROUP_SETTINGS',
-            FileGroupSettings: {
-              Destination: `s3://${destinationBucket}/${objectKey.replace(
-                /\/video\/.*\//,
-                '/mp4/',
-              )}`,
-            },
-          },
-          Outputs: ['144', '240', '480', '720', '1080'].map(size => ({
-            Preset: `${envType}_marsha_video_mp4_${size}`,
-            NameModifier: `_${size}`,
-          })),
-        },
-        {
-          CustomName: 'Video CMAF outputs',
-          Name: 'CMAF',
-          OutputGroupSettings: {
-            Type: 'CMAF_GROUP_SETTINGS',
-            CmafGroupSettings: {
-              WriteDashManifest: 'ENABLED',
-              WriteHlsManifest: 'ENABLED',
-              FragmentLength: 2,
-              SegmentLength: 14,
-              SegmentControl: 'SEGMENTED_FILES',
-              Destination: `s3://${destinationBucket}/${objectKey.replace(
-                /\/video\/.*\//,
-                '/cmaf/',
-              )}`,
-            },
-          },
-          Outputs: [
-            ...['144', '240', '480', '720', '1080'].map(size => ({
-              Preset: `${envType}_marsha_cmaf_video_${size}`,
-              NameModifier: `_${size}`,
-            })),
-            ...['64k', '96k', '128k', '160k', '192k'].map(bitrate => ({
-              Preset: `${envType}_marsha_cmaf_audio_${bitrate}`,
-              NameModifier: `_${bitrate}`,
-            })),
-          ],
-        },
-        {
-          CustomName: 'Thumbnails outputs',
-          Name: 'File Group',
-          OutputGroupSettings: {
-            Type: 'FILE_GROUP_SETTINGS',
-            FileGroupSettings: {
-              Destination: `s3://${destinationBucket}/${objectKey.replace(
-                /\/video\/.*\//,
-                '/thumbnails/',
-              )}`,
-            },
-          },
-          Outputs: ['144', '240', '480', '720', '1080'].map(size => ({
-            Preset: `${envType}_marsha_thumbnail_jpeg_${size}`,
-            NameModifier: `_${size}`,
-          })),
-        },
-        {
-          CustomName: 'Previews outputs',
-          Name: 'File Group',
-          OutputGroupSettings: {
-            Type: 'FILE_GROUP_SETTINGS',
-            FileGroupSettings: {
-              Destination: `s3://${destinationBucket}/${objectKey.replace(
-                /\/video\/.*\//,
-                '/previews/',
-              )}`,
-            },
-          },
-          Outputs: [
-            {
-              Preset: `${envType}_marsha_preview_jpeg_100`,
-              NameModifier: '_100',
-            },
-          ],
-        },
-      ],
-    },
-  };
-
   try {
-    const jobData = await new AWS.MediaConvert({
-      endpoint: process.env.MEDIA_CONVERT_END_POINT,
-    })
-      .createJob(params)
-      .promise();
+    await encodeVideo(objectKey, sourceBucket);
 
     await updateState(objectKey, 'processing');
 

--- a/src/aws/lambda-encode/index.spec.js
+++ b/src/aws/lambda-encode/index.spec.js
@@ -1,0 +1,212 @@
+process.env.DISABLE_SSL_VALIDATION = 'false';
+
+// Don't pollute tests with logs intended for CloudWatch
+jest.spyOn(console, 'log');
+
+// Mock our own sub-modules to simplify our tests
+const mockEncodeTimedTextTrack = jest.fn();
+jest.doMock('./src/encodeTimedTextTrack', () => mockEncodeTimedTextTrack);
+
+const mockEncodeVideo = jest.fn();
+jest.doMock('./src/encodeVideo', () => mockEncodeVideo);
+
+const mockUpdateState = jest.fn();
+jest.doMock('./src/updateState', () => mockUpdateState);
+
+const lambda = require('./index.js').handler;
+
+const callback = jest.fn();
+
+describe('lambda', () => {
+  beforeEach(() => {
+    console.log.mockReset();
+    jest.resetAllMocks();
+  });
+
+  it('reports a specific error when a video object key has an unexpected format', () => {
+    lambda(
+      {
+        Records: [
+          {
+            s3: {
+              bucket: { name: 'some bucket' },
+              object: {
+                key:
+                  '630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/video/dba1512e-d0b3-40cc-ae44-722fbe8cba6a',
+              },
+            },
+          },
+        ],
+      },
+      null,
+      callback,
+    );
+    expect(mockUpdateState).not.toHaveBeenCalled();
+    expect(callback).toHaveBeenCalledWith(
+      'Source videos should be uploaded in a folder of the form "{playlist_id}/videos/{video_id}/{stamp}".',
+    );
+  });
+
+  it('reports a specific error when a timed text object key has an unexpected format', () => {
+    lambda(
+      {
+        Records: [
+          {
+            s3: {
+              bucket: { name: 'some bucket' },
+              object: {
+                key:
+                  '630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/timedtexttrack/dba1512e-d0b3-40cc-ae44-722fbe8cba6a',
+              },
+            },
+          },
+        ],
+      },
+      null,
+      callback,
+    );
+    expect(mockUpdateState).not.toHaveBeenCalled();
+    expect(callback).toHaveBeenCalledWith(
+      'Source timed text files should be uploaded to a folder of the form ' +
+        '"{playlist_id}/timedtexttrack/{timedtext_id}/{stamp}_{language}[_{has_closed_caption}]".',
+    );
+  });
+
+  it('reports an error when the kind of object is unexpected', () => {
+    lambda(
+      {
+        Records: [
+          {
+            s3: {
+              bucket: { name: 'some bucket' },
+              object: {
+                key:
+                  '630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/subtitletrack/dba1512e-d0b3-40cc-ae44-722fbe8cba6a',
+              },
+            },
+          },
+        ],
+      },
+      null,
+      callback,
+    );
+    expect(mockUpdateState).not.toHaveBeenCalled();
+    expect(callback).toHaveBeenCalledWith(
+      'Unrecognized kind subtitletrack in key ' +
+        '"630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/subtitletrack/dba1512e-d0b3-40cc-ae44-722fbe8cba6a".',
+    );
+  });
+
+  it('reports an error when the object key has an unexpected format', () => {
+    lambda(
+      {
+        Records: [
+          {
+            s3: {
+              bucket: { name: 'some bucket' },
+              object: { key: 'invalid key' },
+            },
+          },
+        ],
+      },
+      null,
+      callback,
+    );
+    expect(mockUpdateState).not.toHaveBeenCalled();
+    expect(callback).toHaveBeenCalledWith(
+      'Unrecognized key format "invalid key"',
+    );
+  });
+
+  describe('called with a timed text object', () => {
+    const event = {
+      Records: [
+        {
+          s3: {
+            bucket: {
+              name: 'source bucket',
+            },
+            object: {
+              key:
+                '630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/timedtexttrack/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1542967735_fr',
+            },
+          },
+        },
+      ],
+    };
+
+    it('delegates to encodeTimedTextTrack and calls updateState when it succeeds', async () => {
+      await lambda(event, null, callback);
+
+      expect(mockEncodeTimedTextTrack).toHaveBeenCalledWith(
+        '630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/timedtexttrack/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1542967735_fr',
+        'source bucket',
+      );
+      expect(mockUpdateState).toHaveBeenCalledWith(
+        '630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/timedtexttrack/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1542967735_fr',
+        'ready',
+      );
+    });
+
+    it('delegates to encodeTimedTextTrack and reports the error when it fails', async () => {
+      mockEncodeTimedTextTrack.mockImplementation(
+        () => new Promise((resolve, reject) => reject('Failed!')),
+      );
+
+      await lambda(event, null, callback);
+
+      expect(mockEncodeTimedTextTrack).toHaveBeenCalledWith(
+        '630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/timedtexttrack/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1542967735_fr',
+        'source bucket',
+      );
+      expect(mockUpdateState).not.toHaveBeenCalled();
+      expect(callback).toHaveBeenCalledWith('Failed!');
+    });
+  });
+
+  describe('called with a video object', () => {
+    const event = {
+      Records: [
+        {
+          s3: {
+            bucket: {
+              name: 'source bucket',
+            },
+            object: {
+              key:
+                '630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/video/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1542967735_fr',
+            },
+          },
+        },
+      ],
+    };
+
+    it('delegates to encodeVideo and calls updateState & callback when it succeeds', async () => {
+      await lambda(event, null, callback);
+
+      expect(mockEncodeVideo).toHaveBeenCalledWith(
+        '630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/video/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1542967735_fr',
+        'source bucket',
+      );
+      expect(mockUpdateState).toHaveBeenCalledWith(
+        '630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/video/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1542967735_fr',
+        'processing',
+      );
+    });
+
+    it('delegates to encodeVideo and reports the error when it fails', async () => {
+      mockEncodeVideo.mockImplementation(
+        () => new Promise((resolve, reject) => reject('Failed!')),
+      );
+
+      await lambda(event, null, callback);
+
+      expect(mockEncodeVideo).toHaveBeenCalledWith(
+        '630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/video/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1542967735_fr',
+        'source bucket',
+      );
+      expect(mockUpdateState).not.toHaveBeenCalled();
+      expect(callback).toHaveBeenCalledWith('Failed!');
+    });
+  });
+});

--- a/src/aws/lambda-encode/package.json
+++ b/src/aws/lambda-encode/package.json
@@ -7,6 +7,7 @@
   },
   "description": "Convert a source video to all the formats used in Marsha",
   "dependencies": {
+    "@openfun/subsrt": "1.0.1",
     "aws-sdk": "2.292.0",
     "request": "2.88.0",
     "request-promise-native": "1.0.5"

--- a/src/aws/lambda-encode/src/encodeTimedTextTrack.js
+++ b/src/aws/lambda-encode/src/encodeTimedTextTrack.js
@@ -1,0 +1,41 @@
+const AWS = require('aws-sdk');
+const s3 = new AWS.S3();
+const subsrt = require('@openfun/subsrt');
+
+/**
+ * Convert any uploaded timed text track to `.vtt`.
+ * Read it from the source bucket where it was uploaded and write the results in the destination
+ * bucket as specified from the environment.
+ * @param objectKey The S3 key for the uploaded timed text file, taken from the object creation event.
+ * @param sourceBucket The name of the bucket where the timed text file was uploaded.
+ */
+module.exports = async (objectKey, sourceBucket) => {
+  const destinationBucket = process.env.S3_DESTINATION_BUCKET;
+
+  const timedTextFile = await s3
+    .getObject({ Bucket: sourceBucket, Key: objectKey })
+    .promise();
+
+  let vttTimedText;
+  try {
+    vttTimedText = subsrt.convert(timedTextFile.Body.toString(), {
+      format: 'vtt',
+    });
+  } catch (e) {
+    // Log the file as read from S3 to ease debugging
+    // Make sure encodeTimedTextTrack fails when timed text conversion fails.
+    throw new Error(`Invalid timed text format for ${objectKey}.`);
+  }
+
+  await s3
+    .putObject({
+      Body: vttTimedText,
+      Bucket: destinationBucket,
+      // Transform the source key to the format expected for destination keys:
+      // 630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/timedtexttrack/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1542967735_fr
+      // 👆 becomes 👇
+      // 630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/timedtext/1542967735_fr
+      Key: objectKey.replace(/\/timedtexttrack\/.*\//, '/timedtext/'),
+    })
+    .promise();
+};

--- a/src/aws/lambda-encode/src/encodeTimedTextTrack.spec.js
+++ b/src/aws/lambda-encode/src/encodeTimedTextTrack.spec.js
@@ -1,0 +1,98 @@
+process.env.S3_DESTINATION_BUCKET = 'destination bucket';
+
+// Mock the AWS SDK calls used in encodeTimedTextTrack
+const mockGetObject = jest.fn();
+const mockPutObject = jest.fn();
+jest.mock('aws-sdk', () => ({
+  S3: function() {
+    this.getObject = mockGetObject;
+    this.putObject = mockPutObject;
+  },
+}));
+
+// Mock subsrt so we avoid line break issues between \n and \r\n
+const mockSubsrt = { convert: jest.fn() };
+jest.mock('@openfun/subsrt', () => mockSubsrt);
+
+const encodeTimedTextTrack = require('./encodeTimedTextTrack');
+
+describe('lambda-encode/src/encodeTimedTextTrack', () => {
+  beforeEach(() => {
+    mockGetObject.mockReset();
+    mockPutObject.mockReset();
+    mockSubsrt.convert.mockReset();
+  });
+
+  it('reads the source timed text, converts it to VTT and writes it to destination', async () => {
+    mockGetObject.mockReturnValue({
+      promise: () =>
+        new Promise(resolve =>
+          resolve({ Body: { toString: () => 'input timed text' } }),
+        ),
+    });
+    mockPutObject.mockReturnValue({
+      promise: () => new Promise(resolve => resolve()),
+    });
+    mockSubsrt.convert.mockReturnValue('output timed text');
+
+    await encodeTimedTextTrack('some key', 'source bucket');
+
+    expect(mockGetObject).toHaveBeenCalledWith({
+      Bucket: 'source bucket',
+      Key: 'some key',
+    });
+    expect(mockPutObject).toHaveBeenCalledWith({
+      Body: 'output timed text',
+      Bucket: 'destination bucket',
+      Key: 'some key',
+    });
+    expect(mockSubsrt.convert).toHaveBeenCalledWith('input timed text', {
+      format: 'vtt',
+    });
+  });
+
+  it('throws when it fails to convert the source timed text to VTT', async () => {
+    mockGetObject.mockReturnValue({
+      promise: () =>
+        new Promise(resolve =>
+          resolve({ Body: { toString: () => 'input invalid timed text' } }),
+        ),
+    });
+    mockSubsrt.convert.mockImplementation(() => {
+      throw new Error('Failed!');
+    });
+
+    await expect(
+      encodeTimedTextTrack('some key', 'source bucket'),
+    ).rejects.toEqual(new Error('Invalid timed text format for some key.'));
+  });
+
+  it('throws when it fails to get the timed text file from the source bucket', async () => {
+    mockGetObject.mockReturnValue({
+      promise: () =>
+        new Promise((resolve, reject) => reject(new Error('Failed!'))),
+    });
+
+    await expect(
+      encodeTimedTextTrack('some key', 'source bucket'),
+    ).rejects.toEqual(new Error('Failed!'));
+  });
+
+  it('throws when it fails to put the timed text file to the destination bucket', async () => {
+    mockGetObject.mockReturnValue({
+      promise: () =>
+        new Promise(resolve =>
+          resolve({ Body: { toString: () => 'input timed text' } }),
+        ),
+    });
+    mockPutObject.mockReturnValue({
+      promise: () =>
+        new Promise((resolve, reject) => reject(new Error('Failed!'))),
+    });
+    mockSubsrt.convert.mockReturnValue('output timed text');
+
+    await expect(
+      encodeTimedTextTrack('some key', 'source bucket'),
+    ).rejects.toEqual(new Error('Failed!'));
+  });
+});

--- a/src/aws/lambda-encode/src/encodeVideo.js
+++ b/src/aws/lambda-encode/src/encodeVideo.js
@@ -1,0 +1,133 @@
+const AWS = require('aws-sdk');
+
+/**
+ * Build the appropriate parameters object using our presets and pass it along
+ * to MediaConvert through the AWS SDK to initiate the job.
+ * @param objectKey The S3 key for the uploaded video, taken from the object creation event.
+ * @param sourceBucket The name of the bucket where the video was uploaded.
+ */
+module.exports = async (objectKey, sourceBucket) => {
+  const envType = process.env.ENV_TYPE;
+  const destinationBucket = process.env.S3_DESTINATION_BUCKET;
+
+  let params = {
+    Role: process.env.MEDIA_CONVERT_ROLE,
+    UserMetadata: {
+      Bucket: sourceBucket,
+      ObjectKey: objectKey,
+    },
+    Settings: {
+      AdAvailOffset: 0,
+      Inputs: [
+        {
+          FilterEnable: 'AUTO',
+          PsiControl: 'USE_PSI',
+          FilterStrength: 0,
+          DeblockFilter: 'DISABLED',
+          DenoiseFilter: 'DISABLED',
+          TimecodeSource: 'EMBEDDED',
+          VideoSelector: {
+            ColorSpace: 'FOLLOW',
+          },
+          AudioSelectors: {
+            'Audio Selector 1': {
+              Offset: 0,
+              DefaultSelection: 'DEFAULT',
+              ProgramSelection: 1,
+            },
+          },
+          FileInput: `s3://${sourceBucket}/${objectKey}`,
+        },
+      ],
+      OutputGroups: [
+        {
+          CustomName: 'Video MP4 outputs',
+          Name: 'File Group',
+          OutputGroupSettings: {
+            Type: 'FILE_GROUP_SETTINGS',
+            FileGroupSettings: {
+              Destination: `s3://${destinationBucket}/${objectKey.replace(
+                /\/video\/.*\//,
+                '/mp4/',
+              )}`,
+            },
+          },
+          Outputs: ['144', '240', '480', '720', '1080'].map(size => ({
+            Preset: `${envType}_marsha_video_mp4_${size}`,
+            NameModifier: `_${size}`,
+          })),
+        },
+        {
+          CustomName: 'Video CMAF outputs',
+          Name: 'CMAF',
+          OutputGroupSettings: {
+            Type: 'CMAF_GROUP_SETTINGS',
+            CmafGroupSettings: {
+              WriteDashManifest: 'ENABLED',
+              WriteHlsManifest: 'ENABLED',
+              FragmentLength: 2,
+              SegmentLength: 14,
+              SegmentControl: 'SEGMENTED_FILES',
+              Destination: `s3://${destinationBucket}/${objectKey.replace(
+                /\/video\/.*\//,
+                '/cmaf/',
+              )}`,
+            },
+          },
+          Outputs: [
+            ...['144', '240', '480', '720', '1080'].map(size => ({
+              Preset: `${envType}_marsha_cmaf_video_${size}`,
+              NameModifier: `_${size}`,
+            })),
+            ...['64k', '96k', '128k', '160k', '192k'].map(bitrate => ({
+              Preset: `${envType}_marsha_cmaf_audio_${bitrate}`,
+              NameModifier: `_${bitrate}`,
+            })),
+          ],
+        },
+        {
+          CustomName: 'Thumbnails outputs',
+          Name: 'File Group',
+          OutputGroupSettings: {
+            Type: 'FILE_GROUP_SETTINGS',
+            FileGroupSettings: {
+              Destination: `s3://${destinationBucket}/${objectKey.replace(
+                /\/video\/.*\//,
+                '/thumbnails/',
+              )}`,
+            },
+          },
+          Outputs: ['144', '240', '480', '720', '1080'].map(size => ({
+            Preset: `${envType}_marsha_thumbnail_jpeg_${size}`,
+            NameModifier: `_${size}`,
+          })),
+        },
+        {
+          CustomName: 'Previews outputs',
+          Name: 'File Group',
+          OutputGroupSettings: {
+            Type: 'FILE_GROUP_SETTINGS',
+            FileGroupSettings: {
+              Destination: `s3://${destinationBucket}/${objectKey.replace(
+                /\/video\/.*\//,
+                '/previews/',
+              )}`,
+            },
+          },
+          Outputs: [
+            {
+              Preset: `${envType}_marsha_preview_jpeg_100`,
+              NameModifier: '_100',
+            },
+          ],
+        },
+      ],
+    },
+  };
+
+  await new AWS.MediaConvert({
+    endpoint: process.env.MEDIA_CONVERT_END_POINT,
+  })
+    .createJob(params)
+    .promise();
+};

--- a/src/aws/lambda-encode/yarn.lock
+++ b/src/aws/lambda-encode/yarn.lock
@@ -16,6 +16,11 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
+"@openfun/subsrt@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@openfun/subsrt/-/subsrt-1.0.1.tgz#b735038ef887ffd185a19dd83766f0dc6c58a77b"
+  integrity sha512-zcfdY/q5QGJJkcsCuxIYX/z+8C0ySJfJK5yY2i3oMwylrTZhs80pgdlQnvt09urskb6B54vI6H5sJUitIAAlYA==
+
 "@types/caseless@*":
   version "0.12.1"
   resolved "https://registry.yarnpkg.com/@types/caseless/-/caseless-0.12.1.tgz#9794c69c8385d0192acc471a540d1f8e0d16218a"

--- a/src/aws/roles.tf
+++ b/src/aws/roles.tf
@@ -102,6 +102,37 @@ resource "aws_iam_role_policy_attachment" "lambda_pass_role_policy_attachment" {
   policy_arn = "${aws_iam_policy.lambda_pass_role_policy.arn}"
 }
 
+resource "aws_iam_policy" "lambda_s3_access_policy" {
+  name        = "${terraform.workspace}-marsha-lambda-s3-access-policy"
+  path        = "/"
+  description = "IAM policy to read in source bucket and write in destination bucket"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": ["s3:GetObject"],
+      "Effect": "Allow",
+      "Resource": "arn:aws:s3:::${aws_s3_bucket.marsha_source.bucket}/*"
+    },
+    {
+      "Action": ["s3:PutObject"],
+      "Effect": "Allow",
+      "Resource": "arn:aws:s3:::${aws_s3_bucket.marsha_destination.bucket}/*"
+    }
+  ]
+}
+EOF
+}
+
+# `lambda-encode` needs read access to the source bucket and write access to the destination
+# bucket to read timed text files from the former and write them to the latter.
+resource "aws_iam_role_policy_attachment" "lambda_s3_access_policy_attachment" {
+  role        = "${aws_iam_role.lambda_invocation_role.name}"
+  policy_arn  = "${aws_iam_policy.lambda_s3_access_policy.arn}"
+}
+
 # Media Convert role
 #####################
 

--- a/src/backend/marsha/core/serializers.py
+++ b/src/backend/marsha/core/serializers.py
@@ -16,10 +16,11 @@ from .utils import cloudfront_utils, time_utils
 
 UUID_REGEX = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
 # This regex matches keys in AWS for videos or timed text tracks
+TIMED_TEXT_EXTENSIONS = "|".join(m[0] for m in TimedTextTrack.MODE_CHOICES)
 KEY_PATTERN = (
-    "^(?P<resource_id>{uuid:s})/(?P<model_name>video|timedtexttrack)/(?P<object_id>{uuid:s})/"
-    "(?P<stamp>[0-9]{{10}})(_[a-z]{{2}}(_cc)?)?$".format(uuid=UUID_REGEX)
-)
+    "^(?P<resource_id>{uuid:s})/(?P<model_name>video|timedtexttrack)/(?P<object_id>"
+    "{uuid:s})/(?P<stamp>[0-9]{{10}})(_[a-z]{{2}}_({tt_ex}))?$"
+).format(uuid=UUID_REGEX, tt_ex=TIMED_TEXT_EXTENSIONS)
 KEY_REGEX = re.compile(KEY_PATTERN)
 
 

--- a/src/backend/marsha/core/tests/test_serializers_upload_confirm.py
+++ b/src/backend/marsha/core/tests/test_serializers_upload_confirm.py
@@ -7,6 +7,7 @@ from django.test import TestCase
 
 import pytz
 
+from ..models.video import TimedTextTrack
 from ..serializers import UpdateStateSerializer
 
 
@@ -19,12 +20,15 @@ class UpdateStateSerializerTest(TestCase):
 
     def test_serializers_update_state_valid_data(self):
         """The serializer should return the validated data."""
-        valid_keys = (
+        valid_keys = [
             "{!s}/video/{!s}/0123456789".format(uuid4(), uuid4()),
-            "{!s}/timedtexttrack/{!s}/0123456789".format(uuid4(), uuid4()),
-            "{!s}/timedtexttrack/{!s}/0123456789_fr".format(uuid4(), uuid4()),
-            "{!s}/timedtexttrack/{!s}/0123456789_fr_cc".format(uuid4(), uuid4()),
-        )
+            *[
+                "{!s}/timedtexttrack/{!s}/0123456789_fr_{!s}".format(
+                    uuid4(), uuid4(), mode
+                )
+                for mode, _ in TimedTextTrack.MODE_CHOICES
+            ],
+        ]
         for key in valid_keys:
             state = random.choice(("ready", "error"))
             valid_data = {"key": key, "state": state, "signature": "123abc"}


### PR DESCRIPTION
## Purpose

The encode lambda was originally written to handle incoming "create object" events for videos and trigger a MediaConvert job to encode them in all the formats we need.

As we add support for various forms of timed text (subtitles, ccs, transcripts), we need to handle those as well. This can be done directly in JS in the lambda as it is much less demanding than converting video.

We reworked the lambda to convert all incoming subtitles to WebVTT
and write them to the destination bucket. To do this, it needed
additional access rights to s3.

## Proposal

- [x] spin MediaConvert video encoding job creating to a separate file;
- [x] add access rights to the lambda for timed text (read in source bucket, write in destination bucket);
- [x] write an encodeTimedTextTrack to perform the job on timed text;
- [x] update the main lambda handler to sort & dispatch relevant events.
