### PR TITLE
Display transcript along the video.

### DIFF
--- a/src/frontend/Player/createPlayer.spec.ts
+++ b/src/frontend/Player/createPlayer.spec.ts
@@ -7,9 +7,10 @@ describe('createPlayer', () => {
   it('creates a plyr instance when type player is plyr', () => {
     const jwt = 'foo';
     const ref = 'ref' as any;
+    const dispatch = jest.fn();
 
-    createPlayer('plyr', ref, jwt);
+    createPlayer('plyr', ref, jwt, dispatch);
 
-    expect(createPlyrPlayer).toHaveBeenCalledWith(ref, jwt);
+    expect(createPlyrPlayer).toHaveBeenCalledWith(ref, jwt, dispatch);
   });
 });

--- a/src/frontend/Player/createPlayer.ts
+++ b/src/frontend/Player/createPlayer.ts
@@ -1,3 +1,5 @@
+import { Dispatch } from 'redux';
+
 import {
   VideoPlayerInterface,
   VideoPlayerType,
@@ -8,9 +10,10 @@ export const createPlayer = (
   type: VideoPlayerType,
   ref: HTMLVideoElement,
   jwt: string,
+  dispatch: Dispatch,
 ): VideoPlayerInterface => {
   switch (type) {
     case 'plyr':
-      return createPlyrPlayer(ref, jwt);
+      return createPlyrPlayer(ref, jwt, dispatch);
   }
 };

--- a/src/frontend/Player/createPlyrPlayer.spec.ts
+++ b/src/frontend/Player/createPlyrPlayer.spec.ts
@@ -16,7 +16,7 @@ describe('createPlyrPlayer', () => {
     jest.clearAllMocks();
   });
   it('creates Plyr player and configure it', () => {
-    const player = createPlyrPlayer('ref' as any, 'jwt');
+    const player = createPlyrPlayer('ref' as any, 'jwt', jest.fn());
 
     expect(player.on).toHaveBeenNthCalledWith(
       1,

--- a/src/frontend/Player/createPlyrPlayer.ts
+++ b/src/frontend/Player/createPlyrPlayer.ts
@@ -1,14 +1,20 @@
 import jwt_decode from 'jwt-decode';
 import Plyr from 'plyr';
+import { Dispatch } from 'redux';
 
-import { DecodedJwt } from 'types/jwt';
+import { notifyPlayerTimeUpdate } from '../data/player/actions';
+import { DecodedJwt } from '../types/jwt';
 import {
   InitializedContextExtensions,
   InteractedContextExtensions,
 } from '../types/XAPI';
 import { XAPIStatement } from '../XAPI/XAPIStatement';
 
-export const createPlyrPlayer = (ref: HTMLVideoElement, jwt: string): Plyr => {
+export const createPlyrPlayer = (
+  ref: HTMLVideoElement,
+  jwt: string,
+  dispatch: Dispatch,
+): Plyr => {
   const player = new Plyr(ref, {
     captions: {
       active: true,
@@ -130,6 +136,12 @@ export const createPlyrPlayer = (ref: HTMLVideoElement, jwt: string): Plyr => {
   player.on('ratechange', event => interacted(event));
   player.on('volumechange', event => interacted(event));
   /**************** End interacted event *************************/
+
+  /**************** Dispatch time updated ************************/
+  player.on('timeupdate', event => {
+    dispatch(notifyPlayerTimeUpdate(event.detail.plyr.currentTime));
+  });
+  /**************** End dispatch time updated *********************/
 
   return player;
 };

--- a/src/frontend/components/TranscriptReader/TranscriptReader.spec.tsx
+++ b/src/frontend/components/TranscriptReader/TranscriptReader.spec.tsx
@@ -1,0 +1,93 @@
+import { flushAllPromises } from '../../testSetup';
+
+import { mount, shallow } from 'enzyme';
+import fetchMock from 'fetch-mock';
+import * as React from 'react';
+import { VTTCue } from 'vtt.js';
+
+import { TranscriptSentence } from '../TranscriptSentence/TranscriptSentence';
+import { TranscriptReader } from './TranscriptReader';
+
+const TranscriptContent = `
+WEBVTT
+
+1
+00:00:00.600 --> 00:00:02.240
+-Bonjour. Bonjour à tous.
+
+2
+00:00:02.560 --> 00:00:05.280
+Bienvenue dans ce nouveau MOOC
+"Du manager au leader".
+`;
+
+const cues: VTTCue[] = [
+  {
+    endTime: 2.24,
+    id: '1',
+    startTime: 0.6,
+    text: '-Bonjour. Bonjour à tous.',
+  },
+  {
+    endTime: 5.28,
+    id: '2',
+    startTime: 2.56,
+    text: 'Bienvenue dans ce nouveau MOOC\n"Du manager au leader".',
+  },
+];
+
+const transcript = {
+  url: 'https://example.com/transcript.vtt',
+} as any;
+
+const mockParse = jest.fn();
+const mockFlush = jest.fn();
+
+jest.mock('vtt.js', () => ({
+  WebVTT: {
+    Parser: jest.fn(() => ({
+      flush: mockFlush,
+      parse: mockParse,
+    })),
+    StringDecoder: jest.fn(),
+  },
+}));
+
+describe('<TranscriptReader />', () => {
+  beforeEach(jest.clearAllMocks);
+  afterEach(fetchMock.restore);
+
+  it('fetch a transcript and parse it', async () => {
+    fetchMock.mock(transcript.url, TranscriptContent);
+
+    mount(<TranscriptReader transcript={transcript} currentTime={0} />);
+    await flushAllPromises();
+
+    expect(fetchMock.called()).toBe(true);
+    expect(mockParse).toHaveBeenCalledWith(TranscriptContent);
+    expect(mockFlush).toHaveBeenCalled();
+  });
+
+  it('render every cues', async () => {
+    fetchMock.mock(transcript.url, TranscriptContent);
+
+    const wrapper = shallow(
+      <TranscriptReader transcript={transcript} currentTime={3} />,
+    );
+    await flushAllPromises();
+
+    wrapper.setState({ cues });
+    wrapper.update();
+
+    expect(
+      wrapper.contains(
+        <TranscriptSentence key="1" cue={cues[0]} active={false} />,
+      ),
+    ).toBe(true);
+    expect(
+      wrapper.contains(
+        <TranscriptSentence key="2" cue={cues[1]} active={true} />,
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/frontend/components/TranscriptReader/TranscriptReader.tsx
+++ b/src/frontend/components/TranscriptReader/TranscriptReader.tsx
@@ -1,0 +1,69 @@
+import { Box, Paragraph, Text } from 'grommet';
+import * as React from 'react';
+import { VTTCue, WebVTT } from 'vtt.js';
+
+import { TimedTextTranscript } from '../../types/tracks';
+import { TranscriptSentence } from '../TranscriptSentence/TranscriptSentence';
+
+interface TranscriptReaderProps {
+  transcript: TimedTextTranscript;
+  currentTime: number;
+}
+
+interface TranscriptReaderState {
+  cues: VTTCue[];
+}
+
+export class TranscriptReader extends React.Component<
+  TranscriptReaderProps,
+  TranscriptReaderState
+> {
+  constructor(props: TranscriptReaderProps) {
+    super(props);
+
+    this.state = {
+      cues: [],
+    };
+  }
+
+  async componentDidMount() {
+    const parser = new WebVTT.Parser(window, WebVTT.StringDecoder());
+
+    const response = await fetch(this.props.transcript.url);
+    const content = await response.text();
+    parser.oncue = (cue: VTTCue) => {
+      this.setState(prevState => ({ cues: [...prevState.cues, cue] }));
+    };
+
+    parser.parse(content);
+    parser.flush();
+  }
+
+  render() {
+    const { currentTime } = this.props;
+
+    return (
+      <Box
+        align="start"
+        direction="row"
+        pad="medium"
+        overflow="scroll"
+        height="small"
+      >
+        <Paragraph size="xxlarge">
+          {this.state.cues.map(cue => {
+            return (
+              <TranscriptSentence
+                key={cue.id}
+                cue={cue}
+                active={
+                  cue.startTime < currentTime && cue.endTime > currentTime
+                }
+              />
+            );
+          })}
+        </Paragraph>
+      </Box>
+    );
+  }
+}

--- a/src/frontend/components/TranscriptReaderConnected/TranscriptReaderConnected.tsx
+++ b/src/frontend/components/TranscriptReaderConnected/TranscriptReaderConnected.tsx
@@ -1,0 +1,13 @@
+import { connect } from 'react-redux';
+
+import { RootState } from '../../data/rootReducer';
+import { appStateSuccess } from '../../types/AppData';
+import { TranscriptReader } from '../TranscriptReader/TranscriptReader';
+
+export const mapStateToProps = (state: RootState<appStateSuccess>) => ({
+  currentTime: state.player.currentTime,
+});
+
+export const TranscriptReaderConnected = connect(mapStateToProps)(
+  TranscriptReader,
+);

--- a/src/frontend/components/TranscriptSentence/TranscriptSentence.spec.tsx
+++ b/src/frontend/components/TranscriptSentence/TranscriptSentence.spec.tsx
@@ -1,0 +1,42 @@
+import '../../testSetup';
+
+import { shallow } from 'enzyme';
+import { Text } from 'grommet';
+import * as React from 'react';
+import { VTTCue } from 'vtt.js';
+
+import { ActiveSentence, TranscriptSentence } from './TranscriptSentence';
+
+describe('<TranscriptSentence />', () => {
+  it('display a simple <Text /> when not active', () => {
+    const cue: VTTCue = {
+      endTime: 1,
+      id: 'e67ba62e-ec93-4e04-a8da-bdaed3655262',
+      startTime: 0,
+      text: 'Lorem ipsum dolor sit amet.',
+    };
+
+    const wrapper = shallow(<TranscriptSentence cue={cue} active={false} />);
+
+    expect(wrapper.equals(<Text>Lorem ipsum dolor sit amet. </Text>)).toBe(
+      true,
+    );
+  });
+
+  it('display a <ActiveSentence /> when active', () => {
+    const cue: VTTCue = {
+      endTime: 1,
+      id: 'e67ba62e-ec93-4e04-a8da-bdaed3655262',
+      startTime: 0,
+      text: 'Lorem ipsum dolor sit amet.',
+    };
+
+    const wrapper = shallow(<TranscriptSentence cue={cue} active={true} />);
+
+    expect(
+      wrapper.equals(
+        <ActiveSentence>Lorem ipsum dolor sit amet. </ActiveSentence>,
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/frontend/components/TranscriptSentence/TranscriptSentence.tsx
+++ b/src/frontend/components/TranscriptSentence/TranscriptSentence.tsx
@@ -1,0 +1,24 @@
+import { Text } from 'grommet';
+import * as React from 'react';
+import styled from 'styled-components';
+import { VTTCue } from 'vtt.js';
+
+export const ActiveSentence = styled(Text)`
+  background-color: rgba(242, 94, 35, 0.25);
+  outline: 1px solid rgba(242, 94, 35, 0.5);
+`;
+
+interface TranscriptSentenceProps {
+  cue: VTTCue;
+  active: boolean;
+}
+
+export const TranscriptSentence = (props: TranscriptSentenceProps) => {
+  const { cue, active } = props;
+
+  if (active) {
+    return <ActiveSentence>{cue.text} </ActiveSentence>;
+  } else {
+    return <Text>{cue.text} </Text>;
+  }
+};

--- a/src/frontend/components/Transcripts/Transcripts.spec.tsx
+++ b/src/frontend/components/Transcripts/Transcripts.spec.tsx
@@ -1,0 +1,71 @@
+import '../../testSetup';
+
+import { shallow } from 'enzyme';
+import * as React from 'react';
+import { FormattedMessage } from 'react-intl';
+
+import { TranscriptReaderConnected } from '../TranscriptReaderConnected/TranscriptReaderConnected';
+import { Transcripts } from './Transcripts';
+
+const transcripts = [
+  {
+    id: '1',
+    language: 'fr',
+    url: 'https://example.com/vtt/fr.vtt',
+  },
+  {
+    id: '2',
+    language: 'en',
+    url: 'https://example.com/vtt/en.vtt',
+  },
+] as any;
+
+const languageChoices = [
+  { label: 'English', value: 'en' },
+  { label: 'French', value: 'fr' },
+];
+
+describe('<Transcripts />', () => {
+  afterEach(jest.resetAllMocks);
+
+  it('displays a list of available transcripts', async () => {
+    const wrapper = shallow(
+      <Transcripts
+        languageChoices={languageChoices}
+        getTimedTextTrackLanguageChoices={jest.fn()}
+        transcripts={transcripts}
+        jwt="foo"
+      />,
+    );
+
+    const options = wrapper.find('select').find('option');
+
+    expect(
+      wrapper
+        .find('select')
+        .find(FormattedMessage)
+        .exists(),
+    ).toEqual(true);
+    expect(options.at(0).html()).toEqual('<option value="1">French</option>');
+    expect(options.at(1).html()).toEqual('<option value="2">English</option>');
+
+    expect(wrapper.find(TranscriptReaderConnected).exists()).toEqual(false);
+  });
+
+  it('render <TranscriptReaderConnected /> when a transcript is selected', async () => {
+    const wrapper = shallow(
+      <Transcripts
+        languageChoices={languageChoices}
+        getTimedTextTrackLanguageChoices={jest.fn()}
+        transcripts={transcripts}
+        jwt="foo"
+      />,
+    );
+
+    wrapper.setState({
+      selectedTranscript: transcripts[0],
+    });
+
+    expect(wrapper.find(TranscriptReaderConnected).exists()).toEqual(true);
+  });
+});

--- a/src/frontend/components/Transcripts/Transcripts.tsx
+++ b/src/frontend/components/Transcripts/Transcripts.tsx
@@ -1,0 +1,146 @@
+import { Box, Text } from 'grommet';
+import * as React from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+import styled from 'styled-components';
+
+import { LanguageChoice } from '../../types/LanguageChoice';
+import { TimedTextTranscript } from '../../types/tracks';
+import { Nullable } from '../../utils/types';
+import { ActionLink } from '../ActionLink/ActionLink';
+import { TranscriptReaderConnected } from '../TranscriptReaderConnected/TranscriptReaderConnected';
+
+const messages = defineMessages({
+  hideTranscript: {
+    defaultMessage: 'Hide transcript',
+    description: 'Text to hide a displayed transcript',
+    id: 'components.Transcripts.hideTranscript',
+  },
+  transcriptLabel: {
+    defaultMessage: 'Show a transcript',
+    description: 'Text indicated to choose an available transcript language',
+    id: 'components.Transcripts.transcriptLabel',
+  },
+  transcriptSelectPlaceholder: {
+    defaultMessage: 'Choose a language',
+    description: 'Placeholder for the transcript select box',
+    id: 'components.Transcripts.transcriptSelect',
+  },
+});
+
+const LabelChooseLanguage = styled.label`
+  margin-right: 12px;
+`;
+
+interface TranscriptsProps {
+  jwt: string;
+  getTimedTextTrackLanguageChoices: (jwt: string) => void;
+  languageChoices: LanguageChoice[];
+  transcripts: TimedTextTranscript[];
+}
+
+interface TranscriptsState {
+  selectedTranscript: Nullable<TimedTextTranscript>;
+  selectedLanguage: string;
+}
+
+export class Transcripts extends React.Component<
+  TranscriptsProps,
+  TranscriptsState
+> {
+  constructor(props: TranscriptsProps) {
+    super(props);
+    this.state = {
+      selectedLanguage: '',
+      selectedTranscript: null,
+    };
+  }
+
+  componentDidMount() {
+    const { jwt, getTimedTextTrackLanguageChoices } = this.props;
+
+    getTimedTextTrackLanguageChoices(jwt);
+  }
+
+  disableTranscript() {
+    this.setState({
+      selectedLanguage: '',
+      selectedTranscript: null,
+    });
+  }
+
+  onSelectChange(e: React.SyntheticEvent<HTMLSelectElement>) {
+    e.stopPropagation();
+
+    const id = e.currentTarget.value;
+
+    if (id === '') {
+      this.disableTranscript();
+      return;
+    }
+
+    const transcript = this.props.transcripts.find(ts => ts.id === id);
+
+    if (transcript) {
+      this.setState({
+        selectedLanguage: e.currentTarget.value,
+        selectedTranscript: transcript,
+      });
+    }
+  }
+
+  render() {
+    const { languageChoices, transcripts } = this.props;
+    const options = transcripts.map(transcript => {
+      const language = languageChoices.find(
+        languageChoice => languageChoice.value === transcript.language,
+      );
+      return {
+        label: language ? language.label : transcript.language,
+        value: transcript.id,
+      };
+    });
+    return (
+      <React.Fragment>
+        <Box align="center" justify="center" direction="row" pad="medium">
+          <form>
+            <LabelChooseLanguage htmlFor="languages">
+              <FormattedMessage {...messages.transcriptLabel} />
+            </LabelChooseLanguage>
+            <select
+              id="languages"
+              name="language_choices"
+              onChange={this.onSelectChange.bind(this)}
+              value={this.state.selectedLanguage}
+            >
+              <FormattedMessage {...messages.transcriptSelectPlaceholder}>
+                {message => <option value={''}>{message}</option>}
+              </FormattedMessage>
+              {options.map(language => (
+                <option key={language.value} value={language.value}>
+                  {language.label}
+                </option>
+              ))}
+            </select>
+          </form>
+        </Box>
+        {this.state.selectedTranscript && (
+          <Box>
+            <TranscriptReaderConnected
+              transcript={this.state.selectedTranscript}
+              key={this.state.selectedTranscript.id}
+            />
+            <Box>
+              <ActionLink
+                margin={'small'}
+                alignSelf="center"
+                color={'status-critical'}
+                label={<FormattedMessage {...messages.hideTranscript} />}
+                onClick={this.disableTranscript.bind(this)}
+              />
+            </Box>
+          </Box>
+        )}
+      </React.Fragment>
+    );
+  }
+}

--- a/src/frontend/components/TranscriptsConnected/TranscriptsConnected.tsx
+++ b/src/frontend/components/TranscriptsConnected/TranscriptsConnected.tsx
@@ -1,0 +1,29 @@
+import { connect } from 'react-redux';
+import { Dispatch } from 'redux';
+
+import { RootState } from '../../data/rootReducer';
+import { getTimedTextTrackLanguageChoices } from '../../data/timedTextTrackLanguageChoices/action';
+import { appStateSuccess } from '../../types/AppData';
+import { Transcripts } from '../Transcripts/Transcripts';
+
+const mapStateToProps = (state: RootState<appStateSuccess>) => ({
+  jwt: state.context.jwt,
+  languageChoices: state.languageChoices.items,
+});
+
+const mapDispatchToProps = (dispatch: Dispatch) => ({
+  getTimedTextTrackLanguageChoices: (jwt: string) =>
+    dispatch(getTimedTextTrackLanguageChoices(jwt)),
+});
+
+/**
+ * Component. Displays one TimedTextTrack as part of a list of TimedTextTracks. Provides buttons for
+ * the user to delete it or replace the linked video.
+ * @param deleteTimedTextTrackRecord Action creator that takes a timedtexttrack to remove from the store.
+ * @param jwt The token that will be used to interact with the API.
+ * @param track The timedtexttrack to display.
+ */
+export const TranscriptsConnected = connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(Transcripts);

--- a/src/frontend/components/VideoPlayer/VideoPlayer.spec.tsx
+++ b/src/frontend/components/VideoPlayer/VideoPlayer.spec.tsx
@@ -24,6 +24,10 @@ jest.mock('dashjs', () => ({
   }),
 }));
 
+jest.mock('../TranscriptsConnected/TranscriptsConnected', () => ({
+  TranscriptsConnected: () => <div>TranscriptsConnected</div>,
+}));
+
 describe('VideoPlayer', () => {
   const video = {
     description: 'Some description',
@@ -46,8 +50,11 @@ describe('VideoPlayer', () => {
     },
   } as Video;
 
+  const dispatch = jest.fn();
+
   const props = {
     createPlayer,
+    dispatch,
     getTimedTextTrackLanguageChoices: mockGetTimedTextTrackLanguageChoices,
     jwt: 'foo',
     languageChoices: [{ label: 'French', value: 'fr' }],
@@ -132,6 +139,7 @@ describe('VideoPlayer', () => {
       'plyr',
       expect.any(Element),
       'foo',
+      dispatch,
     );
 
     expect(mockInitialize).toHaveBeenCalledWith(

--- a/src/frontend/components/VideoPlayerConnected/VideoPlayerConnected.tsx
+++ b/src/frontend/components/VideoPlayerConnected/VideoPlayerConnected.tsx
@@ -31,6 +31,7 @@ export const mapStateToProps = (
 });
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
+  dispatch,
   getTimedTextTrackLanguageChoices: (jwt: string) =>
     dispatch(getTimedTextTrackLanguageChoices(jwt)),
 });

--- a/src/frontend/data/player/actions.ts
+++ b/src/frontend/data/player/actions.ts
@@ -1,0 +1,10 @@
+export interface PlayerTimeUpdateNotification {
+  currentTime: number;
+  type: 'PLAYER_TIME_UPDATE_NOTIFY';
+}
+
+export function notifyPlayerTimeUpdate(
+  currentTime: number,
+): PlayerTimeUpdateNotification {
+  return { currentTime, type: 'PLAYER_TIME_UPDATE_NOTIFY' };
+}

--- a/src/frontend/data/player/reducer.spec.ts
+++ b/src/frontend/data/player/reducer.spec.ts
@@ -1,0 +1,33 @@
+import { player } from './reducer';
+
+describe('Reducer: player', () => {
+  const previousState = {
+    currentTime: 1.5,
+  };
+
+  it('returns the state as is when called with an unknown action', () => {
+    expect(player(previousState, { type: '' })).toEqual(previousState);
+  });
+
+  describe('PLAYER_TIME_UPDATE_NOTIFY', () => {
+    it('updates the currentTime property', () => {
+      const stateA = player(previousState, {
+        currentTime: 3,
+        type: 'PLAYER_TIME_UPDATE_NOTIFY',
+      });
+
+      expect(stateA).toEqual({
+        currentTime: 3,
+      });
+
+      const stateB = player(stateA, {
+        currentTime: 2.3,
+        type: 'PLAYER_TIME_UPDATE_NOTIFY',
+      });
+
+      expect(stateB).toEqual({
+        currentTime: 2.3,
+      });
+    });
+  });
+});

--- a/src/frontend/data/player/reducer.ts
+++ b/src/frontend/data/player/reducer.ts
@@ -1,0 +1,30 @@
+import { AnyAction, Reducer } from 'redux';
+
+import { PlayerTimeUpdateNotification } from './actions';
+
+export interface PlayerState {
+  currentTime: number;
+}
+
+export const initialState = {
+  currentTime: 0,
+};
+
+export const player: Reducer<PlayerState> = (
+  state: PlayerState = initialState,
+  action?: PlayerTimeUpdateNotification | AnyAction,
+) => {
+  if (!action) {
+    return state;
+  }
+
+  switch (action.type) {
+    case 'PLAYER_TIME_UPDATE_NOTIFY':
+      return {
+        ...state,
+        currentTime: action.currentTime,
+      };
+  }
+
+  return state;
+};

--- a/src/frontend/data/rootReducer.ts
+++ b/src/frontend/data/rootReducer.ts
@@ -4,6 +4,7 @@ import { Resource } from '../types/tracks';
 import { context, ContextState } from './context/reducer';
 import { byIdActions } from './genericReducers/resourceById/resourceById';
 import { currentQueryActions } from './genericReducers/resourceList/resourceList';
+import { player, PlayerState } from './player/reducer';
 import {
   timedTextTrackLanguageChoices,
   TimedTextTrackLanguageChoicesState,
@@ -21,6 +22,7 @@ export type actionTypes<R extends Resource = Resource> =
 export interface RootState<state extends appState> {
   context: ContextState<state>;
   languageChoices: TimedTextTrackLanguageChoicesState;
+  player: PlayerState;
   resources: {
     [modelName.TIMEDTEXTTRACKS]: TimedTextTracksState;
     [modelName.VIDEOS]: VideosState;
@@ -36,6 +38,7 @@ export const rootReducer = (
     (state && state.languageChoices) || undefined,
     action,
   ),
+  player: player(state!.player, action),
   resources: {
     [modelName.TIMEDTEXTTRACKS]: timedtexttracks(
       (state && state.resources[modelName.TIMEDTEXTTRACKS]) || undefined,

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -77,7 +77,8 @@
     "reselect": "4.0.0",
     "styled-components": "4.0.3",
     "styled-reboot": "3.0.2",
-    "uuid": "3.3.2"
+    "uuid": "3.3.2",
+    "vtt.js": "0.13.0"
   },
   "resolutions": {
     "@types/react": "16.8.2",

--- a/src/frontend/tsconfig.json
+++ b/src/frontend/tsconfig.json
@@ -17,7 +17,8 @@
     "moduleResolution": "node",
     "paths": {
       "plyr": ["types/libs/plyr"],
-      "dashjs": ["types/libs/dashjs"]
+      "dashjs": ["types/libs/dashjs"],
+      "vtt.js": ["types/libs/vtt.js"]
     },
     "strict": true,
     "sourceMap": true,

--- a/src/frontend/types/libs/vtt.js/index.d.ts
+++ b/src/frontend/types/libs/vtt.js/index.d.ts
@@ -1,0 +1,30 @@
+declare module 'vtt.js' {
+  export namespace WebVTT {
+    export function StringDecoder(): TextDecoder;
+    export function convertCueToDOMTree(
+      window: Window,
+      cuetext: string,
+    ): HTMLDivElement;
+    export function processCues(
+      window: Window,
+      cues: any[],
+      overlay: HTMLElement,
+    ): void;
+
+    export class Parser {
+      onflush: () => {};
+      onparsingerror: (error: Error) => {};
+      constructor(window: Window, stringDecoder: TextDecoder);
+      parse(data: string): void;
+      flush(): void;
+      oncue(cue: VTTCue): void;
+    }
+  }
+
+  export interface VTTCue {
+    endTime: number;
+    startTime: number;
+    id: string;
+    text: string;
+  }
+}

--- a/src/frontend/types/tracks.ts
+++ b/src/frontend/types/tracks.ts
@@ -50,6 +50,10 @@ export interface TimedText extends Resource {
   video: Video;
 }
 
+export interface TimedTextTranscript extends TimedText {
+  mode: timedTextMode.TRANSCRIPT;
+}
+
 /** Possible sizes for a video file or stream. Used as keys in lists of files. */
 export type videoSize = '144' | '240' | '480' | '720' | '1080';
 

--- a/src/frontend/yarn.lock
+++ b/src/frontend/yarn.lock
@@ -6731,6 +6731,11 @@ vm-browserify@0.0.4:
   dependencies:
     indexof "0.0.1"
 
+vtt.js@0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/vtt.js/-/vtt.js-0.13.0.tgz#955c667b34d5325b2012cb9e8ba9bad6e0b11ff8"
+  integrity sha1-lVxmezTVMlsgEsuei6m61uCxH/g=
+
 w3c-hr-time@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz#82ac2bff63d950ea9e3189a58a65625fedf19045"


### PR DESCRIPTION
## Purpose

When transcripts are available, the user can select which one to use. Once selected we want to synchronize it with the video and highlight the text currently active.

## Proposal

Our transcript are WebVTT files. We found a library implementing the WebVTT spec in javascript. This lib can parse a file and manage every cues (a cue is a file's chunk).
Once a transcript parsed we just have to synchronize the cues with the video. We listen `timeupdate` from plyr player and we update a timer in the redux store.

- [x] create components responsible to manage transcript files. One to select a file, one to read it and a last one responsible to display every cues.
- [x] synchronize the video with the transcript. We use redux to store the current time and update it.

![transcript](https://user-images.githubusercontent.com/767834/52714276-c00ba080-2f99-11e9-8548-7b86ab3d5db0.gif)

