### PR TITLE
Fix a test that randomly broke with a 1/6 probability

### DIFF
--- a/src/backend/marsha/core/tests/test_api_timed_text_track.py
+++ b/src/backend/marsha/core/tests/test_api_timed_text_track.py
@@ -211,8 +211,12 @@ class TimedTextTrackAPITest(TestCase):
 
     def test_api_timed_text_track_read_list_token_user(self):
         """A token user associated to a video is able to read a list of timed text tracks."""
-        timed_text_track_one = TimedTextTrackFactory()
-        timed_text_track_two = TimedTextTrackFactory(video=timed_text_track_one.video)
+        # Make sure modes differ to avoid random failures as attempting to create a TTT with the
+        # same language and mode as an existing one raises an exception.
+        timed_text_track_one = TimedTextTrackFactory(mode="st")
+        timed_text_track_two = TimedTextTrackFactory(
+            mode="cc", video=timed_text_track_one.video
+        )
         jwt_token = AccessToken()
         jwt_token.payload["video_id"] = str(timed_text_track_one.video.id)
         jwt_token.payload["roles"] = ["instructor"]


### PR DESCRIPTION
## Purpose

We wrote a new test to make sure the GET LIST request on the API for TimedTextTracks works. It creates 2 TimedTextTracks.

This causes it to randomly break if we call the factory without language and mode parameters because TimedTextTracks are unique for each language-mode-video combination.

## Proposal

Simply forcing different modes prevents those random fails.
