### PR TITLE
🐛(api) allow student to access metadata timedtexttrack's action

### DIFF
--- a/src/backend/marsha/core/api.py
+++ b/src/backend/marsha/core/api.py
@@ -168,7 +168,14 @@ class TimedTextTrackViewSet(
     """Viewset for the API of the TimedTextTrack object."""
 
     serializer_class = TimedTextTrackSerializer
-    permission_classes = [IsRelatedVideoTokenOrAdminUser]
+
+    def get_permissions(self):
+        """Instantiate and return the list of permissions that this view requires."""
+        if self.action == "metadata":
+            permission_classes = [IsVideoToken]
+        else:
+            permission_classes = [IsRelatedVideoTokenOrAdminUser]
+        return [permission() for permission in permission_classes]
 
     def get_queryset(self):
         """Restrict list access to timed text tracks related to the video in the JWT token."""


### PR DESCRIPTION
## Purpose

As a student we need to access the OPTIONS endpoint to
retrieve all languages label.

## Proposal

- [x] Change permission class for `metadata` actions.

