### PR TITLE
A add a schema view to the API

### DIFF
--- a/src/backend/marsha/core/tests/test_api_schema.py
+++ b/src/backend/marsha/core/tests/test_api_schema.py
@@ -1,0 +1,14 @@
+"""Tests for the Schema endpoint on the API of the Marsha project."""
+import json
+
+from django.test import TestCase
+
+
+class SchemaAPITest(TestCase):
+    """Test the API route for the schema."""
+
+    def test_api_schema(self):
+        """The API has a schema route that answers."""
+        response = self.client.get("/api/schema")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(json.loads(response.content)["_meta"]["title"], "Marsha API")

--- a/src/backend/marsha/urls.py
+++ b/src/backend/marsha/urls.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.urls import include, path
 
 from rest_framework.routers import DefaultRouter
+from rest_framework.schemas import get_schema_view
 
 from marsha.core.admin import admin_site
 from marsha.core.api import TimedTextTrackViewSet, VideoViewSet, update_state
@@ -20,6 +21,7 @@ urlpatterns = [
     path(f"{admin_site.name}/", admin_site.urls),
     path("lti-video/", VideoLTIView.as_view(), name="lti_video"),
     path("api/update-state", update_state, name="update_state"),
+    path("api/schema", get_schema_view(title="Marsha API"), name="schema"),
     path("api/", include(router.urls)),
 ]
 

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -26,6 +26,7 @@ requires-python = >=3.6
 [options]
 install_requires =
     boto3==1.8.6
+    coreapi==2.3.3
     cryptography==2.3.1
     django==2.0
     dj-database-url==0.5.0


### PR DESCRIPTION
## Purpose

We're currently missing a schema route on the API. It's useful to get access to choices for some fields that can be dynamically changed on the backend side.

## Proposal

Use Django-Rest-Framework's builtin tool to autogenerate a schema and expose it on an API endpoint.