### PR TITLE
🔧(storage) use manifest static files storage class for deployed environments

### DIFF
--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -246,6 +246,13 @@ class Production(Base):
     ALLOWED_HOSTS = values.ListValue(None)
     AWS_SOURCE_BUCKET_NAME = values.Value("production-marsha-source")
 
+    # For static files in production, we want to use a backend that includes a hash in
+    # the filename, that is calculated from the file content, so that browsers always
+    # get the updated version of each file.
+    STATICFILES_STORAGE = (
+        "django.contrib.staticfiles.storage.ManifestStaticFilesStorage"
+    )
+
 
 class Staging(Production):
     """Staging environment settings."""


### PR DESCRIPTION
## Purpose

The static files (css/js) often change but because the files keep the same name, a browser that has it in its cache will not get the new files immediately and will therefore continue to use an outdated version
of such files.

## Proposal

Django proposes a file storage that automatically renames the files to include a hash of their content in their name. The mapping between the original file name and the hashed name is stored in a manifest file
(hence the name of the storage backend).
