### PR TITLE
Split Dashboard video matters into a separate component

### DIFF
--- a/src/frontend/components/Dashboard/Dashboard.spec.tsx
+++ b/src/frontend/components/Dashboard/Dashboard.spec.tsx
@@ -1,96 +1,18 @@
-import { flushAllPromises } from '../../testSetup';
+import '../../testSetup';
 
 import { shallow } from 'enzyme';
-import fetchMock from 'fetch-mock';
 import * as React from 'react';
 
-import { modelName } from '../../types/models';
 import { videoState } from '../../types/Video';
-import { UploadStatusList } from '../UploadStatusList/UploadStatusList';
 import { Dashboard } from './Dashboard';
 
-const mockUpdateVideo = jest.fn();
-
 describe('<Dashboard />', () => {
-  jest.useFakeTimers();
-
-  beforeEach(mockUpdateVideo.mockReset);
-
-  afterEach(fetchMock.restore);
-
-  it('renders & starts polling for the video', async () => {
-    // Create a mock video with the initial state (PROCESSING)
+  it('renders', () => {
     const mockVideo: any = { id: 'dd44', state: videoState.PROCESSING };
-    fetchMock.mock('/api/videos/dd44/', mockVideo);
 
-    const wrapper = shallow(
-      <Dashboard
-        jwt={'cool_token_m8'}
-        updateVideo={mockUpdateVideo}
-        video={mockVideo}
-      />,
-    );
-
-    // Dashboard shows the video as PROCESSING
-    expect(wrapper.html()).toContain('Dashboard');
-    expect(wrapper.find(UploadStatusList).prop('state')).toEqual(
-      videoState.PROCESSING,
-    );
-    expect(fetchMock.called()).not.toBeTruthy();
-
-    // First backend call: the video is still processing
-    jest.advanceTimersByTime(1000 * 60 + 200);
-    await flushAllPromises();
-    expect(fetchMock.lastCall()).toEqual([
-      '/api/videos/dd44/',
-      { headers: { Authorization: 'Bearer cool_token_m8' } },
-    ]);
-
-    // The video will be ready in further responses
-    fetchMock.reset();
-    mockVideo.state = videoState.READY;
-
-    // Second backend call
-    jest.advanceTimersByTime(1000 * 60 + 200);
-    await flushAllPromises();
-    expect(fetchMock.lastCall()).toEqual([
-      '/api/videos/dd44/',
-      { headers: { Authorization: 'Bearer cool_token_m8' } },
-    ]);
-
-    // Dashboard shows the video as READY
-    expect(wrapper.find(UploadStatusList).prop('state')).toEqual(
-      videoState.READY,
-    );
-    expect(mockUpdateVideo).toHaveBeenCalledWith({
-      id: 'dd44',
-      state: 'ready',
-    });
-
-    // Unmount Dashboard to get rid of its interval
-    wrapper.unmount();
-  });
-
-  it('redirects to error when it fails to fetch the video', async () => {
-    fetchMock.mock('/api/videos/ee55/', {
-      throws: 'failed request',
-    });
-    const wrapper = shallow(
-      <Dashboard
-        jwt={'cool_token_m8'}
-        updateVideo={mockUpdateVideo}
-        video={{ id: 'ee55', state: videoState.PROCESSING } as any}
-      />,
-    );
-
-    jest.advanceTimersByTime(1000 * 60 + 200);
-    await flushAllPromises();
-
-    expect(wrapper.name()).toEqual('Redirect');
-    expect(wrapper.prop('push')).toBeTruthy();
-    expect(wrapper.prop('to')).toEqual('/errors/notFound');
-
-    // Unmount Dashboard to get rid of its interval
-    wrapper.unmount();
+    const wrapper = shallow(<Dashboard video={mockVideo} />)
+      .dive()
+      .dive();
+    expect(wrapper.text()).toContain('Dashboard');
   });
 });

--- a/src/frontend/components/Dashboard/Dashboard.tsx
+++ b/src/frontend/components/Dashboard/Dashboard.tsx
@@ -1,27 +1,13 @@
 import * as React from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
-import { Redirect } from 'react-router';
 import styled from 'styled-components';
 
-import { API_ENDPOINT } from '../../settings';
-import { Video, videoState } from '../../types/Video';
-import { Maybe, Nullable } from '../../utils/types';
-import { ROUTE as ERROR_ROUTE } from '../ErrorComponent/ErrorComponent';
-import { H6, IframeHeading } from '../Headings/Headings';
+import { Video } from '../../types/Video';
+import { DashboardVideoPaneConnected } from '../DashboardVideoPaneConnected/DashboardVideoPaneConnected';
+import { IframeHeading } from '../Headings/Headings';
 import { LayoutMainArea } from '../LayoutMainArea/LayoutMainArea';
-import { UploadStatusList } from '../UploadStatusList/UploadStatusList';
-import { DashboardButtons } from './DashboardButtons';
-import { DashboardHelptext } from './DashboardHelptext';
-
-const { UPLOADING } = videoState;
 
 const messages = defineMessages({
-  subtitleForVideo: {
-    defaultMessage: 'Video preparation',
-    description:
-      'Subtitle for the video part of the dashboard (right now the only part until we add timed text tracks).',
-    id: 'components.Dashboard.subtitleForVideo',
-  },
   title: {
     defaultMessage: 'Dashboard',
     description: `Title for the dashboard, where the user can see the status of the video/audio/timed text upload
@@ -44,111 +30,24 @@ const DashboardContainer = styled(LayoutMainArea)`
   align-items: stretch;
 `;
 
-const DashboardInternalHeading = styled(H6)`
-  margin: 0;
-  padding: 0 1rem;
-  font-weight: 400;
-`;
-
-const DashboardInnerContainer = styled.div`
-  flex-grow: 1;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-around;
-`;
-
 /** Props shape for the Dashboard component. */
-interface DashboardProps {
-  isUploading?: boolean;
-  jwt: Nullable<string>;
-  updateVideo: (video: Video) => void;
+export interface DashboardProps {
   video: Video;
-}
-
-interface DashboardState {
-  error: Maybe<boolean>;
-  pollInterval?: number;
-  video: Maybe<Video>;
 }
 
 /** Component. Displays a Dashboard with the state of the video in marsha's pipeline and provides links to
  * the player and to the form to replace the video with another one.
  * Will also be used to manage related tracks such as timed text when they are available.
- * @param isUploading Whether the relevant video file is currently being uploaded.
- * @param jwt The token that will be used to fetch the video record from the server to update it.
- * @param updateVideo Callback to update the video in the store.
  * @param video The video object from AppData. We need it to populate the component before polling starts.
  */
-export class Dashboard extends React.Component<DashboardProps, DashboardState> {
-  state: DashboardState = { error: undefined, video: undefined };
-
-  componentWillMount() {
-    // We only need to poll if the current state is PROCESSING
-    // For other states, there will not be any updates coming from the backend
-    if (this.props.video.state === videoState.PROCESSING) {
-      this.setState({
-        pollInterval: window.setInterval(() => this.pollForVideo(), 1000 * 60),
-      });
-    }
-  }
-
-  componentWillUnmount() {
-    // As a matter of hygiene, stop the polling as we unmount
-    if (this.state.pollInterval) {
-      window.clearInterval(this.state.pollInterval);
-    }
-  }
-
-  async pollForVideo() {
-    const { jwt, updateVideo, video } = this.props; // NB: Video from props
-    try {
-      const response = await fetch(`${API_ENDPOINT}/videos/${video.id}/`, {
-        headers: {
-          Authorization: `Bearer ${jwt}`,
-        },
-      });
-
-      const incomingVideo = await response.json();
-      // If the video is PENDING on the backend and PROCESSING on our end, we're probably experiencing a race
-      // condition where the backend is not yet aware of the end of the upload.
-      if (
-        incomingVideo.state === videoState.PENDING &&
-        video.state === videoState.PROCESSING
-      ) {
-        // Disregard the server-provided video.
-        return;
-      }
-      // When the video is ready, we need to update the App state so VideoForm has access to the URLs when it loads
-      else if (incomingVideo.state === videoState.READY) {
-        updateVideo(incomingVideo);
-      }
-      this.setState({ video: incomingVideo });
-    } catch (error) {
-      this.setState({ error: true });
-    }
-  }
-
+export class Dashboard extends React.Component<DashboardProps> {
   render() {
-    const video = this.state.video || this.props.video;
-    const state = this.props.isUploading ? UPLOADING : video.state;
-
-    if (this.state.error) {
-      return <Redirect push to={ERROR_ROUTE('notFound')} />;
-    }
-
     return (
       <DashboardContainer>
         <IframeHeadingWithLayout>
           <FormattedMessage {...messages.title} />
         </IframeHeadingWithLayout>
-        <DashboardInnerContainer>
-          <DashboardInternalHeading>
-            <FormattedMessage {...messages.subtitleForVideo} />
-          </DashboardInternalHeading>
-          <UploadStatusList state={state} />
-          <DashboardHelptext state={state} />
-          <DashboardButtons state={state} />
-        </DashboardInnerContainer>
+        <DashboardVideoPaneConnected video={this.props.video} />
       </DashboardContainer>
     );
   }

--- a/src/frontend/components/Dashboard/DashboardInternalHeading.tsx
+++ b/src/frontend/components/Dashboard/DashboardInternalHeading.tsx
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+
+import { H6 } from '../Headings/Headings';
+
+export const DashboardInternalHeading = styled(H6)`
+  margin: 0;
+  padding: 0 1rem;
+  font-weight: 400;
+`;

--- a/src/frontend/components/DashboardConnected/DashboardConnected.spec.tsx
+++ b/src/frontend/components/DashboardConnected/DashboardConnected.spec.tsx
@@ -4,19 +4,17 @@ import { mapStateToProps } from './DashboardConnected';
 describe('<DashboardConnected />', () => {
   describe('mapStateToProps()', () => {
     const props = {
-      jwt: 'some token',
+      dispatch: jest.fn(),
       video: { id: 42 } as any,
     };
 
-    it('picks the video and jwt from the store if available', () => {
+    it('picks the video from the store if available', () => {
       const state = {
-        context: { jwt: 'some token' },
         resources: {
           [modelName.VIDEOS]: { byId: { 42: 'some video' as any } },
         },
       } as any;
       expect(mapStateToProps(state, props)).toEqual({
-        jwt: 'some token',
         video: 'some video',
       });
     });

--- a/src/frontend/components/DashboardConnected/DashboardConnected.tsx
+++ b/src/frontend/components/DashboardConnected/DashboardConnected.tsx
@@ -21,7 +21,6 @@ export const mapStateToProps = (
   state: RootState,
   { video }: DashboardConnectedProps,
 ) => ({
-  jwt: state && state.context && state.context.jwt,
   video:
     (state &&
       state.resources[modelName.VIDEOS]!.byId &&
@@ -29,18 +28,9 @@ export const mapStateToProps = (
     video,
 });
 
-/** Create a function that updates a single video in the store. */
-const mapDispatchToProps = (dispatch: Dispatch) => ({
-  updateVideo: (video: Video) => dispatch(addResource(modelName.VIDEOS, video)),
-});
-
 /**
  * Component. Displays a Dashboard with the state of the video in marsha's pipeline and provides links to
  * the player and to the form to replace the video with another one.
- * @param jwt The JSON web token that allows the client to authenticate API requests.
  * @param video The relevant Video record for which we're showing the state.
  */
-export const DashboardConnected = connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(Dashboard);
+export const DashboardConnected = connect(mapStateToProps)(Dashboard);

--- a/src/frontend/components/DashboardVideoPane/DashboardVideoPane.spec.tsx
+++ b/src/frontend/components/DashboardVideoPane/DashboardVideoPane.spec.tsx
@@ -1,0 +1,124 @@
+import { flushAllPromises } from '../../testSetup';
+
+import { shallow } from 'enzyme';
+import fetchMock from 'fetch-mock';
+import * as React from 'react';
+
+jest.mock('../DashboardVideoPaneButtons/DashboardVideoPaneButtons', () => ({
+  DashboardVideoPaneButtons: () => {},
+}));
+
+import { videoState } from '../../types/Video';
+import { UploadStatusList } from '../UploadStatusList/UploadStatusList';
+import { DashboardVideoPane } from './DashboardVideoPane';
+
+const mockUpdateVideo = jest.fn();
+
+describe('<DashboardVideoPane />', () => {
+  jest.useFakeTimers();
+
+  beforeEach(mockUpdateVideo.mockReset);
+
+  afterEach(fetchMock.restore);
+
+  it('renders & starts polling for the video', async () => {
+    // Create a mock video with the initial state (PROCESSING)
+    const mockVideo: any = { id: 'dd44', state: videoState.PROCESSING };
+    fetchMock.mock('/api/videos/dd44/', mockVideo);
+
+    let wrapper = shallow(
+      <DashboardVideoPane
+        jwt={'cool_token_m8'}
+        updateVideo={mockUpdateVideo}
+        video={mockVideo}
+      />,
+    );
+
+    // DashboardVideoPane shows the video as PROCESSING
+    expect(wrapper.find(UploadStatusList).prop('state')).toEqual(
+      videoState.PROCESSING,
+    );
+    expect(fetchMock.called()).not.toBeTruthy();
+
+    // First backend call: the video is still processing
+    jest.advanceTimersByTime(1000 * 60 + 200);
+    await flushAllPromises();
+    expect(fetchMock.lastCall()).toEqual([
+      '/api/videos/dd44/',
+      { headers: { Authorization: 'Bearer cool_token_m8' } },
+    ]);
+
+    // The video will be ready in further responses
+    fetchMock.reset();
+    mockVideo.state = videoState.READY;
+
+    // Second backend call
+    jest.advanceTimersByTime(1000 * 60 + 200);
+    await flushAllPromises();
+
+    expect(fetchMock.lastCall()).toEqual([
+      '/api/videos/dd44/',
+      { headers: { Authorization: 'Bearer cool_token_m8' } },
+    ]);
+    expect(mockUpdateVideo).toHaveBeenCalledWith({
+      id: 'dd44',
+      state: 'ready',
+    });
+
+    wrapper.unmount();
+    wrapper = shallow(
+      <DashboardVideoPane
+        jwt={'cool_token_m8'}
+        updateVideo={mockUpdateVideo}
+        video={mockVideo}
+      />,
+    );
+    // DashboardVideoPane shows the video as READY
+    expect(wrapper.find(UploadStatusList).prop('state')).toEqual(
+      videoState.READY,
+    );
+
+    // Unmount DashboardVideoPane to get rid of its interval
+    wrapper.unmount();
+  });
+
+  it('redirects to error when it fails to fetch the video', async () => {
+    fetchMock.mock('/api/videos/ee55/', {
+      throws: 'failed request',
+    });
+    const wrapper = shallow(
+      <DashboardVideoPane
+        jwt={'cool_token_m8'}
+        updateVideo={mockUpdateVideo}
+        video={{ id: 'ee55', state: videoState.PROCESSING } as any}
+      />,
+    );
+
+    jest.advanceTimersByTime(1000 * 60 + 200);
+    await flushAllPromises();
+
+    expect(wrapper.name()).toEqual('Redirect');
+    expect(wrapper.prop('push')).toBeTruthy();
+    expect(wrapper.prop('to')).toEqual('/errors/notFound');
+
+    // Unmount DashboardVideoPane to get rid of its interval
+    wrapper.unmount();
+  });
+
+  it('redirects to error when the video is in the error state', async () => {
+    const wrapper = shallow(
+      <DashboardVideoPane
+        jwt={'cool_token_m8'}
+        updateVideo={mockUpdateVideo}
+        video={{ id: 'ff66', state: videoState.ERROR } as any}
+      />,
+    );
+
+    expect(wrapper.name()).toEqual('Redirect');
+    expect(wrapper.prop('push')).toBeTruthy();
+    expect(wrapper.prop('to')).toEqual('/errors/upload');
+
+    // Unmount DashboardVideoPane to get rid of its interval
+    wrapper.unmount();
+  });
+});

--- a/src/frontend/components/DashboardVideoPane/DashboardVideoPane.tsx
+++ b/src/frontend/components/DashboardVideoPane/DashboardVideoPane.tsx
@@ -1,0 +1,118 @@
+import * as React from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+import { Redirect } from 'react-router';
+import styled from 'styled-components';
+
+import { API_ENDPOINT } from '../../settings';
+import { Video, videoState } from '../../types/Video';
+import { Nullable } from '../../utils/types';
+import { DashboardInternalHeading } from '../Dashboard/DashboardInternalHeading';
+import { DashboardVideoPaneButtons } from '../DashboardVideoPaneButtons/DashboardVideoPaneButtons';
+import { DashboardVideoPaneHelptext } from '../DashboardVideoPaneHelptext/DashboardVideoPaneHelptext';
+import { ROUTE as ERROR_ROUTE } from '../ErrorComponent/ErrorComponent';
+import { UploadStatusList } from '../UploadStatusList/UploadStatusList';
+
+const messages = defineMessages({
+  title: {
+    defaultMessage: 'Video preparation',
+    description:
+      'Subtitle for the video part of the dashboard (right now the only part until we add timed text tracks).',
+    id: 'components.Dashboard.title',
+  },
+});
+
+const DashboardInnerContainer = styled.div`
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+`;
+
+/** Props shape for the DashboardVideoPane component. */
+export interface DashboardVideoPaneProps {
+  jwt: Nullable<string>;
+  updateVideo: (video: Video) => void;
+  video: Video;
+}
+
+interface DashboardVideoPaneState {
+  error?: boolean;
+  pollInterval?: number;
+}
+
+/** Component. Displays the "video" part of the Dashboard, including the state of the video in
+ * marsha's pipeline. Provides links to the player and to the form to replace the video with another one.
+ * @param jwt The token that will be used to fetch the video record from the server to update it.
+ * @param updateVideo Action creator that takes a video to update it in the store.
+ * @param video The video object from AppData. We need it to populate the component before polling starts.
+ */
+export class DashboardVideoPane extends React.Component<
+  DashboardVideoPaneProps,
+  DashboardVideoPaneState
+> {
+  state: DashboardVideoPaneState = {};
+
+  componentDidMount() {
+    this.setState({
+      pollInterval: window.setInterval(() => this.pollForVideo(), 1000 * 60),
+    });
+  }
+
+  componentWillUnmount() {
+    // As a matter of hygiene, stop the polling as we unmount
+    if (this.state.pollInterval) {
+      window.clearInterval(this.state.pollInterval);
+    }
+  }
+
+  async pollForVideo() {
+    const { jwt, updateVideo, video } = this.props; // NB: Video from props
+    try {
+      const response = await fetch(`${API_ENDPOINT}/videos/${video.id}/`, {
+        headers: {
+          Authorization: `Bearer ${jwt}`,
+        },
+      });
+
+      const incomingVideo = await response.json();
+      // If the video is PENDING on the backend and PROCESSING on our end, we're probably experiencing a race
+      // condition where the backend is not yet aware of the end of the upload.
+      if (
+        incomingVideo.state === videoState.PENDING &&
+        video.state === videoState.PROCESSING
+      ) {
+        // Disregard the server-provided video.
+        return;
+      }
+      // When the video is ready, we need to update the App state so VideoForm has access to the URLs when it loads
+      else if (incomingVideo.state === videoState.READY) {
+        updateVideo(incomingVideo);
+      }
+    } catch (error) {
+      this.setState({ error: true });
+    }
+  }
+
+  render() {
+    const { video } = this.props;
+
+    if (this.state.error) {
+      return <Redirect push to={ERROR_ROUTE('notFound')} />;
+    }
+
+    if (video.state === videoState.ERROR) {
+      return <Redirect push to={ERROR_ROUTE('upload')} />;
+    }
+
+    return (
+      <DashboardInnerContainer>
+        <DashboardInternalHeading>
+          <FormattedMessage {...messages.title} />
+        </DashboardInternalHeading>
+        <UploadStatusList state={video.state} />
+        <DashboardVideoPaneHelptext state={video.state} />
+        <DashboardVideoPaneButtons state={video.state} />
+      </DashboardInnerContainer>
+    );
+  }
+}

--- a/src/frontend/components/DashboardVideoPaneButtons/DashboardVideoPaneButtons.spec.tsx
+++ b/src/frontend/components/DashboardVideoPaneButtons/DashboardVideoPaneButtons.spec.tsx
@@ -4,15 +4,15 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 
 import { videoState } from '../../types/Video';
-import { DashboardButtons } from './DashboardButtons';
+import { DashboardVideoPaneButtons } from './DashboardVideoPaneButtons';
 
 const { ERROR, PENDING, PROCESSING, READY, UPLOADING } = videoState;
 
-describe('<DashboardButtons />', () => {
+describe('<DashboardVideoPaneButtons />', () => {
   it('disables the "Watch" button unless the video is ready', () => {
     // We're testing the "Watch" button
     expect(
-      shallow(<DashboardButtons state={READY} />)
+      shallow(<DashboardVideoPaneButtons state={READY} />)
         .childAt(1)
         .html(),
     ).toContain('Watch');
@@ -20,14 +20,14 @@ describe('<DashboardButtons />', () => {
     // Can't watch the video before it's ready and uploaded
     for (const state of [ERROR, PENDING, PROCESSING, UPLOADING]) {
       expect(
-        shallow(<DashboardButtons state={state} />)
+        shallow(<DashboardVideoPaneButtons state={state} />)
           .childAt(1)
           .prop('disabled'),
       ).toBeTruthy();
     }
 
     expect(
-      shallow(<DashboardButtons state={READY} />)
+      shallow(<DashboardVideoPaneButtons state={READY} />)
         .childAt(1)
         .prop('disabled'),
     ).not.toBeTruthy();
@@ -36,14 +36,14 @@ describe('<DashboardButtons />', () => {
   it('adapts the text of the "Upload" button to the video state', () => {
     for (const state of [ERROR, PROCESSING, READY, UPLOADING]) {
       expect(
-        shallow(<DashboardButtons state={state} />)
+        shallow(<DashboardVideoPaneButtons state={state} />)
           .childAt(0)
           .html(),
       ).toContain('Replace the video');
     }
 
     expect(
-      shallow(<DashboardButtons state={PENDING} />)
+      shallow(<DashboardVideoPaneButtons state={PENDING} />)
         .childAt(0)
         .html(),
     ).toContain('Upload a video');

--- a/src/frontend/components/DashboardVideoPaneButtons/DashboardVideoPaneButtons.tsx
+++ b/src/frontend/components/DashboardVideoPaneButtons/DashboardVideoPaneButtons.tsx
@@ -15,23 +15,23 @@ const messages = defineMessages({
     defaultMessage: 'Watch',
     description:
       'Dashboard button to play the existing video, if there is one.',
-    id: 'components.Dashboard.DashboardButtons.btnPlayVideo',
+    id: 'components.Dashboard.DashboardVideoPaneButtons.btnPlayVideo',
   },
   btnReplaceVideo: {
     defaultMessage: 'Replace the video',
     description:
       'Dashboard button to upload a video to replace the existing one, when there *is* an existing video.',
-    id: 'components.Dashboard.DashboardButtons.btnReplaceVideo',
+    id: 'components.Dashboard.DashboardVideoPaneButtons.btnReplaceVideo',
   },
   btnUploadFirstVideo: {
     defaultMessage: 'Upload a video',
     description:
       'Dashboard button to upload a video, when there is no existing video.',
-    id: 'components.Dashboard.DashboardButtons.btnUploadFirstVideo',
+    id: 'components.Dashboard.DashboardVideoPaneButtons.btnUploadFirstVideo',
   },
 });
 
-const DashboardButtonsStyled = styled.div`
+const DashboardVideoPaneButtonsStyled = styled.div`
   display: flex;
 `;
 
@@ -41,8 +41,8 @@ const DashboardButtonStyled = withLink(styled(Button)`
   margin: 0 1rem;
 `);
 
-/** Props shape for the DashboardButtons component. */
-export interface DashboardButtonsProps {
+/** Props shape for the DashboardVideoPaneButtons component. */
+export interface DashboardVideoPaneButtonsProps {
   state: videoState;
 }
 
@@ -50,8 +50,10 @@ export interface DashboardButtonsProps {
  * look to the video's current state.
  * @param state The current state of the video/track upload.
  */
-export const DashboardButtons = (props: DashboardButtonsProps) => (
-  <DashboardButtonsStyled>
+export const DashboardVideoPaneButtons = (
+  props: DashboardVideoPaneButtonsProps,
+) => (
+  <DashboardVideoPaneButtonsStyled>
     <DashboardButtonStyled variant="primary" to={FORM_ROUTE()}>
       <FormattedMessage
         {...(props.state === PENDING
@@ -66,5 +68,5 @@ export const DashboardButtons = (props: DashboardButtonsProps) => (
     >
       <FormattedMessage {...messages.btnPlayVideo} />
     </DashboardButtonStyled>
-  </DashboardButtonsStyled>
+  </DashboardVideoPaneButtonsStyled>
 );

--- a/src/frontend/components/DashboardVideoPaneConnected/DashboardVideoPaneConnected.tsx
+++ b/src/frontend/components/DashboardVideoPaneConnected/DashboardVideoPaneConnected.tsx
@@ -1,0 +1,33 @@
+import { connect } from 'react-redux';
+import { Dispatch } from 'redux';
+
+import { addResource } from '../../data/genericReducers/resourceById/actions';
+import { RootState } from '../../data/rootReducer';
+import { modelName } from '../../types/models';
+import { Video } from '../../types/Video';
+import {
+  DashboardVideoPane,
+  DashboardVideoPaneProps,
+} from '../DashboardVideoPane/DashboardVideoPane';
+
+export const mapStateToProps = (
+  state: RootState,
+  ownProps: DashboardVideoPaneProps,
+) => ({
+  ...ownProps,
+  jwt: state.context.jwt,
+});
+
+/** Create a function that updates a single video in the store. */
+const mapDispatchToProps = (dispatch: Dispatch) => ({
+  updateVideo: (video: Video) => dispatch(addResource(modelName.VIDEOS, video)),
+});
+
+/**
+ * Component. Displays the "video" part of the Dashboard, including the state of the video in
+ * marsha's pipeline. Provides links to the player and to the form to replace the video with another one.
+ */
+export const DashboardVideoPaneConnected = connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(DashboardVideoPane);

--- a/src/frontend/components/DashboardVideoPaneHelptext/DashboardVideoPaneHelptext.spec.tsx
+++ b/src/frontend/components/DashboardVideoPaneHelptext/DashboardVideoPaneHelptext.spec.tsx
@@ -4,24 +4,28 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 
 import { videoState } from '../../types/Video';
-import { DashboardHelptext } from './DashboardHelptext';
+import { DashboardVideoPaneHelptext } from './DashboardVideoPaneHelptext';
 
 describe('<DashboardHelptext />', () => {
   it('displays the relevant helptext for each state', () => {
     expect(
-      shallow(<DashboardHelptext state={videoState.ERROR} />).html(),
+      shallow(<DashboardVideoPaneHelptext state={videoState.ERROR} />).html(),
     ).toContain('There was an error with your video');
     expect(
-      shallow(<DashboardHelptext state={videoState.PENDING} />).html(),
+      shallow(<DashboardVideoPaneHelptext state={videoState.PENDING} />).html(),
     ).toContain('There is currently no video to display here.');
     expect(
-      shallow(<DashboardHelptext state={videoState.PROCESSING} />).html(),
+      shallow(
+        <DashboardVideoPaneHelptext state={videoState.PROCESSING} />,
+      ).html(),
     ).toContain('Your video is currently processing');
     expect(
-      shallow(<DashboardHelptext state={videoState.READY} />).html(),
+      shallow(<DashboardVideoPaneHelptext state={videoState.READY} />).html(),
     ).toContain('Your video is ready to play');
     expect(
-      shallow(<DashboardHelptext state={videoState.UPLOADING} />).html(),
+      shallow(
+        <DashboardVideoPaneHelptext state={videoState.UPLOADING} />,
+      ).html(),
     ).toContain('Upload in progress');
   });
 });

--- a/src/frontend/components/DashboardVideoPaneHelptext/DashboardVideoPaneHelptext.tsx
+++ b/src/frontend/components/DashboardVideoPaneHelptext/DashboardVideoPaneHelptext.tsx
@@ -14,49 +14,51 @@ const messages: {
       'There was an error with your video. Retry or upload another one.',
     description:
       'Dashboard helptext for when the video failed to upload or get processed.',
-    id: 'components.Dashboard.DashboardHelptext.helptextError',
+    id: 'components.Dashboard.DashboardVideoPaneHelptext.helptextError',
   },
   [PENDING]: {
     defaultMessage: 'There is currently no video to display here.',
     description:
       'Dashboard helptext for the case when there is no existing video nor anything in progress.',
-    id: 'components.Dashboard.DashboardHelptext.helptextPending',
+    id: 'components.Dashboard.DashboardVideoPaneHelptext.helptextPending',
   },
   [PROCESSING]: {
     defaultMessage:
       'Your video is currently processing. This may take up to an hour. Please come back later.',
     description:
       'Dashboard helptext to warn users not to wait for video processing in front of this page.',
-    id: 'components.Dashboard.DashboardHelptext.helptextProcessing',
+    id: 'components.Dashboard.DashboardVideoPaneHelptext.helptextProcessing',
   },
   [READY]: {
     defaultMessage: 'Your video is ready to play.',
     description: 'Dashboard helptext for ready-to-play videos.',
-    id: 'components.Dashboard.DashboardHelptext.helptextReady',
+    id: 'components.Dashboard.DashboardVideoPaneHelptext.helptextReady',
   },
   [UPLOADING]: {
     defaultMessage:
       'Upload in progress... Please do not close or reload this page.',
     description:
       'Dashboard helptext to warn user not to navigate away during video upload.',
-    id: 'components.Dashboard.DashboardHelptext.helptextUploading',
+    id: 'components.Dashboard.DashboardVideoPaneHelptext.helptextUploading',
   },
 });
 
-const DashboardHelptextStyled = styled.div`
+const DashboardVideoPaneHelptextStyled = styled.div`
   padding: 0 1rem;
 `;
 
-/** Props shape for the DashboardHelptext component. */
-export interface DashboardHelptextProps {
+/** Props shape for the DashboardVideoPaneHelptext component. */
+export interface DashboardVideoPaneHelptextProps {
   state: videoState;
 }
 
 /** Component. Displays the relevant helptext for the user depending on the video state.
  * @param state The current state of the video/track upload.
  */
-export const DashboardHelptext = (props: DashboardHelptextProps) => (
-  <DashboardHelptextStyled>
+export const DashboardVideoPaneHelptext = (
+  props: DashboardVideoPaneHelptextProps,
+) => (
+  <DashboardVideoPaneHelptextStyled>
     <FormattedMessage {...messages[props.state]} />
-  </DashboardHelptextStyled>
+  </DashboardVideoPaneHelptextStyled>
 );

--- a/src/frontend/components/VideoForm/VideoForm.spec.tsx
+++ b/src/frontend/components/VideoForm/VideoForm.spec.tsx
@@ -4,16 +4,17 @@ import { shallow } from 'enzyme';
 import fetchMock from 'fetch-mock';
 import * as React from 'react';
 
-const makeFormData = jest.fn().mockReturnValue('form data body');
-jest.doMock('../../utils/makeFormData/makeFormData', () => ({ makeFormData }));
+const mockMakeFormData = jest.fn();
+jest.doMock('../../utils/makeFormData/makeFormData', () => ({
+  makeFormData: mockMakeFormData,
+}));
 
 jest.doMock('react-router-dom', () => ({
   Redirect: () => {},
 }));
 
-import { modelName } from '../../types/models';
 import { Video, videoState } from '../../types/Video';
-import { Dashboard, ROUTE as DASHBOARD_ROUTE } from '../Dashboard/Dashboard';
+import { ROUTE as DASHBOARD_ROUTE } from '../Dashboard/Dashboard';
 import { ROUTE as ERROR_ROUTE } from '../ErrorComponent/ErrorComponent';
 import { VideoForm } from './VideoForm';
 
@@ -27,7 +28,7 @@ describe('VideoForm', () => {
     title: '',
   } as Video;
 
-  beforeEach(mockUpdateVideo.mockReset);
+  beforeEach(jest.resetAllMocks);
 
   afterEach(fetchMock.restore);
 
@@ -80,12 +81,19 @@ describe('VideoForm', () => {
 
     await flushAllPromises();
 
+    mockMakeFormData.mockReturnValue('form data body');
     componentInstance.setState({
       file: { stub: 'file', type: 'video/mp4' } as any,
     });
     componentInstance.upload();
 
-    expect(makeFormData).toHaveBeenCalledWith(
+    expect(mockUpdateVideo).toHaveBeenCalledWith({
+      description: '',
+      id: 'ab42',
+      state: videoState.UPLOADING,
+      title: '',
+    });
+    expect(mockMakeFormData).toHaveBeenCalledWith(
       ['key', 'policy##key'],
       ['acl', 'policy##acl'],
       ['Content-Type', 'video/mp4'],
@@ -131,7 +139,7 @@ describe('VideoForm', () => {
     expect(wrapper.prop('to')).toEqual(ERROR_ROUTE('policy'));
   });
 
-  it('redirects to /errors/upload when it fails to upload the file', async () => {
+  it('marks the video with an error state when it fails to upload the file', async () => {
     // 1st call: home API call to get the AWS upload policy
     fetchMock.mock(
       '/api/videos/ab42/upload-policy/',
@@ -167,55 +175,11 @@ describe('VideoForm', () => {
     });
     componentInstance.upload();
 
-    expect(wrapper.name()).toEqual('Redirect');
-    expect(wrapper.prop('push')).toBeTruthy();
-    expect(wrapper.prop('to')).toEqual(ERROR_ROUTE('upload'));
-  });
-
-  it('shows the Dashboard with `isUploading` while the file is uploading', async () => {
-    // 1st call: home API call to get the AWS upload policy
-    fetchMock.mock(
-      '/api/videos/ab42/upload-policy/',
-      JSON.stringify({
-        acl: 'policy##acl',
-        bucket: 'good-ol-bucket',
-        key: 'policy##key',
-        policy: 'policy##policy',
-        s3_endpoint: 's3.aws.example.com',
-        x_amz_algorithm: 'policy##x_amz_algorithm',
-        x_amz_credential: 'policy##x_amz_credential',
-        x_amz_date: 'policy##x_amz_date',
-        x_amz_signature: 'policy##x_amz_signature',
-      }),
-    );
-
-    // 2nd call: AWS bucket multipart POST to upload the file
-    // We're not completing the promise in order to say in the UPLOADING state
-    const awsMockPromise = new Promise(() => {});
-    fetchMock.mock('https://s3.aws.example.com/good-ol-bucket', awsMockPromise);
-
-    const wrapper = shallow(
-      <VideoForm
-        jwt={'some_token'}
-        updateVideo={mockUpdateVideo}
-        video={video}
-      />,
-    );
-    const componentInstance = wrapper.instance() as VideoForm;
-    componentInstance.setState({
-      file: { stub: 'file', type: 'video/mp4' } as any,
+    expect(mockUpdateVideo).toHaveBeenCalledWith({
+      description: '',
+      id: 'ab42',
+      state: videoState.ERROR,
+      title: '',
     });
-    componentInstance.upload();
-
-    expect(
-      wrapper.equals(
-        <Dashboard
-          isUploading={true}
-          jwt={'some_token'}
-          updateVideo={mockUpdateVideo}
-          video={video}
-        />,
-      ),
-    ).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Purpose

As we're about to add timed text management to the Dashboard, we need to use a separate DashboardVideoPane component to display the part of the Dashboard that is about the video and hold the related logic.

## Proposal

To do this, we removed a little "hack" which consisted in having VideoForm display a Dashboard during upload to avoid making upload states shared between components. This meant updating the video directly in the store to reflect its client-side state rather than what the record on the backend "probably" holds.

We also move dashboard-related components to their own folders from components/Dashboard to keep a cleaner structure.
