### PR TITLE
✅(VideoPlayer) correctly test shaka player instantiation

### DIFF
--- a/src/frontend/components/VideoPlayer/VideoPlayer.spec.tsx
+++ b/src/frontend/components/VideoPlayer/VideoPlayer.spec.tsx
@@ -78,9 +78,10 @@ describe('VideoPlayer', () => {
   });
 
   describe('in an environment without EME', () => {
-    beforeEach(() => mockShakaPlayer.isBrowserSupported.mockReturnValue(true));
+    beforeEach(() => mockShakaPlayer.isBrowserSupported.mockReturnValue(false));
 
     it('never instantiates shaka', () => {
+      mount(<VideoPlayer video={video} />); // Mount so videojs is called with an element
       expect(mockShakaPlayer.prototype.constructor).not.toHaveBeenCalled();
       expect(mockShakaPlayer.prototype.load).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
In an environment without EME shaka player should not never been
instantiated. The actual test doesn't simulate this on a mounted
VideoPlayer instance so the test was wrong.

## Proposal

Mount a `<VideoPlayer />` instance to check if shaka player is instanciated or not.