### PR TITLE
🚑(frontend) hide the <DashboardTimedTextPane />

### DIFF
--- a/src/frontend/components/Dashboard/Dashboard.tsx
+++ b/src/frontend/components/Dashboard/Dashboard.tsx
@@ -48,7 +48,6 @@ export class Dashboard extends React.Component<DashboardProps> {
           <FormattedMessage {...messages.title} />
         </IframeHeadingWithLayout>
         <DashboardVideoPaneConnected video={this.props.video} />
-        <DashboardTimedTextPaneConnected video={this.props.video} />
       </DashboardContainer>
     );
   }


### PR DESCRIPTION
## Purpose

Description...

We need to hide the `<DashboardTimedTextPane />` for now to enable new deployments.

We want to avoid confusing users until we are able to display the subtitles, closed captions & transcripts in the video player and to make some improvements to the timed text uploading process.

Description...

We can easily add it back as soon as we want by just adding back `<DashboardTimedTextPaneConnected />` to the `<Dashboard />`.
