### PR TITLE
🐛(video) fix duplicating videos for playlist/site portability

### DIFF
--- a/src/backend/marsha/core/lti.py
+++ b/src/backend/marsha/core/lti.py
@@ -324,11 +324,19 @@ class LTI:
         )
 
         # Create the video, pointing to the file from the origin video if any
-        return Video.objects.create(
-            duplicated_from=origin_video,
-            lti_id=self.resource_link_id,
-            playlist=playlist,
-            state=READY if origin_video else PENDING,
-            title=self.resource_link_title,
-            uploaded_on=origin_video.uploaded_on if origin_video else None,
-        )
+        kwargs = {
+            "lti_id": self.resource_link_id,
+            "playlist": playlist,
+            "state": PENDING,
+            "title": self.resource_link_title,
+        }
+        if origin_video:
+            kwargs.update(
+                {
+                    "duplicated_from": origin_video,
+                    "resource_id": origin_video.resource_id,
+                    "state": READY,
+                    "uploaded_on": origin_video.uploaded_on,
+                }
+            )
+        return Video.objects.create(**kwargs)

--- a/src/backend/marsha/core/tests/test_lti.py
+++ b/src/backend/marsha/core/tests/test_lti.py
@@ -411,6 +411,8 @@ class PortabilityVideoLTITestCase(TestCase):
         self.assertEqual(new_video.duplicated_from, video)
         self.assertEqual(new_video.state, "ready")
         self.assertEqual(new_video.uploaded_on, video.uploaded_on)
+        self.assertEqual(new_video.lti_id, video.lti_id)
+        self.assertEqual(new_video.resource_id, video.resource_id)
         self.assertNotEqual(new_video.playlist, video.playlist)
         self.assertEqual(new_video.playlist.consumer_site, passport.consumer_site)
 
@@ -475,6 +477,8 @@ class PortabilityVideoLTITestCase(TestCase):
         self.assertIsNone(new_video.duplicated_from)
         self.assertEqual(new_video.state, "pending")
         self.assertIsNone(new_video.uploaded_on)
+        self.assertEqual(new_video.lti_id, video.lti_id)
+        self.assertNotEqual(new_video.resource_id, video.resource_id)
         self.assertNotEqual(new_video.playlist, video.playlist)
         self.assertEqual(new_video.playlist.consumer_site, passport.consumer_site)
 
@@ -536,6 +540,8 @@ class PortabilityVideoLTITestCase(TestCase):
         self.assertNotEqual(new_video.playlist, video.playlist)
         self.assertEqual(new_video.state, "pending")
         self.assertIsNone(new_video.uploaded_on)
+        self.assertEqual(new_video.lti_id, video.lti_id)
+        self.assertNotEqual(new_video.resource_id, video.resource_id)
         self.assertNotEqual(new_video.playlist, video.playlist)
         self.assertEqual(new_video.playlist.consumer_site, passport.consumer_site)
 
@@ -596,6 +602,8 @@ class PortabilityVideoLTITestCase(TestCase):
         self.assertEqual(new_video.duplicated_from, video)
         self.assertEqual(new_video.state, "ready")
         self.assertEqual(new_video.uploaded_on, video.uploaded_on)
+        self.assertEqual(new_video.lti_id, video.lti_id)
+        self.assertEqual(new_video.resource_id, video.resource_id)
         self.assertNotEqual(new_video.playlist, video.playlist)
 
     @mock.patch.object(LTIOAuthServer, "verify_request", return_value=True)
@@ -658,6 +666,8 @@ class PortabilityVideoLTITestCase(TestCase):
         self.assertNotEqual(new_video.playlist, video.playlist)
         self.assertEqual(new_video.state, "pending")
         self.assertIsNone(new_video.uploaded_on)
+        self.assertEqual(new_video.lti_id, video.lti_id)
+        self.assertNotEqual(new_video.resource_id, video.resource_id)
 
     @mock.patch.object(LTIOAuthServer, "verify_request", return_value=True)
     def test_lti_get_video_other_playlist_portable_not_ready_student(self, mock_verify):
@@ -719,6 +729,8 @@ class PortabilityVideoLTITestCase(TestCase):
         self.assertNotEqual(new_video.playlist, video.playlist)
         self.assertEqual(new_video.state, "pending")
         self.assertIsNone(new_video.uploaded_on)
+        self.assertEqual(new_video.lti_id, video.lti_id)
+        self.assertNotEqual(new_video.resource_id, video.resource_id)
 
     @mock.patch.object(LTIOAuthServer, "verify_request", return_value=True)
     def test_lti_get_video_other_playlist_not_portable_student(self, mock_verify):
@@ -781,6 +793,8 @@ class PortabilityVideoLTITestCase(TestCase):
         self.assertEqual(new_video.duplicated_from, video)
         self.assertEqual(new_video.state, "ready")
         self.assertEqual(new_video.uploaded_on, video.uploaded_on)
+        self.assertEqual(new_video.lti_id, video.lti_id)
+        self.assertEqual(new_video.resource_id, video.resource_id)
         self.assertNotEqual(new_video.playlist, video.playlist)
 
     @mock.patch.object(LTIOAuthServer, "verify_request", return_value=True)
@@ -847,6 +861,8 @@ class PortabilityVideoLTITestCase(TestCase):
         self.assertNotEqual(new_video.playlist, video.playlist)
         self.assertEqual(new_video.state, "pending")
         self.assertIsNone(new_video.uploaded_on)
+        self.assertEqual(new_video.lti_id, video.lti_id)
+        self.assertNotEqual(new_video.resource_id, video.resource_id)
 
     @mock.patch.object(LTIOAuthServer, "verify_request", return_value=True)
     def test_lti_get_video_other_pl_site_portable_not_ready_student(self, mock_verify):
@@ -909,6 +925,8 @@ class PortabilityVideoLTITestCase(TestCase):
         self.assertNotEqual(new_video.playlist, video.playlist)
         self.assertEqual(new_video.state, "pending")
         self.assertIsNone(new_video.uploaded_on)
+        self.assertEqual(new_video.lti_id, video.lti_id)
+        self.assertNotEqual(new_video.resource_id, video.resource_id)
 
     @mock.patch.object(LTIOAuthServer, "verify_request", return_value=True)
     def test_lti_get_video_other_pl_site_not_portable_student(self, mock_verify):
@@ -969,6 +987,8 @@ class PortabilityVideoLTITestCase(TestCase):
         self.assertEqual(new_video.playlist, video.playlist)
         self.assertEqual(new_video.state, "pending")
         self.assertIsNone(new_video.uploaded_on)
+        self.assertEqual(new_video.lti_id, "df7")
+        self.assertNotEqual(new_video.resource_id, video.resource_id)
         # No new playlist is created
         self.assertEqual(Playlist.objects.count(), 1)
 


### PR DESCRIPTION
## Purpose

When duplicating a video, we forgot to set the "resource_id" field so we ended-up with copies that pointed to a file that did not exist in S3.

Furthermore, the video was duplicated endlessly each time the instructor was trying to access it. Big bug indeed.

## Proposal

- [x] set the `resource_id` field when duplicating videos,
- [x] the bug was not spotted because of insufficient tests so I added the missing assertions to existing portability tests.
