### PR TITLE
♻️(timedtext) load timed text tracks from object video if present

### DIFF
--- a/src/frontend/components/VideoPlayer/VideoPlayer.spec.tsx
+++ b/src/frontend/components/VideoPlayer/VideoPlayer.spec.tsx
@@ -44,7 +44,6 @@ describe('VideoPlayer', () => {
 
   const props = {
     createPlayer,
-    getTimedTextTrackList: jest.fn(),
     jwt: 'foo',
     timedtexttracks: {
       objects: [
@@ -126,7 +125,7 @@ describe('VideoPlayer', () => {
       expect.any(Element),
       'foo',
     );
-    expect(props.getTimedTextTrackList).toHaveBeenCalledTimes(1);
+
     expect(mockInitialize).toHaveBeenCalledWith(
       expect.any(Element),
       'https://example.com/dash.mpd',

--- a/src/frontend/components/VideoPlayerConnected/VideoPlayerConnected.tsx
+++ b/src/frontend/components/VideoPlayerConnected/VideoPlayerConnected.tsx
@@ -32,34 +32,8 @@ export const mapStateToProps = (
     video,
 });
 
-/** Create a function that triggers a get to the API for the timedtexttracks. */
-const mergeProps = (
-  {
-    jwt,
-    timedtexttracks,
-    video,
-  }: {
-    jwt: string;
-    timedtexttracks: ConsumableQuery<TimedText>;
-    video: Nullable<Video>;
-  },
-  { dispatch }: { dispatch: Dispatch },
-  { createPlayer }: VideoPlayerConnectedProps,
-) => ({
-  createPlayer,
-  getTimedTextTrackList: () =>
-    dispatch(getResourceList(jwt, modelName.TIMEDTEXTTRACKS)),
-  jwt,
-  timedtexttracks,
-  video,
-});
-
 /**
  * Component. Displays a player to show the video from context.
  * @param video The video to show.
  */
-export const VideoPlayerConnected = connect(
-  mapStateToProps,
-  null!,
-  mergeProps,
-)(VideoPlayer);
+export const VideoPlayerConnected = connect(mapStateToProps)(VideoPlayer);

--- a/src/frontend/data/bootstrapStore.ts
+++ b/src/frontend/data/bootstrapStore.ts
@@ -1,11 +1,13 @@
 import { applyMiddleware, compose, createStore } from 'redux';
 import createSagaMiddleware from 'redux-saga';
 
+import { requestStatus } from '../types/api';
 import { AppData } from '../types/AppData';
 import { modelName } from '../types/models';
 import { initialState } from './context/reducer';
 import { rootReducer } from './rootReducer';
 import { rootSaga } from './rootSaga';
+import { TimedTextTracksState } from './timedtexttracks/reducer';
 
 const sagaMiddleware = createSagaMiddleware();
 
@@ -13,12 +15,38 @@ export const bootstrapStore = (appData: AppData) => {
   const composeEnhancers =
     (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 
+  let timeTextTracksState: TimedTextTracksState | null = null;
+  if (appData.video && appData.video.timed_text_tracks.length > 0) {
+    timeTextTracksState = appData.video.timed_text_tracks.reduce(
+      (acc, item, index) => ({
+        byId: {
+          ...acc.byId,
+          [item.id]: item,
+        },
+        currentQuery: {
+          ...acc.currentQuery,
+          items: {
+            ...acc.currentQuery.items,
+            [index]: item.id,
+          },
+        },
+      }),
+      {
+        byId: {},
+        currentQuery: {
+          items: {},
+          status: requestStatus.SUCCESS,
+        },
+      },
+    );
+  }
+
   const store = createStore(
     rootReducer,
     {
       context: initialState,
       resources: {
-        [modelName.TIMEDTEXTTRACKS]: {},
+        [modelName.TIMEDTEXTTRACKS]: timeTextTracksState || {},
         [modelName.VIDEOS]: {
           ...(appData.video
             ? { byId: { [appData.video.id]: appData.video } }

--- a/src/frontend/types/tracks.ts
+++ b/src/frontend/types/tracks.ts
@@ -58,6 +58,7 @@ export interface Video extends Resource {
   description: string;
   id: string;
   is_ready_to_play: boolean;
+  timed_text_tracks: TimedText[];
   title: string;
   upload_state: uploadState;
   urls: {


### PR DESCRIPTION
## Purpose

Timed text tracks are present in the video object when marsha is loaded.
We must use them instead of querying again the timed text track API
endpoint. This endpoint can consume a lot of resource.

## Proposal

in `bootstrapStore` we populate the `resource.timedtexttracks` state. Doing this we can keep video and timestexttracks reducer separated and the timedtexttracks can still be maintain like we do right now.

- [x] update video type
- [x] manage timed text tracks in `bootstrapStore`
- [x] update `VideoPlayer` to not fetch timedtexttracks API endpoint.

Once this PR merged, I will update #234 to allow the `OPTIONS` method of this endpoint to be fetched by students.

