### PR TITLE
✨(frontend) add a saga to handle timed text tracks languages choices

### DIFF
--- a/src/frontend/components/TimedTextCreationForm/TimedTextCreationForm.spec.tsx
+++ b/src/frontend/components/TimedTextCreationForm/TimedTextCreationForm.spec.tsx
@@ -10,27 +10,15 @@ jest.mock(
   }),
 );
 
-jest.mock(
-  '../../data/sideEffects/getTimedTextTrackLanguageChoices/getTimedTextTrackLanguageChoices',
-  () => ({
-    getTimedTextTrackLanguageChoices: jest.fn(),
-  }),
-);
-
 import { createTimedTextTrack } from '../../data/sideEffects/createTimedTextTrack/createTimedTextTrack';
-import { getTimedTextTrackLanguageChoices } from '../../data/sideEffects/getTimedTextTrackLanguageChoices/getTimedTextTrackLanguageChoices';
 import { modelName } from '../../types/models';
 import { timedTextMode } from '../../types/tracks';
-import { ERROR_COMPONENT_ROUTE } from '../ErrorComponent/route';
 import { UPLOAD_FORM_ROUTE } from '../UploadForm/route';
 import { TimedTextCreationForm } from './TimedTextCreationForm';
 
 const mockCreateTimedTextTrack: jest.Mock<
   typeof createTimedTextTrack
 > = createTimedTextTrack as any;
-const mockGetTimedTextTrackLanguageChoices: jest.Mock<
-  typeof getTimedTextTrackLanguageChoices
-> = getTimedTextTrackLanguageChoices as any;
 
 const mockCreateTimedTextTrackRecord = jest.fn();
 
@@ -38,12 +26,13 @@ describe('<TimedTextCreationForm />', () => {
   afterEach(jest.resetAllMocks);
 
   it('renders and loads the language choices', async () => {
-    mockGetTimedTextTrackLanguageChoices.mockResolvedValue([
-      { label: 'English', value: 'en' },
-      { label: 'French', value: 'fr' },
-    ]);
     const wrapper = shallow(
       <TimedTextCreationForm
+        getTimedTextTrackLanguageChoices={jest.fn()}
+        languageChoices={[
+          { label: 'English', value: 'en' },
+          { label: 'French', value: 'fr' },
+        ]}
         createTimedTextTrack={mockCreateTimedTextTrackRecord}
         jwt={'some token'}
         mode={timedTextMode.SUBTITLE}
@@ -53,32 +42,6 @@ describe('<TimedTextCreationForm />', () => {
     await flushAllPromises();
 
     expect(wrapper.html()).toContain('Add a language');
-    expect(mockGetTimedTextTrackLanguageChoices).toHaveBeenCalled();
-    expect(wrapper.instance().state).toEqual({
-      languageChoices: [
-        { label: 'English', value: 'en' },
-        { label: 'French', value: 'fr' },
-      ],
-    });
-  });
-
-  it('redirects to <ErrorComponent /> when it fails to get the language choices', async () => {
-    mockGetTimedTextTrackLanguageChoices.mockRejectedValue(
-      new Error('Failed to get language choices.'),
-    );
-    const wrapper = shallow(
-      <TimedTextCreationForm
-        createTimedTextTrack={jest.fn()}
-        jwt={'some token'}
-        mode={timedTextMode.SUBTITLE}
-      />,
-    );
-
-    await flushAllPromises();
-
-    expect(wrapper.name()).toEqual('Redirect');
-    expect(wrapper.prop('push')).toBeTruthy();
-    expect(wrapper.prop('to')).toEqual(ERROR_COMPONENT_ROUTE('notFound'));
   });
 
   describe('createAndGoToUpload()', () => {
@@ -88,6 +51,11 @@ describe('<TimedTextCreationForm />', () => {
     beforeEach(() => {
       wrapper = shallow(
         <TimedTextCreationForm
+          getTimedTextTrackLanguageChoices={jest.fn()}
+          languageChoices={[
+            { label: 'English', value: 'en' },
+            { label: 'French', value: 'fr' },
+          ]}
           createTimedTextTrack={mockCreateTimedTextTrackRecord}
           jwt={'some token'}
           mode={timedTextMode.SUBTITLE}

--- a/src/frontend/components/TimedTextCreationForm/TimedTextCreationForm.tsx
+++ b/src/frontend/components/TimedTextCreationForm/TimedTextCreationForm.tsx
@@ -8,7 +8,7 @@ import { ActionMeta, ValueType } from 'react-select/lib/types';
 import styled from 'styled-components';
 
 import { createTimedTextTrack } from '../../data/sideEffects/createTimedTextTrack/createTimedTextTrack';
-import { getTimedTextTrackLanguageChoices } from '../../data/sideEffects/getTimedTextTrackLanguageChoices/getTimedTextTrackLanguageChoices';
+import { LanguageChoice } from '../../types/LanguageChoice';
 import { modelName } from '../../types/models';
 import { TimedText, timedTextMode } from '../../types/tracks';
 import { theme } from '../../utils/theme/theme';
@@ -56,14 +56,15 @@ interface SelectOption {
 /** Props shape for the TimedTextCreationForm component. */
 export interface TimedTextCreationFormProps {
   createTimedTextTrack: (timedtexttrack: TimedText) => void;
-  jwt: Nullable<string>;
+  getTimedTextTrackLanguageChoices: (jwt: string) => void;
+  jwt: string;
+  languageChoices: LanguageChoice[];
   mode: timedTextMode;
 }
 
 /** State shape for the TimedTextCreationForm component. */
 interface TimedTextCreationFormState {
   error?: 'creation' | 'schema';
-  languageChoices: SelectOption[];
   newTTLanguage?: string;
   newTTUploadId?: TimedText['id'];
 }
@@ -78,22 +79,12 @@ export class TimedTextCreationForm extends React.Component<
   TimedTextCreationFormProps,
   TimedTextCreationFormState
 > {
-  constructor(props: TimedTextCreationFormProps) {
-    super(props);
-    this.state = { languageChoices: [] };
-  }
+  state: TimedTextCreationFormState = {};
 
-  async componentDidMount() {
-    try {
-      const languageChoices = await getTimedTextTrackLanguageChoices(
-        this.props.jwt,
-      );
-      this.setState({
-        languageChoices,
-      });
-    } catch (error) {
-      this.setState({ error: 'schema' });
-    }
+  componentDidMount() {
+    const { jwt, getTimedTextTrackLanguageChoices } = this.props;
+
+    getTimedTextTrackLanguageChoices(jwt);
   }
 
   async createAndGoToUpload() {
@@ -121,7 +112,8 @@ export class TimedTextCreationForm extends React.Component<
   }
 
   render() {
-    const { error, languageChoices, newTTLanguage, newTTUploadId } = this.state;
+    const { error, newTTLanguage, newTTUploadId } = this.state;
+    const { languageChoices } = this.props;
 
     if (error === 'schema') {
       return <Redirect push to={ERROR_COMPONENT_ROUTE('notFound')} />;

--- a/src/frontend/components/TimedTextCreationFormConnected/TimedTextCreationFormConnected.ts
+++ b/src/frontend/components/TimedTextCreationFormConnected/TimedTextCreationFormConnected.ts
@@ -3,6 +3,7 @@ import { Dispatch } from 'redux';
 
 import { addResource } from '../../data/genericReducers/resourceById/actions';
 import { RootState } from '../../data/rootReducer';
+import { getTimedTextTrackLanguageChoices } from '../../data/timedTextTrackLanguageChoices/action';
 import { appStateSuccess } from '../../types/AppData';
 import { modelName } from '../../types/models';
 import { TimedText } from '../../types/tracks';
@@ -10,11 +11,14 @@ import { TimedTextCreationForm } from '../TimedTextCreationForm/TimedTextCreatio
 
 const mapStateToProps = (state: RootState<appStateSuccess>) => ({
   jwt: state.context.jwt,
+  languageChoices: state.languageChoices.items,
 });
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
   createTimedTextTrack: (timedtexttrack: TimedText) =>
     dispatch(addResource(modelName.TIMEDTEXTTRACKS, timedtexttrack)),
+  getTimedTextTrackLanguageChoices: (jwt: string) =>
+    dispatch(getTimedTextTrackLanguageChoices(jwt)),
 });
 
 /**

--- a/src/frontend/components/TimedTextListItem/TimedTextListItem.spec.tsx
+++ b/src/frontend/components/TimedTextListItem/TimedTextListItem.spec.tsx
@@ -9,29 +9,17 @@ jest.mock(
   () => ({ deleteTimedTextTrack: jest.fn() }),
 );
 
-jest.mock(
-  '../../data/sideEffects/getTimedTextTrackLanguageChoices/getTimedTextTrackLanguageChoices',
-  () => ({
-    getTimedTextTrackLanguageChoices: jest.fn(),
-  }),
-);
-
 jest.mock('react-router-dom', () => ({
   Link: () => null,
 }));
 
 import { deleteTimedTextTrack } from '../../data/sideEffects/deleteTimedTextTrack/deleteTimedTextTrack';
-import { getTimedTextTrackLanguageChoices } from '../../data/sideEffects/getTimedTextTrackLanguageChoices/getTimedTextTrackLanguageChoices';
 import { TimedText, uploadState } from '../../types/tracks';
 import { TimedTextListItem } from './TimedTextListItem';
 
 const mockDeleteTimedTextTrack: jest.Mock<
   typeof deleteTimedTextTrack
 > = deleteTimedTextTrack as any;
-const mockGetTimedTextTrackLanguageChoices: jest.Mock<
-  typeof getTimedTextTrackLanguageChoices
-> = getTimedTextTrackLanguageChoices as any;
-
 const mockUpdateTimedTextTrackRecord = jest.fn();
 
 describe('<TimedTextListItem />', () => {
@@ -40,16 +28,22 @@ describe('<TimedTextListItem />', () => {
   afterEach(fetchMock.restore);
 
   const mockDeleteTimedTextTrackRecord = jest.fn();
+  const mockGetTimedTextTrackLanguageChoices = jest.fn();
+
+  const languageChoices = [
+    {
+      label: 'French',
+      value: 'fr',
+    },
+  ];
 
   it('renders a track, showing its language and status', async () => {
-    mockGetTimedTextTrackLanguageChoices.mockReturnValue(
-      Promise.resolve([{ label: 'French', value: 'fr' }]),
-    );
-
     const wrapper = shallow(
       <TimedTextListItem
+        getTimedTextTrackLanguageChoices={mockGetTimedTextTrackLanguageChoices}
         deleteTimedTextTrackRecord={mockDeleteTimedTextTrackRecord}
         updateTimedTextTrackRecord={jest.fn()}
+        languageChoices={languageChoices}
         jwt={'some token'}
         track={
           {
@@ -61,21 +55,17 @@ describe('<TimedTextListItem />', () => {
       />,
     );
 
-    await flushAllPromises();
-
     expect(wrapper.html()).toContain('French');
     expect(wrapper.html()).toContain('Ready');
   });
 
   it('renders & fail to poll a ready timed text track', async () => {
-    mockGetTimedTextTrackLanguageChoices.mockReturnValue(
-      Promise.resolve([{ label: 'French', value: 'fr' }]),
-    );
-
     shallow(
       <TimedTextListItem
+        getTimedTextTrackLanguageChoices={mockGetTimedTextTrackLanguageChoices}
         deleteTimedTextTrackRecord={mockDeleteTimedTextTrackRecord}
         updateTimedTextTrackRecord={mockUpdateTimedTextTrackRecord}
+        languageChoices={languageChoices}
         jwt={'some token'}
         track={
           {
@@ -87,7 +77,6 @@ describe('<TimedTextListItem />', () => {
         }
       />,
     );
-    await flushAllPromises();
 
     fetchMock.mock(
       '/api/timedtexttracks/1/',
@@ -129,14 +118,12 @@ describe('<TimedTextListItem />', () => {
   });
 
   it('renders & fail to poll a ready timed text track', async () => {
-    mockGetTimedTextTrackLanguageChoices.mockReturnValue(
-      Promise.resolve([{ label: 'French', value: 'fr' }]),
-    );
-
     shallow(
       <TimedTextListItem
+        getTimedTextTrackLanguageChoices={mockGetTimedTextTrackLanguageChoices}
         deleteTimedTextTrackRecord={mockDeleteTimedTextTrackRecord}
         updateTimedTextTrackRecord={mockUpdateTimedTextTrackRecord}
+        languageChoices={languageChoices}
         jwt={'some token'}
         track={
           {
@@ -148,7 +135,6 @@ describe('<TimedTextListItem />', () => {
         }
       />,
     );
-    await flushAllPromises();
 
     fetchMock.mock(
       '/api/timedtexttracks/1/',
@@ -202,8 +188,12 @@ describe('<TimedTextListItem />', () => {
 
       const wrapper = shallow(
         <TimedTextListItem
+          getTimedTextTrackLanguageChoices={
+            mockGetTimedTextTrackLanguageChoices
+          }
           deleteTimedTextTrackRecord={mockDeleteTimedTextTrackRecord}
           updateTimedTextTrackRecord={jest.fn()}
+          languageChoices={languageChoices}
           jwt={'some token'}
           track={timedtexttrack}
         />,

--- a/src/frontend/components/TimedTextListItemConnected/TimedTextListItemConnected.ts
+++ b/src/frontend/components/TimedTextListItemConnected/TimedTextListItemConnected.ts
@@ -6,6 +6,7 @@ import {
   deleteResource,
 } from '../../data/genericReducers/resourceById/actions';
 import { RootState } from '../../data/rootReducer';
+import { getTimedTextTrackLanguageChoices } from '../../data/timedTextTrackLanguageChoices/action';
 import { appStateSuccess } from '../../types/AppData';
 import { modelName } from '../../types/models';
 import { TimedText } from '../../types/tracks';
@@ -13,11 +14,14 @@ import { TimedTextListItem } from '../TimedTextListItem/TimedTextListItem';
 
 const mapStateToProps = (state: RootState<appStateSuccess>) => ({
   jwt: state.context.jwt,
+  languageChoices: state.languageChoices.items,
 });
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
   deleteTimedTextTrackRecord: (timedtexttrack: TimedText) =>
     dispatch(deleteResource(modelName.TIMEDTEXTTRACKS, timedtexttrack)),
+  getTimedTextTrackLanguageChoices: (jwt: string) =>
+    dispatch(getTimedTextTrackLanguageChoices(jwt)),
   updateTimedTextTrackRecord: (timedtexttrack: TimedText) =>
     dispatch(addResource(modelName.TIMEDTEXTTRACKS, timedtexttrack)),
 });

--- a/src/frontend/data/bootstrapStore.ts
+++ b/src/frontend/data/bootstrapStore.ts
@@ -7,6 +7,7 @@ import { modelName } from '../types/models';
 import { initialState } from './context/reducer';
 import { rootReducer } from './rootReducer';
 import { rootSaga } from './rootSaga';
+import { initialState as timedTextTrackLanguageChoicesInitialState } from './timedTextTrackLanguageChoices/reducer';
 import { TimedTextTracksState } from './timedtexttracks/reducer';
 
 const sagaMiddleware = createSagaMiddleware();
@@ -45,6 +46,7 @@ export const bootstrapStore = (appData: AppData) => {
     rootReducer,
     {
       context: initialState,
+      languageChoices: timedTextTrackLanguageChoicesInitialState,
       resources: {
         [modelName.TIMEDTEXTTRACKS]: timeTextTracksState || {},
         [modelName.VIDEOS]: {

--- a/src/frontend/data/rootReducer.ts
+++ b/src/frontend/data/rootReducer.ts
@@ -5,6 +5,10 @@ import { context, ContextState } from './context/reducer';
 import { byIdActions } from './genericReducers/resourceById/resourceById';
 import { currentQueryActions } from './genericReducers/resourceList/resourceList';
 import {
+  timedTextTrackLanguageChoices,
+  TimedTextTrackLanguageChoicesState,
+} from './timedTextTrackLanguageChoices/reducer';
+import {
   timedtexttracks,
   TimedTextTracksState,
 } from './timedtexttracks/reducer';
@@ -16,6 +20,7 @@ export type actionTypes<R extends Resource = Resource> =
 
 export interface RootState<state extends appState> {
   context: ContextState<state>;
+  languageChoices: TimedTextTrackLanguageChoicesState;
   resources: {
     [modelName.TIMEDTEXTTRACKS]: TimedTextTracksState;
     [modelName.VIDEOS]: VideosState;
@@ -27,6 +32,10 @@ export const rootReducer = (
   action: actionTypes,
 ) => ({
   context: context(state!.context, action),
+  languageChoices: timedTextTrackLanguageChoices(
+    (state && state.languageChoices) || undefined,
+    action,
+  ),
   resources: {
     [modelName.TIMEDTEXTTRACKS]: timedtexttracks(
       (state && state.resources[modelName.TIMEDTEXTTRACKS]) || undefined,

--- a/src/frontend/data/rootSaga.ts
+++ b/src/frontend/data/rootSaga.ts
@@ -1,8 +1,9 @@
 import { all } from 'redux-saga/effects';
 
 import { getResourceListSaga } from './sagas/getResourceList';
+import { getTimedTextTrackLanguageChoicesSaga } from './sagas/getTimedTextTrackLanguageChoices';
 
 // Aggregate all our sagas through the parallelization effect
 export function* rootSaga() {
-  yield all([getResourceListSaga()]);
+  yield all([getResourceListSaga(), getTimedTextTrackLanguageChoicesSaga()]);
 }

--- a/src/frontend/data/sagas/getTimedTextTrackLanguageChoices/index.spec.ts
+++ b/src/frontend/data/sagas/getTimedTextTrackLanguageChoices/index.spec.ts
@@ -1,0 +1,163 @@
+import fetchMock from 'fetch-mock';
+import { call, cancel, put, select, takeLeading } from 'redux-saga/effects';
+
+import {
+  didTimedTextTrackLanguageChoices,
+  failedTimedTextTrackLanguageChoices,
+  TimedTextTrackLanguageChoicesGet,
+} from '../../../data/timedTextTrackLanguageChoices/action';
+import { requestStatus } from '../../../types/api';
+import {
+  fetchTimedTextTrackLanguageChoices,
+  getTimedTextTrackLanguageChoices,
+  getTimedTextTrackLanguageChoicesSaga,
+  selector,
+} from './';
+
+describe('sideEffects/getTimedTextTrackLanguageChoices saga', () => {
+  afterEach(fetchMock.restore);
+
+  describe('fetchTimedTextTrackLanguageChoices()', () => {
+    it('gets the timedtexttrack route options and returns formatted language choices', async () => {
+      const response = {
+        actions: {
+          POST: {
+            language: {
+              choices: [
+                {
+                  display_name: 'English',
+                  value: 'en',
+                },
+                {
+                  display_name: 'French',
+                  value: 'fr',
+                },
+              ],
+            },
+          },
+        },
+      };
+      fetchMock.mock('/api/timedtexttracks/', JSON.stringify(response), {
+        method: 'OPTIONS',
+      });
+      const languageChoices = await fetchTimedTextTrackLanguageChoices(
+        'some token',
+      );
+
+      expect(languageChoices).toEqual([
+        { label: 'English', value: 'en' },
+        { label: 'French', value: 'fr' },
+      ]);
+      expect(fetchMock.lastCall()![1]!.headers).toEqual({
+        Authorization: 'Bearer some token',
+      });
+    });
+
+    it('throws when it fails to get the route options (request failure)', async () => {
+      fetchMock.mock(
+        '/api/timedtexttracks/',
+        Promise.reject(
+          new Error('Failed to fetch OPTIONS /api/timedtexttracks/'),
+        ),
+        { method: 'OPTIONS' },
+      );
+
+      await expect(
+        fetchTimedTextTrackLanguageChoices('some token'),
+      ).rejects.toThrowError('Failed to fetch OPTIONS /api/timedtexttracks/');
+    });
+
+    it('throws when it fails to get the route options (API error)', async () => {
+      fetchMock.mock('/api/timedtexttracks/', 400, { method: 'OPTIONS' });
+
+      await expect(
+        fetchTimedTextTrackLanguageChoices('some token'),
+      ).rejects.toThrowError('Failed to fetch OPTIONS /api/timedtexttracks/');
+    });
+  });
+
+  describe('getTimedTextTrackLanguageChoices()', () => {
+    it('fetchs the API and yields the result in a success action', () => {
+      const action: TimedTextTrackLanguageChoicesGet = {
+        jwt: 'some token',
+        type: 'TIMED_TEXT_TRACK_LANGUAGE_CHOICES_GET',
+      };
+      const response = [
+        {
+          label: 'French',
+          value: 'fr',
+        },
+        {
+          label: 'English',
+          value: 'en',
+        },
+      ];
+
+      const gen = getTimedTextTrackLanguageChoices(action);
+      expect(gen.next().value).toEqual(select(selector));
+
+      expect(gen.next(requestStatus.PENDING).value).toEqual(
+        call(fetchTimedTextTrackLanguageChoices, 'some token'),
+      );
+
+      expect(gen.next(response).value).toEqual(
+        put(didTimedTextTrackLanguageChoices(response)),
+      );
+    });
+
+    it('fetchs the API and catch request error', () => {
+      const action: TimedTextTrackLanguageChoicesGet = {
+        jwt: 'some token',
+        type: 'TIMED_TEXT_TRACK_LANGUAGE_CHOICES_GET',
+      };
+
+      const gen = getTimedTextTrackLanguageChoices(action);
+      expect(gen.next().value).toEqual(select(selector));
+
+      expect(gen.next(requestStatus.PENDING).value).toEqual(
+        call(fetchTimedTextTrackLanguageChoices, 'some token'),
+      );
+
+      expect(gen.throw!(new Error('request failed')).value).toEqual(
+        put(failedTimedTextTrackLanguageChoices('request failed')),
+      );
+    });
+
+    it('cancels the saga if current language state is in success', () => {
+      const action: TimedTextTrackLanguageChoicesGet = {
+        jwt: 'some token',
+        type: 'TIMED_TEXT_TRACK_LANGUAGE_CHOICES_GET',
+      };
+
+      const gen = getTimedTextTrackLanguageChoices(action);
+      expect(gen.next().value).toEqual(select(selector));
+
+      expect(gen.next(requestStatus.SUCCESS).value).toEqual(cancel());
+    });
+
+    it('cancels the saga if current language state is in failure', () => {
+      const action: TimedTextTrackLanguageChoicesGet = {
+        jwt: 'some token',
+        type: 'TIMED_TEXT_TRACK_LANGUAGE_CHOICES_GET',
+      };
+
+      const gen = getTimedTextTrackLanguageChoices(action);
+      expect(gen.next().value).toEqual(select(selector));
+
+      expect(gen.next(requestStatus.FAILURE).value).toEqual(cancel());
+    });
+  });
+
+  describe('getTimedTextTrackLanguageChoicesSaga()', () => {
+    it('calls takeLeading function', () => {
+      const gen = getTimedTextTrackLanguageChoicesSaga();
+
+      expect(gen.next().value).toEqual(
+        takeLeading(
+          'TIMED_TEXT_TRACK_LANGUAGE_CHOICES_GET',
+          getTimedTextTrackLanguageChoices,
+        ),
+      );
+    });
+  });
+});

--- a/src/frontend/data/sagas/getTimedTextTrackLanguageChoices/index.ts
+++ b/src/frontend/data/sagas/getTimedTextTrackLanguageChoices/index.ts
@@ -1,0 +1,79 @@
+import { call, cancel, put, select, takeLeading } from 'redux-saga/effects';
+
+import { RootState } from '../../../data/rootReducer';
+import { API_ENDPOINT } from '../../../settings';
+import { requestStatus } from '../../../types/api';
+import { appStateSuccess } from '../../../types/AppData';
+import { LanguageChoice } from '../../../types/LanguageChoice';
+import { modelName } from '../../../types/models';
+import { RouteOptions } from '../../../types/RouteOptions';
+import { TimedText } from '../../../types/tracks';
+import {
+  didTimedTextTrackLanguageChoices,
+  failedTimedTextTrackLanguageChoices,
+  TimedTextTrackLanguageChoicesGet,
+} from '../../timedTextTrackLanguageChoices/action';
+
+/**
+ * Get the list of available choices for the language filed on timedtexttracks.
+ * @param jwt The token that will be used to authenticate with the API.
+ */
+export async function fetchTimedTextTrackLanguageChoices(
+  jwt: string,
+): Promise<LanguageChoice[]> {
+  const response = await fetch(
+    `${API_ENDPOINT}/${modelName.TIMEDTEXTTRACKS}/`,
+    {
+      headers: {
+        Authorization: `Bearer ${jwt}`,
+      },
+      method: 'OPTIONS',
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch OPTIONS ${API_ENDPOINT}/${modelName.TIMEDTEXTTRACKS}/`,
+    );
+  }
+
+  const routeOptions: RouteOptions<TimedText> = await response.json();
+
+  return routeOptions.actions.POST.language.choices!.map(
+    ({ display_name, value }) => ({
+      label: display_name,
+      value,
+    }),
+  );
+}
+
+export const selector = (state: RootState<appStateSuccess>) =>
+  state.languageChoices.status;
+
+export function* getTimedTextTrackLanguageChoices(
+  action: TimedTextTrackLanguageChoicesGet,
+) {
+  const currentLanguagesChoicesStatus = yield select(selector);
+
+  if (currentLanguagesChoicesStatus === requestStatus.PENDING) {
+    const { jwt } = action;
+    try {
+      const languageChoices: LanguageChoice[] = yield call(
+        fetchTimedTextTrackLanguageChoices,
+        jwt,
+      );
+      yield put(didTimedTextTrackLanguageChoices(languageChoices));
+    } catch (e) {
+      yield put(failedTimedTextTrackLanguageChoices(e.message));
+    }
+  } else {
+    yield cancel();
+  }
+}
+
+export function* getTimedTextTrackLanguageChoicesSaga() {
+  yield takeLeading(
+    'TIMED_TEXT_TRACK_LANGUAGE_CHOICES_GET',
+    getTimedTextTrackLanguageChoices,
+  );
+}

--- a/src/frontend/data/timedTextTrackLanguageChoices/action.ts
+++ b/src/frontend/data/timedTextTrackLanguageChoices/action.ts
@@ -1,0 +1,37 @@
+import { LanguageChoice } from '../../types/LanguageChoice';
+
+export interface TimedTextTrackLanguageChoicesGet {
+  jwt: string;
+  type: 'TIMED_TEXT_TRACK_LANGUAGE_CHOICES_GET';
+}
+
+export const getTimedTextTrackLanguageChoices = (
+  jwt: string,
+): TimedTextTrackLanguageChoicesGet => ({
+  jwt,
+  type: 'TIMED_TEXT_TRACK_LANGUAGE_CHOICES_GET',
+});
+
+export interface TimedTextTrackLanguageChoicesFailure {
+  error: Error | string;
+  type: 'TIMED_TEXT_TRACK_LANGUAGE_CHOICES_FAILURE';
+}
+
+export const failedTimedTextTrackLanguageChoices = (
+  error: TimedTextTrackLanguageChoicesFailure['error'],
+): TimedTextTrackLanguageChoicesFailure => ({
+  error,
+  type: 'TIMED_TEXT_TRACK_LANGUAGE_CHOICES_FAILURE',
+});
+
+export interface TimedTextTrackLanguageChoicesSuccess {
+  languageChoices: LanguageChoice[];
+  type: 'TIMED_TEXT_TRACK_LANGUAGE_CHOICES_SUCCESS';
+}
+
+export const didTimedTextTrackLanguageChoices = (
+  languageChoices: LanguageChoice[],
+): TimedTextTrackLanguageChoicesSuccess => ({
+  languageChoices,
+  type: 'TIMED_TEXT_TRACK_LANGUAGE_CHOICES_SUCCESS',
+});

--- a/src/frontend/data/timedTextTrackLanguageChoices/reducer.spec.ts
+++ b/src/frontend/data/timedTextTrackLanguageChoices/reducer.spec.ts
@@ -1,0 +1,110 @@
+import { requestStatus } from '../../types/api';
+import { LanguageChoice } from '../../types/LanguageChoice';
+import {
+  TimedTextTrackLanguageChoicesFailure,
+  TimedTextTrackLanguageChoicesGet,
+  TimedTextTrackLanguageChoicesSuccess,
+} from './action';
+import {
+  timedTextTrackLanguageChoices,
+  TimedTextTrackLanguageChoicesState,
+} from './reducer';
+
+describe('Reducer: timedTextTrackLanguageChoices', () => {
+  it('returns the state as is when called with an unknown action', () => {
+    const previousState: TimedTextTrackLanguageChoicesState = {
+      items: [
+        {
+          label: 'French',
+          value: 'fr',
+        },
+      ],
+      status: requestStatus.SUCCESS,
+    };
+
+    expect(timedTextTrackLanguageChoices(previousState, { type: '' })).toEqual(
+      previousState,
+    );
+  });
+
+  it('returns empty items and failure status on TIMED_TEXT_TRACK_LANGUAGE_CHOICES_FAILURE action', () => {
+    const previousState: TimedTextTrackLanguageChoicesState = {
+      items: [],
+      status: null,
+    };
+
+    const action: TimedTextTrackLanguageChoicesFailure = {
+      error: 'it fails !',
+      type: 'TIMED_TEXT_TRACK_LANGUAGE_CHOICES_FAILURE',
+    };
+
+    expect(timedTextTrackLanguageChoices(previousState, action)).toEqual({
+      items: [],
+      status: requestStatus.FAILURE,
+    });
+  });
+
+  it('returns empty items and pending status on TIMED_TEXT_TRACK_LANGUAGE_CHOICES_GET action', () => {
+    const previousState: TimedTextTrackLanguageChoicesState = {
+      items: [],
+      status: null,
+    };
+
+    const action: TimedTextTrackLanguageChoicesGet = {
+      jwt: 'secured token',
+      type: 'TIMED_TEXT_TRACK_LANGUAGE_CHOICES_GET',
+    };
+
+    expect(timedTextTrackLanguageChoices(previousState, action)).toEqual({
+      items: [],
+      status: requestStatus.PENDING,
+    });
+  });
+  it('returns items and success status on TIMED_TEXT_TRACK_LANGUAGE_CHOICES_SUCCESS action', () => {
+    const previousState: TimedTextTrackLanguageChoicesState = {
+      items: [],
+      status: null,
+    };
+
+    const items: LanguageChoice[] = [
+      {
+        label: 'English',
+        value: 'en',
+      },
+      {
+        label: 'French',
+        value: 'fr',
+      },
+    ];
+    const action: TimedTextTrackLanguageChoicesSuccess = {
+      languageChoices: items,
+      type: 'TIMED_TEXT_TRACK_LANGUAGE_CHOICES_SUCCESS',
+    };
+
+    expect(timedTextTrackLanguageChoices(previousState, action)).toEqual({
+      items,
+      status: requestStatus.SUCCESS,
+    });
+  });
+
+  it('returns the current state if status is alreasy in success', () => {
+    const previousState: TimedTextTrackLanguageChoicesState = {
+      items: [
+        {
+          label: 'French',
+          value: 'fr',
+        },
+      ],
+      status: requestStatus.SUCCESS,
+    };
+
+    const action: TimedTextTrackLanguageChoicesGet = {
+      jwt: 'secured token',
+      type: 'TIMED_TEXT_TRACK_LANGUAGE_CHOICES_GET',
+    };
+
+    expect(timedTextTrackLanguageChoices(previousState, action)).toEqual(
+      previousState,
+    );
+  });
+});

--- a/src/frontend/data/timedTextTrackLanguageChoices/reducer.ts
+++ b/src/frontend/data/timedTextTrackLanguageChoices/reducer.ts
@@ -1,0 +1,55 @@
+import { AnyAction } from 'redux';
+
+import { requestStatus } from '../../types/api';
+import { LanguageChoice } from '../../types/LanguageChoice';
+import { Nullable } from '../../utils/types';
+import {
+  TimedTextTrackLanguageChoicesFailure,
+  TimedTextTrackLanguageChoicesGet,
+  TimedTextTrackLanguageChoicesSuccess,
+} from './action';
+
+export interface TimedTextTrackLanguageChoicesState {
+  items: LanguageChoice[];
+  status: Nullable<requestStatus>;
+}
+
+export type TimedTextTrackLanguageChoicesActions =
+  | AnyAction
+  | TimedTextTrackLanguageChoicesGet
+  | TimedTextTrackLanguageChoicesFailure
+  | TimedTextTrackLanguageChoicesSuccess;
+
+export const initialState = {
+  items: [],
+  status: null,
+};
+
+export const timedTextTrackLanguageChoices = (
+  state: TimedTextTrackLanguageChoicesState = initialState,
+  action: TimedTextTrackLanguageChoicesActions,
+): TimedTextTrackLanguageChoicesState => {
+  if (state.status === requestStatus.SUCCESS) {
+    return state;
+  }
+
+  switch (action.type) {
+    case 'TIMED_TEXT_TRACK_LANGUAGE_CHOICES_GET':
+      return {
+        items: [],
+        status: requestStatus.PENDING,
+      };
+    case 'TIMED_TEXT_TRACK_LANGUAGE_CHOICES_FAILURE':
+      return {
+        items: [],
+        status: requestStatus.FAILURE,
+      };
+    case 'TIMED_TEXT_TRACK_LANGUAGE_CHOICES_SUCCESS':
+      return {
+        items: (action as TimedTextTrackLanguageChoicesSuccess).languageChoices,
+        status: requestStatus.SUCCESS,
+      };
+  }
+
+  return state;
+};

--- a/src/frontend/types/LanguageChoice.ts
+++ b/src/frontend/types/LanguageChoice.ts
@@ -1,0 +1,4 @@
+export interface LanguageChoice {
+  label: string;
+  value: string;
+}


### PR DESCRIPTION
## Purpose

We want to manage language choices in redux store. Once in the store we
can connect every component using them. This will avoid multiple call to
the API for nothing.

## Proposal

Description...

- [x] create a saga to fetch the API and retrieve language choices.
- [x] create a new entry in the redux store with language choices.
- [x] use languages choices in the store on all component using language choices.

