### PR TITLE
🐛(crowdin) use fundocker/crowdin image in CI docker-compose

### DIFF
--- a/docker/compose/ci/docker-compose.yml
+++ b/docker/compose/ci/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - "db"
 
   crowdin:
-    image: alconost/crowdin
+    image: fundocker/crowdin:2.0.27
     volumes:
       - ".:/app"
     environment:


### PR DESCRIPTION
## Purpose

CI does not use our new fundocker/crowdin image so it fails to upload
translations when a branch is merged on master.

## Proposal

- [x] change the image used in CI's  docker-compose.yml` file