### PR TITLE
✨(redux) enable devtools to ease development

### DIFF
--- a/src/frontend/data/bootstrapStore.ts
+++ b/src/frontend/data/bootstrapStore.ts
@@ -1,4 +1,4 @@
-import { applyMiddleware, createStore } from 'redux';
+import { applyMiddleware, compose, createStore } from 'redux';
 import createSagaMiddleware from 'redux-saga';
 
 import { AppData } from '../types/AppData';
@@ -10,6 +10,9 @@ import { rootSaga } from './rootSaga';
 const sagaMiddleware = createSagaMiddleware();
 
 export const bootstrapStore = (appData: AppData) => {
+  const composeEnhancers =
+    (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
+
   const store = createStore(
     rootReducer,
     {
@@ -23,7 +26,7 @@ export const bootstrapStore = (appData: AppData) => {
         },
       },
     },
-    applyMiddleware(sagaMiddleware),
+    composeEnhancers(applyMiddleware(sagaMiddleware)),
   );
 
   sagaMiddleware.run(rootSaga);

--- a/src/frontend/utils/types.ts
+++ b/src/frontend/utils/types.ts
@@ -3,17 +3,7 @@ export type Maybe<T> = T | undefined;
 export type Nullable<T> = T | null;
 
 /**
- * Compare 2 types and get all the values that are in type `T` and not in type `U`.
- * For instance:
- *   `Diff<'a' | 'b' | 'c', 'b' | 'c'>` is `'a'`
- */
-type Diff<
-  T extends string | number | symbol,
-  U extends string | number | symbol
-> = ({ [P in T]: P } & { [P in U]: never } & { [x: string]: never })[T];
-
-/**
  * Omit all keys from type T that are in K.
  * `Omit<{ a: null, b: null, c: null }, 'a' | 'c'>` is `{ b: null }`
  */
-export type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;
+export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;


### PR DESCRIPTION
## Purpose

Redux devtools are a must have when working with redux. It eases a lot
the lifecycle development and has no impact on performance.

## Proposal

- [x] Use redux devtools compose function to enable redux devtools.

This PR target PR #215 

