### PR TITLE
🐛(timedtext) add vtt extensions to destination files

### DIFF
--- a/src/aws/lambda-encode/src/encodeTimedTextTrack.js
+++ b/src/aws/lambda-encode/src/encodeTimedTextTrack.js
@@ -35,7 +35,7 @@ module.exports = async (objectKey, sourceBucket) => {
       // 630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/timedtexttrack/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1542967735_fr
       // 👆 becomes 👇
       // 630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/timedtext/1542967735_fr
-      Key: objectKey.replace(/\/timedtexttrack\/.*\//, '/timedtext/'),
+      Key: `${objectKey.replace(/\/timedtexttrack\/.*\//, '/timedtext/')}.vtt`,
     })
     .promise();
 };

--- a/src/aws/lambda-encode/src/encodeTimedTextTrack.spec.js
+++ b/src/aws/lambda-encode/src/encodeTimedTextTrack.spec.js
@@ -44,7 +44,7 @@ describe('lambda-encode/src/encodeTimedTextTrack', () => {
     expect(mockPutObject).toHaveBeenCalledWith({
       Body: 'output timed text',
       Bucket: 'destination bucket',
-      Key: 'some key',
+      Key: 'some key.vtt',
     });
     expect(mockSubsrt.convert).toHaveBeenCalledWith('input timed text', {
       format: 'vtt',


### PR DESCRIPTION
## Purpose

The encodeTimedTextTrack lambda did not add vtt extension to destination files. It is impossible to retrieve them from the backend without this extension.

## Proposal

Force to add the `.vtt` extension in the encode lambda.

