### PR TITLE
Docker translation step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,8 +44,8 @@ jobs:
   build:
     # We use the machine executor, i.e. a VM, not a container
     machine:
-      # Cache docker layers so that we strongly speed up this job execution
-      docker_layer_caching: true
+      # Avoid cache in the production build
+      docker_layer_caching: false
     working_directory: ~/marsha
     steps:
       # Checkout repository sources
@@ -290,6 +290,9 @@ jobs:
       - run:
           name: Install front-end dependencies
           command: yarn install --frozen-lockfile
+      - run:
+          name: Compile translations
+          command: yarn generate-translations
       - run:
           name: Build front-end application
           command: yarn build

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ WORKDIR /app
 COPY ./src/frontend /app/
 
 RUN yarn install --frozen-lockfile && \
+    yarn generate-translations && \
     yarn build --mode=production -o marsha/static/js/index.js
 
 # ---- final application image ----

--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,7 @@ test:  ## Run django tests for the marsha project.
 
 .PHONY: build-front
 build-front: ## Build front application
+	@$(YARN) generate-translations
 	@$(YARN) build
 
 .PHONY: watch-front
@@ -131,7 +132,6 @@ env.d/development:
 bootstrap: env.d/development ## Prepare Docker images for the project
 	@$(COMPOSE) build base;
 	@$(COMPOSE) build app;
-	@$(YARN) build-dev
 	@echo 'Waiting until database is up…';
 	$(COMPOSE_RUN_APP) dockerize -wait tcp://db:5432 -timeout 60s
 	${MAKE} migrate;

--- a/docker/images/alpine/Dockerfile
+++ b/docker/images/alpine/Dockerfile
@@ -44,6 +44,7 @@ WORKDIR /app
 COPY ./src/frontend /app/
 
 RUN yarn install && \
+    yarn generate-translations && \
     yarn build -o marsha/static/js/index.js
 
 # ---- final application image ----

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -4,7 +4,7 @@
   "description": "🐠 a FUN LTI video provider",
   "main": "front/index.tsx",
   "scripts": {
-    "build": "yarn generate-translations; tsc --noEmit && webpack",
+    "build": "tsc --noEmit && webpack",
     "build-dev": "yarn copy-iframe-resizer; yarn build",
     "generate-l10n-template": "rip json2pot 'i18n/**/*.json' -o i18n/frontend.pot",
     "generate-translations": "rip po2json './translations/*.po' -o './translations/translation.json' -m './i18n/**/*.json'",


### PR DESCRIPTION
## Purpose

Having compiling translation task inscluded in the yarn build task is confusing and circleci keep unwanted cache when build production step is executed. We want to split the translation and the build in two different steps and avoid having docker cache when the product image is built

## Proposal

- [x] split build and translation tak in two distinct tasks
- [x] Avoid having docker cache when production image is build

