### PR TITLE
Use node 10 to run builds & tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -252,7 +252,7 @@ jobs:
   # ---- Front-end jobs ----
   build-front:
     docker:
-      - image: circleci/node:9-browsers
+      - image: circleci/node:10
     working_directory: ~/marsha/src/frontend
     steps:
       - checkout:
@@ -276,7 +276,7 @@ jobs:
 
   lint-front-tslint:
     docker:
-      - image: circleci/node:9-browsers
+      - image: circleci/node:10
     working_directory: ~/marsha/src/frontend
     steps:
       - checkout:
@@ -290,7 +290,7 @@ jobs:
 
   lint-front-prettier:
     docker:
-      - image: circleci/node:9-browsers
+      - image: circleci/node:10
     working_directory: ~/marsha/src/frontend
     steps:
       - checkout:
@@ -304,7 +304,7 @@ jobs:
 
   test-front:
     docker:
-      - image: circleci/node:9-browsers
+      - image: circleci/node:10
     working_directory: ~/marsha/src/frontend
     steps:
       - checkout:
@@ -319,7 +319,9 @@ jobs:
   # ---- Lambda related jobs ----
   test-lambda-configure:
     docker:
-      - image: circleci/node:8.11.3
+      - image: circleci/node:8.10
+      # Run on the highest version of node available on AWS Lambda
+      # https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Runtime
     working_directory: ~/marsha/src/aws/lambda-configure
     steps:
       - checkout:
@@ -341,7 +343,9 @@ jobs:
 
   test-lambda-encode:
     docker:
-      - image: circleci/node:8.11.3
+      - image: circleci/node:8.10
+      # Run on the highest version of node available on AWS Lambda
+      # https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Runtime
     working_directory: ~/marsha/src/aws/lambda-encode
     steps:
       - checkout:
@@ -363,7 +367,9 @@ jobs:
 
   test-lambda-update-state:
     docker:
-      - image: circleci/node:8.11.3
+      - image: circleci/node:8.10
+      # Run on the highest version of node available on AWS Lambda
+      # https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Runtime
     working_directory: ~/marsha/src/aws/lambda-update-state
     steps:
       - checkout:

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN mkdir /install && \
     pip install --prefix=/install .
 
 # ---- front-end builder image ----
-FROM node:9 as front-builder
+FROM node:10 as front-builder
 
 WORKDIR /app
 

--- a/docker/images/alpine/Dockerfile
+++ b/docker/images/alpine/Dockerfile
@@ -37,7 +37,7 @@ RUN python -c "import configparser; c = configparser.ConfigParser(); c.read('/se
     print(c['options']['install_requires'])" | xargs pip install --prefix=/install
 
 # ---- front-end builder image ----
-FROM node:9 as front-builder
+FROM node:10 as front-builder
 
 WORKDIR /app
 

--- a/src/aws/lambda-configure/package.json
+++ b/src/aws/lambda-configure/package.json
@@ -3,7 +3,7 @@
   "name": "aws-marsha-configure",
   "version": "0.0.1",
   "engines": {
-    "node": "^8.10"
+    "node": ">8.10"
   },
   "description": "Configure AWS via a Lambda for what can not be configured via Terraform for the Marsha video workflow",
   "repository": {

--- a/src/aws/lambda-encode/package.json
+++ b/src/aws/lambda-encode/package.json
@@ -3,7 +3,7 @@
   "name": "aws-marsha-convert",
   "version": "0.0.1",
   "engines": {
-    "node": "^8.10"
+    "node": ">8.10"
   },
   "description": "Convert a source video to all the formats used in Marsha",
   "dependencies": {

--- a/src/aws/lambda-update-state/package.json
+++ b/src/aws/lambda-update-state/package.json
@@ -3,7 +3,7 @@
   "name": "aws-marsha-update-state",
   "version": "0.0.1",
   "engines": {
-    "node": "^8.10"
+    "node": ">8.10"
   },
   "description": "Confirm to the server when encoding for a video is complete",
   "repository": {

--- a/src/aws/lambda.tf
+++ b/src/aws/lambda.tf
@@ -4,6 +4,8 @@
 resource "aws_lambda_function" "marsha_configure_lambda" {
   function_name    = "${terraform.workspace}-marsha-configure"
   handler          = "index.handler"
+  # Run on the highest version of node available on AWS lambda
+  # https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Runtime
   runtime          = "nodejs8.10"
   filename         = "dist/marsha_configure.zip"
   source_code_hash = "${base64sha256(file("dist/marsha_configure.zip"))}"
@@ -50,6 +52,8 @@ EOF
 resource "aws_lambda_function" "marsha_encode_lambda" {
   function_name    = "${terraform.workspace}-marsha-encode"
   handler          = "index.handler"
+  # Run on the highest version of node available on AWS lambda
+  # https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Runtime
   runtime          = "nodejs8.10"
   filename         = "dist/marsha_encode.zip"
   source_code_hash = "${base64sha256(file("dist/marsha_encode.zip"))}"
@@ -82,6 +86,8 @@ resource "aws_lambda_permission" "allow_bucket" {
 resource "aws_lambda_function" "marsha_update_state_lambda" {
   function_name    = "${terraform.workspace}-marsha-update-state"
   handler          = "index.handler"
+  # Run on the highest version of node available on AWS lambda
+  # https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Runtime
   runtime          = "nodejs8.10"
   filename         = "dist/marsha_update-state.zip"
   source_code_hash = "${base64sha256(file("dist/marsha_update-state.zip"))}"


### PR DESCRIPTION
## Purpose

Node 9 is EOL and Node 8 is soon to be, and is already an old version at this point.

## Proposal

Switch Node versions in Dockerfiles & CircleCI builds to Node 10, which is the current LTS. To do this cleanly we also changed the `engines` field in lambdas to accept versions above 8.
