### PR TITLE
🔥(frontend) remove Diff type util

### DIFF
--- a/src/frontend/utils/types.ts
+++ b/src/frontend/utils/types.ts
@@ -3,17 +3,7 @@ export type Maybe<T> = T | undefined;
 export type Nullable<T> = T | null;
 
 /**
- * Compare 2 types and get all the values that are in type `T` and not in type `U`.
- * For instance:
- *   `Diff<'a' | 'b' | 'c', 'b' | 'c'>` is `'a'`
- */
-type Diff<
-  T extends string | number | symbol,
-  U extends string | number | symbol
-> = ({ [P in T]: P } & { [P in U]: never } & { [x: string]: never })[T];
-
-/**
  * Omit all keys from type T that are in K.
  * `Omit<{ a: null, b: null, c: null }, 'a' | 'c'>` is `{ b: null }`
  */
-export type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;
+export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;


### PR DESCRIPTION
## Purpose

We implemented the `Diff` util for types to help with the implementation of `Omit` (and as something that could be useful on its own).

It turns out TypeScript includes a built-in implementation in `Exclude` since version 2.8, which means we do not need to bake our own.

## Proposal

Remove `Diff`.

