### PR TITLE
⚡️(player) use a poster to speed up player displaying

### DIFF
--- a/src/frontend/components/VideoPlayer/VideoPlayer.spec.tsx
+++ b/src/frontend/components/VideoPlayer/VideoPlayer.spec.tsx
@@ -39,6 +39,9 @@ describe('VideoPlayer', () => {
         144: 'https://example.com/144p.mp4',
         1080: 'https://example.com/1080p.mp4',
       },
+      thumbnails: {
+        720: 'https://example.com/144p.jpg',
+      },
     },
   } as Video;
 

--- a/src/frontend/components/VideoPlayer/VideoPlayer.tsx
+++ b/src/frontend/components/VideoPlayer/VideoPlayer.tsx
@@ -76,7 +76,11 @@ export class VideoPlayer extends React.Component<
     }
 
     return (
-      <video ref={node => (this.videoNodeRef = node)} crossOrigin="anonymous">
+      <video
+        ref={node => (this.videoNodeRef = node)}
+        crossOrigin="anonymous"
+        poster={video.urls.thumbnails[720]}
+      >
         <source
           src={video.urls.manifests.hls}
           size="auto"


### PR DESCRIPTION
## Purpose

The player must start as fast as possible and show a thumbnail of the video.

Fix #241 

## Proposal

AWS craft thumbnails for us, we just have to use them as a video poster. The thumbnails seem to always be the first video frame.

- [x] Use `poster` attribute on `video` tag to display available thumbnail.

