### PR TITLE
Fix an issue that prevented proper logging for lambda-encode

### DIFF
--- a/src/aws/lambda-encode/index.js
+++ b/src/aws/lambda-encode/index.js
@@ -27,24 +27,29 @@ exports.handler = async (event, context, callback) => {
     return;
   }
 
-  try {
-    switch (kind) {
-      case 'timedtexttrack':
+  switch (kind) {
+    case 'timedtexttrack':
+      try {
         await encodeTimedTextTrack(objectKey, sourceBucket);
         await updateState(objectKey, 'ready');
-        console.log(
-          `Successfully received and encoded timedtexttrack ${objectKey} from ${sourceBucket}.`,
-        );
-        break;
+      } catch (error) {
+        return callback(error);
+      }
+      console.log(
+        `Successfully received and encoded timedtexttrack ${objectKey} from ${sourceBucket}.`,
+      );
+      break;
 
-      case 'video':
-        await encodeVideo(objectKey, sourceBucket);
+    case 'video':
+      let jobData;
+      try {
+        jobData = await encodeVideo(objectKey, sourceBucket);
         await updateState(objectKey, 'processing');
-        console.log(JSON.stringify(jobData, null, 2));
-        callback(null, { Job: jobData.Job.Id });
-        break;
-    }
-  } catch (error) {
-    callback(error);
+      } catch (error) {
+        return callback(error);
+      }
+      console.log(JSON.stringify(jobData, null, 2));
+      callback(null, { Job: jobData.Job.Id });
+      break;
   }
 };

--- a/src/aws/lambda-encode/index.spec.js
+++ b/src/aws/lambda-encode/index.spec.js
@@ -182,6 +182,7 @@ describe('lambda', () => {
     };
 
     it('delegates to encodeVideo and calls updateState & callback when it succeeds', async () => {
+      mockEncodeVideo.mockReturnValue(Promise.resolve({ Job: { Id: '42' } }));
       await lambda(event, null, callback);
 
       expect(mockEncodeVideo).toHaveBeenCalledWith(

--- a/src/aws/lambda-encode/src/encodeVideo.js
+++ b/src/aws/lambda-encode/src/encodeVideo.js
@@ -125,7 +125,7 @@ module.exports = async (objectKey, sourceBucket) => {
     },
   };
 
-  await new AWS.MediaConvert({
+  return await new AWS.MediaConvert({
     endpoint: process.env.MEDIA_CONVERT_END_POINT,
   })
     .createJob(params)


### PR DESCRIPTION
## Purpose

We forgot to return the MediaConvert Job Data from `encodeVideo` into the handler; this causes it to fail when it attempts to log said Job Data it did not receive.

The problem was not caught in the tests because the whole code block was wrapped in a `try/catch` block to catch side-effect related issues.

## Proposal

We reduced the scope of the `try/catch` to only encompass side effect calls and make the relevant unit test fail. We could then simply update both `encodeVideo` and our mock to have the expected behavior of returning the Job Data.
