### PR TITLE
refactor JWT token usage

### DIFF
--- a/src/backend/marsha/core/lti.py
+++ b/src/backend/marsha/core/lti.py
@@ -201,7 +201,7 @@ class LTI:
         # Remove all spaces from the string and extra trailing or leading commas
         roles = re.sub(r"[\s+]", "", roles).strip(",")
         # Return a set of the roles mentioned in the request
-        return set(roles.lower().split(",")) if roles else set()
+        return roles.lower().split(",") if roles else []
 
     @property
     def is_instructor(self):
@@ -213,7 +213,7 @@ class LTI:
             True if the user is an instructor, False otherwise
 
         """
-        return bool(LTI_ROLES[INSTRUCTOR] & self.roles)
+        return bool(LTI_ROLES[INSTRUCTOR] & set(self.roles))
 
     @property
     def is_student(self):
@@ -225,7 +225,7 @@ class LTI:
             True if the user is a student, False otherwise
 
         """
-        return bool(LTI_ROLES[STUDENT] & self.roles)
+        return bool(LTI_ROLES[STUDENT] & set(self.roles))
 
     def get_or_create_video(self):
         """Get or create the video targeted by the LTI launch request.

--- a/src/backend/marsha/core/templates/core/lti_development.html
+++ b/src/backend/marsha/core/templates/core/lti_development.html
@@ -56,6 +56,8 @@
           value="course-v1:ufr+mathematics+0001"
         />
         <input type="text" name="roles" value="Instructor" />
+        <input type="text" name="user_id" value="56255f3807599c377bf0e5bf072359fd" />
+        <input type="text" name="lis_person_contact_email_primary" value="contact@openfun.fr" />
         <input type="submit" />
       </form>
 
@@ -93,6 +95,8 @@
           value="course-v1:ufr+mathematics+0001"
         />
         <input type="text" name="roles" value="Instructor" />
+        <input type="text" name="user_id" value="56255f3807599c377bf0e5bf072359fd" />
+        <input type="text" name="lis_person_contact_email_primary" value="contact@openfun.fr" />        
         <input type="submit" />
       </form>
     </section>

--- a/src/backend/marsha/core/tests/test_api_timed_text_track.py
+++ b/src/backend/marsha/core/tests/test_api_timed_text_track.py
@@ -34,6 +34,23 @@ class TimedTextTrackAPITest(TestCase):
             content, {"detail": "Authentication credentials were not provided."}
         )
 
+    def test_api_timed_text_track_read_detail_student(self):
+        """Student users should not be allowed to read a timed text track detail."""
+        timed_text_track = TimedTextTrackFactory()
+        jwt_token = AccessToken()
+        jwt_token.payload["video_id"] = str(timed_text_track.video.id)
+        jwt_token.payload["roles"] = ["student"]
+        # Get the timed text track using the JWT token
+        response = self.client.get(
+            "/api/timedtexttracks/{!s}/".format(timed_text_track.id),
+            HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token),
+        )
+        self.assertEqual(response.status_code, 403)
+        content = json.loads(response.content)
+        self.assertEqual(
+            content, {"detail": "Only admin users or object owners are allowed."}
+        )
+
     @override_settings(CLOUDFRONT_SIGNED_URLS_ACTIVE=False)
     def test_api_timed_text_track_read_detail_token_user(self):
         """A token user associated to a video can read a timed text track related to this video."""
@@ -47,6 +64,7 @@ class TimedTextTrackAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["video_id"] = str(timed_text_track.video.id)
+        jwt_token.payload["roles"] = ["instructor"]
 
         # Get the timed text track using the JWT token
         response = self.client.get(
@@ -93,6 +111,7 @@ class TimedTextTrackAPITest(TestCase):
         timed_text_track = TimedTextTrackFactory(uploaded_on=None)
         jwt_token = AccessToken()
         jwt_token.payload["video_id"] = str(timed_text_track.video.id)
+        jwt_token.payload["roles"] = ["instructor"]
 
         # Get the timed text track using the JWT token
         response = self.client.get(
@@ -116,6 +135,7 @@ class TimedTextTrackAPITest(TestCase):
             )
             jwt_token = AccessToken()
             jwt_token.payload["video_id"] = str(timed_text_track.video.id)
+            jwt_token.payload["roles"] = ["instructor"]
 
             # Get the timed_text_track linked to the JWT token
             response = self.client.get(
@@ -143,6 +163,7 @@ class TimedTextTrackAPITest(TestCase):
         )
         jwt_token = AccessToken()
         jwt_token.payload["video_id"] = str(timed_text_track.video.id)
+        jwt_token.payload["roles"] = ["instructor"]
 
         # Get the timed_text_track via the API using the JWT token
         # fix the time so that the url signature is deterministic and can be checked
@@ -194,6 +215,7 @@ class TimedTextTrackAPITest(TestCase):
         timed_text_track_two = TimedTextTrackFactory(video=timed_text_track_one.video)
         jwt_token = AccessToken()
         jwt_token.payload["video_id"] = str(timed_text_track_one.video.id)
+        jwt_token.payload["roles"] = ["instructor"]
 
         response = self.client.get(
             "/api/timedtexttracks/", HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token)
@@ -227,6 +249,7 @@ class TimedTextTrackAPITest(TestCase):
         video = VideoFactory(id="f8c30d0d-2bb4-440d-9e8d-f4b231511f1f")
         jwt_token = AccessToken()
         jwt_token.payload["video_id"] = str(video.id)
+        jwt_token.payload["roles"] = ["instructor"]
 
         data = {"language": "fr"}
         response = self.client.post(
@@ -277,6 +300,7 @@ class TimedTextTrackAPITest(TestCase):
         timed_text_track = TimedTextTrackFactory(language="fr")
         jwt_token = AccessToken()
         jwt_token.payload["video_id"] = str(timed_text_track.video.id)
+        jwt_token.payload["roles"] = ["instructor"]
 
         data = {"language": "en"}
         response = self.client.put(
@@ -294,6 +318,7 @@ class TimedTextTrackAPITest(TestCase):
         timed_text_track = TimedTextTrackFactory(mode="cc")
         jwt_token = AccessToken()
         jwt_token.payload["video_id"] = str(timed_text_track.video.id)
+        jwt_token.payload["roles"] = ["instructor"]
 
         response = self.client.get(
             "/api/timedtexttracks/{!s}/".format(timed_text_track.id),
@@ -317,6 +342,7 @@ class TimedTextTrackAPITest(TestCase):
         timed_text_track = TimedTextTrackFactory()
         jwt_token = AccessToken()
         jwt_token.payload["video_id"] = str(timed_text_track.video.id)
+        jwt_token.payload["roles"] = ["instructor"]
 
         response = self.client.get(
             "/api/timedtexttracks/{!s}/".format(timed_text_track.id),
@@ -342,6 +368,7 @@ class TimedTextTrackAPITest(TestCase):
         timed_text_track = TimedTextTrackFactory(state="pending")
         jwt_token = AccessToken()
         jwt_token.payload["video_id"] = str(timed_text_track.video.id)
+        jwt_token.payload["roles"] = ["instructor"]
 
         response = self.client.get(
             "/api/timedtexttracks/{!s}/".format(timed_text_track.id),
@@ -366,6 +393,7 @@ class TimedTextTrackAPITest(TestCase):
         original_id = timed_text_track.id
         jwt_token = AccessToken()
         jwt_token.payload["video_id"] = str(timed_text_track.video.id)
+        jwt_token.payload["roles"] = ["instructor"]
 
         response = self.client.get(
             "/api/timedtexttracks/{!s}/".format(timed_text_track.id),
@@ -390,6 +418,7 @@ class TimedTextTrackAPITest(TestCase):
         original_video = timed_text_track.video
         jwt_token = AccessToken()
         jwt_token.payload["video_id"] = str(timed_text_track.video.id)
+        jwt_token.payload["roles"] = ["instructor"]
 
         response = self.client.get(
             "/api/timedtexttracks/{!s}/".format(timed_text_track.id),
@@ -414,6 +443,7 @@ class TimedTextTrackAPITest(TestCase):
         timed_text_track_update = TimedTextTrackFactory(language="en")
         jwt_token = AccessToken()
         jwt_token.payload["video_id"] = str(other_video.id)
+        jwt_token.payload["roles"] = ["instructor"]
 
         data = {"language": "fr"}
         response = self.client.put(
@@ -437,6 +467,7 @@ class TimedTextTrackAPITest(TestCase):
         timed_text_track = TimedTextTrackFactory()
         jwt_token = AccessToken()
         jwt_token.payload["video_id"] = str(timed_text_track.video.id)
+        jwt_token.payload["roles"] = ["instructor"]
         self.assertEqual(timed_text_track.state, "pending")
         self.assertIsNone(timed_text_track.uploaded_on)
 
@@ -476,6 +507,7 @@ class TimedTextTrackAPITest(TestCase):
         timed_text_tracks = TimedTextTrackFactory.create_batch(2)
         jwt_token = AccessToken()
         jwt_token.payload["video_id"] = str(timed_text_tracks[0].video.id)
+        jwt_token.payload["roles"] = ["instructor"]
 
         # Try deleting the timed text tracks using the JWT token
         for timed_text_track in timed_text_tracks:
@@ -523,6 +555,7 @@ class TimedTextTrackAPITest(TestCase):
         timed_text_track = TimedTextTrackFactory()
         jwt_token = AccessToken()
         jwt_token.payload["video_id"] = str(timed_text_track.video.id)
+        jwt_token.payload["roles"] = ["instructor"]
 
         response = self.client.delete(
             "/api/timedtexttracks/", HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token)
@@ -569,6 +602,7 @@ class TimedTextTrackAPITest(TestCase):
         )
         jwt_token = AccessToken()
         jwt_token.payload["video_id"] = str(timed_text_track.video.id)
+        jwt_token.payload["roles"] = ["instructor"]
 
         # Get the upload policy for this timed text track
         # It should generate a key file with the Unix timestamp of the present time

--- a/src/backend/marsha/core/tests/test_api_video.py
+++ b/src/backend/marsha/core/tests/test_api_video.py
@@ -61,9 +61,26 @@ class VideoAPITest(TestCase):
             content, {"detail": "Authentication credentials were not provided."}
         )
 
+    def test_api_video_read_detail_student(self):
+        """Student users should not be allowed to read a video detail."""
+        video = VideoFactory()
+        jwt_token = AccessToken()
+        jwt_token.payload["video_id"] = str(video.id)
+        jwt_token.payload["roles"] = ["student"]
+        # Get the video linked to the JWT token
+        response = self.client.get(
+            "/api/videos/{!s}/".format(video.id),
+            HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token),
+        )
+        self.assertEqual(response.status_code, 403)
+        content = json.loads(response.content)
+        self.assertEqual(
+            content, {"detail": "Only admin users or object owners are allowed."}
+        )
+
     @override_settings(CLOUDFRONT_SIGNED_URLS_ACTIVE=False)
     def test_api_video_read_detail_token_user(self):
-        """A token user associated to a video should be able to read the detail of this video."""
+        """Instructors should be able to read the detail of their video."""
         video = VideoFactory(
             resource_id="a2f27fde-973a-4e89-8dca-cc59e01d255c",
             uploaded_on=datetime(2018, 8, 8, tzinfo=pytz.utc),
@@ -79,6 +96,7 @@ class VideoAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["video_id"] = str(video.id)
+        jwt_token.payload["roles"] = ["instructor"]
 
         # Get the video linked to the JWT token
         response = self.client.get(
@@ -163,6 +181,7 @@ class VideoAPITest(TestCase):
         video = VideoFactory(uploaded_on=None)
         jwt_token = AccessToken()
         jwt_token.payload["video_id"] = str(video.id)
+        jwt_token.payload["roles"] = ["instructor"]
 
         # Get the video linked to the JWT token
         response = self.client.get(
@@ -198,6 +217,7 @@ class VideoAPITest(TestCase):
             )
             jwt_token = AccessToken()
             jwt_token.payload["video_id"] = str(video.id)
+            jwt_token.payload["roles"] = ["instructor"]
 
             # Get the video linked to the JWT token
             response = self.client.get(
@@ -234,6 +254,7 @@ class VideoAPITest(TestCase):
         )
         jwt_token = AccessToken()
         jwt_token.payload["video_id"] = str(video.id)
+        jwt_token.payload["roles"] = ["instructor"]
 
         # Get the video linked to the JWT token
         # fix the time so that the url signature is deterministic and can be checked
@@ -289,6 +310,7 @@ class VideoAPITest(TestCase):
         video = VideoFactory()
         jwt_token = AccessToken()
         jwt_token.payload["video_id"] = str(video.id)
+        jwt_token.payload["roles"] = ["instructor"]
 
         response = self.client.get(
             "/api/videos/", HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token)
@@ -344,6 +366,7 @@ class VideoAPITest(TestCase):
         video = VideoFactory(title="my title")
         jwt_token = AccessToken()
         jwt_token.payload["video_id"] = str(video.id)
+        jwt_token.payload["roles"] = ["instructor"]
         data = {"title": "my new title"}
         response = self.client.put(
             "/api/videos/{!s}/".format(video.id),
@@ -360,6 +383,7 @@ class VideoAPITest(TestCase):
         video = VideoFactory(description="my description")
         jwt_token = AccessToken()
         jwt_token.payload["video_id"] = str(video.id)
+        jwt_token.payload["roles"] = ["instructor"]
 
         response = self.client.get(
             "/api/videos/{!s}/".format(video.id),
@@ -382,6 +406,7 @@ class VideoAPITest(TestCase):
         video = VideoFactory()
         jwt_token = AccessToken()
         jwt_token.payload["video_id"] = str(video.id)
+        jwt_token.payload["roles"] = ["instructor"]
 
         response = self.client.get(
             "/api/videos/{!s}/".format(video.id),
@@ -406,6 +431,7 @@ class VideoAPITest(TestCase):
         video = VideoFactory(state="pending")
         jwt_token = AccessToken()
         jwt_token.payload["video_id"] = str(video.id)
+        jwt_token.payload["roles"] = ["instructor"]
 
         response = self.client.get(
             "/api/videos/{!s}/".format(video.id),
@@ -430,6 +456,7 @@ class VideoAPITest(TestCase):
         original_id = video.id
         jwt_token = AccessToken()
         jwt_token.payload["video_id"] = str(video.id)
+        jwt_token.payload["roles"] = ["instructor"]
 
         response = self.client.get(
             "/api/videos/{!s}/".format(video.id),
@@ -454,6 +481,7 @@ class VideoAPITest(TestCase):
         video_update = VideoFactory(title="my title")
         jwt_token = AccessToken()
         jwt_token.payload["video_id"] = str(video_token.id)
+        jwt_token.payload["roles"] = ["instructor"]
 
         data = {"title": "my new title"}
         response = self.client.put(
@@ -472,6 +500,7 @@ class VideoAPITest(TestCase):
         video = VideoFactory(description="my description")
         jwt_token = AccessToken()
         jwt_token.payload["video_id"] = str(video.id)
+        jwt_token.payload["roles"] = ["instructor"]
 
         data = {"description": "my new description"}
 
@@ -501,6 +530,7 @@ class VideoAPITest(TestCase):
         videos = VideoFactory.create_batch(2)
         jwt_token = AccessToken()
         jwt_token.payload["video_id"] = str(videos[0].id)
+        jwt_token.payload["roles"] = ["instructor"]
 
         # Try deleting the video linked to the JWT token and the other one
         for video in videos:
@@ -542,6 +572,7 @@ class VideoAPITest(TestCase):
         video = VideoFactory()
         jwt_token = AccessToken()
         jwt_token.payload["video_id"] = str(video.id)
+        jwt_token.payload["roles"] = ["instructor"]
 
         response = self.client.delete(
             "/api/videos/", HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token)
@@ -580,6 +611,7 @@ class VideoAPITest(TestCase):
         )
         jwt_token = AccessToken()
         jwt_token.payload["video_id"] = str(video.id)
+        jwt_token.payload["roles"] = ["instructor"]
 
         # Get the upload policy for this video
         # It should generate a key file with the Unix timestamp of the present time

--- a/src/backend/marsha/core/tests/test_views_lti_video.py
+++ b/src/backend/marsha/core/tests/test_views_lti_video.py
@@ -1,4 +1,5 @@
 """Test the LTI interconnection with Open edX."""
+import hashlib
 from html import unescape
 import json
 import random
@@ -40,6 +41,8 @@ class ViewsTestCase(TestCase):
             "roles": "instructor",
             "context_id": "abc",
             "oauth_consumer_key": "ABC123",
+            "user_id": "56255f3807599c377bf0e5bf072359fd",
+            "lis_person_contact_email_primary": "contact@openfun.fr",
         }
         with mock.patch.object(
             LTI, "verify", return_value=passport.consumer_site
@@ -57,6 +60,15 @@ class ViewsTestCase(TestCase):
         data_jwt = match.group(1)
         jwt_token = AccessToken(data_jwt)
         self.assertEqual(jwt_token.payload["video_id"], str(video.id))
+        self.assertEqual(jwt_token.payload["user_id"], str(data.get("user_id")))
+        self.assertEqual(jwt_token.payload["context_id"], str(data.get("context_id")))
+        self.assertEqual(jwt_token.payload["roles"], [data.get("roles")])
+        self.assertEqual(
+            jwt_token.payload["email"],
+            hashlib.sha256(
+                data.get("lis_person_contact_email_primary").encode("utf8")
+            ).hexdigest(),
+        )
 
         data_state = match.group(2)
         self.assertEqual(data_state, "instructor")
@@ -95,6 +107,8 @@ class ViewsTestCase(TestCase):
             "roles": "student",
             "context_id": "abc",
             "oauth_consumer_key": "ABC123",
+            "user_id": "56255f3807599c377bf0e5bf072359fd",
+            "lis_person_contact_email_primary": "contact@openfun.fr",
         }
         with mock.patch.object(
             LTI, "verify", return_value=passport.consumer_site
@@ -104,9 +118,25 @@ class ViewsTestCase(TestCase):
         self.assertContains(response, "<html>")
         content = response.content.decode("utf-8")
 
-        data_state = re.search(
-            '<div class="marsha-frontend-data" data-state="(.*)">', content
-        ).group(1)
+        match = re.search(
+            '<div class="marsha-frontend-data" data-jwt="(.*)" data-state="(.*)">',
+            content,
+        )
+
+        data_jwt = match.group(1)
+        jwt_token = AccessToken(data_jwt)
+        self.assertEqual(jwt_token.payload["video_id"], str(video.id))
+        self.assertEqual(jwt_token.payload["user_id"], str(data.get("user_id")))
+        self.assertEqual(jwt_token.payload["context_id"], str(data.get("context_id")))
+        self.assertEqual(jwt_token.payload["roles"], [data.get("roles")])
+        self.assertEqual(
+            jwt_token.payload["email"],
+            hashlib.sha256(
+                data.get("lis_person_contact_email_primary").encode("utf8")
+            ).hexdigest(),
+        )
+
+        data_state = match.group(2)
         self.assertEqual(data_state, "student")
 
         data_video = re.search(
@@ -136,6 +166,8 @@ class ViewsTestCase(TestCase):
             "roles": "student",
             "context_id": "abc",
             "oauth_consumer_key": "ABC123",
+            "user_id": "56255f3807599c377bf0e5bf072359fd",
+            "lis_person_contact_email_primary": "contact@openfun.fr",
         }
         with mock.patch.object(
             LTI, "verify", return_value=passport.consumer_site
@@ -200,6 +232,8 @@ class ViewsTestCase(TestCase):
             "roles": "instructor",
             "context_id": "abc",
             "oauth_consumer_key": "ABC123",
+            "user_id": "56255f3807599c377bf0e5bf072359fd",
+            "lis_person_contact_email_primary": "contact@openfun.fr",
         }
         with mock.patch.object(LTI, "verify", return_value=passport.consumer_site):
             response = self.client.post("/lti-video/", data)
@@ -233,15 +267,33 @@ class DevelopmentViewsTestCase(TestCase):
             "roles": "student",
             "context_id": "abc",
             "tool_consumer_instance_guid": "example.com",
+            "user_id": "56255f3807599c377bf0e5bf072359fd",
+            "lis_person_contact_email_primary": "contact@openfun.fr",
         }
         response = self.client.post("/lti-video/", data)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "<html>")
         content = response.content.decode("utf-8")
 
-        data_state = re.search(
-            '<div class="marsha-frontend-data" data-state="(.*)">', content
-        ).group(1)
+        match = re.search(
+            '<div class="marsha-frontend-data" data-jwt="(.*)" data-state="(.*)">',
+            content,
+        )
+
+        data_jwt = match.group(1)
+        jwt_token = AccessToken(data_jwt)
+        self.assertEqual(jwt_token.payload["video_id"], str(video.id))
+        self.assertEqual(jwt_token.payload["user_id"], str(data.get("user_id")))
+        self.assertEqual(jwt_token.payload["context_id"], str(data.get("context_id")))
+        self.assertEqual(jwt_token.payload["roles"], [data.get("roles")])
+        self.assertEqual(
+            jwt_token.payload["email"],
+            hashlib.sha256(
+                data.get("lis_person_contact_email_primary").encode("utf8")
+            ).hexdigest(),
+        )
+
+        data_state = match.group(2)
         self.assertEqual(data_state, "student")
 
         data_video = re.search(
@@ -275,6 +327,8 @@ class DevelopmentViewsTestCase(TestCase):
             "roles": "instructor",
             "context_id": "abc",
             "tool_consumer_instance_guid": "example.com",
+            "user_id": "56255f3807599c377bf0e5bf072359fd",
+            "lis_person_contact_email_primary": "contact@openfun.fr",
         }
         response = self.client.post("/lti-video/", data)
         self.assertEqual(response.status_code, 200)
@@ -289,6 +343,15 @@ class DevelopmentViewsTestCase(TestCase):
         data_jwt = match.group(1)
         jwt_token = AccessToken(data_jwt)
         self.assertEqual(jwt_token.payload["video_id"], str(video.id))
+        self.assertEqual(jwt_token.payload["user_id"], str(data.get("user_id")))
+        self.assertEqual(jwt_token.payload["context_id"], str(data.get("context_id")))
+        self.assertEqual(jwt_token.payload["roles"], [data.get("roles")])
+        self.assertEqual(
+            jwt_token.payload["email"],
+            hashlib.sha256(
+                data.get("lis_person_contact_email_primary").encode("utf8")
+            ).hexdigest(),
+        )
 
         data_state = match.group(2)
         self.assertEqual(data_state, "instructor")
@@ -320,6 +383,8 @@ class DevelopmentViewsTestCase(TestCase):
             "roles": "instructor",
             "context_id": "abc",
             "tool_consumer_instance_guid": "example.com",
+            "user_id": "56255f3807599c377bf0e5bf072359fd",
+            "lis_person_contact_email_primary": "contact@openfun.fr",
         }
         response = self.client.post("/lti-video/", data)
         self.assertEqual(response.status_code, 200)
@@ -334,6 +399,15 @@ class DevelopmentViewsTestCase(TestCase):
         jwt_token = AccessToken(data_jwt)
         video = Video.objects.get()
         self.assertEqual(jwt_token.payload["video_id"], str(video.id))
+        self.assertEqual(jwt_token.payload["user_id"], str(data.get("user_id")))
+        self.assertEqual(jwt_token.payload["context_id"], str(data.get("context_id")))
+        self.assertEqual(jwt_token.payload["roles"], [data.get("roles")])
+        self.assertEqual(
+            jwt_token.payload["email"],
+            hashlib.sha256(
+                data.get("lis_person_contact_email_primary").encode("utf8")
+            ).hexdigest(),
+        )
 
         data_state = match.group(2)
         self.assertEqual(data_state, "instructor")
@@ -367,7 +441,13 @@ class DevelopmentViewsTestCase(TestCase):
             playlist__consumer_site__domain="example.com",
         )
         role = random.choice(["instructor", "student"])
-        data = {"resource_link_id": "123", "roles": role, "context_id": "abc"}
+        data = {
+            "resource_link_id": "123",
+            "roles": role,
+            "context_id": "abc",
+            "user_id": "56255f3807599c377bf0e5bf072359fd",
+            "lis_person_contact_email_primary": "contact@openfun.fr",
+        }
 
         with self.assertRaises(ImproperlyConfigured):
             self.client.post("/lti-video/", data)


### PR DESCRIPTION
## Purpose

A JWT token should be used for every users allowing us to set information in it. Doing this will avoid us to implement a session. No sensitive information can be stored in the token.

## Proposal

- [x] create the JWT token if there is a video object
- [x] add information in the token
- [x] refactor how permissions are checked
