### PR TITLE
🔖(patch) bump release to 2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.6.0] - 2019-04-01
+
+### Added
+
+- Upload a custom video thumbnail
+- use S3 to store and Cloudfront to distribute static files
+
 ### Fixed
 
 - Replace the `CLOUDFRONT_URL` setting by a `CLOUDFRONT_DOMAIN` setting to uniformize with what

--- a/src/aws/lambda-configure/package.json
+++ b/src/aws/lambda-configure/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-configure",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "engines": {
     "node": ">8.10"
   },

--- a/src/aws/lambda-encode/package.json
+++ b/src/aws/lambda-encode/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-convert",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "engines": {
     "node": ">8.10"
   },

--- a/src/aws/lambda-update-state/package.json
+++ b/src/aws/lambda-update-state/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-update-state",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "engines": {
     "node": ">8.10"
   },

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -2,7 +2,7 @@
 name = marsha
 description = A FUN video provider for Open edX
 long_description = file:README.rst
-version = 2.5.0
+version = 2.6.0
 author = Open FUN (France Universite Numerique)
 author_email = fun.dev@fun-mooc.fr
 license = MIT

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marsha",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "🐠 a FUN LTI video provider",
   "main": "front/index.tsx",
   "scripts": {


### PR DESCRIPTION
### Added

- Upload a custom video thumbnail
- use S3 to store and Cloudfront to distribute static files

### Fixed

- Replace the `CLOUDFRONT_URL` setting by a `CLOUDFRONT_DOMAIN` setting to uniformize with what
  django-storages is doing and share the same settings.
- Downgrade django-storages to 1.6.3, the last version compatible with ManifestStaticFilesStorage

