### PR TITLE
Add a feature check for MSE support before using DashJS in the player

### DIFF
--- a/src/frontend/utils/isAbrSupported.ts
+++ b/src/frontend/utils/isAbrSupported.ts
@@ -1,0 +1,7 @@
+/**
+ * Dashjs requires the Media Source Extensions (MSE) to work. They are not available in every browser,
+ * we therefore need to do a feature check before we initialize dash.
+ */
+export const isMSESupported = () =>
+  !!(window as { MediaSource?: MediaSource }).MediaSource &&
+  !!MediaSource.isTypeSupported;


### PR DESCRIPTION
## Purpose

The `<VideoPlayer />` did not run a feature check before initializing dashjs. This caused an exception on iOS devices as they do not offer the MSE that dashjs relies on. There, ABR is supported through builtin HLS instead.

## Proposal

We can simply add a check for MSE and only load dashjs when they are available. iOS can then use HLS and other non-MSE-compatible browsers will just use MP4 sources.

We took this opportunity to stop loading MP4 sources when dashjs is enabled as loading the MP4 sources adds a UI to select video definition, which is always overridden by dashjs.