### PR TITLE
Deactivate video modification when the video is not in the original consumer site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - LRS credentials can be configured at the consumer site level.
 - Configure in the consumer site admin panel if by default videos can show a download link.
+- Do not allow video modification when the consumer site used is not the one used
+  to create the video.
 
 ### Changed
 

--- a/src/backend/marsha/core/permissions.py
+++ b/src/backend/marsha/core/permissions.py
@@ -33,8 +33,10 @@ class IsVideoTokenOrAdminUser(permissions.IsAdminUser):
 
         """
         user = request.user
-        if isinstance(user, TokenUser) and LTI_ROLES[INSTRUCTOR] & set(
-            user.token.payload.get("roles", [])
+        if (
+            isinstance(user, TokenUser)
+            and LTI_ROLES[INSTRUCTOR] & set(user.token.payload.get("roles", []))
+            and user.token.payload.get("read_only", True) is False
         ):
             return True
 

--- a/src/backend/marsha/core/tests/test_api_thumbnail.py
+++ b/src/backend/marsha/core/tests/test_api_thumbnail.py
@@ -48,6 +48,22 @@ class ThumbnailApiTest(TestCase):
 
         self.assertEqual(response.status_code, 403)
 
+    def test_api_thumbnail_instructor_read_detail_in_read_only(self):
+        """Instructor should not be able to read thumbnails in a read_only mode."""
+        thumbnail = ThumbnailFactory()
+
+        jwt_token = AccessToken()
+        jwt_token.payload["video_id"] = str(thumbnail.video.id)
+        jwt_token.payload["roles"] = ["instructor"]
+        jwt_token.payload["read_only"] = True
+
+        response = self.client.get(
+            "/api/thumbnail/{!s}/".format(thumbnail.id),
+            HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token),
+        )
+
+        self.assertEqual(response.status_code, 403)
+
     @override_settings(CLOUDFRONT_SIGNED_URLS_ACTIVE=False)
     def test_api_thumbnail_read_detail_token_user(self):
         """Instructors should be able to read details of thumbnail assotiated to their video."""
@@ -59,6 +75,7 @@ class ThumbnailApiTest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["video_id"] = str(video.id)
         jwt_token.payload["roles"] = ["instructor"]
+        jwt_token.payload["read_only"] = False
 
         response = self.client.get(
             "/api/thumbnail/{!s}/".format(thumbnail.id),
@@ -96,6 +113,7 @@ class ThumbnailApiTest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["video_id"] = str(video.id)
         jwt_token.payload["roles"] = ["instructor"]
+        jwt_token.payload["read_only"] = False
 
         response = self.client.get(
             "/api/thumbnail/{!s}/".format(thumbnail.id),
@@ -154,6 +172,7 @@ class ThumbnailApiTest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["video_id"] = str(video.id)
         jwt_token.payload["roles"] = ["instructor"]
+        jwt_token.payload["read_only"] = False
 
         response = self.client.post(
             "/api/thumbnail/", HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token)
@@ -174,6 +193,21 @@ class ThumbnailApiTest(TestCase):
                 "video": str(video.id),
             },
         )
+
+    def test_api_thumbnail_instructor_create_in_read_only(self):
+        """Instructor should not be able to create thumbnails in a read_only mode."""
+        thumbnail = ThumbnailFactory()
+
+        jwt_token = AccessToken()
+        jwt_token.payload["video_id"] = str(thumbnail.video.id)
+        jwt_token.payload["roles"] = ["instructor"]
+        jwt_token.payload["read_only"] = True
+
+        response = self.client.post(
+            "/api/thumbnail/", HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token)
+        )
+
+        self.assertEqual(response.status_code, 403)
 
     def test_api_thumbnail_delete_anonymous(self):
         """Anonymous users should not be able to delete a thumbnail."""
@@ -206,6 +240,7 @@ class ThumbnailApiTest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["video_id"] = str(video.id)
         jwt_token.payload["roles"] = ["instructor"]
+        jwt_token.payload["read_only"] = False
 
         response = self.client.delete(
             "/api/thumbnail/{!s}/".format(thumbnail.id),
@@ -213,6 +248,22 @@ class ThumbnailApiTest(TestCase):
         )
         self.assertEqual(response.status_code, 204)
         self.assertFalse(Thumbnail.objects.filter(id=thumbnail.id).exists())
+
+    def test_api_thumbnail_delete_instructor_in_read_only(self):
+        """Instructor should not be able to delete thumbnails in a read_only mode."""
+        thumbnail = ThumbnailFactory()
+
+        jwt_token = AccessToken()
+        jwt_token.payload["video_id"] = str(thumbnail.video.id)
+        jwt_token.payload["roles"] = ["instructor"]
+        jwt_token.payload["read_only"] = True
+
+        response = self.client.delete(
+            "/api/thumbnail/{!s}/".format(thumbnail.id),
+            HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token),
+        )
+
+        self.assertEqual(response.status_code, 403)
 
     def test_api_thumbnail_delete_instructor_other_video(self):
         """Instructor users should not be able to delete a thumbnail on another video."""
@@ -223,6 +274,7 @@ class ThumbnailApiTest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["video_id"] = str(video_token.id)
         jwt_token.payload["roles"] = ["instructor"]
+        jwt_token.payload["read_only"] = False
 
         response = self.client.delete(
             "/api/thumbnail/{!s}/".format(thumbnail.id),
@@ -263,6 +315,7 @@ class ThumbnailApiTest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["video_id"] = str(video.id)
         jwt_token.payload["roles"] = ["instructor"]
+        jwt_token.payload["read_only"] = False
 
         # Get the upload policy for this thumbnail
         # It should generate a key file with the Unix timestamp of the present time
@@ -323,3 +376,19 @@ class ThumbnailApiTest(TestCase):
         # The upload_state of the thumbnail should have been reset
         thumbnail.refresh_from_db()
         self.assertEqual(thumbnail.upload_state, "pending")
+
+    def test_api_thumbnail_initiate_upload_instructor_read_only(self):
+        """Instructor should not be able to initiate thumbnails upload in a read_only mode."""
+        thumbnail = ThumbnailFactory()
+
+        jwt_token = AccessToken()
+        jwt_token.payload["video_id"] = str(thumbnail.video.id)
+        jwt_token.payload["roles"] = ["instructor"]
+        jwt_token.payload["read_only"] = True
+
+        response = self.client.post(
+            "/api/thumbnail/{!s}/initiate-upload/".format(thumbnail.id),
+            HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token),
+        )
+
+        self.assertEqual(response.status_code, 403)

--- a/src/backend/marsha/core/tests/test_api_timed_text_track.py
+++ b/src/backend/marsha/core/tests/test_api_timed_text_track.py
@@ -127,6 +127,7 @@ class TimedTextTrackAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["video_id"] = str(timed_text_track.video.id)
         jwt_token.payload["roles"] = ["instructor"]
+        jwt_token.payload["read_only"] = False
 
         # Get the timed text track using the JWT token
         response = self.client.get(
@@ -163,6 +164,21 @@ class TimedTextTrackAPITest(TestCase):
         content = json.loads(response.content)
         self.assertEqual(content, {"detail": "Not found."})
 
+    def test_api_timed_text_track_read_instructor_in_read_only(self):
+        """Instructor should not be able to read a timed text track in read_only mode."""
+        timed_text_track = TimedTextTrackFactory()
+
+        jwt_token = AccessToken()
+        jwt_token.payload["video_id"] = str(timed_text_track.video.id)
+        jwt_token.payload["roles"] = ["instructor"]
+        jwt_token.payload["read_only"] = True
+
+        response = self.client.get(
+            "/api/timedtexttracks/{!s}/".format(timed_text_track.id),
+            HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token),
+        )
+        self.assertEqual(response.status_code, 403)
+
     @override_settings(CLOUDFRONT_SIGNED_URLS_ACTIVE=False)
     def test_api_timed_text_track_read_detail_token_user_no_active_stamp(self):
         """A timed text track with no active stamp should not fail.
@@ -173,6 +189,7 @@ class TimedTextTrackAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["video_id"] = str(timed_text_track.video.id)
         jwt_token.payload["roles"] = ["instructor"]
+        jwt_token.payload["read_only"] = False
 
         # Get the timed text track using the JWT token
         response = self.client.get(
@@ -193,6 +210,7 @@ class TimedTextTrackAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["video_id"] = str(timed_text_track.video.id)
         jwt_token.payload["roles"] = ["instructor"]
+        jwt_token.payload["read_only"] = False
 
         # Get the timed_text_track linked to the JWT token
         response = self.client.get(
@@ -221,6 +239,7 @@ class TimedTextTrackAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["video_id"] = str(timed_text_track.video.id)
         jwt_token.payload["roles"] = ["instructor"]
+        jwt_token.payload["read_only"] = False
 
         # Get the timed_text_track via the API using the JWT token
         # fix the time so that the url signature is deterministic and can be checked
@@ -280,6 +299,7 @@ class TimedTextTrackAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["video_id"] = str(timed_text_track_one.video.id)
         jwt_token.payload["roles"] = ["instructor"]
+        jwt_token.payload["read_only"] = False
 
         response = self.client.get(
             "/api/timedtexttracks/", HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token)
@@ -314,6 +334,7 @@ class TimedTextTrackAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["video_id"] = str(video.id)
         jwt_token.payload["roles"] = ["instructor"]
+        jwt_token.payload["read_only"] = False
 
         data = {"language": "fr"}
         response = self.client.post(
@@ -338,6 +359,20 @@ class TimedTextTrackAPITest(TestCase):
                 "video": "f8c30d0d-2bb4-440d-9e8d-f4b231511f1f",
             },
         )
+
+    def test_api_timed_text_track_create_instructor_in_read_only(self):
+        """Instructor should not be able to create a timed text track in read_only mode."""
+        timed_text_track = TimedTextTrackFactory()
+
+        jwt_token = AccessToken()
+        jwt_token.payload["video_id"] = str(timed_text_track.video.id)
+        jwt_token.payload["roles"] = ["instructor"]
+        jwt_token.payload["read_only"] = True
+
+        response = self.client.post(
+            "/api/timedtexttracks/", HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token)
+        )
+        self.assertEqual(response.status_code, 403)
 
     def test_api_timed_text_track_create_staff_or_user(self):
         """Users authenticated via a session shouldn't be able to create new timed text tracks."""
@@ -366,6 +401,7 @@ class TimedTextTrackAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["video_id"] = str(timed_text_track.video.id)
         jwt_token.payload["roles"] = ["instructor"]
+        jwt_token.payload["read_only"] = False
 
         data = {"language": "en"}
         response = self.client.put(
@@ -384,6 +420,7 @@ class TimedTextTrackAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["video_id"] = str(timed_text_track.video.id)
         jwt_token.payload["roles"] = ["instructor"]
+        jwt_token.payload["read_only"] = False
 
         response = self.client.get(
             "/api/timedtexttracks/{!s}/".format(timed_text_track.id),
@@ -408,6 +445,7 @@ class TimedTextTrackAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["video_id"] = str(timed_text_track.video.id)
         jwt_token.payload["roles"] = ["instructor"]
+        jwt_token.payload["read_only"] = False
 
         response = self.client.get(
             "/api/timedtexttracks/{!s}/".format(timed_text_track.id),
@@ -433,6 +471,7 @@ class TimedTextTrackAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["video_id"] = str(timed_text_track.video.id)
         jwt_token.payload["roles"] = ["instructor"]
+        jwt_token.payload["read_only"] = False
 
         response = self.client.get(
             "/api/timedtexttracks/{!s}/".format(timed_text_track.id),
@@ -452,6 +491,21 @@ class TimedTextTrackAPITest(TestCase):
         timed_text_track.refresh_from_db()
         self.assertEqual(timed_text_track.upload_state, "pending")
 
+    def test_api_timed_text_track_update_instructor_in_read_only(self):
+        """Instructor should not be able to update a timed text track in read_only mode."""
+        timed_text_track = TimedTextTrackFactory()
+
+        jwt_token = AccessToken()
+        jwt_token.payload["video_id"] = str(timed_text_track.video.id)
+        jwt_token.payload["roles"] = ["instructor"]
+        jwt_token.payload["read_only"] = True
+
+        response = self.client.put(
+            "/api/timedtexttracks/{!s}/".format(timed_text_track.id),
+            HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token),
+        )
+        self.assertEqual(response.status_code, 403)
+
     def test_api_timed_text_track_patch_detail_token_user_stamp_and_state(self):
         """Token users should not be able to patch upload state and active stamp.
 
@@ -461,6 +515,7 @@ class TimedTextTrackAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["video_id"] = str(timed_text_track.video.id)
         jwt_token.payload["roles"] = ["instructor"]
+        jwt_token.payload["read_only"] = False
         self.assertEqual(timed_text_track.upload_state, "pending")
         self.assertIsNone(timed_text_track.uploaded_on)
 
@@ -485,6 +540,7 @@ class TimedTextTrackAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["video_id"] = str(timed_text_track.video.id)
         jwt_token.payload["roles"] = ["instructor"]
+        jwt_token.payload["read_only"] = False
 
         response = self.client.get(
             "/api/timedtexttracks/{!s}/".format(timed_text_track.id),
@@ -510,6 +566,7 @@ class TimedTextTrackAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["video_id"] = str(timed_text_track.video.id)
         jwt_token.payload["roles"] = ["instructor"]
+        jwt_token.payload["read_only"] = False
 
         response = self.client.get(
             "/api/timedtexttracks/{!s}/".format(timed_text_track.id),
@@ -535,6 +592,7 @@ class TimedTextTrackAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["video_id"] = str(other_video.id)
         jwt_token.payload["roles"] = ["instructor"]
+        jwt_token.payload["read_only"] = False
 
         data = {"language": "fr"}
         response = self.client.put(
@@ -546,6 +604,21 @@ class TimedTextTrackAPITest(TestCase):
         self.assertEqual(response.status_code, 404)
         timed_text_track_update.refresh_from_db()
         self.assertEqual(timed_text_track_update.language, "en")
+
+    def test_api_timed_text_track_patch_instructor_in_read_only(self):
+        """Instructor should not be able to patch a timed text track in read_only mode."""
+        timed_text_track = TimedTextTrackFactory()
+
+        jwt_token = AccessToken()
+        jwt_token.payload["video_id"] = str(timed_text_track.video.id)
+        jwt_token.payload["roles"] = ["instructor"]
+        jwt_token.payload["read_only"] = True
+
+        response = self.client.patch(
+            "/api/timedtexttracks/{!s}/".format(timed_text_track.id),
+            HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token),
+        )
+        self.assertEqual(response.status_code, 403)
 
     def test_api_timed_text_track_delete_detail_anonymous(self):
         """Anonymous users should not be allowed to delete a timed text track."""
@@ -571,6 +644,7 @@ class TimedTextTrackAPITest(TestCase):
             jwt_token = AccessToken()
             jwt_token.payload["video_id"] = str(timed_text_track.video.id)
             jwt_token.payload["roles"] = ["instructor"]
+            jwt_token.payload["read_only"] = False
             response = self.client.delete(
                 "/api/timedtexttracks/{!s}/".format(timed_text_track.id),
                 HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token),
@@ -614,6 +688,7 @@ class TimedTextTrackAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["video_id"] = str(timed_text_track.video.id)
         jwt_token.payload["roles"] = ["instructor"]
+        jwt_token.payload["read_only"] = False
 
         response = self.client.delete(
             "/api/timedtexttracks/", HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token)
@@ -635,6 +710,21 @@ class TimedTextTrackAPITest(TestCase):
             self.assertEqual(response.status_code, 401)
 
         self.assertTrue(TimedTextTrack.objects.filter(id=timed_text_track.id).exists())
+
+    def test_api_timed_text_track_delete_instructor_in_read_only(self):
+        """Instructor should not be able to delete a timed text track in read_only mode."""
+        timed_text_track = TimedTextTrackFactory()
+
+        jwt_token = AccessToken()
+        jwt_token.payload["video_id"] = str(timed_text_track.video.id)
+        jwt_token.payload["roles"] = ["instructor"]
+        jwt_token.payload["read_only"] = True
+
+        response = self.client.delete(
+            "/api/timedtexttracks/{!s}/".format(timed_text_track.id),
+            HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token),
+        )
+        self.assertEqual(response.status_code, 403)
 
     def test_api_timed_text_track_initiate_upload_anonymous_user(self):
         """Anonymous users should not be allowed to initiate an upload."""
@@ -662,6 +752,7 @@ class TimedTextTrackAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["video_id"] = str(timed_text_track.video.id)
         jwt_token.payload["roles"] = ["instructor"]
+        jwt_token.payload["read_only"] = False
 
         # Create other timed text tracks to check that their upload state are unaffected
         # Make sure we avoid unicty constraints by setting a different language
@@ -769,3 +860,18 @@ class TimedTextTrackAPITest(TestCase):
             self.assertEqual(
                 content, {"detail": "Authentication credentials were not provided."}
             )
+
+    def test_api_timed_text_track_instructor_initiate_upload_in_read_only(self):
+        """Instructor should not be able to initiate a timed text track upload in read_only."""
+        timed_text_track = TimedTextTrackFactory()
+
+        jwt_token = AccessToken()
+        jwt_token.payload["video_id"] = str(timed_text_track.video.id)
+        jwt_token.payload["roles"] = ["instructor"]
+        jwt_token.payload["read_only"] = True
+
+        response = self.client.post(
+            "/api/timedtexttracks/{!s}/initiate-upload/".format(timed_text_track.id),
+            HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token),
+        )
+        self.assertEqual(response.status_code, 403)

--- a/src/backend/marsha/core/tests/test_views_lti_video.py
+++ b/src/backend/marsha/core/tests/test_views_lti_video.py
@@ -64,6 +64,7 @@ class ViewsTestCase(TestCase):
         self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
         self.assertEqual(jwt_token.payload["roles"], [data["roles"]])
         self.assertEqual(jwt_token.payload["locale"], "fr_FR")
+        self.assertFalse(jwt_token.payload["read_only"])
         self.assertDictEqual(
             jwt_token.payload["course"],
             {"school_name": "ufr", "course_name": "mathematics", "course_run": "00001"},
@@ -86,6 +87,66 @@ class ViewsTestCase(TestCase):
                 "description": video.description,
                 "id": str(video.id),
                 "upload_state": "pending",
+                "timed_text_tracks": [],
+                "thumbnail": None,
+                "title": video.title,
+                "urls": None,
+            },
+        )
+        # Make sure we only go through LTI verification once as it is costly (getting passport +
+        # signature)
+        self.assertEqual(mock_verify.call_count, 1)
+
+    def test_views_lti_video_read_only_video(self):
+        """A video from another portable playlist should have read_only attribute set to True."""
+        passport = ConsumerSiteLTIPassportFactory(consumer_site__domain="example.com")
+        video = VideoFactory(
+            playlist__is_portable_to_playlist=True,
+            playlist__is_portable_to_consumer_site=True,
+            upload_state="ready",
+        )
+        data = {
+            "resource_link_id": video.lti_id,
+            "context_id": "another-playlist",
+            "roles": "instructor",
+            "oauth_consumer_key": passport.oauth_consumer_key,
+            "user_id": "56255f3807599c377bf0e5bf072359fd",
+            "launch_presentation_locale": "fr",
+        }
+        with mock.patch.object(
+            LTI, "verify", return_value=passport.consumer_site
+        ) as mock_verify:
+            response = self.client.post("/lti/videos/{!s}".format(video.pk), data)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "<html>")
+        content = response.content.decode("utf-8")
+
+        # Extract the JWT Token and state
+        match = re.search(
+            '<div class="marsha-frontend-data" data-jwt="(.*)" data-state="(.*)">',
+            content,
+        )
+        data_jwt = match.group(1)
+        jwt_token = AccessToken(data_jwt)
+        self.assertTrue(jwt_token.payload["read_only"])
+
+        data_state = match.group(2)
+        self.assertEqual(data_state, "instructor")
+
+        # Extract the video data
+        data_video = re.search(
+            '<div class="marsha-frontend-data" id="video" data-video="(.*)">', content
+        ).group(1)
+
+        self.assertEqual(
+            json.loads(unescape(data_video)),
+            {
+                "active_stamp": None,
+                "is_ready_to_play": False,
+                "show_download": True,
+                "description": video.description,
+                "id": str(video.id),
+                "upload_state": "ready",
                 "timed_text_tracks": [],
                 "thumbnail": None,
                 "title": video.title,
@@ -131,6 +192,7 @@ class ViewsTestCase(TestCase):
         self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
         self.assertEqual(jwt_token.payload["roles"], [data["roles"]])
         self.assertEqual(jwt_token.payload["locale"], "en_US")
+        self.assertTrue(jwt_token.payload["read_only"])
         self.assertDictEqual(
             jwt_token.payload["course"],
             {"school_name": "ufr", "course_name": "mathematics", "course_run": "00001"},

--- a/src/backend/marsha/core/views.py
+++ b/src/backend/marsha/core/views.py
@@ -86,6 +86,8 @@ class VideoLTIView(TemplateResponseMixin, View):
                     "roles": lti.roles,
                     "course": lti.get_course_info(),
                     "locale": locale,
+                    "read_only": lti.is_student
+                    or video.playlist.lti_id != lti.context_id,
                 }
             )
             try:

--- a/src/frontend/components/InstructorView/InstructorView.spec.tsx
+++ b/src/frontend/components/InstructorView/InstructorView.spec.tsx
@@ -1,6 +1,7 @@
 import '../../testSetup';
 
 import { shallow } from 'enzyme';
+import { Button } from 'grommet';
 import React from 'react';
 
 import { ERROR_COMPONENT_ROUTE } from '../ErrorComponent/route';
@@ -13,7 +14,7 @@ jest.mock('../withLink/withLink', () => ({
 describe('<InstructorView />', () => {
   it('renders the children inside a <Preview />', () => {
     const wrapper = shallow(
-      <InstructorView videoId={'42'}>
+      <InstructorView videoId={'42'} readOnly={false}>
         <div className="some-child" />
       </InstructorView>,
     );
@@ -27,7 +28,7 @@ describe('<InstructorView />', () => {
 
   it('renders the instructor controls', () => {
     const controlsWrapper = shallow(
-      <InstructorView videoId={'42'}>
+      <InstructorView videoId={'42'} readOnly={false}>
         <div className="some-child" />
       </InstructorView>,
     ).find(InstructorControls);
@@ -38,7 +39,7 @@ describe('<InstructorView />', () => {
 
   it('redirects to the error component when it is missing the video ID', () => {
     const wrapper = shallow(
-      <InstructorView videoId={null}>
+      <InstructorView videoId={null} readOnly={false}>
         <div />
       </InstructorView>,
     );
@@ -46,5 +47,18 @@ describe('<InstructorView />', () => {
     expect(wrapper.name()).toEqual('Redirect');
     expect(wrapper.prop('push')).toBeTruthy();
     expect(wrapper.prop('to')).toEqual(ERROR_COMPONENT_ROUTE('lti'));
+  });
+
+  it('disable the button when read_only is true', () => {
+    const wrapper = shallow(
+      <InstructorView videoId={'42'} readOnly={true}>
+        <div />
+      </InstructorView>,
+    );
+
+    expect(wrapper.html()).toContain(
+      'This video is imported from another playlist. You can go to the original playlist to directly modify this video, or delete it from the current playlist and replace it by a new video.',
+    );
+    expect(wrapper.find(Button).prop('disabled')).toEqual(true);
   });
 });

--- a/src/frontend/components/InstructorView/InstructorView.tsx
+++ b/src/frontend/components/InstructorView/InstructorView.tsx
@@ -18,6 +18,13 @@ const messages = defineMessages({
     description: `Text for the button in the instructor view that allows the instructor to go to the dashboard.`,
     id: 'components.InstructorView.btnDashboard',
   },
+  disabledDashboard: {
+    defaultMessage:
+      'This video is imported from another playlist. You can go to the original playlist to directly modify this video, or delete it from the current playlist and replace it by a new video.',
+    description:
+      'Text explaining that the ivdeo is in read_only mode and the dashboard is not available',
+    id: 'components.InstructorView.disabledDashboard',
+  },
   title: {
     defaultMessage: 'Instructor Preview 👆',
     description: `Title for the Instructor View. Describes the area appearing right above, which is a preview
@@ -47,23 +54,31 @@ const BtnWithLink = withLink(Button);
 interface InstructorViewProps {
   children: React.ReactNode;
   videoId: Nullable<Video['id']>;
+  readOnly: boolean;
 }
 
-export const InstructorView = ({ children, videoId }: InstructorViewProps) =>
-  videoId ? (
+export const InstructorView = ({
+  children,
+  videoId,
+  readOnly,
+}: InstructorViewProps) => {
+  const message = readOnly ? messages.disabledDashboard : messages.title;
+  return videoId ? (
     <React.Fragment>
       <PreviewWrapper>
         <Preview>{children}</Preview>
       </PreviewWrapper>
       <InstructorControls>
-        <FormattedMessage {...messages.title} />
+        <FormattedMessage {...message} />
         <BtnWithLink
           color={'brand'}
           label={<FormattedMessage {...messages.btnDashboard} />}
           to={DASHBOARD_ROUTE()}
+          disabled={readOnly}
         />
       </InstructorControls>
     </React.Fragment>
   ) : (
     <Redirect push to={ERROR_COMPONENT_ROUTE('lti')} />
   );
+};

--- a/src/frontend/components/InstructorViewConnected/InstructorViewConnected.spec.tsx
+++ b/src/frontend/components/InstructorViewConnected/InstructorViewConnected.spec.tsx
@@ -7,12 +7,18 @@ describe('<InstructorViewConnected />', () => {
     it('passes the context videoId', () => {
       const state = {
         context: {
+          decodedJwt: {
+            read_only: false,
+          },
           ltiResourceVideo: {
             id: '42',
           },
         },
       } as RootState<appStateSuccess>;
-      expect(mapStateToProps(state)).toEqual({ videoId: '42' });
+      expect(mapStateToProps(state)).toEqual({
+        readOnly: false,
+        videoId: '42',
+      });
     });
   });
 });

--- a/src/frontend/components/InstructorViewConnected/InstructorViewConnected.tsx
+++ b/src/frontend/components/InstructorViewConnected/InstructorViewConnected.tsx
@@ -5,6 +5,7 @@ import { appStateSuccess } from '../../types/AppData';
 import { InstructorView } from '../InstructorView/InstructorView';
 
 export const mapStateToProps = (state: RootState<appStateSuccess>) => ({
+  readOnly: state.context.decodedJwt.read_only,
   videoId: state.context.ltiResourceVideo.id,
 });
 

--- a/src/frontend/data/context/reducer.spec.ts
+++ b/src/frontend/data/context/reducer.spec.ts
@@ -1,9 +1,11 @@
 import { appState } from '../../types/AppData';
+import { DecodedJwt } from '../../types/jwt';
 import { Video } from '../../types/tracks';
 import { context } from './reducer';
 
 describe('Reducer: context', () => {
   const previousState = {
+    decodedJwt: {} as DecodedJwt,
     jwt: 'some token',
     ltiResourceVideo: {} as Video,
     ltiState: appState.INSTRUCTOR,
@@ -23,6 +25,7 @@ describe('Reducer: context', () => {
       });
 
       expect(stateA).toEqual({
+        decodedJwt: {} as DecodedJwt,
         jwt: 'some token',
         ltiResourceVideo: {} as Video,
         ltiState: appState.INSTRUCTOR,
@@ -36,6 +39,7 @@ describe('Reducer: context', () => {
       });
 
       expect(stateB).toEqual({
+        decodedJwt: {} as DecodedJwt,
         jwt: 'some token',
         ltiResourceVideo: {} as Video,
         ltiState: appState.INSTRUCTOR,
@@ -49,6 +53,7 @@ describe('Reducer: context', () => {
           type: 'UPLOAD_PROGRESS_NOTIFY',
         }),
       ).toEqual({
+        decodedJwt: {} as DecodedJwt,
         jwt: 'some token',
         ltiResourceVideo: {} as Video,
         ltiState: appState.INSTRUCTOR,

--- a/src/frontend/data/context/reducer.ts
+++ b/src/frontend/data/context/reducer.ts
@@ -1,12 +1,15 @@
+import jwt_decode from 'jwt-decode';
 import { AnyAction, Reducer } from 'redux';
 
 import { appState } from '../../types/AppData';
+import { DecodedJwt } from '../../types/jwt';
 import { UploadableObject, Video } from '../../types/tracks';
 import { appData } from '../appData';
 import { UploadProgressNotification } from './actions';
 
 export interface ContextState<state> {
   jwt: state extends appState.ERROR ? null : string;
+  decodedJwt: state extends appState.ERROR ? null : DecodedJwt;
   ltiResourceVideo: state extends appState.ERROR ? null : Video;
   ltiState: state;
   uploads_progress: {
@@ -15,6 +18,7 @@ export interface ContextState<state> {
 }
 
 export const initialState = {
+  decodedJwt: appData.jwt ? (jwt_decode(appData.jwt) as DecodedJwt) : null,
   jwt: appData.jwt || null,
   ltiResourceVideo: appData.video || null,
   ltiState: appData.state,

--- a/src/frontend/types/jwt.ts
+++ b/src/frontend/types/jwt.ts
@@ -6,4 +6,5 @@ export interface DecodedJwt {
   user_id: string;
   video_id: string;
   locale: string;
+  read_only: boolean;
 }


### PR DESCRIPTION
## Purpose

A video can be portable and when an instructor sees it from another playlist it should not be possible to edit it. 

## Proposal

We introduce a new property in the JWT token allowing us to know if the instructor can edit or not a video. If he can't, the dashboard is disabled and the API is not accessible for him.

- [x] Add a `read_only` property in the JWT token.
- [x] Reject all API calls if the video is in read_only.
- [x] Disable the dashboard in the frontend application.

