### PR TITLE
Fix moving static files to s3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Replace the `CLOUDFRONT_URL` setting by a `CLOUDFRONT_DOMAIN` setting to uniformize with what
+  django-storages is doing and share the same settings.
+
 ## [2.5.0] - 2019-03-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Replace the `CLOUDFRONT_URL` setting by a `CLOUDFRONT_DOMAIN` setting to uniformize with what
   django-storages is doing and share the same settings.
+- Downgrade django-storages to 1.6.3, the last version compatible with ManifestStaticFilesStorage
 
 ## [2.5.0] - 2019-03-25
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     * Create a new environment variable: `DJANGO_AWS_S3_REGION_NAME`
       (see [doc](./docs/env.md#django_aws_s3_region_name) for information about how
       to set this variable),
+    * Create a new environment variable: `DJANGO_CLOUDFRONT_DOMAIN`
+      (see [doc](./docs/env.md#django_cloudfront_domain) for information about how
+      to set this variable),
     * Update your AWS stack to create the necessary buckets, CloudFront distribution
       and bucket policy. To do so, checkout the new release code and run:
 
@@ -41,3 +44,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### After switching
 
 - Remove the `DJANGO_AWS_DEFAULT_REGION` environment variable.
+- Remove the `DJANGO_CLOUDFRONT_URL` environment variable.

--- a/docs/env.md
+++ b/docs/env.md
@@ -268,9 +268,10 @@ Note: Preview images are never signed as a matter of policy; adaptive streaming 
   - `True` in all other environments.
 - Choices: `True` or `False`
 
-#### DJANGO_CLOUDFRONT_URL
+#### DJANGO_CLOUDFRONT_DOMAIN
 
-The URL for the AWS Cloudfront distribution for the relevant AWS deployment. This is the domain that will be used to distribute processed files to end users.
+The domain for the AWS Cloudfront distribution for the relevant AWS deployment. This is the domain
+that will be used to distribute processed files to end users.
 
 - Type: string
 - Required: Yes

--- a/env.d/ci
+++ b/env.d/ci
@@ -16,5 +16,5 @@ DJANGO_AWS_ACCESS_KEY_ID=aws-access-key-id
 DJANGO_AWS_SECRET_ACCESS_KEY=aws-secret-access-key
 
 # AWS
-DJANGO_CLOUDFRONT_URL=https://abc.cloudfront.net
+DJANGO_CLOUDFRONT_DOMAIN=abc.cloudfront.net
 DJANGO_UPDATE_STATE_SHARED_SECRETS=dummy,secret

--- a/env.d/development.dist
+++ b/env.d/development.dist
@@ -24,7 +24,7 @@ DJANGO_AWS_SOURCE_BUCKET_NAME=dev-marsha-source
 
 # Cloudfront Signed URLs for mp4 files
 DJANGO_CLOUDFRONT_SIGNED_URLS_ACTIVE=False
-DJANGO_CLOUDFRONT_URL=https://yourCloudfrontUrl
+DJANGO_CLOUDFRONT_DOMAIN=yourCloudfrontUrl
 # variable below should be uncommented if DJANGO_CLOUDFRONT_SIGNED_URLS_ACTIVE is set to True
 # DJANGO_CLOUDFRONT_PRIVATE_KEY_PATH=/path/to/cloudfront/ssh/private_key
 # DJANGO_CLOUDFRONT_ACCESS_KEY_ID=YourCloudfrontAccessKeyId

--- a/env.d/test
+++ b/env.d/test
@@ -16,5 +16,5 @@ DJANGO_AWS_ACCESS_KEY_ID=aws-access-key-id
 DJANGO_AWS_SECRET_ACCESS_KEY=aws-secret-access-key
 
 # AWS
-DJANGO_CLOUDFRONT_URL=https://abc.cloudfront.net
+DJANGO_CLOUDFRONT_DOMAIN=abc.cloudfront.net
 DJANGO_UPDATE_STATE_SHARED_SECRETS=dummy,secret

--- a/src/aws/cloudfront.tf
+++ b/src/aws/cloudfront.tf
@@ -106,7 +106,7 @@ resource "aws_cloudfront_distribution" "marsha_cloudfront_distribution" {
 
   # Static bucket: allow public access
   ordered_cache_behavior {
-    path_pattern     = "*/static/*"
+    path_pattern     = "/static/*"
     allowed_methods  = ["GET", "HEAD", "OPTIONS"]
     cached_methods   = ["GET", "HEAD", "OPTIONS"]
     target_origin_id = "${local.s3_static_origin_id}"

--- a/src/backend/marsha/core/serializers.py
+++ b/src/backend/marsha/core/serializers.py
@@ -146,8 +146,10 @@ class TimedTextTrackSerializer(serializers.ModelSerializer):
         """
         if obj.uploaded_on:
 
-            base = "{cloudfront:s}/{video!s}".format(
-                cloudfront=settings.CLOUDFRONT_URL, video=obj.video.pk
+            base = "{protocol:s}://{cloudfront:s}/{video!s}".format(
+                protocol=settings.AWS_S3_URL_PROTOCOL,
+                cloudfront=settings.CLOUDFRONT_DOMAIN,
+                video=obj.video.pk,
             )
             url = "{base:s}/timedtext/{stamp:s}_{language:s}{mode:s}.vtt".format(
                 base=base,
@@ -239,8 +241,10 @@ class ThumbnailSerializer(serializers.ModelSerializer):
 
         """
         if obj.uploaded_on:
-            base = "{cloudfront:s}/{video!s}".format(
-                cloudfront=settings.CLOUDFRONT_URL, video=obj.video.pk
+            base = "{protocol:s}://{cloudfront:s}/{video!s}".format(
+                protocol=settings.AWS_S3_URL_PROTOCOL,
+                cloudfront=settings.CLOUDFRONT_DOMAIN,
+                video=obj.video.pk,
             )
             urls = {}
             for resolution in settings.VIDEO_RESOLUTIONS:
@@ -324,8 +328,10 @@ class VideoSerializer(serializers.ModelSerializer):
 
         urls = {"mp4": {}, "thumbnails": {}}
 
-        base = "{cloudfront:s}/{pk!s}".format(
-            cloudfront=settings.CLOUDFRONT_URL, pk=obj.pk
+        base = "{protocol:s}://{cloudfront:s}/{pk!s}".format(
+            protocol=settings.AWS_S3_URL_PROTOCOL,
+            cloudfront=settings.CLOUDFRONT_DOMAIN,
+            pk=obj.pk,
         )
         stamp = time_utils.to_timestamp(obj.uploaded_on)
 

--- a/src/backend/marsha/core/storage.py
+++ b/src/backend/marsha/core/storage.py
@@ -33,4 +33,4 @@ class ConfigurableManifestS3Boto3Storage(
     """
 
     bucket_name = settings.AWS_STATIC_BUCKET_NAME
-    custom_domain = settings.CLOUDFRONT_URL
+    custom_domain = settings.CLOUDFRONT_DOMAIN

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -352,6 +352,10 @@ class Production(Base):
     }
     AWS_STATIC_BUCKET_NAME = values.Value("production-marsha-static")
 
+    # folder where static will be stored. It matches the path_pattern used
+    # in the cloudfront configuration.
+    AWS_LOCATION = Base.STATIC_URL
+
 
 class Staging(Production):
     """Staging environment settings."""

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -37,7 +37,8 @@ install_requires =
     djangorestframework==3.8
     djangorestframework_simplejwt==3.2.3
     django-safedelete==0.5.1
-    django-storages==1.7.1
+    # superior versions of django-storages are not compatible with ManifestStaticFilesStorage
+    django-storages==1.6.3
     dockerflow==2018.4.0
     gunicorn==19.8.1
     # Warning from psycopg2 "The psycopg2 wheel package will be renamed from release 2.8" => psyopg2-binary


### PR DESCRIPTION
## Purpose

Two bugs prevented us from deploying the new feature of hosting static files on S3/CloudFront:

- django-storages incompatibility with ManifestStaticFilesStorage backend
- repeated protocol in the cloudfront urls computed by the static files storage backend (https://https://cloudfront-url)

## Proposal

- Downgrade django-storages to 1.6.3 which is the last version to work with ManifestStaticFilesStorage,
- Refactor CloudFront url setting to align on what django-storages is doing : one setting for protocol and one setting for domain.
