### PR TITLE
Prepare the app to handle timedtexttracks

### DIFF
--- a/src/frontend/components/UploadForm/UploadForm.tsx
+++ b/src/frontend/components/UploadForm/UploadForm.tsx
@@ -24,10 +24,15 @@ const messages = defineMessages({
 });
 
 const titleMessages = defineMessages({
+  [modelName.TIMEDTEXTTRACKS]: {
+    defaultMessage: 'Upload a new subtitles/captions/transcript file',
+    description: 'Title for the timed text file upload form',
+    id: 'components.UploadForm.title-timedtexttracks',
+  },
   [modelName.VIDEOS]: {
     defaultMessage: 'Create a new video',
     description: 'Title for the video upload form',
-    id: 'components.UploadForm.title',
+    id: 'components.UploadForm.title-videos',
   },
 });
 

--- a/src/frontend/data/bootstrapStore.ts
+++ b/src/frontend/data/bootstrapStore.ts
@@ -12,6 +12,7 @@ export const bootstrapStore = (appData: AppData) =>
       ltiState: appData.state,
     },
     resources: {
+      [modelName.TIMEDTEXTTRACKS]: {},
       [modelName.VIDEOS]: {
         ...(appData.video
           ? { byId: { [appData.video.id]: appData.video } }

--- a/src/frontend/data/rootReducer.ts
+++ b/src/frontend/data/rootReducer.ts
@@ -4,6 +4,10 @@ import { appState } from '../types/AppData';
 import { modelName } from '../types/models';
 import { Video } from '../types/tracks';
 import { Nullable } from '../utils/types';
+import {
+  timedtexttracks,
+  TimedTextTracksState,
+} from './timedtexttracks/reducer';
 import { videos, VideosState } from './videos/reducer';
 
 export interface RootState {
@@ -13,6 +17,7 @@ export interface RootState {
     ltiState: appState;
   };
   resources: {
+    [modelName.TIMEDTEXTTRACKS]: TimedTextTracksState;
     [modelName.VIDEOS]: VideosState;
   };
 }
@@ -20,6 +25,10 @@ export interface RootState {
 export const rootReducer: Reducer<RootState> = (state, action) => ({
   context: state!.context,
   resources: {
+    [modelName.TIMEDTEXTTRACKS]: timedtexttracks(
+      (state && state.resources[modelName.TIMEDTEXTTRACKS]) || undefined,
+      action,
+    ),
     [modelName.VIDEOS]: videos(
       (state && state.resources[modelName.VIDEOS]) || undefined,
       action,

--- a/src/frontend/data/timedtexttracks/reducer.ts
+++ b/src/frontend/data/timedtexttracks/reducer.ts
@@ -1,0 +1,36 @@
+import { AnyAction, Reducer } from 'redux';
+
+import { modelName } from '../../types/models';
+import { ResourceByIdState } from '../../types/Resource';
+import { TimedText } from '../../types/tracks';
+import { Maybe } from '../../utils/types';
+import {
+  ResourceAdd,
+  ResourceMultipleAdd,
+} from '../genericReducers/resourceById/actions';
+import {
+  byId,
+  initialState as resourceByIdInit,
+} from '../genericReducers/resourceById/resourceById';
+
+const initialState = { ...resourceByIdInit };
+
+export type TimedTextTracksState = Maybe<ResourceByIdState<TimedText>>;
+
+export const timedtexttracks: Reducer<TimedTextTracksState> = (
+  state: TimedTextTracksState = initialState,
+  action?: ResourceAdd<TimedText> | ResourceMultipleAdd<TimedText> | AnyAction,
+) => {
+  if (!action) {
+    return state;
+  }
+
+  if (
+    action.resourceName &&
+    action.resourceName !== modelName.TIMEDTEXTTRACKS
+  ) {
+    return state;
+  }
+
+  return byId(state, action);
+};

--- a/src/frontend/types/RouteOptions.ts
+++ b/src/frontend/types/RouteOptions.ts
@@ -1,0 +1,25 @@
+export interface RouteOptions<Resource> {
+  actions: { POST: RouteOptionAction<Resource> };
+  description: string;
+  name: string;
+  parses: string[];
+  renders: string[];
+}
+
+type RouteOptionAction<Resource> = {
+  [key in keyof Resource]: RouteOptionsActionField
+};
+
+interface RouteOptionsActionField {
+  choices?: RouteOptionsActionFieldChoice[];
+  help_text?: string;
+  label: string;
+  readonly: boolean;
+  required: boolean;
+  type: string;
+}
+
+interface RouteOptionsActionFieldChoice {
+  display_name: string;
+  value: string;
+}

--- a/src/frontend/types/Schema.ts
+++ b/src/frontend/types/Schema.ts
@@ -1,0 +1,50 @@
+interface SchemaEndpointActionDescription {
+  _type: string;
+  action: string;
+  description: string;
+  url: string;
+}
+
+interface SchemaEndpointActionDescriptionWithFields
+  extends SchemaEndpointActionDescription {
+  fields: SchemaFieldDescription[];
+}
+
+interface SchemaFieldDescription {
+  location: string;
+  name: string;
+  schema: {
+    _type: string;
+    description: string;
+    enum?: string[];
+    required?: boolean;
+    title: string;
+  };
+}
+
+export interface Schema {
+  _type: string;
+  _meta: {
+    url: string;
+    title: string;
+  };
+  timedtexttracks: {
+    create: SchemaEndpointActionDescriptionWithFields & {
+      encoding: string;
+    };
+    list: SchemaEndpointActionDescription;
+    partial_update: SchemaEndpointActionDescriptionWithFields;
+    read: SchemaEndpointActionDescriptionWithFields;
+    update: SchemaEndpointActionDescriptionWithFields;
+    upload_policy: SchemaEndpointActionDescriptionWithFields;
+  };
+  'update-state': {
+    create: SchemaEndpointActionDescription;
+  };
+  videos: {
+    read: SchemaEndpointActionDescriptionWithFields;
+    partial_update: SchemaEndpointActionDescriptionWithFields;
+    update: SchemaEndpointActionDescriptionWithFields;
+    upload_policy: SchemaEndpointActionDescriptionWithFields;
+  };
+}

--- a/src/frontend/types/models.ts
+++ b/src/frontend/types/models.ts
@@ -1,3 +1,4 @@
 export enum modelName {
+  TIMEDTEXTTRACKS = 'timedtexttracks',
   VIDEOS = 'videos',
 }

--- a/src/frontend/types/tracks.ts
+++ b/src/frontend/types/tracks.ts
@@ -22,6 +22,27 @@ export enum trackState {
   UPLOADING = 'uploading',
 }
 
+/** Possible modes for a timed text track.
+ *
+ * We're using modes instead of different objects to represent subtitles, transcripts and closed captions
+ * as they're both the same types of files that go through the same pipelines, and have the same kinds
+ * of relations to video tracks.
+ */
+export enum timedTextMode {
+  SUBTITLE = 'st',
+  TRANSCRIPT = 'ts',
+  CLOSED_CAPTIONING = 'cc',
+}
+
+/** A timed text track record as it exists on the backend. */
+export interface TimedText extends Resource {
+  language: string;
+  mode: timedTextMode;
+  state: trackState;
+  uploaded_on: string;
+  video: Video;
+}
+
 /** Possible sizes for a video file or stream. Used as keys in lists of files. */
 export type videoSize = '144' | '240' | '480' | '720' | '1080';
 
@@ -41,4 +62,4 @@ export interface Video extends Resource {
   };
 }
 
-export type UploadableObject = Video;
+export type UploadableObject = TimedText | Video;


### PR DESCRIPTION
## Purpose

Until now marsha only supported one kind of Resource, Video. As we're adding timed text tracks, we need to add in some relevant types and adapt our data (RootState & reducer) to handle them.

## Proposal

Update types & reducer to handle timed text tracks.

We also took this opportunity to add typings for schemas & route OPTIONS as we are going to need them.
