### PR TITLE
♻️(aws) run yarn install in docker node to use node 8

### DIFF
--- a/src/aws/Makefile
+++ b/src/aws/Makefile
@@ -59,8 +59,7 @@ lambda:
 	@rm -rf dist && mkdir dist
 	@for lambda_name in configure encode update-state ; do \
 		cd ./lambda-$$lambda_name ; \
-		rm -rf node_modules ; \
-		yarn install --frozen-lockfile --production=true ; \
+		docker run --rm -it -v "${PWD}:/app" -w "/app/lambda-$$lambda_name" node:8 bash -c "rm -rf node_modules; yarn install --frozen-lockfile --production=true" ; \
 		zip -q -r9 ../dist/marsha_$$lambda_name.zip *; \
 		cd - ; \
 	done
@@ -71,8 +70,7 @@ test:
 	@echo "Test all lambda packages"
 	@for lambda_name in configure encode update-state ; do \
 		cd ./lambda-$$lambda_name ; \
-		rm -rf node_modules ; \
-		yarn install --frozen-lockfile ; \
+		docker run --rm -it -v "${PWD}:/app" -w "/app/lambda-$$lambda_name" node:8 bash -c "rm -rf node_modules; yarn install --frozen-lockfile" ; \
 		yarn test; \
 		cd - ; \
 	done


### PR DESCRIPTION
## Purpose
Lambda needs to be run with node 8 so their package.json enforce this
version. To be sure to use the good version the yarn install is now run
in a docker node container in version 8.

Fixes #111 

## Proposal

- [x]  execute yarn install in a docker node container in version 8
