### PR TITLE
👷(circleci) add check CHANGELOG job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -273,6 +273,16 @@ jobs:
                   -timeout 60s \
                     python manage.py test
 
+  check-changelog:
+    machine: true
+    working_directory: ~/marsha
+    steps:
+      - checkout
+      - run:
+          name: Check that the CHANGELOG has been modified in the current branch
+          command: |
+            git whatchanged --name-only --pretty="" origin..HEAD | grep CHANGELOG
+
   # ---- Front-end jobs ----
   build-front:
     docker:
@@ -687,6 +697,12 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - check-changelog:
+          filters:
+            branches:
+              ignore: master
+            tags:
+              ignore: /.*/
 
       # Docker alpine jobs
       #


### PR DESCRIPTION
## Purpose

We need a way to remind us to update the project's `CHANGELOG` when we submitting a PR.

## Proposal

- [x] add a `check-changelog` job to the CI

One may believe that this is another annoying task, but the experience we had with Arnold's repository shows that it drastically speeds up the release cycle since almost everything has already been prepared upfront.

You may have noticed that this job **is not required** to merge a PR since the `CHANGELOG` does not have to be updated for every submitted changes.