### PR TITLE
✨(frontend) add a link to the dashboard from the video form

### DIFF
--- a/src/frontend/components/VideoForm/VideoForm.spec.tsx
+++ b/src/frontend/components/VideoForm/VideoForm.spec.tsx
@@ -10,6 +10,7 @@ jest.doMock('../../utils/makeFormData/makeFormData', () => ({
 }));
 
 jest.doMock('react-router-dom', () => ({
+  Link: () => null,
   Redirect: () => {},
 }));
 

--- a/src/frontend/components/VideoForm/VideoForm.tsx
+++ b/src/frontend/components/VideoForm/VideoForm.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
-import { Redirect } from 'react-router-dom';
+import { Link, Redirect } from 'react-router-dom';
 import styled from 'styled-components';
 
 import { API_ENDPOINT } from '../../settings';
@@ -20,6 +20,11 @@ const messages = defineMessages({
     description:
       'CTA for the form button for a video & its title & description',
     id: 'components.VideoForm.button',
+  },
+  linkToDashboard: {
+    defaultMessage: 'Back to dashboard',
+    description: 'Text for the link to the dashboard in the video form.',
+    id: 'components.VideoForm.linkToDashboard',
   },
   title: {
     defaultMessage: 'Create a new video',
@@ -45,6 +50,11 @@ const IframeHeadingWithLayout = styled(IframeHeading)`
 const VideoUploadFieldContainer = styled.div`
   flex-grow: 1;
   display: flex;
+`;
+
+const VideoFormBack = styled.div`
+  line-height: 2rem;
+  padding: 0.5rem 1rem;
 `;
 
 interface VideoFormProps {
@@ -150,16 +160,23 @@ export class VideoForm extends React.Component<VideoFormProps, VideoFormState> {
 
       default:
         return (
-          <VideoFormContainer>
-            <IframeHeadingWithLayout>
-              <FormattedMessage {...messages.title} />
-            </IframeHeadingWithLayout>
-            <VideoUploadFieldContainer>
-              <VideoUploadField
-                onContentUpdated={this.onVideoFieldContentUpdated.bind(this)}
-              />
-            </VideoUploadFieldContainer>
-          </VideoFormContainer>
+          <div>
+            <VideoFormContainer>
+              <IframeHeadingWithLayout>
+                <FormattedMessage {...messages.title} />
+              </IframeHeadingWithLayout>
+              <VideoUploadFieldContainer>
+                <VideoUploadField
+                  onContentUpdated={this.onVideoFieldContentUpdated.bind(this)}
+                />
+              </VideoUploadFieldContainer>
+            </VideoFormContainer>
+            <VideoFormBack>
+              <Link to={DASHBOARD_ROUTE()}>
+                <FormattedMessage {...messages.linkToDashboard} />
+              </Link>
+            </VideoFormBack>
+          </div>
         );
     }
   }


### PR DESCRIPTION
## Purpose

There are some circumstances when users need to be able to browse from the video form to the dashboard: when they clicked to update the video but elected not to upload a new file, or when they want to update timed text files before the video.

## Proposal

To accomodate these screnarii, we added a link in the video form that points to the dashboard.
