### PR TITLE
🔧(front) use core-js 3 combined with babel-preset-env

### DIFF
--- a/src/frontend/babel.config.js
+++ b/src/frontend/babel.config.js
@@ -14,6 +14,7 @@ module.exports = {
       {
         forceAllTransforms: true,
         useBuiltIns: 'usage',
+        corejs: 3,
       },
     ],
     '@babel/preset-typescript',

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -61,6 +61,7 @@
     "webpack-cli": "3.3.0"
   },
   "dependencies": {
+    "core-js": "3",
     "dashjs": "2.9.3",
     "grommet": "2.6.5",
     "iframe-resizer": "4.0.4",

--- a/src/frontend/yarn.lock
+++ b/src/frontend/yarn.lock
@@ -2426,7 +2426,7 @@ core-js-pure@3.0.0:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.0.0.tgz#a5679adb4875427c8c0488afc93e6f5b7125859b"
   integrity sha512-yPiS3fQd842RZDgo/TAKGgS0f3p2nxssF1H65DIZvZv0Od5CygP8puHXn3IQiM/39VAvgCbdaMQpresrbGgt9g==
 
-core-js@3.0.0:
+core-js@3, core-js@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.0.0.tgz#a8dbfa978d29bfc263bfb66c556d0ca924c28957"
   integrity sha512-WBmxlgH2122EzEJ6GH8o9L/FeoUKxxxZ6q6VUxoTlsE4EvbTWKJb447eyVxTEuq0LpXjlq/kCB2qgBvsYRkLvQ==


### PR DESCRIPTION
## Purpose

Babel-preset-env 7.4.0 can be used with core-js 3 and core-js 2. We have
to explicitly which version we want to use or we will have a warning
message when building the project. You can find more information here
https://github.com/zloirock/core-js/blob/master/docs/2019-03-19-core-js-3-babel-and-a-look-into-the-future.md#usebuiltins-usage-with-corejs-3

## Proposal

- [x] require core-js 3
- [x] change babel config to add `corejs: 3` in `@babel/present-env` settings.
