### PR TITLE
🔖(patch) bump release to 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.1.0] - 2019-01-08
+
 ### Added
 
-TBD
+- Prepare the app to handle timedtexttracks (full functionality yet to come)
+- Add an API schema view
+- Extend timed text track language choices to all Django languages
+- Create a JWT token for every roles not just instructors (needed to add context to xAPI requests)
+- Allow timed text track list GET requests on the API (permissions are fixed in a separate commit)
+- Switch to redux for frontend state management
+- Add a link to the dashboard from the video form
+- Split Dashboard video matters into a separate component
+- Run yarn install in docker node to use node 8
+
+### Fixed
+
+- Minor fixes and improvements on features and tests
+
+[unreleased]: https://github.com/openfun/marsha/compare/v1.1.0...master
+[1.1.0]: https://github.com/openfun/marsha/compare/v1.0.0...v1.1.0

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -2,7 +2,7 @@
 name = marsha
 description = A FUN video provider for Open edX
 long_description = file:README.rst
-version = 1.0.0
+version = 1.1.0
 author = Open FUN (France Universite Numerique)
 author_email = fun.dev@fun-mooc.fr
 license = MIT

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marsha",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "🐠 a FUN LTI video provider",
   "main": "front/index.tsx",
   "scripts": {


### PR DESCRIPTION
# Added

- Prepare the app to handle timedtexttracks (full functionality yet to come)
- Add an API schema view
- Extend timed text track language choices to all Django languages
- Create a JWT token for every roles not just instructors (needed to add context to xAPI requests)
- Allow timed text track list GET requests on the API (permissions are fixed in a separate commit)
- Switch to redux for frontend state management
- Add a link to the dashboard from the video form
- Split Dashboard video matters into a separate component
- Run yarn install in docker node to use node 8

# Fixed

- Minor fixes and improvements on features and tests
