### PR TITLE
🐛(video) fix initiate upload updating all objects instead of just one

### DIFF
--- a/src/backend/marsha/core/api.py
+++ b/src/backend/marsha/core/api.py
@@ -131,7 +131,7 @@ class VideoViewSet(
         )
 
         # Reset the upload state of the video
-        Video.objects.update(upload_state=PENDING)
+        Video.objects.filter(pk=pk).update(upload_state=PENDING)
 
         return Response(policy)
 
@@ -191,7 +191,7 @@ class TimedTextTrackViewSet(
             {"key": key, "max_file_size": SUBTITLE_SOURCE_MAX_SIZE, "stamp": stamp}
         )
 
-        # Reset the upload state of the video
-        TimedTextTrack.objects.update(upload_state=PENDING)
+        # Reset the upload state of the timed text track
+        TimedTextTrack.objects.filter(pk=pk).update(upload_state=PENDING)
 
         return Response(policy)


### PR DESCRIPTION
## Purpose

We use an `update` query to reset the `upload_state` on a video (resp timed text track) when initiating an upload. The query was mistakenly targetting all objects in the database instead of only the precise object targetted by the API endpoint.

## Proposal

I added a filter to target the specific object of the API endpoint.




