### PR TITLE
Improve context typings to reflect the actual values

### DIFF
--- a/src/frontend/components/AppRoutes/AppRoutes.tsx
+++ b/src/frontend/components/AppRoutes/AppRoutes.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { MemoryRouter, Route, Switch } from 'react-router-dom';
 
 import { RootState } from '../../data/rootReducer';
+import { appState } from '../../types/AppData';
 import { DASHBOARD_ROUTE } from '../Dashboard/route';
 import { DashboardConnected } from '../DashboardConnected/DashboardConnected';
 import { ErrorComponent } from '../ErrorComponent/ErrorComponent';
@@ -15,7 +16,7 @@ import { VIDEO_PLAYER_ROUTE } from '../VideoPlayer/route';
 import { VideoPlayerConnected } from '../VideoPlayerConnected/VideoPlayerConnected';
 
 interface AppRoutesProps {
-  context: RootState['context'];
+  context: RootState<appState>['context'];
 }
 
 export const AppRoutes = ({ context }: AppRoutesProps) => {

--- a/src/frontend/components/AppRoutesConnected/AppRoutesConnected.tsx
+++ b/src/frontend/components/AppRoutesConnected/AppRoutesConnected.tsx
@@ -1,12 +1,13 @@
 import { connect } from 'react-redux';
 
 import { RootState } from '../../data/rootReducer';
+import { appState } from '../../types/AppData';
 import { AppRoutes } from '../AppRoutes/AppRoutes';
 
 /**
  * Pick the state context so it can be used to render any route.
  */
-export const mapStateToProps = (state: RootState) => ({
+export const mapStateToProps = (state: RootState<appState>) => ({
   context: state.context,
 });
 

--- a/src/frontend/components/DashboardConnected/DashboardConnected.spec.tsx
+++ b/src/frontend/components/DashboardConnected/DashboardConnected.spec.tsx
@@ -46,11 +46,6 @@ describe('<DashboardConnected />', () => {
       expect(mapStateToProps(state, props)).toEqual({
         video: { id: 42 },
       });
-
-      state = undefined;
-      expect(mapStateToProps(state, props)).toEqual({
-        video: { id: 42 },
-      });
     });
   });
 });

--- a/src/frontend/components/DashboardConnected/DashboardConnected.tsx
+++ b/src/frontend/components/DashboardConnected/DashboardConnected.tsx
@@ -1,8 +1,7 @@
 import { connect } from 'react-redux';
-import { Dispatch } from 'redux';
 
-import { addResource } from '../../data/genericReducers/resourceById/actions';
 import { RootState } from '../../data/rootReducer';
+import { appStateSuccess } from '../../types/AppData';
 import { modelName } from '../../types/models';
 import { Video } from '../../types/tracks';
 import { Dashboard } from '../Dashboard/Dashboard';
@@ -18,13 +17,12 @@ interface DashboardConnectedProps {
  * Also, just pass the jwt along.
  */
 export const mapStateToProps = (
-  state: RootState,
+  state: RootState<appStateSuccess>,
   { video }: DashboardConnectedProps,
 ) => ({
   video:
-    (state &&
-      state.resources[modelName.VIDEOS]!.byId &&
-      state.resources[modelName.VIDEOS]!.byId[(video && video.id) || '']) ||
+    (state.resources[modelName.VIDEOS]!.byId &&
+      state.resources[modelName.VIDEOS]!.byId[video.id]) ||
     video,
 });
 

--- a/src/frontend/components/DashboardTimedTextPaneConnected/DashboardTimedTextPaneConnected.tsx
+++ b/src/frontend/components/DashboardTimedTextPaneConnected/DashboardTimedTextPaneConnected.tsx
@@ -3,11 +3,12 @@ import { Dispatch } from 'redux';
 
 import { addMultipleResources } from '../../data/genericReducers/resourceById/actions';
 import { RootState } from '../../data/rootReducer';
+import { appStateSuccess } from '../../types/AppData';
 import { modelName } from '../../types/models';
 import { TimedText } from '../../types/tracks';
 import { DashboardTimedTextPane } from '../DashboardTimedTextPane/DashboardTimedTextPane';
 
-const mapStateToProps = (state: RootState) => ({
+const mapStateToProps = (state: RootState<appStateSuccess>) => ({
   jwt: state.context.jwt,
 });
 

--- a/src/frontend/components/DashboardVideoPane/DashboardVideoPane.tsx
+++ b/src/frontend/components/DashboardVideoPane/DashboardVideoPane.tsx
@@ -5,7 +5,6 @@ import styled from 'styled-components';
 
 import { API_ENDPOINT } from '../../settings';
 import { uploadState, Video } from '../../types/tracks';
-import { Nullable } from '../../utils/types';
 import { DashboardInternalHeading } from '../Dashboard/DashboardInternalHeading';
 import { DashboardVideoPaneButtons } from '../DashboardVideoPaneButtons/DashboardVideoPaneButtons';
 import { DashboardVideoPaneHelptext } from '../DashboardVideoPaneHelptext/DashboardVideoPaneHelptext';
@@ -40,7 +39,7 @@ const DashboardVideoPaneInternalHeading = styled(DashboardInternalHeading)`
 
 /** Props shape for the DashboardVideoPane component. */
 export interface DashboardVideoPaneProps {
-  jwt: Nullable<string>;
+  jwt: string;
   updateVideo: (video: Video) => void;
   video: Video;
 }

--- a/src/frontend/components/DashboardVideoPaneConnected/DashboardVideoPaneConnected.tsx
+++ b/src/frontend/components/DashboardVideoPaneConnected/DashboardVideoPaneConnected.tsx
@@ -3,18 +3,12 @@ import { Dispatch } from 'redux';
 
 import { addResource } from '../../data/genericReducers/resourceById/actions';
 import { RootState } from '../../data/rootReducer';
+import { appStateSuccess } from '../../types/AppData';
 import { modelName } from '../../types/models';
 import { Video } from '../../types/tracks';
-import {
-  DashboardVideoPane,
-  DashboardVideoPaneProps,
-} from '../DashboardVideoPane/DashboardVideoPane';
+import { DashboardVideoPane } from '../DashboardVideoPane/DashboardVideoPane';
 
-export const mapStateToProps = (
-  state: RootState,
-  ownProps: DashboardVideoPaneProps,
-) => ({
-  ...ownProps,
+const mapStateToProps = (state: RootState<appStateSuccess>) => ({
   jwt: state.context.jwt,
 });
 

--- a/src/frontend/components/InstructorViewConnected/InstructorViewConnected.spec.tsx
+++ b/src/frontend/components/InstructorViewConnected/InstructorViewConnected.spec.tsx
@@ -1,4 +1,5 @@
 import { RootState } from '../../data/rootReducer';
+import { appStateSuccess } from '../../types/AppData';
 import { mapStateToProps } from './InstructorViewConnected';
 
 describe('<InstructorViewConnected />', () => {
@@ -10,13 +11,8 @@ describe('<InstructorViewConnected />', () => {
             id: '42',
           },
         },
-      } as RootState;
+      } as RootState<appStateSuccess>;
       expect(mapStateToProps(state)).toEqual({ videoId: '42' });
-    });
-
-    it('defaults to null', () => {
-      const state = { context: {} } as RootState;
-      expect(mapStateToProps(state)).toEqual({ videoId: null });
     });
   });
 });

--- a/src/frontend/components/InstructorViewConnected/InstructorViewConnected.tsx
+++ b/src/frontend/components/InstructorViewConnected/InstructorViewConnected.tsx
@@ -1,14 +1,11 @@
 import { connect } from 'react-redux';
 
 import { RootState } from '../../data/rootReducer';
+import { appStateSuccess } from '../../types/AppData';
 import { InstructorView } from '../InstructorView/InstructorView';
 
-export const mapStateToProps = (state: RootState) => ({
-  videoId:
-    (state &&
-      state.context.ltiResourceVideo &&
-      state.context.ltiResourceVideo.id) ||
-    null,
+export const mapStateToProps = (state: RootState<appStateSuccess>) => ({
+  videoId: state.context.ltiResourceVideo.id,
 });
 
 export const InstructorViewConnected = connect(mapStateToProps)(InstructorView);

--- a/src/frontend/components/InstructorWrapperConnected/InstructorWrapperConnected.tsx
+++ b/src/frontend/components/InstructorWrapperConnected/InstructorWrapperConnected.tsx
@@ -1,12 +1,13 @@
 import { connect } from 'react-redux';
 
 import { RootState } from '../../data/rootReducer';
+import { appStateSuccess } from '../../types/AppData';
 import { InstructorWrapper } from '../InstructorWrapper/InstructorWrapper';
 
 /**
  * Simply pick the ltiState statically from the context.
  */
-export const mapStateToProps = (state: RootState) => ({
+export const mapStateToProps = (state: RootState<appStateSuccess>) => ({
   ltiState: state.context.ltiState,
 });
 

--- a/src/frontend/components/RedirectOnLoadConnected/RedirectOnLoadConnected.tsx
+++ b/src/frontend/components/RedirectOnLoadConnected/RedirectOnLoadConnected.tsx
@@ -1,12 +1,13 @@
 import { connect } from 'react-redux';
 
 import { RootState } from '../../data/rootReducer';
+import { appState } from '../../types/AppData';
 import { RedirectOnLoad } from '../RedirectOnLoad/RedirectOnLoad';
 
 /**
  * Simply pick the video & ltiState statically from the context.
  */
-export const mapStateToProps = (state: RootState) => ({
+export const mapStateToProps = (state: RootState<appState>) => ({
   ltiState: state.context.ltiState,
   video: state.context.ltiResourceVideo,
 });

--- a/src/frontend/components/TimedTextCreationFormConnected/TimedTextCreationFormConnected.ts
+++ b/src/frontend/components/TimedTextCreationFormConnected/TimedTextCreationFormConnected.ts
@@ -3,18 +3,12 @@ import { Dispatch } from 'redux';
 
 import { addResource } from '../../data/genericReducers/resourceById/actions';
 import { RootState } from '../../data/rootReducer';
+import { appStateSuccess } from '../../types/AppData';
 import { modelName } from '../../types/models';
 import { TimedText } from '../../types/tracks';
-import {
-  TimedTextCreationForm,
-  TimedTextCreationFormProps,
-} from '../TimedTextCreationForm/TimedTextCreationForm';
+import { TimedTextCreationForm } from '../TimedTextCreationForm/TimedTextCreationForm';
 
-const mapStateToProps = (
-  state: RootState,
-  ownProps: TimedTextCreationFormProps,
-) => ({
-  ...ownProps,
+const mapStateToProps = (state: RootState<appStateSuccess>) => ({
   jwt: state.context.jwt,
 });
 

--- a/src/frontend/components/TimedTextListItemConnected/TimedTextListItemConnected.ts
+++ b/src/frontend/components/TimedTextListItemConnected/TimedTextListItemConnected.ts
@@ -3,11 +3,12 @@ import { Dispatch } from 'redux';
 
 import { deleteResource } from '../../data/genericReducers/resourceById/actions';
 import { RootState } from '../../data/rootReducer';
+import { appStateSuccess } from '../../types/AppData';
 import { modelName } from '../../types/models';
 import { TimedText } from '../../types/tracks';
 import { TimedTextListItem } from '../TimedTextListItem/TimedTextListItem';
 
-const mapStateToProps = (state: RootState) => ({
+const mapStateToProps = (state: RootState<appStateSuccess>) => ({
   jwt: state.context.jwt,
 });
 

--- a/src/frontend/components/UploadForm/UploadForm.tsx
+++ b/src/frontend/components/UploadForm/UploadForm.tsx
@@ -13,7 +13,7 @@ import {
   uploadState,
 } from '../../types/tracks';
 import { makeFormData } from '../../utils/makeFormData/makeFormData';
-import { Maybe, Nullable } from '../../utils/types';
+import { Maybe } from '../../utils/types';
 import { DASHBOARD_ROUTE } from '../Dashboard/route';
 import { ERROR_COMPONENT_ROUTE } from '../ErrorComponent/route';
 import { IframeHeading } from '../Headings/Headings';
@@ -78,7 +78,7 @@ const UploadFormBack = styled.div`
 
 /** Props shape for the UploadForm component. */
 interface UploadFormProps {
-  jwt: Nullable<string>;
+  jwt: string;
   object: Maybe<UploadableObject>;
   objectType: modelName;
   updateObject: (object: UploadableObject) => void;

--- a/src/frontend/components/UploadFormConnected/UploadFormConnected.tsx
+++ b/src/frontend/components/UploadFormConnected/UploadFormConnected.tsx
@@ -3,6 +3,7 @@ import { Dispatch } from 'redux';
 
 import { addResource } from '../../data/genericReducers/resourceById/actions';
 import { RootState } from '../../data/rootReducer';
+import { appStateSuccess } from '../../types/AppData';
 import { modelName } from '../../types/models';
 import { UploadableObject } from '../../types/tracks';
 import { UploadForm } from '../UploadForm/UploadForm';
@@ -18,12 +19,11 @@ interface UploadFormConnectedProps {
  * Also, just pass the jwt and objectType along.
  */
 export const mapStateToProps = (
-  state: RootState,
+  state: RootState<appStateSuccess>,
   { objectId, objectType }: UploadFormConnectedProps,
 ) => ({
-  jwt: state && state.context && state.context.jwt,
+  jwt: state.context.jwt,
   object:
-    state &&
     state.resources[objectType]!.byId &&
     state.resources[objectType]!.byId[objectId],
   objectType,

--- a/src/frontend/components/VideoPlayerConnected/VideoPlayerConnected.spec.tsx
+++ b/src/frontend/components/VideoPlayerConnected/VideoPlayerConnected.spec.tsx
@@ -45,11 +45,6 @@ describe('<VideoPlayerConnected />', () => {
       expect(mapStateToProps(state, props)).toEqual({
         video: { id: 42 },
       });
-
-      state = undefined;
-      expect(mapStateToProps(state, props)).toEqual({
-        video: { id: 42 },
-      });
     });
   });
 });

--- a/src/frontend/components/VideoPlayerConnected/VideoPlayerConnected.tsx
+++ b/src/frontend/components/VideoPlayerConnected/VideoPlayerConnected.tsx
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux';
 
 import { RootState } from '../../data/rootReducer';
+import { appStateSuccess } from '../../types/AppData';
 import { modelName } from '../../types/models';
 import { VideoPlayer, VideoPlayerProps } from '../VideoPlayer/VideoPlayer';
 
@@ -9,12 +10,11 @@ import { VideoPlayer, VideoPlayerProps } from '../VideoPlayer/VideoPlayer';
  * state if available as it will hold the most recent version.
  */
 export const mapStateToProps = (
-  state: RootState,
+  state: RootState<appStateSuccess>,
   { video }: VideoPlayerProps,
 ) => ({
   video:
-    (state &&
-      state.resources[modelName.VIDEOS]!.byId &&
+    (state.resources[modelName.VIDEOS]!.byId &&
       state.resources[modelName.VIDEOS]!.byId[(video && video.id) || '']) ||
     video,
 });

--- a/src/frontend/data/rootReducer.ts
+++ b/src/frontend/data/rootReducer.ts
@@ -3,18 +3,17 @@ import { Reducer } from 'redux';
 import { appState } from '../types/AppData';
 import { modelName } from '../types/models';
 import { Video } from '../types/tracks';
-import { Nullable } from '../utils/types';
 import {
   timedtexttracks,
   TimedTextTracksState,
 } from './timedtexttracks/reducer';
 import { videos, VideosState } from './videos/reducer';
 
-export interface RootState {
+export interface RootState<state extends appState> {
   context: {
-    jwt: Nullable<string>;
-    ltiResourceVideo: Nullable<Video>;
-    ltiState: appState;
+    jwt: state extends appState.ERROR ? null : string;
+    ltiResourceVideo: state extends appState.ERROR ? null : Video;
+    ltiState: state;
   };
   resources: {
     [modelName.TIMEDTEXTTRACKS]: TimedTextTracksState;
@@ -22,7 +21,7 @@ export interface RootState {
   };
 }
 
-export const rootReducer: Reducer<RootState> = (state, action) => ({
+export const rootReducer: Reducer<RootState<appState>> = (state, action) => ({
   context: state!.context,
   resources: {
     [modelName.TIMEDTEXTTRACKS]: timedtexttracks(

--- a/src/frontend/types/AppData.ts
+++ b/src/frontend/types/AppData.ts
@@ -8,6 +8,8 @@ export enum appState {
   STUDENT = 'student',
 }
 
+export type appStateSuccess = appState.INSTRUCTOR | appState.STUDENT;
+
 export interface AppData {
   jwt: string;
   policy?: AWSPolicy;


### PR DESCRIPTION
## Purpose

Typings for `RootState['context']` were inaccurate: by using `Nullables`, we had technically correct but imprecise types. This forced us to manage those `Nullable` values in places where they were not really `Nullable`.

## Proposal

We can instead parameterize `RootState` to more reliably represent the actual values: when app state is ERROR, some keys hold `null`, when it is not, they  hold the actual values.

Closes #197. 