### PR TITLE
Display timed text tracks in Plyr player

### DIFF
--- a/src/frontend/Player/createPlyrPlayer.ts
+++ b/src/frontend/Player/createPlyrPlayer.ts
@@ -9,7 +9,11 @@ import {
 import { XAPIStatement } from '../XAPI/XAPIStatement';
 
 export const createPlyrPlayer = (ref: HTMLVideoElement, jwt: string): Plyr => {
-  const player = new Plyr(ref, { debug: true });
+  const player = new Plyr(ref, {
+    captions: {
+      active: true,
+    },
+  });
   const decodedToken: DecodedJwt = jwt_decode(jwt);
 
   const xapiStatement = new XAPIStatement(jwt, decodedToken.session_id);

--- a/src/frontend/components/Spinner/Spinner.spec.tsx
+++ b/src/frontend/components/Spinner/Spinner.spec.tsx
@@ -1,0 +1,13 @@
+import { Meter } from 'grommet';
+import '../../testSetup';
+
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+import { Spinner } from './Spinner';
+
+describe('<Spinner />', () => {
+  it('renders', () => {
+    expect(shallow(<Spinner />).find(Meter).length).toBe(1);
+  });
+});

--- a/src/frontend/components/Spinner/Spinner.tsx
+++ b/src/frontend/components/Spinner/Spinner.tsx
@@ -1,0 +1,48 @@
+import { Meter } from 'grommet';
+import { normalizeColor } from 'grommet/utils';
+import * as React from 'react';
+
+import { theme } from '../../utils/theme/theme';
+
+interface SpinnerState {
+  value: number;
+}
+
+export class Spinner extends React.Component<{}, SpinnerState> {
+  state = { value: 0 };
+  timer: number | undefined = undefined;
+
+  componentDidMount() {
+    this.timer = window.setInterval(() => {
+      this.setState((prevState: SpinnerState) => {
+        let value: number = prevState.value + 1;
+        if (value > 100) {
+          value = 0;
+        }
+
+        return { value };
+      });
+    }, 10);
+  }
+
+  componentWillUnmount() {
+    window.clearInterval(this.timer);
+  }
+
+  render() {
+    return (
+      <Meter
+        type="circle"
+        values={
+          [
+            {
+              background: normalizeColor('brand', theme),
+              label: `Spinner-${this.state.value}`,
+              value: this.state.value,
+            },
+          ] as any
+        }
+      />
+    );
+  }
+}

--- a/src/frontend/components/VideoPlayer/VideoPlayer.spec.tsx
+++ b/src/frontend/components/VideoPlayer/VideoPlayer.spec.tsx
@@ -4,7 +4,9 @@ import { mount, shallow } from 'enzyme';
 import * as React from 'react';
 import shaka from 'shaka-player';
 
-import { Video } from '../../types/tracks';
+import { requestStatus } from '../../types/api';
+import { timedTextMode, uploadState, Video } from '../../types/tracks';
+import { Spinner } from '../Spinner/Spinner';
 import { VideoPlayer } from './VideoPlayer';
 
 const mockShakaPlayer: jest.Mocked<typeof shaka.Player> = shaka.Player as any;
@@ -37,29 +39,104 @@ describe('VideoPlayer', () => {
 
   const props = {
     createPlayer,
+    getTimedTextTrackList: () => {},
     jwt: 'foo',
+    timedtexttracks: {
+      objects: [],
+      status: requestStatus.PENDING,
+    },
+    video,
+  };
+
+  const loadedProps = {
+    createPlayer,
+    getTimedTextTrackList: () => {},
+    jwt: 'foo',
+    timedtexttracks: {
+      objects: [
+        {
+          active_stamp: 1549385921,
+          id: 'ttt-1',
+          is_ready_to_play: true,
+          language: 'fr',
+          mode: timedTextMode.SUBTITLE,
+          upload_state: uploadState.READY,
+          url: 'https://example.com//timedtext/ttt-1.vtt',
+          video,
+        },
+        {
+          active_stamp: 1549385922,
+          id: 'ttt-2',
+          is_ready_to_play: false,
+          language: 'fr',
+          mode: timedTextMode.SUBTITLE,
+          upload_state: uploadState.READY,
+          url: 'https://example.com//timedtext/ttt-2.vtt',
+          video,
+        },
+        {
+          active_stamp: 1549385923,
+          id: 'ttt-3',
+          is_ready_to_play: true,
+          language: 'fr',
+          mode: timedTextMode.CLOSED_CAPTIONING,
+          upload_state: uploadState.READY,
+          url: 'https://example.com//timedtext/ttt-3.vtt',
+          video,
+        },
+        {
+          active_stamp: 1549385924,
+          id: 'ttt-4',
+          is_ready_to_play: true,
+          language: 'fr',
+          mode: timedTextMode.TRANSCRIPT,
+          upload_state: uploadState.READY,
+          url: 'https://example.com//timedtext/ttt-4.vtt',
+          video,
+        },
+      ],
+      status: requestStatus.SUCCESS,
+    },
     video,
   };
 
   beforeEach(() => jest.clearAllMocks());
 
   it('renders the video element with all the relevant sources', () => {
-    const wrapper = shallow(<VideoPlayer {...props} />);
+    const wrapper = shallow(<VideoPlayer {...loadedProps} />);
+    const content = wrapper.html();
 
-    expect(wrapper.html()).toContain(
+    expect(content).toContain(
       '<source src="https://example.com/hls.m3u8" type="application/vnd.apple.mpegURL"/>',
     );
-    expect(wrapper.html()).toContain(
+    expect(content).toContain(
       '<source size="144" src="https://example.com/144p.mp4" type="video/mp4"/>',
     );
-    expect(wrapper.html()).toContain(
+    expect(content).toContain(
       '<source size="1080" src="https://example.com/1080p.mp4" type="video/mp4"/>',
+    );
+
+    expect(content).toContain(
+      '<track src="https://example.com//timedtext/ttt-1.vtt" srcLang="fr" kind="subtitles" label="fr"/>',
+    );
+    expect(content).toContain(
+      '<track src="https://example.com//timedtext/ttt-3.vtt" srcLang="fr" kind="captions" label="fr"/>',
     );
   });
 
-  it('starts up the player when it mounts', () => {
+  it('starts up the player when Timedtexttracks are loaded', () => {
     // Mount so videojs is called with an element
-    mount(<VideoPlayer {...props} />);
+    const wrapper = mount(<VideoPlayer {...props} />);
+    expect(createPlayer).not.toHaveBeenCalledWith(
+      'plyr',
+      expect.any(Element),
+      'foo',
+    );
+
+    expect(wrapper.find(Spinner).length).toBe(1);
+
+    wrapper.setProps(loadedProps);
+    wrapper.update();
     expect(createPlayer).toHaveBeenCalledWith(
       'plyr',
       expect.any(Element),
@@ -68,9 +145,10 @@ describe('VideoPlayer', () => {
   });
 
   it('cleans up the player when it unmounts', () => {
-    const instance = shallow(
-      <VideoPlayer {...props} />,
-    ).instance() as VideoPlayer;
+    const wrapper = mount(<VideoPlayer {...props} />);
+    wrapper.setProps(loadedProps);
+    wrapper.update();
+    const instance = wrapper.instance() as VideoPlayer;
     instance.componentWillUnmount();
     expect(instance.state.player!.destroy).toHaveBeenCalled();
   });
@@ -79,7 +157,9 @@ describe('VideoPlayer', () => {
     beforeEach(() => mockShakaPlayer.isBrowserSupported.mockReturnValue(true));
 
     it('instantiates shaka Player and loads our dash manifest', () => {
-      mount(<VideoPlayer {...props} />);
+      const wrapper = mount(<VideoPlayer {...props} />);
+      wrapper.setProps(loadedProps);
+      wrapper.update();
 
       expect(mockShakaPlayer.prototype.constructor).toHaveBeenCalledWith(
         expect.any(HTMLMediaElement),
@@ -96,7 +176,9 @@ describe('VideoPlayer', () => {
     beforeEach(() => mockShakaPlayer.isBrowserSupported.mockReturnValue(false));
 
     it('never instantiates shaka', () => {
-      mount(<VideoPlayer {...props} />); // Mount so videojs is called with an element
+      const wrapper = mount(<VideoPlayer {...props} />);
+      wrapper.setProps(loadedProps);
+      wrapper.update(); // Mount so videojs is called with an element
       expect(mockShakaPlayer.prototype.constructor).not.toHaveBeenCalled();
       expect(mockShakaPlayer.prototype.load).not.toHaveBeenCalled();
     });

--- a/src/frontend/components/VideoPlayerConnected/VideoPlayerConnected.spec.tsx
+++ b/src/frontend/components/VideoPlayerConnected/VideoPlayerConnected.spec.tsx
@@ -1,4 +1,6 @@
+import { requestStatus } from '../../types/api';
 import { modelName } from '../../types/models';
+import { TimedText } from '../../types/tracks';
 import { mapStateToProps } from './VideoPlayerConnected';
 
 describe('<VideoPlayerConnected />', () => {
@@ -16,10 +18,15 @@ describe('<VideoPlayerConnected />', () => {
         },
         resources: {
           [modelName.VIDEOS]: { byId: { 42: 'some video' as any } },
+          [modelName.TIMEDTEXTTRACKS]: {},
         },
       } as any;
       expect(mapStateToProps(state, props)).toEqual({
         jwt: 'foo',
+        timedtexttracks: {
+          objects: [],
+          status: null,
+        },
         video: 'some video',
       });
     });
@@ -31,10 +38,15 @@ describe('<VideoPlayerConnected />', () => {
         },
         resources: {
           [modelName.VIDEOS]: { byId: { 43: 'some video' as any } },
+          [modelName.TIMEDTEXTTRACKS]: {},
         },
       } as any;
       expect(mapStateToProps(state, props)).toEqual({
         jwt: 'foo',
+        timedtexttracks: {
+          objects: [],
+          status: null,
+        },
         video: { id: 42 },
       });
 
@@ -44,10 +56,15 @@ describe('<VideoPlayerConnected />', () => {
         },
         resources: {
           [modelName.VIDEOS]: { byId: {} },
+          [modelName.TIMEDTEXTTRACKS]: {},
         },
       } as any;
       expect(mapStateToProps(state, props)).toEqual({
         jwt: 'foo',
+        timedtexttracks: {
+          objects: [],
+          status: null,
+        },
         video: { id: 42 },
       });
 
@@ -57,10 +74,45 @@ describe('<VideoPlayerConnected />', () => {
         },
         resources: {
           [modelName.VIDEOS]: {},
+          [modelName.TIMEDTEXTTRACKS]: {},
         },
       } as any;
       expect(mapStateToProps(state, props)).toEqual({
         jwt: 'foo',
+        timedtexttracks: {
+          objects: [],
+          status: null,
+        },
+        video: { id: 42 },
+      });
+    });
+
+    it('retrieves timed text tracks from a successful query', () => {
+      const state = {
+        context: {
+          jwt: 'foo',
+        },
+        resources: {
+          [modelName.VIDEOS]: {},
+          [modelName.TIMEDTEXTTRACKS]: {
+            byId: {
+              42: { id: '42' } as TimedText,
+              84: { id: '84' } as TimedText,
+              168: { id: '168' } as TimedText,
+            },
+            currentQuery: {
+              items: { 0: '42', 1: '84', 2: '168' },
+              status: requestStatus.SUCCESS,
+            },
+          },
+        },
+      } as any;
+      expect(mapStateToProps(state, props)).toEqual({
+        jwt: 'foo',
+        timedtexttracks: {
+          objects: [{ id: '42' }, { id: '84' }, { id: '168' }],
+          status: requestStatus.SUCCESS,
+        },
         video: { id: 42 },
       });
     });

--- a/src/frontend/components/VideoPlayerConnected/VideoPlayerConnected.tsx
+++ b/src/frontend/components/VideoPlayerConnected/VideoPlayerConnected.tsx
@@ -1,8 +1,14 @@
 import { connect } from 'react-redux';
+import { Dispatch } from 'redux';
 
+import { getResourceList } from '../../data/genericReducers/resourceList/actions';
 import { RootState } from '../../data/rootReducer';
+import { getTimedTextTracks } from '../../data/timedtexttracks/selector';
+import { ConsumableQuery } from '../../types/api';
 import { appStateSuccess } from '../../types/AppData';
 import { modelName } from '../../types/models';
+import { TimedText, Video } from '../../types/tracks';
+import { Nullable } from '../../utils/types';
 import { VideoPlayer, VideoPlayerProps } from '../VideoPlayer/VideoPlayer';
 
 type VideoPlayerConnectedProps = Pick<
@@ -19,14 +25,41 @@ export const mapStateToProps = (
   { video }: VideoPlayerConnectedProps,
 ) => ({
   jwt: state.context.jwt,
+  timedtexttracks: getTimedTextTracks(state),
   video:
     (state.resources[modelName.VIDEOS]!.byId &&
       state.resources[modelName.VIDEOS]!.byId[(video && video.id) || '']) ||
     video,
 });
 
+/** Create a function that triggers a get to the API for the timedtexttracks. */
+const mergeProps = (
+  {
+    jwt,
+    timedtexttracks,
+    video,
+  }: {
+    jwt: string;
+    timedtexttracks: ConsumableQuery<TimedText>;
+    video: Nullable<Video>;
+  },
+  { dispatch }: { dispatch: Dispatch },
+  { createPlayer }: VideoPlayerConnectedProps,
+) => ({
+  createPlayer,
+  getTimedTextTrackList: () =>
+    dispatch(getResourceList(jwt, modelName.TIMEDTEXTTRACKS)),
+  jwt,
+  timedtexttracks,
+  video,
+});
+
 /**
  * Component. Displays a player to show the video from context.
  * @param video The video to show.
  */
-export const VideoPlayerConnected = connect(mapStateToProps)(VideoPlayer);
+export const VideoPlayerConnected = connect(
+  mapStateToProps,
+  null!,
+  mergeProps,
+)(VideoPlayer);

--- a/src/frontend/types/libs/plyr/index.d.ts
+++ b/src/frontend/types/libs/plyr/index.d.ts
@@ -537,7 +537,9 @@ declare namespace Plyr {
   }
 
   export interface CaptionOptions {
-    defaultActive?: boolean;
+    active?: boolean;
+    update?: boolean;
+    language?: string;
   }
 
   export interface StorageOptions {

--- a/src/frontend/types/tracks.ts
+++ b/src/frontend/types/tracks.ts
@@ -45,7 +45,6 @@ export interface TimedText extends Resource {
   is_ready_to_play: boolean;
   language: string;
   mode: timedTextMode;
-  uploaded_on: string;
   upload_state: uploadState;
   url: string;
   video: Video;


### PR DESCRIPTION
## Purpose

We want to enrich the plyr player with timed text tracks. There is everything needed to upload and manage them, now we have to display them in the player.

## Proposal

We can reuse the work done before to retrieve tracks in the redux store and fetch them from the API. We will do this work in the `<VideoPlayerConnected />` component and then exploit the tracks in the `<VideoPlayer />` component.

- [x] Enable captions in plyr player to display them
- [x] Improve `<VideoPlayerConnected />` to retrieve timed text tracks
- [x] display tracks in `<VideoPlayer />`

