### PR TITLE
✨(api) allow timed text track list GET requests on the API

### DIFF
--- a/src/backend/marsha/core/api.py
+++ b/src/backend/marsha/core/api.py
@@ -131,6 +131,7 @@ class VideoViewSet(
 
 class TimedTextTrackViewSet(
     mixins.CreateModelMixin,
+    mixins.ListModelMixin,
     mixins.RetrieveModelMixin,
     mixins.UpdateModelMixin,
     viewsets.GenericViewSet,


### PR DESCRIPTION
## Purpose

We need to make list GET requests on timed text tracks to display the dashboard and allow users to manage their subtitles, transcripts & closed captions.

## Proposal

Allowing those requests is just a matter of adding the relevant DRF mixin to the TimedTextTrack viewset.
