### PR TITLE
Group track-related types in a common file

### DIFF
--- a/src/frontend/components/Dashboard/Dashboard.spec.tsx
+++ b/src/frontend/components/Dashboard/Dashboard.spec.tsx
@@ -3,12 +3,12 @@ import '../../testSetup';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 
-import { videoState } from '../../types/Video';
+import { trackState } from '../../types/tracks';
 import { Dashboard } from './Dashboard';
 
 describe('<Dashboard />', () => {
   it('renders', () => {
-    const mockVideo: any = { id: 'dd44', state: videoState.PROCESSING };
+    const mockVideo: any = { id: 'dd44', state: trackState.PROCESSING };
 
     const wrapper = shallow(<Dashboard video={mockVideo} />)
       .dive()

--- a/src/frontend/components/Dashboard/Dashboard.tsx
+++ b/src/frontend/components/Dashboard/Dashboard.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import styled from 'styled-components';
 
-import { Video } from '../../types/Video';
+import { Video } from '../../types/tracks';
 import { DashboardVideoPaneConnected } from '../DashboardVideoPaneConnected/DashboardVideoPaneConnected';
 import { IframeHeading } from '../Headings/Headings';
 import { LayoutMainArea } from '../LayoutMainArea/LayoutMainArea';

--- a/src/frontend/components/DashboardConnected/DashboardConnected.tsx
+++ b/src/frontend/components/DashboardConnected/DashboardConnected.tsx
@@ -4,7 +4,7 @@ import { Dispatch } from 'redux';
 import { addResource } from '../../data/genericReducers/resourceById/actions';
 import { RootState } from '../../data/rootReducer';
 import { modelName } from '../../types/models';
-import { Video } from '../../types/Video';
+import { Video } from '../../types/tracks';
 import { Dashboard } from '../Dashboard/Dashboard';
 
 /** Props shape for the DashboardConnected component. */

--- a/src/frontend/components/DashboardVideoPane/DashboardVideoPane.spec.tsx
+++ b/src/frontend/components/DashboardVideoPane/DashboardVideoPane.spec.tsx
@@ -8,7 +8,7 @@ jest.mock('../DashboardVideoPaneButtons/DashboardVideoPaneButtons', () => ({
   DashboardVideoPaneButtons: () => {},
 }));
 
-import { videoState } from '../../types/Video';
+import { trackState } from '../../types/tracks';
 import { UploadStatusList } from '../UploadStatusList/UploadStatusList';
 import { DashboardVideoPane } from './DashboardVideoPane';
 
@@ -23,7 +23,7 @@ describe('<DashboardVideoPane />', () => {
 
   it('renders & starts polling for the video', async () => {
     // Create a mock video with the initial state (PROCESSING)
-    const mockVideo: any = { id: 'dd44', state: videoState.PROCESSING };
+    const mockVideo: any = { id: 'dd44', state: trackState.PROCESSING };
     fetchMock.mock('/api/videos/dd44/', mockVideo);
 
     let wrapper = shallow(
@@ -36,7 +36,7 @@ describe('<DashboardVideoPane />', () => {
 
     // DashboardVideoPane shows the video as PROCESSING
     expect(wrapper.find(UploadStatusList).prop('state')).toEqual(
-      videoState.PROCESSING,
+      trackState.PROCESSING,
     );
     expect(fetchMock.called()).not.toBeTruthy();
 
@@ -50,7 +50,7 @@ describe('<DashboardVideoPane />', () => {
 
     // The video will be ready in further responses
     fetchMock.reset();
-    mockVideo.state = videoState.READY;
+    mockVideo.state = trackState.READY;
 
     // Second backend call
     jest.advanceTimersByTime(1000 * 60 + 200);
@@ -75,7 +75,7 @@ describe('<DashboardVideoPane />', () => {
     );
     // DashboardVideoPane shows the video as READY
     expect(wrapper.find(UploadStatusList).prop('state')).toEqual(
-      videoState.READY,
+      trackState.READY,
     );
 
     // Unmount DashboardVideoPane to get rid of its interval
@@ -90,7 +90,7 @@ describe('<DashboardVideoPane />', () => {
       <DashboardVideoPane
         jwt={'cool_token_m8'}
         updateVideo={mockUpdateVideo}
-        video={{ id: 'ee55', state: videoState.PROCESSING } as any}
+        video={{ id: 'ee55', state: trackState.PROCESSING } as any}
       />,
     );
 
@@ -110,7 +110,7 @@ describe('<DashboardVideoPane />', () => {
       <DashboardVideoPane
         jwt={'cool_token_m8'}
         updateVideo={mockUpdateVideo}
-        video={{ id: 'ff66', state: videoState.ERROR } as any}
+        video={{ id: 'ff66', state: trackState.ERROR } as any}
       />,
     );
 

--- a/src/frontend/components/DashboardVideoPane/DashboardVideoPane.tsx
+++ b/src/frontend/components/DashboardVideoPane/DashboardVideoPane.tsx
@@ -4,7 +4,7 @@ import { Redirect } from 'react-router';
 import styled from 'styled-components';
 
 import { API_ENDPOINT } from '../../settings';
-import { Video, videoState } from '../../types/Video';
+import { trackState, Video } from '../../types/tracks';
 import { Nullable } from '../../utils/types';
 import { DashboardInternalHeading } from '../Dashboard/DashboardInternalHeading';
 import { DashboardVideoPaneButtons } from '../DashboardVideoPaneButtons/DashboardVideoPaneButtons';
@@ -78,14 +78,14 @@ export class DashboardVideoPane extends React.Component<
       // If the video is PENDING on the backend and PROCESSING on our end, we're probably experiencing a race
       // condition where the backend is not yet aware of the end of the upload.
       if (
-        incomingVideo.state === videoState.PENDING &&
-        video.state === videoState.PROCESSING
+        incomingVideo.state === trackState.PENDING &&
+        video.state === trackState.PROCESSING
       ) {
         // Disregard the server-provided video.
         return;
       }
       // When the video is ready, we need to update the App state so VideoForm has access to the URLs when it loads
-      else if (incomingVideo.state === videoState.READY) {
+      else if (incomingVideo.state === trackState.READY) {
         updateVideo(incomingVideo);
       }
     } catch (error) {
@@ -100,7 +100,7 @@ export class DashboardVideoPane extends React.Component<
       return <Redirect push to={ERROR_ROUTE('notFound')} />;
     }
 
-    if (video.state === videoState.ERROR) {
+    if (video.state === trackState.ERROR) {
       return <Redirect push to={ERROR_ROUTE('upload')} />;
     }
 

--- a/src/frontend/components/DashboardVideoPaneButtons/DashboardVideoPaneButtons.spec.tsx
+++ b/src/frontend/components/DashboardVideoPaneButtons/DashboardVideoPaneButtons.spec.tsx
@@ -3,10 +3,10 @@ import '../../testSetup';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 
-import { videoState } from '../../types/Video';
+import { trackState } from '../../types/tracks';
 import { DashboardVideoPaneButtons } from './DashboardVideoPaneButtons';
 
-const { ERROR, PENDING, PROCESSING, READY, UPLOADING } = videoState;
+const { ERROR, PENDING, PROCESSING, READY, UPLOADING } = trackState;
 
 describe('<DashboardVideoPaneButtons />', () => {
   it('disables the "Watch" button unless the video is ready', () => {

--- a/src/frontend/components/DashboardVideoPaneButtons/DashboardVideoPaneButtons.tsx
+++ b/src/frontend/components/DashboardVideoPaneButtons/DashboardVideoPaneButtons.tsx
@@ -2,13 +2,13 @@ import * as React from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import styled from 'styled-components';
 
-import { videoState } from '../../types/Video';
+import { trackState } from '../../types/tracks';
 import { Button } from '../Button/Button';
 import { ROUTE as FORM_ROUTE } from '../VideoForm/VideoForm';
 import { ROUTE as PLAYER_ROUTE } from '../VideoPlayer/VideoPlayer';
 import { withLink } from '../withLink/withLink';
 
-const { PENDING, READY } = videoState;
+const { PENDING, READY } = trackState;
 
 const messages = defineMessages({
   btnPlayVideo: {
@@ -43,7 +43,7 @@ const DashboardButtonStyled = withLink(styled(Button)`
 
 /** Props shape for the DashboardVideoPaneButtons component. */
 export interface DashboardVideoPaneButtonsProps {
-  state: videoState;
+  state: trackState;
 }
 
 /** Component. Displays buttons with links to the Player & the Form, adapting their state and

--- a/src/frontend/components/DashboardVideoPaneConnected/DashboardVideoPaneConnected.tsx
+++ b/src/frontend/components/DashboardVideoPaneConnected/DashboardVideoPaneConnected.tsx
@@ -4,7 +4,7 @@ import { Dispatch } from 'redux';
 import { addResource } from '../../data/genericReducers/resourceById/actions';
 import { RootState } from '../../data/rootReducer';
 import { modelName } from '../../types/models';
-import { Video } from '../../types/Video';
+import { Video } from '../../types/tracks';
 import {
   DashboardVideoPane,
   DashboardVideoPaneProps,

--- a/src/frontend/components/DashboardVideoPaneHelptext/DashboardVideoPaneHelptext.spec.tsx
+++ b/src/frontend/components/DashboardVideoPaneHelptext/DashboardVideoPaneHelptext.spec.tsx
@@ -3,28 +3,28 @@ import '../../testSetup';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 
-import { videoState } from '../../types/Video';
+import { trackState } from '../../types/tracks';
 import { DashboardVideoPaneHelptext } from './DashboardVideoPaneHelptext';
 
 describe('<DashboardHelptext />', () => {
   it('displays the relevant helptext for each state', () => {
     expect(
-      shallow(<DashboardVideoPaneHelptext state={videoState.ERROR} />).html(),
+      shallow(<DashboardVideoPaneHelptext state={trackState.ERROR} />).html(),
     ).toContain('There was an error with your video');
     expect(
-      shallow(<DashboardVideoPaneHelptext state={videoState.PENDING} />).html(),
+      shallow(<DashboardVideoPaneHelptext state={trackState.PENDING} />).html(),
     ).toContain('There is currently no video to display here.');
     expect(
       shallow(
-        <DashboardVideoPaneHelptext state={videoState.PROCESSING} />,
+        <DashboardVideoPaneHelptext state={trackState.PROCESSING} />,
       ).html(),
     ).toContain('Your video is currently processing');
     expect(
-      shallow(<DashboardVideoPaneHelptext state={videoState.READY} />).html(),
+      shallow(<DashboardVideoPaneHelptext state={trackState.READY} />).html(),
     ).toContain('Your video is ready to play');
     expect(
       shallow(
-        <DashboardVideoPaneHelptext state={videoState.UPLOADING} />,
+        <DashboardVideoPaneHelptext state={trackState.UPLOADING} />,
       ).html(),
     ).toContain('Upload in progress');
   });

--- a/src/frontend/components/DashboardVideoPaneHelptext/DashboardVideoPaneHelptext.tsx
+++ b/src/frontend/components/DashboardVideoPaneHelptext/DashboardVideoPaneHelptext.tsx
@@ -2,12 +2,12 @@ import * as React from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import styled from 'styled-components';
 
-import { videoState } from '../../types/Video';
+import { trackState } from '../../types/tracks';
 
-const { ERROR, PENDING, PROCESSING, READY, UPLOADING } = videoState;
+const { ERROR, PENDING, PROCESSING, READY, UPLOADING } = trackState;
 
 const messages: {
-  [state in videoState]: FormattedMessage.MessageDescriptor
+  [state in trackState]: FormattedMessage.MessageDescriptor
 } = defineMessages({
   [ERROR]: {
     defaultMessage:
@@ -49,7 +49,7 @@ const DashboardVideoPaneHelptextStyled = styled.div`
 
 /** Props shape for the DashboardVideoPaneHelptext component. */
 export interface DashboardVideoPaneHelptextProps {
-  state: videoState;
+  state: trackState;
 }
 
 /** Component. Displays the relevant helptext for the user depending on the video state.

--- a/src/frontend/components/RedirectOnLoad/RedirectOnLoad.spec.tsx
+++ b/src/frontend/components/RedirectOnLoad/RedirectOnLoad.spec.tsx
@@ -4,7 +4,7 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 
 import { appState } from '../../types/AppData';
-import { videoState } from '../../types/Video';
+import { trackState } from '../../types/tracks';
 import { ROUTE as DASHBOARD_ROUTE } from '../Dashboard/Dashboard';
 import { ROUTE as ERROR_ROUTE } from '../ErrorComponent/ErrorComponent';
 import { ROUTE as FORM_ROUTE } from '../VideoForm/VideoForm';
@@ -26,7 +26,7 @@ describe('<RedirectOnLoad />', () => {
     const wrapper = shallow(
       <RedirectOnLoad
         ltiState={appState.INSTRUCTOR}
-        video={{ state: videoState.READY } as any}
+        video={{ state: trackState.READY } as any}
       />,
     );
 
@@ -39,7 +39,7 @@ describe('<RedirectOnLoad />', () => {
     const wrapper = shallow(
       <RedirectOnLoad
         ltiState={appState.STUDENT}
-        video={{ state: videoState.READY } as any}
+        video={{ state: trackState.READY } as any}
       />,
     );
 
@@ -52,7 +52,7 @@ describe('<RedirectOnLoad />', () => {
     const wrapper = shallow(
       <RedirectOnLoad
         ltiState={appState.INSTRUCTOR}
-        video={{ state: videoState.PENDING } as any}
+        video={{ state: trackState.PENDING } as any}
       />,
     );
 
@@ -65,7 +65,7 @@ describe('<RedirectOnLoad />', () => {
     const wrapper = shallow(
       <RedirectOnLoad
         ltiState={appState.INSTRUCTOR}
-        video={{ state: videoState.PROCESSING } as any}
+        video={{ state: trackState.PROCESSING } as any}
       />,
     );
 

--- a/src/frontend/components/RedirectOnLoad/RedirectOnLoad.tsx
+++ b/src/frontend/components/RedirectOnLoad/RedirectOnLoad.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Redirect } from 'react-router-dom';
 
 import { appState } from '../../types/AppData';
-import { Video, videoState } from '../../types/Video';
+import { trackState, Video } from '../../types/tracks';
 import { Nullable } from '../../utils/types';
 import { ROUTE as DASHBOARD_ROUTE } from '../Dashboard/Dashboard';
 import { ROUTE as ERROR_ROUTE } from '../ErrorComponent/ErrorComponent';
@@ -24,12 +24,12 @@ export const RedirectOnLoad = ({ ltiState, video }: RedirectOnLoadProps) => {
     return <Redirect push to={ERROR_ROUTE('lti')} />;
   }
   // Everyone gets the video when it exists (so that instructors see the iframes like a student would by default)
-  else if (video && video.state === videoState.READY) {
+  else if (video && video.state === trackState.READY) {
     return <Redirect push to={PLAYER_ROUTE()} />;
   }
   // Only instructors are allowed to interact with a non-ready video
   else if (ltiState === appState.INSTRUCTOR) {
-    if (video!.state === videoState.PENDING) {
+    if (video!.state === trackState.PENDING) {
       return <Redirect push to={FORM_ROUTE()} />;
     } else {
       return <Redirect push to={DASHBOARD_ROUTE()} />;

--- a/src/frontend/components/UploadStatusList/UploadStatusList.spec.tsx
+++ b/src/frontend/components/UploadStatusList/UploadStatusList.spec.tsx
@@ -3,11 +3,11 @@ import '../../testSetup';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 
-import { videoState } from '../../types/Video';
+import { trackState } from '../../types/tracks';
 import { statusIconKey, UploadStatus } from './UploadStatus';
 import { UploadStatusList } from './UploadStatusList';
 
-const { ERROR, PENDING, PROCESSING, READY, UPLOADING } = videoState;
+const { ERROR, PENDING, PROCESSING, READY, UPLOADING } = trackState;
 
 describe('<UploadStatusList />', () => {
   it('renders the status list for PENDING', () => {

--- a/src/frontend/components/UploadStatusList/UploadStatusList.tsx
+++ b/src/frontend/components/UploadStatusList/UploadStatusList.tsx
@@ -2,11 +2,11 @@ import * as React from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import styled from 'styled-components';
 
-import { videoState } from '../../types/Video';
+import { trackState } from '../../types/tracks';
 import { colors } from '../../utils/theme/theme';
 import { statusIconKey, UploadStatus } from './UploadStatus';
 
-const { PROCESSING, READY, UPLOADING } = videoState;
+const { PROCESSING, READY, UPLOADING } = trackState;
 
 const messages = defineMessages({
   statusProcessed: {
@@ -47,7 +47,7 @@ const UploadStatusListStyled = styled.ul`
 
 /** Props shape for the UploadStatusList component. */
 export interface UploadStatusListProps {
-  state: videoState;
+  state: trackState;
 }
 
 /** Component. Displays the list of statuses for an upload, showing (and/or highlighting)

--- a/src/frontend/components/VideoForm/VideoForm.spec.tsx
+++ b/src/frontend/components/VideoForm/VideoForm.spec.tsx
@@ -14,7 +14,7 @@ jest.doMock('react-router-dom', () => ({
   Redirect: () => {},
 }));
 
-import { Video, videoState } from '../../types/Video';
+import { trackState, Video } from '../../types/tracks';
 import { ROUTE as DASHBOARD_ROUTE } from '../Dashboard/Dashboard';
 import { ROUTE as ERROR_ROUTE } from '../ErrorComponent/ErrorComponent';
 import { VideoForm } from './VideoForm';
@@ -91,7 +91,7 @@ describe('VideoForm', () => {
     expect(mockUpdateVideo).toHaveBeenCalledWith({
       description: '',
       id: 'ab42',
-      state: videoState.UPLOADING,
+      state: trackState.UPLOADING,
       title: '',
     });
     expect(mockMakeFormData).toHaveBeenCalledWith(
@@ -115,7 +115,7 @@ describe('VideoForm', () => {
     expect(mockUpdateVideo).toHaveBeenCalledWith({
       description: '',
       id: 'ab42',
-      state: videoState.PROCESSING,
+      state: trackState.PROCESSING,
       title: '',
     });
     expect(wrapper.name()).toEqual('Redirect');
@@ -179,7 +179,7 @@ describe('VideoForm', () => {
     expect(mockUpdateVideo).toHaveBeenCalledWith({
       description: '',
       id: 'ab42',
-      state: videoState.ERROR,
+      state: trackState.ERROR,
       title: '',
     });
   });

--- a/src/frontend/components/VideoForm/VideoForm.tsx
+++ b/src/frontend/components/VideoForm/VideoForm.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 
 import { API_ENDPOINT } from '../../settings';
 import { AWSPolicy } from '../../types/AWSPolicy';
-import { Video, videoState } from '../../types/Video';
+import { trackState, Video } from '../../types/tracks';
 import { makeFormData } from '../../utils/makeFormData/makeFormData';
 import { Maybe, Nullable } from '../../utils/types';
 import { ROUTE as DASHBOARD_ROUTE } from '../Dashboard/Dashboard';
@@ -120,7 +120,7 @@ export class VideoForm extends React.Component<VideoFormProps, VideoFormState> {
       // Useful for the Dashboard loader and help text.
       updateVideo({
         ...video,
-        state: videoState.UPLOADING,
+        state: trackState.UPLOADING,
       });
 
       const response = await fetch(
@@ -134,7 +134,7 @@ export class VideoForm extends React.Component<VideoFormProps, VideoFormState> {
       if (response.ok) {
         updateVideo({
           ...video,
-          state: videoState.PROCESSING,
+          state: trackState.PROCESSING,
         });
       } else {
         throw new Error('Failed to upload video.');
@@ -142,7 +142,7 @@ export class VideoForm extends React.Component<VideoFormProps, VideoFormState> {
     } catch (error) {
       updateVideo({
         ...video,
-        state: videoState.ERROR,
+        state: trackState.ERROR,
       });
     }
   }

--- a/src/frontend/components/VideoFormConnected/VideoFormConnected.tsx
+++ b/src/frontend/components/VideoFormConnected/VideoFormConnected.tsx
@@ -4,7 +4,7 @@ import { Dispatch } from 'redux';
 import { addResource } from '../../data/genericReducers/resourceById/actions';
 import { RootState } from '../../data/rootReducer';
 import { modelName } from '../../types/models';
-import { Video } from '../../types/Video';
+import { Video } from '../../types/tracks';
 import { VideoForm } from '../VideoForm/VideoForm';
 
 /** Props shape for the VideoFormConnected component. */

--- a/src/frontend/components/VideoPlayer/VideoPlayer.spec.tsx
+++ b/src/frontend/components/VideoPlayer/VideoPlayer.spec.tsx
@@ -5,7 +5,7 @@ import Plyr from 'plyr';
 import * as React from 'react';
 import shaka from 'shaka-player';
 
-import { Video } from '../../types/Video';
+import { Video } from '../../types/tracks';
 import { VideoPlayer } from './VideoPlayer';
 
 const mockShakaPlayer: jest.Mocked<typeof shaka.Player> = shaka.Player as any;

--- a/src/frontend/components/VideoPlayer/VideoPlayer.tsx
+++ b/src/frontend/components/VideoPlayer/VideoPlayer.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { Redirect } from 'react-router';
 import shaka from 'shaka-player';
 
-import { Video, videoSize } from '../../types/Video';
+import { Video, videoSize } from '../../types/tracks';
 import { Maybe, Nullable } from '../../utils/types';
 import { ROUTE as ERROR_ROUTE } from '../ErrorComponent/ErrorComponent';
 import './VideoPlayer.css'; // Improve some plyr styles

--- a/src/frontend/data/rootReducer.ts
+++ b/src/frontend/data/rootReducer.ts
@@ -2,7 +2,7 @@ import { Reducer } from 'redux';
 
 import { appState } from '../types/AppData';
 import { modelName } from '../types/models';
-import { Video } from '../types/Video';
+import { Video } from '../types/tracks';
 import { Nullable } from '../utils/types';
 import { videos, VideosState } from './videos/reducer';
 

--- a/src/frontend/data/videos/reducer.ts
+++ b/src/frontend/data/videos/reducer.ts
@@ -2,7 +2,7 @@ import { AnyAction, Reducer } from 'redux';
 
 import { modelName } from '../../types/models';
 import { ResourceByIdState } from '../../types/Resource';
-import { Video } from '../../types/Video';
+import { Video } from '../../types/tracks';
 import { Maybe } from '../../utils/types';
 import {
   ResourceAdd,

--- a/src/frontend/types/AppData.ts
+++ b/src/frontend/types/AppData.ts
@@ -1,6 +1,6 @@
 import { Nullable } from '../utils/types';
 import { AWSPolicy } from './AWSPolicy';
-import { Video } from './Video';
+import { Video } from './tracks';
 
 export enum appState {
   ERROR = 'error',

--- a/src/frontend/types/tracks.ts
+++ b/src/frontend/types/tracks.ts
@@ -1,22 +1,20 @@
 import { Resource } from './Resource';
 
-/** Possible sizes for a video file or stream. Used as keys in lists of files. */
-export type videoSize = '144' | '240' | '480' | '720' | '1080';
-
-/** Possible states for a video.
+/** Possible states for a track, whether video or other such as timed text.
  *
  * NB: PENDING, PROCESSING, READY and ERROR are the actual possible values
  * for the state field on a video record.
  *
- * UPLOADING does not exist as a video state on the backend side, as during
+ * UPLOADING does not exist as a track state on the backend side, as during
  * upload the model value for the state is still PENDING. However, here
- * on the frontend, they are two different states as far as the user is concerned.
+ * on the frontend, they are two different states as far as the user is concerned,
+ * especially when it comes to videos which might take a long time to upload.
  *
  * We add it in to make it easier to work with those states. It should not actually be
- * applied on any Video but will be used as a stand-in wherever we're passing
- * video state without the full video and need to represent this state.
+ * applied on any Video or other track record but will be used as a stand-in in our local
+ * track representations and whenever we might need to pass such state information around.
  */
-export enum videoState {
+export enum trackState {
   ERROR = 'error',
   PENDING = 'pending',
   PROCESSING = 'processing',
@@ -24,11 +22,14 @@ export enum videoState {
   UPLOADING = 'uploading',
 }
 
+/** Possible sizes for a video file or stream. Used as keys in lists of files. */
+export type videoSize = '144' | '240' | '480' | '720' | '1080';
+
 /** A Video record as it exists on the backend. */
 export interface Video extends Resource {
   description: string;
   id: string;
-  state: videoState;
+  state: trackState;
   title: string;
   urls: {
     manifests: {


### PR DESCRIPTION
## Purpose

As we're about to add a type for timed text tracks and some related enums, we decided it would be more tidy to keep those types together in the same file, mirrorring the organization of code on the backend side, rather than split them into an arbitrary number of files.

We also need to make apparent the fact that states are shared between different types of tracks, which the name `videoState` does not convey. 

## Proposal

- [x] Group track-related types in a `types/tracks.ts` file
- [x] Rename `videoState` to `trackState` so it can be cleanly used for both video tracks and timed text tracks.
