### PR TITLE
🐛(timedtexttrack) exclude existing language in language choices

### DIFF
--- a/src/frontend/components/DashboardTimedTextManager/DashboardTimedTextManager.tsx
+++ b/src/frontend/components/DashboardTimedTextManager/DashboardTimedTextManager.tsx
@@ -36,10 +36,13 @@ export class DashboardTimedTextManager extends React.Component<
         <DashboardInternalHeading>
           <FormattedMessage {...message} />
         </DashboardInternalHeading>
-        {tracks.map(track => (
-          <TimedTextListItemConnected key={track.id} track={track} />
-        ))}
-        <TimedTextCreationFormConnected mode={mode} />
+        {tracks.map(track => {
+          return <TimedTextListItemConnected key={track.id} track={track} />;
+        })}
+        <TimedTextCreationFormConnected
+          mode={mode}
+          excludedLanguages={tracks.map(track => track.language)}
+        />
       </DashboardTimedTextManagerStyled>
     );
   }

--- a/src/frontend/components/TimedTextCreationForm/TimedTextCreationForm.spec.tsx
+++ b/src/frontend/components/TimedTextCreationForm/TimedTextCreationForm.spec.tsx
@@ -2,6 +2,7 @@ import { flushAllPromises } from '../../testSetup';
 
 import { shallow, ShallowWrapper } from 'enzyme';
 import * as React from 'react';
+import Select from 'react-select';
 
 jest.mock(
   '../../data/sideEffects/createTimedTextTrack/createTimedTextTrack',
@@ -29,6 +30,7 @@ describe('<TimedTextCreationForm />', () => {
     const wrapper = shallow(
       <TimedTextCreationForm
         getTimedTextTrackLanguageChoices={jest.fn()}
+        excludedLanguages={['en']}
         languageChoices={[
           { label: 'English', value: 'en' },
           { label: 'French', value: 'fr' },
@@ -42,6 +44,9 @@ describe('<TimedTextCreationForm />', () => {
     await flushAllPromises();
 
     expect(wrapper.html()).toContain('Add a language');
+    expect(wrapper.find(Select).prop('options')).toEqual([
+      { label: 'French', value: 'fr' },
+    ]);
   });
 
   describe('createAndGoToUpload()', () => {
@@ -52,6 +57,7 @@ describe('<TimedTextCreationForm />', () => {
       wrapper = shallow(
         <TimedTextCreationForm
           getTimedTextTrackLanguageChoices={jest.fn()}
+          excludedLanguages={[]}
           languageChoices={[
             { label: 'English', value: 'en' },
             { label: 'French', value: 'fr' },

--- a/src/frontend/components/TimedTextCreationForm/TimedTextCreationForm.tsx
+++ b/src/frontend/components/TimedTextCreationForm/TimedTextCreationForm.tsx
@@ -58,6 +58,7 @@ export interface TimedTextCreationFormProps {
   createTimedTextTrack: (timedtexttrack: TimedText) => void;
   getTimedTextTrackLanguageChoices: (jwt: string) => void;
   jwt: string;
+  excludedLanguages: string[];
   languageChoices: LanguageChoice[];
   mode: timedTextMode;
 }
@@ -113,7 +114,11 @@ export class TimedTextCreationForm extends React.Component<
 
   render() {
     const { error, newTTLanguage, newTTUploadId } = this.state;
-    const { languageChoices } = this.props;
+    const { languageChoices, excludedLanguages } = this.props;
+
+    const availableLanguages = languageChoices.filter(
+      language => !excludedLanguages.includes(language.value),
+    );
 
     if (error === 'schema') {
       return <Redirect push to={ERROR_COMPONENT_ROUTE('notFound')} />;
@@ -133,7 +138,7 @@ export class TimedTextCreationForm extends React.Component<
         <FormattedMessage {...messages.addTrackLabel} />
         <Select
           onChange={this.onSelectChange.bind(this)}
-          options={languageChoices}
+          options={availableLanguages}
           styles={{ input: styles => ({ ...styles, width: '8rem' }) }}
         />
         <Button


### PR DESCRIPTION
## Purpose

Once a timed text track created, it is not possible to create an other
one with the same language. To avoid this mistake the language should not
be available in the language select box.

Fix #236 

## Proposal

For each mode we need to know every languages already created and them exclude them from the list of available languages.

- [x] Group existing language code for each mode.
- [x] Exclude them from the list of available language to create.

