### PR TITLE
Fix an issue in the update-state serializer

### DIFF
--- a/src/backend/marsha/core/serializers.py
+++ b/src/backend/marsha/core/serializers.py
@@ -19,7 +19,7 @@ UUID_REGEX = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
 TIMED_TEXT_EXTENSIONS = "|".join(m[0] for m in TimedTextTrack.MODE_CHOICES)
 KEY_PATTERN = (
     "^{uuid:s}/(?P<model_name>video|timedtexttrack)/(?P<object_id>"
-    "{uuid:s})/(?P<stamp>[0-9]{{10}})(_[a-z]{{2}}_({tt_ex}))?$"
+    "{uuid:s})/(?P<stamp>[0-9]{{10}})(_[a-z-]{{2,10}}_({tt_ex}))?$"
 ).format(uuid=UUID_REGEX, tt_ex=TIMED_TEXT_EXTENSIONS)
 KEY_REGEX = re.compile(KEY_PATTERN)
 

--- a/src/backend/marsha/core/tests/test_serializers_update_state.py
+++ b/src/backend/marsha/core/tests/test_serializers_update_state.py
@@ -23,9 +23,10 @@ class UpdateStateSerializerTest(TestCase):
         valid_keys = [
             "{!s}/video/{!s}/0123456789".format(uuid4(), uuid4()),
             *[
-                "{!s}/timedtexttrack/{!s}/0123456789_fr_{!s}".format(
-                    uuid4(), uuid4(), mode
+                "{!s}/timedtexttrack/{!s}/0123456789_{:s}_{:s}".format(
+                    uuid4(), uuid4(), language, mode
                 )
+                for language in ["fr", "ast", "zh-hans"]
                 for mode, _ in TimedTextTrack.MODE_CHOICES
             ],
         ]


### PR DESCRIPTION
## Purpose

The update state serializer rejected incoming requests for timed text for languages that had codes longer than 2 letters. This prevented them from being marked as PROCESSING and READY.

This was due to an expectation in the KEY REGEX for the serializer that language codes where 2 letters long, when they can be longer and include dashes.

## Proposal

Just update the regex to accept longer codes with dashes. Update the test to secure this behavior.
