### PR TITLE
enhance <TimedTestListItem /> buttons

### DIFF
--- a/src/frontend/components/Dashboard/Dashboard.tsx
+++ b/src/frontend/components/Dashboard/Dashboard.tsx
@@ -48,6 +48,7 @@ export class Dashboard extends React.Component<DashboardProps> {
           <FormattedMessage {...messages.title} />
         </IframeHeadingWithLayout>
         <DashboardVideoPaneConnected video={this.props.video} />
+        <DashboardTimedTextPaneConnected />
       </DashboardContainer>
     );
   }

--- a/src/frontend/components/TimedTextListItem/TimedTextListItem.tsx
+++ b/src/frontend/components/TimedTextListItem/TimedTextListItem.tsx
@@ -25,6 +25,12 @@ const messages = defineMessages({
       'Link text to replace a subtitle/transcript/captions item with a new file (for the same language).',
     id: 'components.TimedTextListItem.replace',
   },
+  upload: {
+    defaultMessage: 'Upload',
+    description:
+      'Link text to upload a missing subtitle/transcript/captions item file.',
+    id: 'components.TimedTextListItem.upload',
+  },
 });
 
 const TimedTextListItemStyled = styled.div`
@@ -147,7 +153,11 @@ export class TimedTextListItem extends React.Component<
           />
           &nbsp;/&nbsp;
           <Link to={UPLOAD_FORM_ROUTE(modelName.TIMEDTEXTTRACKS, track.id)}>
-            <FormattedMessage {...messages.replace} />
+            <FormattedMessage
+              {...(track.upload_state === uploadState.PENDING
+                ? messages.upload
+                : messages.replace)}
+            />
           </Link>
         </TimedTextListItemActions>
       </TimedTextListItemStyled>


### PR DESCRIPTION
## Purpose

When a track is missing (PENDING upload state) the button should not be replace but upload.

With this last modification I think everything we can enable timed text tracks in the Dashboard. The upload form explain what you are uploading so there is no need to change it IMO.

## Proposal

display a `Upload` button when a track is not uploaded yet.

- [x] display a `Upload` button when a track is not uploaded yet.
- [x] enable timed text track in the Dashboard

