### PR TITLE
🐛(crowdin) use fundocker image to run crowdin-cli

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - "db"
 
   crowdin:
-    image: alconost/crowdin
+    image: fundocker/crowdin:2.0.27
     volumes:
       - ".:/app"
     env_file:


### PR DESCRIPTION
## Purpose

Previous image used in the project does not exists anymore, it was
deleted by its owner. We built a new one available on the fundocker
account.

## Proposal

- [x] use our own image for the `crowdin` service.