### PR TITLE
✨(player) display language label in Plyr captions

### DIFF
--- a/src/frontend/components/VideoPlayer/VideoPlayer.spec.tsx
+++ b/src/frontend/components/VideoPlayer/VideoPlayer.spec.tsx
@@ -13,6 +13,7 @@ const createPlayer = jest.fn(() => ({
 
 const mockInitialize = jest.fn();
 const mockSetInitialBitrateFor = jest.fn();
+const mockGetTimedTextTrackLanguageChoices = jest.fn();
 
 jest.mock('dashjs', () => ({
   MediaPlayer: () => ({
@@ -47,7 +48,9 @@ describe('VideoPlayer', () => {
 
   const props = {
     createPlayer,
+    getTimedTextTrackLanguageChoices: mockGetTimedTextTrackLanguageChoices,
     jwt: 'foo',
+    languageChoices: [{ label: 'French', value: 'fr' }],
     timedtexttracks: {
       objects: [
         {
@@ -74,7 +77,7 @@ describe('VideoPlayer', () => {
           active_stamp: 1549385923,
           id: 'ttt-3',
           is_ready_to_play: true,
-          language: 'fr',
+          language: 'en',
           mode: timedTextMode.CLOSED_CAPTIONING,
           upload_state: uploadState.READY,
           url: 'https://example.com//timedtext/ttt-3.vtt',
@@ -113,11 +116,13 @@ describe('VideoPlayer', () => {
     );
 
     expect(content).toContain(
-      '<track src="https://example.com//timedtext/ttt-1.vtt" srcLang="fr" kind="subtitles" label="fr"/>',
+      '<track src="https://example.com//timedtext/ttt-1.vtt" srcLang="fr" kind="subtitles" label="French"/>',
     );
     expect(content).toContain(
-      '<track src="https://example.com//timedtext/ttt-3.vtt" srcLang="fr" kind="captions" label="fr"/>',
+      '<track src="https://example.com//timedtext/ttt-3.vtt" srcLang="en" kind="captions" label="en"/>',
     );
+
+    expect(mockGetTimedTextTrackLanguageChoices).toHaveBeenCalledWith('foo');
   });
 
   it('starts up the player when it mounts', () => {

--- a/src/frontend/components/VideoPlayerConnected/VideoPlayerConnected.spec.tsx
+++ b/src/frontend/components/VideoPlayerConnected/VideoPlayerConnected.spec.tsx
@@ -11,10 +11,20 @@ describe('<VideoPlayerConnected />', () => {
       video: { id: 42 } as any,
     };
 
+    const languageChoices = [{ label: 'French', value: 'fr' }];
+
     it('picks video from the store if available', () => {
       const state = {
         context: {
           jwt: 'foo',
+        },
+        languageChoices: {
+          items: [
+            {
+              label: 'French',
+              value: 'fr',
+            },
+          ],
         },
         resources: {
           [modelName.VIDEOS]: { byId: { 42: 'some video' as any } },
@@ -23,6 +33,7 @@ describe('<VideoPlayerConnected />', () => {
       } as any;
       expect(mapStateToProps(state, props)).toEqual({
         jwt: 'foo',
+        languageChoices,
         timedtexttracks: {
           objects: [],
           status: null,
@@ -36,6 +47,10 @@ describe('<VideoPlayerConnected />', () => {
         context: {
           jwt: 'foo',
         },
+        languageChoices: {
+          items: languageChoices,
+          status: requestStatus.SUCCESS,
+        },
         resources: {
           [modelName.VIDEOS]: { byId: { 43: 'some video' as any } },
           [modelName.TIMEDTEXTTRACKS]: {},
@@ -43,6 +58,7 @@ describe('<VideoPlayerConnected />', () => {
       } as any;
       expect(mapStateToProps(state, props)).toEqual({
         jwt: 'foo',
+        languageChoices,
         timedtexttracks: {
           objects: [],
           status: null,
@@ -53,6 +69,10 @@ describe('<VideoPlayerConnected />', () => {
       state = {
         context: {
           jwt: 'foo',
+        },
+        languageChoices: {
+          items: languageChoices,
+          status: requestStatus.SUCCESS,
         },
         resources: {
           [modelName.VIDEOS]: { byId: {} },
@@ -61,6 +81,7 @@ describe('<VideoPlayerConnected />', () => {
       } as any;
       expect(mapStateToProps(state, props)).toEqual({
         jwt: 'foo',
+        languageChoices,
         timedtexttracks: {
           objects: [],
           status: null,
@@ -72,6 +93,10 @@ describe('<VideoPlayerConnected />', () => {
         context: {
           jwt: 'foo',
         },
+        languageChoices: {
+          items: languageChoices,
+          status: requestStatus.SUCCESS,
+        },
         resources: {
           [modelName.VIDEOS]: {},
           [modelName.TIMEDTEXTTRACKS]: {},
@@ -79,6 +104,7 @@ describe('<VideoPlayerConnected />', () => {
       } as any;
       expect(mapStateToProps(state, props)).toEqual({
         jwt: 'foo',
+        languageChoices,
         timedtexttracks: {
           objects: [],
           status: null,
@@ -91,6 +117,10 @@ describe('<VideoPlayerConnected />', () => {
       const state = {
         context: {
           jwt: 'foo',
+        },
+        languageChoices: {
+          items: languageChoices,
+          status: requestStatus.SUCCESS,
         },
         resources: {
           [modelName.VIDEOS]: {},
@@ -109,6 +139,7 @@ describe('<VideoPlayerConnected />', () => {
       } as any;
       expect(mapStateToProps(state, props)).toEqual({
         jwt: 'foo',
+        languageChoices,
         timedtexttracks: {
           objects: [{ id: '42' }, { id: '84' }, { id: '168' }],
           status: requestStatus.SUCCESS,

--- a/src/frontend/components/VideoPlayerConnected/VideoPlayerConnected.tsx
+++ b/src/frontend/components/VideoPlayerConnected/VideoPlayerConnected.tsx
@@ -1,14 +1,11 @@
 import { connect } from 'react-redux';
 import { Dispatch } from 'redux';
 
-import { getResourceList } from '../../data/genericReducers/resourceList/actions';
 import { RootState } from '../../data/rootReducer';
+import { getTimedTextTrackLanguageChoices } from '../../data/timedTextTrackLanguageChoices/action';
 import { getTimedTextTracks } from '../../data/timedtexttracks/selector';
-import { ConsumableQuery } from '../../types/api';
 import { appStateSuccess } from '../../types/AppData';
 import { modelName } from '../../types/models';
-import { TimedText, Video } from '../../types/tracks';
-import { Nullable } from '../../utils/types';
 import { VideoPlayer, VideoPlayerProps } from '../VideoPlayer/VideoPlayer';
 
 type VideoPlayerConnectedProps = Pick<
@@ -25,6 +22,7 @@ export const mapStateToProps = (
   { video }: VideoPlayerConnectedProps,
 ) => ({
   jwt: state.context.jwt,
+  languageChoices: state.languageChoices.items,
   timedtexttracks: getTimedTextTracks(state),
   video:
     (state.resources[modelName.VIDEOS]!.byId &&
@@ -32,8 +30,16 @@ export const mapStateToProps = (
     video,
 });
 
+const mapDispatchToProps = (dispatch: Dispatch) => ({
+  getTimedTextTrackLanguageChoices: (jwt: string) =>
+    dispatch(getTimedTextTrackLanguageChoices(jwt)),
+});
+
 /**
  * Component. Displays a player to show the video from context.
  * @param video The video to show.
  */
-export const VideoPlayerConnected = connect(mapStateToProps)(VideoPlayer);
+export const VideoPlayerConnected = connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(VideoPlayer);


### PR DESCRIPTION
## Purpose

We can display the language label instead of its code in the player
captions' list.

## Proposal

- [x] connect `langaugesChoices` to `<VideoPlayer />`
- [x] use language label in track tag

