### PR TITLE
Improve usability for admin users (understanding LTI Exceptions)

### DIFF
--- a/src/backend/marsha/core/admin.py
+++ b/src/backend/marsha/core/admin.py
@@ -193,6 +193,7 @@ class VideoAdmin(admin.ModelAdmin):
         "id",
         "title",
         link_field("playlist"),
+        link_field("consumer_site"),
         "lti_id",
         "upload_state",
         "uploaded_on",

--- a/src/backend/marsha/core/admin.py
+++ b/src/backend/marsha/core/admin.py
@@ -11,6 +11,7 @@ from marsha.core.models import (
     ConsumerSite,
     ConsumerSiteAccess,
     ConsumerSiteOrganization,
+    ConsumerSitePortability,
     LTIPassport,
     Organization,
     OrganizationAccess,
@@ -111,13 +112,29 @@ class ConsumerSiteOrganizationsInline(admin.TabularInline):
     verbose_name_plural = _("organizations")
 
 
+class ConsumerSitePortabilityInline(admin.TabularInline):
+    """Inline to display consumer sites to which a consumer site is automatically portable."""
+
+    model = ConsumerSitePortability
+    fk_name = "source_site"
+    verbose_name = _("portable to")
+    verbose_name_plural = _("portable to")
+
+
 @admin.register(ConsumerSite, site=admin_site)
 class ConsumerSiteAdmin(admin.ModelAdmin):
     """Admin class for the ConsumerSite model."""
 
     list_display = ("id", "name", "domain", "created_on", "updated_on")
     search_fields = ("id", "name", "domain")
-    inlines = [ConsumerSiteUsersInline, ConsumerSiteOrganizationsInline]
+    inlines = [
+        ConsumerSitePortabilityInline,
+        ConsumerSiteUsersInline,
+        ConsumerSiteOrganizationsInline,
+    ]
+
+    fields = ("id", "name", "domain", "created_on", "updated_on")
+    readonly_fields = ["id", "created_on", "updated_on"]
 
 
 class OrganizationUsersInline(admin.TabularInline):

--- a/src/backend/marsha/core/admin.py
+++ b/src/backend/marsha/core/admin.py
@@ -200,6 +200,7 @@ class VideoAdmin(admin.ModelAdmin):
         "updated_on",
         "created_on",
     )
+    list_select_related = ("playlist__consumer_site",)
     fields = (
         "id",
         "title",
@@ -292,6 +293,7 @@ class PlaylistAdmin(admin.ModelAdmin):
         "updated_on",
         "created_on",
     )
+    list_select_related = ("consumer_site", "organization")
     fields = (
         "id",
         "title",
@@ -342,6 +344,7 @@ class LTIPassportAdmin(admin.ModelAdmin):
         "updated_on",
         "created_on",
     )
+    list_select_related = ("consumer_site", "playlist")
     fields = (
         "oauth_consumer_key",
         "shared_secret",

--- a/src/backend/marsha/core/admin.py
+++ b/src/backend/marsha/core/admin.py
@@ -115,8 +115,8 @@ class ConsumerSiteOrganizationsInline(admin.TabularInline):
 class ConsumerSiteAdmin(admin.ModelAdmin):
     """Admin class for the ConsumerSite model."""
 
-    list_display = ("name", "domain", "created_on", "updated_on")
-    search_fields = ("name", "domain")
+    list_display = ("id", "name", "domain", "created_on", "updated_on")
+    search_fields = ("id", "name", "domain")
     inlines = [ConsumerSiteUsersInline, ConsumerSiteOrganizationsInline]
 
 
@@ -169,11 +169,11 @@ class SignTrackInline(admin.TabularInline):
 class VideoAdmin(admin.ModelAdmin):
     """Admin class for the Video model."""
 
-    list_display = ("title", "created_by")
     exclude = ("duplicated_from",)
     inlines = [AudioTrackInline, TimedTextTrackInline, SignTrackInline]
 
     list_display = (
+        "id",
         "title",
         link_field("playlist"),
         "lti_id",
@@ -183,6 +183,7 @@ class VideoAdmin(admin.ModelAdmin):
         "created_on",
     )
     fields = (
+        "id",
         "title",
         "description",
         "playlist",
@@ -195,6 +196,7 @@ class VideoAdmin(admin.ModelAdmin):
         "created_on",
     )
     readonly_fields = [
+        "id",
         "created_by",
         "created_on",
         "duplicated_from",
@@ -204,9 +206,11 @@ class VideoAdmin(admin.ModelAdmin):
     ]
     list_filter = ("upload_state", "playlist__consumer_site__domain")
     search_fields = (
+        "id",
         "lti_id",
         "playlist__consumer_site__domain",
         "playlist__consumer_site__name",
+        "playlist__id",
         "playlist__lti_id",
         "playlist__title",
         "playlist__organization__name",
@@ -223,6 +227,7 @@ class VideosInline(admin.TabularInline):
     verbose_name_plural = _("videos")
 
     fields = (
+        "id",
         "title",
         "playlist",
         "lti_id",
@@ -232,6 +237,7 @@ class VideosInline(admin.TabularInline):
         "created_on",
     )
     readonly_fields = [
+        "id",
         "created_by",
         "created_on",
         "duplicated_from",
@@ -253,11 +259,11 @@ class PlaylistAccessesInline(admin.TabularInline):
 class PlaylistAdmin(admin.ModelAdmin):
     """Admin class for the Playlist model."""
 
-    list_display = ("title", "organization", "created_by", "is_public")
     exclude = ("duplicated_from",)
     inlines = [VideosInline, PlaylistAccessesInline]
 
     list_display = (
+        "id",
         "title",
         link_field("organization"),
         link_field("consumer_site"),
@@ -269,6 +275,7 @@ class PlaylistAdmin(admin.ModelAdmin):
         "created_on",
     )
     fields = (
+        "id",
         "title",
         "organization",
         "consumer_site",
@@ -281,7 +288,13 @@ class PlaylistAdmin(admin.ModelAdmin):
         "updated_on",
         "created_on",
     )
-    readonly_fields = ["created_by", "created_on", "duplicated_from", "updated_on"]
+    readonly_fields = [
+        "id",
+        "created_by",
+        "created_on",
+        "duplicated_from",
+        "updated_on",
+    ]
     list_filter = (
         "consumer_site__domain",
         "is_public",
@@ -289,6 +302,7 @@ class PlaylistAdmin(admin.ModelAdmin):
         "is_portable_to_consumer_site",
     )
     search_fields = (
+        "id",
         "consumer_site__domain",
         "consumer_site__name",
         "organization__name",

--- a/src/backend/marsha/core/models/video.py
+++ b/src/backend/marsha/core/models/video.py
@@ -218,6 +218,11 @@ class Video(BaseModel):
         return result
 
     @property
+    def consumer_site(self):
+        """Return the consumer site linked to this video via the playlist."""
+        return self.playlist.consumer_site
+
+    @property
     def is_ready_to_play(self):
         """Whether the video is ready to play (ie) has been sucessfully uploaded.
 

--- a/src/backend/marsha/core/tests/test_lti.py
+++ b/src/backend/marsha/core/tests/test_lti.py
@@ -147,7 +147,8 @@ class VideoLTITestCase(TestCase):
         with self.assertRaises(LTIException) as context:
             lti.verify()
         self.assertEqual(
-            context.exception.args[0], "Host domain does not match registered passport."
+            context.exception.args[0],
+            "Host domain (not-example.com) does not match registered passport (example.com).",
         )
 
     @mock.patch.object(LTIOAuthServer, "verify_request", return_value=True)
@@ -555,11 +556,13 @@ class PortabilityVideoLTITestCase(TestCase):
         """Above case 1-2-1-2-1.
 
         An LTI Exception should be raised if an instructor tries to retrieve a video that is
-        existing for another consumer site but not ready, even if it is portable to another
+        already existing for a consumer site but not ready, even if it is portable to another
         consumer site.
         """
         passport = ConsumerSiteLTIPassportFactory(consumer_site__domain="example.com")
         video = VideoFactory(
+            id="77fbf317-3e99-41bd-819c-130531313139",
+            playlist__lti_id="a-playlist",
             playlist__is_portable_to_consumer_site=True,
             upload_state=random.choice(
                 [s[0] for s in STATE_CHOICES if s[0] != "ready"]
@@ -578,8 +581,8 @@ class PortabilityVideoLTITestCase(TestCase):
         self.assertEqual(
             context.exception.args[0],
             (
-                "A video with this ID already exists but is not portable "
-                "to your playlist and/or consumer site."
+                "The video ID 77fbf317-3e99-41bd-819c-130531313139 already exists but is not "
+                "portable to your playlist (a-playlist) and/or consumer site (example.com)."
             ),
         )
         # No new playlist or video are created
@@ -662,6 +665,8 @@ class PortabilityVideoLTITestCase(TestCase):
         consumer_site = ConsumerSiteFactory(domain="example.com")
         passport = ConsumerSiteLTIPassportFactory(consumer_site=consumer_site)
         video = VideoFactory(
+            id="77fbf317-3e99-41bd-819c-130531313139",
+            playlist__lti_id="a-playlist",
             playlist__is_portable_to_consumer_site=False,
             upload_state=random.choice(
                 [s[0] for s in STATE_CHOICES if s[0] != "ready"]
@@ -684,8 +689,8 @@ class PortabilityVideoLTITestCase(TestCase):
         self.assertEqual(
             context.exception.args[0],
             (
-                "A video with this ID already exists but is not portable "
-                "to your playlist and/or consumer site."
+                "The video ID 77fbf317-3e99-41bd-819c-130531313139 already exists but is not "
+                "portable to your playlist (a-playlist) and/or consumer site (example.com)."
             ),
         )
         # No new playlist or video are created
@@ -735,11 +740,13 @@ class PortabilityVideoLTITestCase(TestCase):
         """Above case 1-2-3-1.
 
         An LTIException should be raised if an instructor tries to retrieve a video that is
-        existing for another consumer site but not portable to another consumer site, even if it
+        already existing for a consumer site but not portable to another consumer site, even if it
         is ready.
         """
         passport = ConsumerSiteLTIPassportFactory(consumer_site__domain="example.com")
         video = video = VideoFactory(
+            id="77fbf317-3e99-41bd-819c-130531313139",
+            playlist__lti_id="a-playlist",
             playlist__is_portable_to_consumer_site=False,
             upload_state=random.choice([s[0] for s in STATE_CHOICES]),
         )
@@ -756,8 +763,8 @@ class PortabilityVideoLTITestCase(TestCase):
         self.assertEqual(
             context.exception.args[0],
             (
-                "A video with this ID already exists but is not portable "
-                "to your playlist and/or consumer site."
+                "The video ID 77fbf317-3e99-41bd-819c-130531313139 already exists but is not "
+                "portable to your playlist (a-playlist) and/or consumer site (example.com)."
             ),
         )
         # No new playlist or video are created
@@ -818,11 +825,13 @@ class PortabilityVideoLTITestCase(TestCase):
         """Above case 1-3-1-2-1.
 
         An LTIException should be raised if an instructor tries to retrieve a video that is
-        existing in another playlist but not ready, even if it is portable to another
+        already existing in a playlist but not ready, even if it is portable to another
         playlist.
         """
         passport = ConsumerSiteLTIPassportFactory(consumer_site__domain="example.com")
         video = VideoFactory(
+            id="77fbf317-3e99-41bd-819c-130531313139",
+            playlist__lti_id="a-playlist",
             playlist__consumer_site=passport.consumer_site,
             playlist__is_portable_to_playlist=True,
             upload_state=random.choice(
@@ -842,8 +851,8 @@ class PortabilityVideoLTITestCase(TestCase):
         self.assertEqual(
             context.exception.args[0],
             (
-                "A video with this ID already exists but is not portable "
-                "to your playlist and/or consumer site."
+                "The video ID 77fbf317-3e99-41bd-819c-130531313139 already exists but is not "
+                "portable to your playlist (another-playlist) and/or consumer site (example.com)."
             ),
         )
 
@@ -880,14 +889,15 @@ class PortabilityVideoLTITestCase(TestCase):
     def test_lti_get_video_other_playlist_not_portable_instructor(self, mock_verify):
         """Above case 1-3-2-1.
 
-        An LTIException should be raises if an instructor tries to retrieve a video that is
-        existing in another playlist but not portable to another playlist, even if it
+        An LTIException should be raised if an instructor tries to retrieve a video that is
+        existing in a playlist but not portable to another playlist, even if it
         is ready.
         """
         passport = ConsumerSiteLTIPassportFactory(consumer_site__domain="example.com")
         video = VideoFactory(
+            id="77fbf317-3e99-41bd-819c-130531313139",
             lti_id="df7",
-            playlist__lti_id="wrong",
+            playlist__lti_id="a-playlist",
             playlist__consumer_site=passport.consumer_site,
             playlist__is_portable_to_playlist=False,
             upload_state=random.choice([s[0] for s in STATE_CHOICES]),
@@ -905,8 +915,8 @@ class PortabilityVideoLTITestCase(TestCase):
         self.assertEqual(
             context.exception.args[0],
             (
-                "A video with this ID already exists but is not portable "
-                "to your playlist and/or consumer site."
+                "The video ID 77fbf317-3e99-41bd-819c-130531313139 already exists but is not "
+                "portable to your playlist (another-playlist) and/or consumer site (example.com)."
             ),
         )
 
@@ -972,11 +982,13 @@ class PortabilityVideoLTITestCase(TestCase):
         """Above case 1-4-1-1-2-1.
 
         An LTIException should be raised if an instructor tries to retrieve a video that is
-        existing in another playlist on another consumer site but not ready, even if it is
+        already existing in a playlist on another consumer site but not ready, even if it is
         portable to another playlist AND to another consumer site.
         """
         passport = ConsumerSiteLTIPassportFactory(consumer_site__domain="example.com")
         video = VideoFactory(
+            id="77fbf317-3e99-41bd-819c-130531313139",
+            playlist__lti_id="a-playlist",
             playlist__is_portable_to_playlist=True,
             playlist__is_portable_to_consumer_site=True,
             upload_state=random.choice(
@@ -996,8 +1008,8 @@ class PortabilityVideoLTITestCase(TestCase):
         self.assertEqual(
             context.exception.args[0],
             (
-                "A video with this ID already exists but is not portable "
-                "to your playlist and/or consumer site."
+                "The video ID 77fbf317-3e99-41bd-819c-130531313139 already exists but is not "
+                "portable to your playlist (another-playlist) and/or consumer site (example.com)."
             ),
         )
         # No new playlist or video are created
@@ -1081,7 +1093,9 @@ class PortabilityVideoLTITestCase(TestCase):
             oauth_consumer_key="ABC123", consumer_site=consumer_site
         )
         video = VideoFactory(
+            id="77fbf317-3e99-41bd-819c-130531313139",
             lti_id="df7",
+            playlist__lti_id="a-playlist",
             playlist__is_portable_to_playlist=True,
             playlist__is_portable_to_consumer_site=False,
             upload_state=random.choice(
@@ -1105,8 +1119,8 @@ class PortabilityVideoLTITestCase(TestCase):
         self.assertEqual(
             context.exception.args[0],
             (
-                "A video with this ID already exists but is not portable "
-                "to your playlist and/or consumer site."
+                "The video ID 77fbf317-3e99-41bd-819c-130531313139 already exists but is not "
+                "portable to your playlist (another-playlist) and/or consumer site (example.com)."
             ),
         )
         # No new playlist or video are created
@@ -1153,13 +1167,15 @@ class PortabilityVideoLTITestCase(TestCase):
     def test_lti_get_video_other_pl_site_not_portable_instructor(self, mock_verify):
         """Above cases 1-4-1-3-1 and 1-4-2-1.
 
-        An LTIException should be raised if an instructor tries to retrieve a video existing
-        on another playlist and another consumer site but not portable either to another playlist
-        or to another consumer site, even if it is ready.
+        An LTIException should be raised if an instructor tries to retrieve a video already
+        existing in a playlist and another consumer site but not portable either to another
+        playlist or to another consumer site, even if it is ready.
         """
         passport = ConsumerSiteLTIPassportFactory(consumer_site__domain="example.com")
         one_not_portable = random.choice([True, False])
         video = VideoFactory(
+            id="77fbf317-3e99-41bd-819c-130531313139",
+            playlist__lti_id="a-playlist",
             playlist__is_portable_to_playlist=one_not_portable,
             playlist__is_portable_to_consumer_site=not one_not_portable,
             upload_state=random.choice([s[0] for s in STATE_CHOICES]),
@@ -1177,8 +1193,8 @@ class PortabilityVideoLTITestCase(TestCase):
         self.assertEqual(
             context.exception.args[0],
             (
-                "A video with this ID already exists but is not portable "
-                "to your playlist and/or consumer site."
+                "The video ID 77fbf317-3e99-41bd-819c-130531313139 already exists but is not "
+                "portable to your playlist (another-playlist) and/or consumer site (example.com)."
             ),
         )
         # No new playlist or video are created

--- a/src/backend/marsha/core/tests/test_views_openedx_lti_video.py
+++ b/src/backend/marsha/core/tests/test_views_openedx_lti_video.py
@@ -1,6 +1,7 @@
 """Test the LTI interconnection with Open edX."""
 from html import unescape
 import json
+from logging import Logger
 import random
 import re
 from unittest import mock
@@ -222,8 +223,9 @@ class ViewsTestCase(TestCase):
         # signature)
         self.assertEqual(mock_verify.call_count, 1)
 
-    @mock.patch.object(LTI, "verify", side_effect=LTIException)
-    def test_views_video_lti_post_error(self, mock_verify):
+    @mock.patch.object(Logger, "warning")
+    @mock.patch.object(LTI, "verify", side_effect=LTIException("lti error"))
+    def test_views_video_lti_post_error(self, mock_verify, mock_logger):
         """Validate the response returned in case of an LTI exception."""
         role = random.choice(["instructor", "student"])
         data = {
@@ -235,6 +237,8 @@ class ViewsTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "<html>")
         content = response.content.decode("utf-8")
+
+        mock_logger.assert_called_once_with("LTI Exception: %s", "lti error")
 
         data_state = re.search(
             '<div class="marsha-frontend-data" data-state="(.*)">', content

--- a/src/backend/marsha/core/views.py
+++ b/src/backend/marsha/core/views.py
@@ -1,5 +1,6 @@
 """Views of the ``core`` app of the Marsha project."""
 import json
+from logging import getLogger
 import uuid
 
 from django.utils.decorators import method_decorator
@@ -14,6 +15,9 @@ from rest_framework_simplejwt.tokens import AccessToken
 from .lti import LTI, OpenEdxLTI
 from .models.account import INSTRUCTOR, STUDENT
 from .serializers import VideoSerializer
+
+
+logger = getLogger(__name__)
 
 
 @method_decorator(csrf_exempt, name="dispatch")
@@ -57,7 +61,8 @@ class VideoLTIView(TemplateResponseMixin, View):
         lti = self.get_lti()
         try:
             video = lti.get_or_create_video()
-        except LTIException:
+        except LTIException as error:
+            logger.warning("LTI Exception: %s", str(error))
             return {"state": "error", "video_data": "null"}
 
         context = {"state": INSTRUCTOR if lti.is_instructor else STUDENT}

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -125,17 +125,6 @@ class Base(Configuration):
         )
     }
 
-    LOGGING = {
-        "version": 1,
-        "disable_existing_loggers": False,
-        "handlers": {
-            "console": {"class": "logging.StreamHandler", "stream": "ext://sys.stdout"}
-        },
-        "loggers": {
-            "marsha": {"handlers": ["console"], "level": "INFO", "propagate": True}
-        },
-    }
-
     # Password validation
     # https://docs.djangoproject.com/en/2.0/ref/settings/#auth-password-validators
     AUTH_PASSWORD_VALIDATORS = [
@@ -172,7 +161,21 @@ class Base(Configuration):
     VIDEO_RESOLUTIONS = [144, 240, 480, 720, 1080]
 
     # Logging
-    LOGGING = values.DictValue({"version": 1})
+    LOGGING = values.DictValue(
+        {
+            "version": 1,
+            "disable_existing_loggers": False,
+            "handlers": {
+                "console": {
+                    "class": "logging.StreamHandler",
+                    "stream": "ext://sys.stdout",
+                }
+            },
+            "loggers": {
+                "marsha": {"handlers": ["console"], "level": "INFO", "propagate": True}
+            },
+        }
+    )
 
     # AWS
     AWS_ACCESS_KEY_ID = values.SecretValue()
@@ -243,16 +246,21 @@ class Development(Base):
     DEBUG = values.BooleanValue(True)
     CLOUDFRONT_SIGNED_URLS_ACTIVE = values.BooleanValue(False)
 
-    LOGGING = {
-        "version": 1,
-        "disable_existing_loggers": False,
-        "handlers": {
-            "console": {"class": "logging.StreamHandler", "stream": "ext://sys.stdout"}
-        },
-        "loggers": {
-            "marsha": {"handlers": ["console"], "level": "DEBUG", "propagate": True}
-        },
-    }
+    LOGGING = values.DictValue(
+        {
+            "version": 1,
+            "disable_existing_loggers": False,
+            "handlers": {
+                "console": {
+                    "class": "logging.StreamHandler",
+                    "stream": "ext://sys.stdout",
+                }
+            },
+            "loggers": {
+                "marsha": {"handlers": ["console"], "level": "DEBUG", "propagate": True}
+            },
+        }
+    )
 
 
 class Test(Base):


### PR DESCRIPTION
## Purpose

We need to improve usability for admin users to help them understand when they get LTI Errors.

## Proposal

- [x] Display ID field in admin views
- [x] Allow searching objects by ID
- [x] Log LTI Exceptions as warnings
- [x] Allow defining consumer site automatic portabilities from admin
- [x] Add the `consume site` on the video admin list view
- [x] Optimize admin view queries
- [x] Fix logging configuration and make it configurable

 