### PR TITLE
✨(redux) enable devtools to ease development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- enable redux devtools
+
 ## [2.2.0] - 2019-02-05
 
 ### Added

--- a/src/frontend/data/bootstrapStore.ts
+++ b/src/frontend/data/bootstrapStore.ts
@@ -1,4 +1,4 @@
-import { applyMiddleware, createStore } from 'redux';
+import { applyMiddleware, compose, createStore } from 'redux';
 import createSagaMiddleware from 'redux-saga';
 
 import { AppData } from '../types/AppData';
@@ -10,6 +10,9 @@ import { rootSaga } from './rootSaga';
 const sagaMiddleware = createSagaMiddleware();
 
 export const bootstrapStore = (appData: AppData) => {
+  const composeEnhancers =
+    (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
+
   const store = createStore(
     rootReducer,
     {
@@ -23,7 +26,7 @@ export const bootstrapStore = (appData: AppData) => {
         },
       },
     },
-    applyMiddleware(sagaMiddleware),
+    composeEnhancers(applyMiddleware(sagaMiddleware)),
   );
 
   sagaMiddleware.run(rootSaga);


### PR DESCRIPTION
This PR was initially open in #218 but not merged in master but in temporary branch.

I reopen it to merge it in master.

## Purpose

Redux devtools are a must have when working with redux. It eases a lot
the lifecycle development and has no impact on performance.

## Proposal

- [x] Use redux devtools compose function to enable redux devtools.

