### PR TITLE
♻️(frontend) fix the link to <UploadForm /> in <InstructorView />

### DIFF
--- a/src/frontend/components/InstructorView/InstructorView.spec.tsx
+++ b/src/frontend/components/InstructorView/InstructorView.spec.tsx
@@ -3,12 +3,13 @@ import '../../testSetup';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 
+import { ROUTE as ERROR_ROUTE } from '../ErrorComponent/ErrorComponent';
 import { InstructorControls, InstructorView, Preview } from './InstructorView';
 
 describe('<InstructorView />', () => {
   it('renders the children inside a <Preview />', () => {
     const wrapper = shallow(
-      <InstructorView>
+      <InstructorView videoId={'42'}>
         <div className="some-child" />
       </InstructorView>,
     );
@@ -22,12 +23,24 @@ describe('<InstructorView />', () => {
 
   it('renders the instructor controls', () => {
     const controlsWrapper = shallow(
-      <InstructorView>
+      <InstructorView videoId={'42'}>
         <div className="some-child" />
       </InstructorView>,
     ).find(InstructorControls);
 
     expect(controlsWrapper.html()).toContain('Instructor Preview 👆');
     expect(controlsWrapper.html()).toContain('Replace the video');
+  });
+
+  it('redirects to the error component when it is missing the video ID', () => {
+    const wrapper = shallow(
+      <InstructorView videoId={null}>
+        <div />
+      </InstructorView>,
+    );
+
+    expect(wrapper.name()).toEqual('Redirect');
+    expect(wrapper.prop('push')).toBeTruthy();
+    expect(wrapper.prop('to')).toEqual(ERROR_ROUTE('lti'));
   });
 });

--- a/src/frontend/components/InstructorView/InstructorView.tsx
+++ b/src/frontend/components/InstructorView/InstructorView.tsx
@@ -1,9 +1,14 @@
 import * as React from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
+import { Redirect } from 'react-router-dom';
 import styled from 'styled-components';
 
+import { modelName } from '../../types/models';
+import { Video } from '../../types/tracks';
 import { colors } from '../../utils/theme/theme';
+import { Nullable } from '../../utils/types';
 import { Button } from '../Button/Button';
+import { ROUTE as ERROR_ROUTE } from '../ErrorComponent/ErrorComponent';
 import { ROUTE as FORM_ROUTE } from '../UploadForm/UploadForm';
 import { withLink } from '../withLink/withLink';
 
@@ -40,16 +45,27 @@ export const InstructorControls = styled.div`
 
 const BtnWithLink = withLink(Button);
 
-export const InstructorView = (props: { children: React.ReactNode }) => (
-  <React.Fragment>
-    <PreviewWrapper>
-      <Preview>{props.children}</Preview>
-    </PreviewWrapper>
-    <InstructorControls>
-      <FormattedMessage {...messages.title} />
-      <BtnWithLink to={FORM_ROUTE()} variant="primary">
-        <FormattedMessage {...messages.btnUpdateVideo} />
-      </BtnWithLink>
-    </InstructorControls>
-  </React.Fragment>
-);
+interface InstructorViewProps {
+  children: React.ReactNode;
+  videoId: Nullable<Video['id']>;
+}
+
+export const InstructorView = ({ children, videoId }: InstructorViewProps) =>
+  videoId ? (
+    <React.Fragment>
+      <PreviewWrapper>
+        <Preview>{children}</Preview>
+      </PreviewWrapper>
+      <InstructorControls>
+        <FormattedMessage {...messages.title} />
+        <BtnWithLink
+          to={FORM_ROUTE(modelName.VIDEOS, videoId)}
+          variant="primary"
+        >
+          <FormattedMessage {...messages.btnUpdateVideo} />
+        </BtnWithLink>
+      </InstructorControls>
+    </React.Fragment>
+  ) : (
+    <Redirect push to={ERROR_ROUTE('lti')} />
+  );

--- a/src/frontend/components/InstructorViewConnected/InstructorViewConnected.spec.tsx
+++ b/src/frontend/components/InstructorViewConnected/InstructorViewConnected.spec.tsx
@@ -1,0 +1,22 @@
+import { RootState } from '../../data/rootReducer';
+import { mapStateToProps } from './InstructorViewConnected';
+
+describe('<InstructorViewConnected />', () => {
+  describe('mapStateToProps()', () => {
+    it('passes the context videoId', () => {
+      const state = {
+        context: {
+          ltiResourceVideo: {
+            id: '42',
+          },
+        },
+      } as RootState;
+      expect(mapStateToProps(state)).toEqual({ videoId: '42' });
+    });
+
+    it('defaults to null', () => {
+      const state = { context: {} } as RootState;
+      expect(mapStateToProps(state)).toEqual({ videoId: null });
+    });
+  });
+});

--- a/src/frontend/components/InstructorViewConnected/InstructorViewConnected.tsx
+++ b/src/frontend/components/InstructorViewConnected/InstructorViewConnected.tsx
@@ -1,0 +1,14 @@
+import { connect } from 'react-redux';
+
+import { RootState } from '../../data/rootReducer';
+import { InstructorView } from '../InstructorView/InstructorView';
+
+export const mapStateToProps = (state: RootState) => ({
+  videoId:
+    (state &&
+      state.context.ltiResourceVideo &&
+      state.context.ltiResourceVideo.id) ||
+    null,
+});
+
+export const InstructorViewConnected = connect(mapStateToProps)(InstructorView);

--- a/src/frontend/components/InstructorWrapper/InstructorWrapper.spec.tsx
+++ b/src/frontend/components/InstructorWrapper/InstructorWrapper.spec.tsx
@@ -4,7 +4,7 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 
 import { appState } from '../../types/AppData';
-import { InstructorView } from '../InstructorView/InstructorView';
+import { InstructorViewConnected } from '../InstructorViewConnected/InstructorViewConnected';
 import { InstructorWrapper } from './InstructorWrapper';
 
 describe('<InstructorWrapper />', () => {
@@ -15,10 +15,10 @@ describe('<InstructorWrapper />', () => {
       </InstructorWrapper>,
     );
 
-    expect(wrapper.find(InstructorView).exists()).toBe(true);
+    expect(wrapper.find(InstructorViewConnected).exists()).toBe(true);
     expect(
       wrapper
-        .find(InstructorView)
+        .find(InstructorViewConnected)
         .containsMatchingElement(<div className="some-child" />),
     ).toBe(true);
   });
@@ -30,7 +30,7 @@ describe('<InstructorWrapper />', () => {
       </InstructorWrapper>,
     );
 
-    expect(wrapper.find(InstructorView).exists()).not.toBe(true);
+    expect(wrapper.find(InstructorViewConnected).exists()).not.toBe(true);
     expect(
       wrapper.containsMatchingElement(<div className="some-child" />),
     ).toBe(true);

--- a/src/frontend/components/InstructorWrapper/InstructorWrapper.tsx
+++ b/src/frontend/components/InstructorWrapper/InstructorWrapper.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { appState } from '../../types/AppData';
-import { InstructorView } from '../InstructorView/InstructorView';
+import { InstructorViewConnected } from '../InstructorViewConnected/InstructorViewConnected';
 
 interface InstructorWrapperProps {
   ltiState: appState;
@@ -12,7 +12,7 @@ export class InstructorWrapper extends React.Component<InstructorWrapperProps> {
     const { children, ltiState } = this.props;
 
     if (ltiState === appState.INSTRUCTOR) {
-      return <InstructorView>{children}</InstructorView>;
+      return <InstructorViewConnected>{children}</InstructorViewConnected>;
     } else {
       return children;
     }


### PR DESCRIPTION
## Purpose 

We recently updated the upload component (now callled `<UploadForm />`) to be more generic. It now needs to be passed a model name and an object ID.

We did not update the link in the `<InstructorView />` to account for that change.

## Proposal

We need to get the video from context (hence the `Connected` wrapper) and pass it to `<InstructorView />` so it can generate a working link.