### PR TITLE
💩(player) attempt to fix video playback on iOS devices

### DIFF
--- a/src/frontend/components/VideoPlayer/VideoPlayer.spec.tsx
+++ b/src/frontend/components/VideoPlayer/VideoPlayer.spec.tsx
@@ -117,10 +117,6 @@ describe('VideoPlayer', () => {
     mockIsMSESupported.mockReturnValue(true);
     const wrapper = mount(<VideoPlayer {...props} />);
 
-    // Source for HLS is always rendered (as non iOS browsers will not load it)
-    expect(wrapper.html()).toContain(
-      '<source src="https://example.com/hls.m3u8" type="application/vnd.apple.mpegURL">',
-    );
     // Sources for basic MP4 are not rendered as they are not useful when DashJS is active
     expect(wrapper.html()).not.toContain(
       '<source size="144" src="https://example.com/144p.mp4" type="video/mp4">',
@@ -173,10 +169,6 @@ describe('VideoPlayer', () => {
     mockIsMSESupported.mockReturnValue(false);
     const wrapper = mount(<VideoPlayer {...props} />);
 
-    // Source for HLS is always rendered (as non iOS browsers will not load it)
-    expect(wrapper.html()).toContain(
-      '<source src="https://example.com/hls.m3u8" type="application/vnd.apple.mpegURL">',
-    );
     // Sources for basic MP4 are rendered
     expect(wrapper.html()).toContain(
       '<source size="144" src="https://example.com/144p.mp4" type="video/mp4">',

--- a/src/frontend/components/VideoPlayer/VideoPlayer.tsx
+++ b/src/frontend/components/VideoPlayer/VideoPlayer.tsx
@@ -126,11 +126,6 @@ export class VideoPlayer extends React.Component<
           crossOrigin="anonymous"
           poster={video.urls.thumbnails[720]}
         >
-          <source
-            src={video.urls.manifests.hls}
-            size="auto"
-            type="application/vnd.apple.mpegURL"
-          />
           {!this.state.isDashSupported &&
             (Object.keys(video.urls.mp4) as videoSize[]).map(size => (
               <source


### PR DESCRIPTION
## Purpose

iOS devices are supposed to manage Adaptive bitrate playback with the HLS spec natively. For a reason we have yet to uncover, we get errors as we try to play an HLS video (our current theory is that our manifest file and/or video fragments may be in a format iOS devices do not support).

## Proposal

We therefore removed HLS from the sources so iOS devices will just use regular old `.mp4` files.

We cannot be sure yet that this works as our development environments fail due to CORS issues (that do not exist on staging & production environments).

