### PR TITLE
Isolate route definitions to avoid circular dependencies

### DIFF
--- a/src/frontend/components/AppRoutes/AppRoutes.tsx
+++ b/src/frontend/components/AppRoutes/AppRoutes.tsx
@@ -2,18 +2,16 @@ import React from 'react';
 import { MemoryRouter, Route, Switch } from 'react-router-dom';
 
 import { RootState } from '../../data/rootReducer';
-import { ROUTE as DASHBOARD_ROUTE } from '../Dashboard/Dashboard';
+import { DASHBOARD_ROUTE } from '../Dashboard/route';
 import { DashboardConnected } from '../DashboardConnected/DashboardConnected';
-import {
-  ErrorComponent,
-  ROUTE as ERROR_ROUTE,
-} from '../ErrorComponent/ErrorComponent';
+import { ErrorComponent } from '../ErrorComponent/ErrorComponent';
+import { ERROR_COMPONENT_ROUTE } from '../ErrorComponent/route';
 import { InstructorWrapperConnected } from '../InstructorWrapperConnected/InstructorWrapperConnected';
-import { ROUTE as HOME_ROUTE } from '../RedirectOnLoad/RedirectOnLoad';
+import { REDIRECT_ON_LOAD_ROUTE } from '../RedirectOnLoad/route';
 import { RedirectOnLoadConnected } from '../RedirectOnLoadConnected/RedirectOnLoadConnected';
-import { ROUTE as FORM_ROUTE } from '../UploadForm/UploadForm';
+import { UPLOAD_FORM_ROUTE } from '../UploadForm/route';
 import { UploadFormConnected } from '../UploadFormConnected/UploadFormConnected';
-import { ROUTE as PLAYER_ROUTE } from '../VideoPlayer/VideoPlayer';
+import { VIDEO_PLAYER_ROUTE } from '../VideoPlayer/route';
 import { VideoPlayerConnected } from '../VideoPlayerConnected/VideoPlayerConnected';
 
 interface AppRoutesProps {
@@ -26,7 +24,7 @@ export const AppRoutes = ({ context }: AppRoutesProps) => {
       <Switch>
         <Route
           exact
-          path={PLAYER_ROUTE()}
+          path={VIDEO_PLAYER_ROUTE()}
           render={() => (
             <InstructorWrapperConnected>
               <VideoPlayerConnected video={context.ltiResourceVideo} />
@@ -35,7 +33,7 @@ export const AppRoutes = ({ context }: AppRoutesProps) => {
         />
         <Route
           exact
-          path={FORM_ROUTE()}
+          path={UPLOAD_FORM_ROUTE()}
           render={({ match }) => (
             <UploadFormConnected
               objectId={match.params.objectId}
@@ -45,7 +43,7 @@ export const AppRoutes = ({ context }: AppRoutesProps) => {
         />
         <Route
           exact
-          path={ERROR_ROUTE()}
+          path={ERROR_COMPONENT_ROUTE()}
           render={({ match }) => <ErrorComponent code={match.params.code} />}
         />
         <Route
@@ -53,7 +51,10 @@ export const AppRoutes = ({ context }: AppRoutesProps) => {
           path={DASHBOARD_ROUTE()}
           render={() => <DashboardConnected video={context.ltiResourceVideo} />}
         />
-        <Route path={HOME_ROUTE()} component={RedirectOnLoadConnected} />
+        <Route
+          path={REDIRECT_ON_LOAD_ROUTE()}
+          component={RedirectOnLoadConnected}
+        />
       </Switch>
     </MemoryRouter>
   );

--- a/src/frontend/components/Dashboard/Dashboard.tsx
+++ b/src/frontend/components/Dashboard/Dashboard.tsx
@@ -16,8 +16,6 @@ const messages = defineMessages({
   },
 });
 
-export const ROUTE = () => '/dashboard';
-
 const IframeHeadingWithLayout = styled(IframeHeading)`
   flex-grow: 0;
   margin: 0;

--- a/src/frontend/components/Dashboard/route.ts
+++ b/src/frontend/components/Dashboard/route.ts
@@ -1,0 +1,4 @@
+/**
+ * Route for the `<Dashboard />` component.
+ */
+export const DASHBOARD_ROUTE = () => '/dashboard';

--- a/src/frontend/components/DashboardVideoPane/DashboardVideoPane.tsx
+++ b/src/frontend/components/DashboardVideoPane/DashboardVideoPane.tsx
@@ -9,7 +9,7 @@ import { Nullable } from '../../utils/types';
 import { DashboardInternalHeading } from '../Dashboard/DashboardInternalHeading';
 import { DashboardVideoPaneButtons } from '../DashboardVideoPaneButtons/DashboardVideoPaneButtons';
 import { DashboardVideoPaneHelptext } from '../DashboardVideoPaneHelptext/DashboardVideoPaneHelptext';
-import { ROUTE as ERROR_ROUTE } from '../ErrorComponent/ErrorComponent';
+import { ERROR_COMPONENT_ROUTE } from '../ErrorComponent/route';
 import { UploadStatusList } from '../UploadStatusList/UploadStatusList';
 
 const messages = defineMessages({
@@ -97,11 +97,11 @@ export class DashboardVideoPane extends React.Component<
     const { video } = this.props;
 
     if (this.state.error) {
-      return <Redirect push to={ERROR_ROUTE('notFound')} />;
+      return <Redirect push to={ERROR_COMPONENT_ROUTE('notFound')} />;
     }
 
     if (!video.is_ready_to_play && video.upload_state === uploadState.ERROR) {
-      return <Redirect push to={ERROR_ROUTE('upload')} />;
+      return <Redirect push to={ERROR_COMPONENT_ROUTE('upload')} />;
     }
 
     return (

--- a/src/frontend/components/DashboardVideoPaneButtons/DashboardVideoPaneButtons.tsx
+++ b/src/frontend/components/DashboardVideoPaneButtons/DashboardVideoPaneButtons.tsx
@@ -4,8 +4,8 @@ import styled from 'styled-components';
 
 import { uploadState } from '../../types/tracks';
 import { Button } from '../Button/Button';
-import { ROUTE as FORM_ROUTE } from '../UploadForm/UploadForm';
-import { ROUTE as PLAYER_ROUTE } from '../VideoPlayer/VideoPlayer';
+import { UPLOAD_FORM_ROUTE } from '../UploadForm/route';
+import { VIDEO_PLAYER_ROUTE } from '../VideoPlayer/route';
 import { withLink } from '../withLink/withLink';
 
 const { PENDING, READY } = uploadState;
@@ -54,7 +54,7 @@ export const DashboardVideoPaneButtons = (
   props: DashboardVideoPaneButtonsProps,
 ) => (
   <DashboardVideoPaneButtonsStyled>
-    <DashboardButtonStyled variant="primary" to={FORM_ROUTE()}>
+    <DashboardButtonStyled variant="primary" to={UPLOAD_FORM_ROUTE()}>
       <FormattedMessage
         {...(props.state === PENDING
           ? messages.btnUploadFirstVideo
@@ -64,7 +64,7 @@ export const DashboardVideoPaneButtons = (
     <DashboardButtonStyled
       variant="primary"
       disabled={props.state !== READY}
-      to={PLAYER_ROUTE()}
+      to={VIDEO_PLAYER_ROUTE()}
     >
       <FormattedMessage {...messages.btnPlayVideo} />
     </DashboardButtonStyled>

--- a/src/frontend/components/ErrorComponent/ErrorComponent.tsx
+++ b/src/frontend/components/ErrorComponent/ErrorComponent.tsx
@@ -81,9 +81,6 @@ const messages = {
   }),
 };
 
-export const ROUTE = (code?: ErrorComponentProps['code']) =>
-  code ? `/errors/${code}` : '/errors/:code';
-
 export const ErrorComponent = (props: ErrorComponentProps) => {
   return (
     <ErrorComponentStyled>

--- a/src/frontend/components/ErrorComponent/route.ts
+++ b/src/frontend/components/ErrorComponent/route.ts
@@ -1,0 +1,8 @@
+import { ErrorComponentProps } from './ErrorComponent';
+
+/**
+ * Route for the `<ErrorComponent />` component.
+ * @param code One of the error codes (strings) supported by `<ErrorComponent />`
+ */
+export const ERROR_COMPONENT_ROUTE = (code?: ErrorComponentProps['code']) =>
+  code ? `/errors/${code}` : '/errors/:code';

--- a/src/frontend/components/InstructorView/InstructorView.spec.tsx
+++ b/src/frontend/components/InstructorView/InstructorView.spec.tsx
@@ -3,7 +3,7 @@ import '../../testSetup';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 
-import { ROUTE as ERROR_ROUTE } from '../ErrorComponent/ErrorComponent';
+import { ERROR_COMPONENT_ROUTE } from '../ErrorComponent/route';
 import { InstructorControls, InstructorView, Preview } from './InstructorView';
 
 describe('<InstructorView />', () => {
@@ -41,6 +41,6 @@ describe('<InstructorView />', () => {
 
     expect(wrapper.name()).toEqual('Redirect');
     expect(wrapper.prop('push')).toBeTruthy();
-    expect(wrapper.prop('to')).toEqual(ERROR_ROUTE('lti'));
+    expect(wrapper.prop('to')).toEqual(ERROR_COMPONENT_ROUTE('lti'));
   });
 });

--- a/src/frontend/components/InstructorView/InstructorView.tsx
+++ b/src/frontend/components/InstructorView/InstructorView.tsx
@@ -8,8 +8,8 @@ import { Video } from '../../types/tracks';
 import { colors } from '../../utils/theme/theme';
 import { Nullable } from '../../utils/types';
 import { Button } from '../Button/Button';
-import { ROUTE as ERROR_ROUTE } from '../ErrorComponent/ErrorComponent';
-import { ROUTE as FORM_ROUTE } from '../UploadForm/UploadForm';
+import { ERROR_COMPONENT_ROUTE } from '../ErrorComponent/route';
+import { UPLOAD_FORM_ROUTE } from '../UploadForm/route';
 import { withLink } from '../withLink/withLink';
 
 const messages = defineMessages({
@@ -59,7 +59,7 @@ export const InstructorView = ({ children, videoId }: InstructorViewProps) =>
       <InstructorControls>
         <FormattedMessage {...messages.title} />
         <BtnWithLink
-          to={FORM_ROUTE(modelName.VIDEOS, videoId)}
+          to={UPLOAD_FORM_ROUTE(modelName.VIDEOS, videoId)}
           variant="primary"
         >
           <FormattedMessage {...messages.btnUpdateVideo} />
@@ -67,5 +67,5 @@ export const InstructorView = ({ children, videoId }: InstructorViewProps) =>
       </InstructorControls>
     </React.Fragment>
   ) : (
-    <Redirect push to={ERROR_ROUTE('lti')} />
+    <Redirect push to={ERROR_COMPONENT_ROUTE('lti')} />
   );

--- a/src/frontend/components/RedirectOnLoad/RedirectOnLoad.spec.tsx
+++ b/src/frontend/components/RedirectOnLoad/RedirectOnLoad.spec.tsx
@@ -6,10 +6,10 @@ import * as React from 'react';
 import { appState } from '../../types/AppData';
 import { modelName } from '../../types/models';
 import { uploadState } from '../../types/tracks';
-import { ROUTE as DASHBOARD_ROUTE } from '../Dashboard/Dashboard';
-import { ROUTE as ERROR_ROUTE } from '../ErrorComponent/ErrorComponent';
-import { ROUTE as FORM_ROUTE } from '../UploadForm/UploadForm';
-import { ROUTE as PLAYER_ROUTE } from '../VideoPlayer/VideoPlayer';
+import { DASHBOARD_ROUTE } from '../Dashboard/route';
+import { ERROR_COMPONENT_ROUTE } from '../ErrorComponent/route';
+import { UPLOAD_FORM_ROUTE } from '../UploadForm/route';
+import { VIDEO_PLAYER_ROUTE } from '../VideoPlayer/route';
 import { RedirectOnLoad } from './RedirectOnLoad';
 
 describe('<RedirectOnLoad />', () => {
@@ -20,7 +20,7 @@ describe('<RedirectOnLoad />', () => {
 
     expect(wrapper.name()).toEqual('Redirect');
     expect(wrapper.prop('push')).toBeTruthy();
-    expect(wrapper.prop('to')).toEqual(ERROR_ROUTE('lti'));
+    expect(wrapper.prop('to')).toEqual(ERROR_COMPONENT_ROUTE('lti'));
   });
 
   it('redirects instructors to the player when the video is ready', () => {
@@ -35,7 +35,7 @@ describe('<RedirectOnLoad />', () => {
     );
     expect(wrapper.name()).toEqual('Redirect');
     expect(wrapper.prop('push')).toBeTruthy();
-    expect(wrapper.prop('to')).toEqual(PLAYER_ROUTE());
+    expect(wrapper.prop('to')).toEqual(VIDEO_PLAYER_ROUTE());
 
     // The video is `is_ready_to_play` with a pending upload
     wrapper = shallow(
@@ -48,7 +48,7 @@ describe('<RedirectOnLoad />', () => {
     );
     expect(wrapper.name()).toEqual('Redirect');
     expect(wrapper.prop('push')).toBeTruthy();
-    expect(wrapper.prop('to')).toEqual(PLAYER_ROUTE());
+    expect(wrapper.prop('to')).toEqual(VIDEO_PLAYER_ROUTE());
 
     // The video is `is_ready_to_play` with an upload error
     wrapper = shallow(
@@ -61,7 +61,7 @@ describe('<RedirectOnLoad />', () => {
     );
     expect(wrapper.name()).toEqual('Redirect');
     expect(wrapper.prop('push')).toBeTruthy();
-    expect(wrapper.prop('to')).toEqual(PLAYER_ROUTE());
+    expect(wrapper.prop('to')).toEqual(VIDEO_PLAYER_ROUTE());
   });
 
   it('redirects students to /player when the video is ready', () => {
@@ -76,7 +76,7 @@ describe('<RedirectOnLoad />', () => {
     );
     expect(wrapper.name()).toEqual('Redirect');
     expect(wrapper.prop('push')).toBeTruthy();
-    expect(wrapper.prop('to')).toEqual(PLAYER_ROUTE());
+    expect(wrapper.prop('to')).toEqual(VIDEO_PLAYER_ROUTE());
 
     // The video is `is_ready_to_play` with a pending upload
     wrapper = shallow(
@@ -89,7 +89,7 @@ describe('<RedirectOnLoad />', () => {
     );
     expect(wrapper.name()).toEqual('Redirect');
     expect(wrapper.prop('push')).toBeTruthy();
-    expect(wrapper.prop('to')).toEqual(PLAYER_ROUTE());
+    expect(wrapper.prop('to')).toEqual(VIDEO_PLAYER_ROUTE());
 
     // The video is `is_ready_to_play` with an upload error
     wrapper = shallow(
@@ -102,7 +102,7 @@ describe('<RedirectOnLoad />', () => {
     );
     expect(wrapper.name()).toEqual('Redirect');
     expect(wrapper.prop('push')).toBeTruthy();
-    expect(wrapper.prop('to')).toEqual(PLAYER_ROUTE());
+    expect(wrapper.prop('to')).toEqual(VIDEO_PLAYER_ROUTE());
   });
 
   it('redirects instructors to /form when there is no video yet', () => {
@@ -121,7 +121,9 @@ describe('<RedirectOnLoad />', () => {
 
     expect(wrapper.name()).toEqual('Redirect');
     expect(wrapper.prop('push')).toBeTruthy();
-    expect(wrapper.prop('to')).toEqual(FORM_ROUTE(modelName.VIDEOS, '42'));
+    expect(wrapper.prop('to')).toEqual(
+      UPLOAD_FORM_ROUTE(modelName.VIDEOS, '42'),
+    );
   });
 
   it('redirects instructors to /dashboard when there is a video undergoing processing', () => {
@@ -157,7 +159,7 @@ describe('<RedirectOnLoad />', () => {
 
     expect(wrapper.name()).toEqual('Redirect');
     expect(wrapper.prop('push')).toBeTruthy();
-    expect(wrapper.prop('to')).toEqual(ERROR_ROUTE('notFound'));
+    expect(wrapper.prop('to')).toEqual(ERROR_COMPONENT_ROUTE('notFound'));
   });
 
   it('redirects students to the error view when the video is null', () => {
@@ -167,6 +169,6 @@ describe('<RedirectOnLoad />', () => {
 
     expect(wrapper.name()).toEqual('Redirect');
     expect(wrapper.prop('push')).toBeTruthy();
-    expect(wrapper.prop('to')).toEqual(ERROR_ROUTE('notFound'));
+    expect(wrapper.prop('to')).toEqual(ERROR_COMPONENT_ROUTE('notFound'));
   });
 });

--- a/src/frontend/components/RedirectOnLoad/RedirectOnLoad.tsx
+++ b/src/frontend/components/RedirectOnLoad/RedirectOnLoad.tsx
@@ -5,12 +5,10 @@ import { appState } from '../../types/AppData';
 import { modelName } from '../../types/models';
 import { uploadState, Video } from '../../types/tracks';
 import { Nullable } from '../../utils/types';
-import { ROUTE as DASHBOARD_ROUTE } from '../Dashboard/Dashboard';
-import { ROUTE as ERROR_ROUTE } from '../ErrorComponent/ErrorComponent';
-import { ROUTE as FORM_ROUTE } from '../UploadForm/UploadForm';
-import { ROUTE as PLAYER_ROUTE } from '../VideoPlayer/VideoPlayer';
-
-export const ROUTE = () => '/';
+import { DASHBOARD_ROUTE } from '../Dashboard/route';
+import { ERROR_COMPONENT_ROUTE } from '../ErrorComponent/route';
+import { UPLOAD_FORM_ROUTE } from '../UploadForm/route';
+import { VIDEO_PLAYER_ROUTE } from '../VideoPlayer/route';
 
 interface RedirectOnLoadProps {
   ltiState: appState;
@@ -22,16 +20,18 @@ interface RedirectOnLoadProps {
 export const RedirectOnLoad = ({ ltiState, video }: RedirectOnLoadProps) => {
   // Get LTI errors out of the way
   if (ltiState === appState.ERROR) {
-    return <Redirect push to={ERROR_ROUTE('lti')} />;
+    return <Redirect push to={ERROR_COMPONENT_ROUTE('lti')} />;
   }
   // Everyone gets the video when it exists (so that instructors see the iframes like a student would by default)
   else if (video && video.is_ready_to_play) {
-    return <Redirect push to={PLAYER_ROUTE()} />;
+    return <Redirect push to={VIDEO_PLAYER_ROUTE()} />;
   }
   // Only instructors are allowed to interact with a non-ready video
   else if (ltiState === appState.INSTRUCTOR) {
     if (video!.upload_state === uploadState.PENDING) {
-      return <Redirect push to={FORM_ROUTE(modelName.VIDEOS, video!.id)} />;
+      return (
+        <Redirect push to={UPLOAD_FORM_ROUTE(modelName.VIDEOS, video!.id)} />
+      );
     } else {
       return <Redirect push to={DASHBOARD_ROUTE()} />;
     }
@@ -39,6 +39,6 @@ export const RedirectOnLoad = ({ ltiState, video }: RedirectOnLoadProps) => {
   // For safety default to the 404 view: this is for students, and any other role we add later on and don't add
   // a special clause for, when the video is not ready.
   else {
-    return <Redirect push to={ERROR_ROUTE('notFound')} />;
+    return <Redirect push to={ERROR_COMPONENT_ROUTE('notFound')} />;
   }
 };

--- a/src/frontend/components/RedirectOnLoad/route.ts
+++ b/src/frontend/components/RedirectOnLoad/route.ts
@@ -1,0 +1,4 @@
+/**
+ * Route for the `<RedirectOnLoad />` component.
+ */
+export const REDIRECT_ON_LOAD_ROUTE = () => '/';

--- a/src/frontend/components/UploadForm/UploadForm.spec.tsx
+++ b/src/frontend/components/UploadForm/UploadForm.spec.tsx
@@ -21,8 +21,8 @@ jest.doMock('react-router-dom', () => ({
 
 import { modelName } from '../../types/models';
 import { uploadState, Video } from '../../types/tracks';
-import { ROUTE as DASHBOARD_ROUTE } from '../Dashboard/Dashboard';
-import { ROUTE as ERROR_ROUTE } from '../ErrorComponent/ErrorComponent';
+import { DASHBOARD_ROUTE } from '../Dashboard/route';
+import { ERROR_COMPONENT_ROUTE } from '../ErrorComponent/route';
 import { UploadForm } from './UploadForm';
 
 const mockUpdateObject = jest.fn();
@@ -160,7 +160,7 @@ describe('UploadForm', () => {
 
       expect(wrapper.name()).toEqual('Redirect');
       expect(wrapper.prop('push')).toBeTruthy();
-      expect(wrapper.prop('to')).toEqual(ERROR_ROUTE('policy'));
+      expect(wrapper.prop('to')).toEqual(ERROR_COMPONENT_ROUTE('policy'));
 
       expect(fetchMock.lastCall()).toBeUndefined();
       expect(mockMakeFormData).not.toHaveBeenCalled();

--- a/src/frontend/components/UploadForm/UploadForm.tsx
+++ b/src/frontend/components/UploadForm/UploadForm.tsx
@@ -9,8 +9,8 @@ import { modelName } from '../../types/models';
 import { UploadableObject, uploadState } from '../../types/tracks';
 import { makeFormData } from '../../utils/makeFormData/makeFormData';
 import { Maybe, Nullable } from '../../utils/types';
-import { ROUTE as DASHBOARD_ROUTE } from '../Dashboard/Dashboard';
-import { ROUTE as ERROR_ROUTE } from '../ErrorComponent/ErrorComponent';
+import { DASHBOARD_ROUTE } from '../Dashboard/route';
+import { ERROR_COMPONENT_ROUTE } from '../ErrorComponent/route';
 import { IframeHeading } from '../Headings/Headings';
 import { LayoutMainArea } from '../LayoutMainArea/LayoutMainArea';
 import { UploadField } from '../UploadField/UploadField';
@@ -57,22 +57,6 @@ const UploadFormBack = styled.div`
   line-height: 2rem;
   padding: 0.5rem 1rem;
 `;
-
-/**
- * Route for the `<UploadForm />` component.
- * @param objectType The model name for the object for which we're uploading a file.
- * @param objectId The ID of said object.
- */
-export const ROUTE = (
-  objectType?: modelName,
-  objectId?: UploadableObject['id'],
-) => {
-  if (objectType) {
-    return `/form/${objectType}/${objectId}`;
-  } else {
-    return `/form/:objectType(${Object.values(modelName).join('|')})/:objectId`;
-  }
-};
 
 /** Props shape for the UploadForm component. */
 interface UploadFormProps {
@@ -176,10 +160,10 @@ export class UploadForm extends React.Component<
         return <Redirect push to={DASHBOARD_ROUTE()} />;
 
       case 'not_found_error':
-        return <Redirect push to={ERROR_ROUTE('notFound')} />;
+        return <Redirect push to={ERROR_COMPONENT_ROUTE('notFound')} />;
 
       case 'policy_error':
-        return <Redirect push to={ERROR_ROUTE('policy')} />;
+        return <Redirect push to={ERROR_COMPONENT_ROUTE('policy')} />;
 
       default:
         return (

--- a/src/frontend/components/UploadForm/route.ts
+++ b/src/frontend/components/UploadForm/route.ts
@@ -1,0 +1,18 @@
+import { modelName } from '../../types/models';
+import { UploadableObject } from '../../types/tracks';
+
+/**
+ * Route for the `<UploadForm />` component.
+ * @param objectType The model name for the object for which we're uploading a file.
+ * @param objectId The ID of said object.
+ */
+export const UPLOAD_FORM_ROUTE = (
+  objectType?: modelName,
+  objectId?: UploadableObject['id'],
+) => {
+  if (objectType) {
+    return `/form/${objectType}/${objectId}`;
+  } else {
+    return `/form/:objectType(${Object.values(modelName).join('|')})/:objectId`;
+  }
+};

--- a/src/frontend/components/VideoPlayer/VideoPlayer.tsx
+++ b/src/frontend/components/VideoPlayer/VideoPlayer.tsx
@@ -6,7 +6,7 @@ import shaka from 'shaka-player';
 
 import { Video, videoSize } from '../../types/tracks';
 import { Maybe, Nullable } from '../../utils/types';
-import { ROUTE as ERROR_ROUTE } from '../ErrorComponent/ErrorComponent';
+import { ERROR_COMPONENT_ROUTE } from '../ErrorComponent/route';
 import './VideoPlayer.css'; // Improve some plyr styles
 
 export interface VideoPlayerProps {
@@ -16,8 +16,6 @@ export interface VideoPlayerProps {
 interface VideoPlayerState {
   player: Maybe<Plyr>;
 }
-
-export const ROUTE = () => '/player';
 
 export class VideoPlayer extends React.Component<
   VideoPlayerProps,
@@ -76,7 +74,7 @@ export class VideoPlayer extends React.Component<
 
     // The video is somehow missing
     if (!video) {
-      return <Redirect push to={ERROR_ROUTE('notFound')} />;
+      return <Redirect push to={ERROR_COMPONENT_ROUTE('notFound')} />;
     }
 
     return (

--- a/src/frontend/components/VideoPlayer/route.ts
+++ b/src/frontend/components/VideoPlayer/route.ts
@@ -1,0 +1,4 @@
+/**
+ * Route for the `<VideoPlayer />` component.
+ */
+export const VIDEO_PLAYER_ROUTE = () => '/player';


### PR DESCRIPTION
## Purpose

Route definitions from routable components can be imported in many other components or utilities to perform redirects and simple add links.

This can easily cause circular dependencies as routable components are interlinked to create a consistent UI.

## Proposal

Moving the route definitions to their own files should help us avoid this issue by isolating those most frequently imported values.