### PR TITLE
bump version 2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.7.0] - 2019-04-24
+
 ### Added
 
 - LRS credentials can be configured at the consumer site level.
@@ -207,7 +209,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Minor fixes and improvements on features and tests
 
-[unreleased]: https://github.com/openfun/marsha/compare/v2.5.0...master
+[unreleased]: https://github.com/openfun/marsha/compare/v2.7.0...master
+[2.7.0]: https://github.com/openfun/marsha/compare/v2.6.0...v2.7.0
+[2.6.0]: https://github.com/openfun/marsha/compare/v2.5.0...v2.6.0
 [2.5.0]: https://github.com/openfun/marsha/compare/v2.4.0...v2.5.0
 [2.4.0]: https://github.com/openfun/marsha/compare/v2.3.1...v2.4.0
 [2.3.1]: https://github.com/openfun/marsha/compare/v2.3.0...v2.3.1

--- a/src/aws/lambda-configure/package.json
+++ b/src/aws/lambda-configure/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-configure",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "engines": {
     "node": ">8.10"
   },

--- a/src/aws/lambda-encode/package.json
+++ b/src/aws/lambda-encode/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-convert",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "engines": {
     "node": ">8.10"
   },

--- a/src/aws/lambda-update-state/package.json
+++ b/src/aws/lambda-update-state/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-update-state",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "engines": {
     "node": ">8.10"
   },

--- a/src/backend/locale/es_ES/LC_MESSAGES/django.po
+++ b/src/backend/locale/es_ES/LC_MESSAGES/django.po
@@ -1,0 +1,582 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: marsha\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-04-18 13:21+0000\n"
+"PO-Revision-Date: 2019-04-24 09:49\n"
+"Last-Translator: Manuel Raynaud (lunika)\n"
+"Language-Team: Spanish\n"
+"Language: es_ES\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: crowdin.com\n"
+"X-Crowdin-Project: marsha\n"
+"X-Crowdin-Language: es-ES\n"
+"X-Crowdin-File: backend.pot\n"
+
+#: marsha/core/admin.py:77
+#, python-brace-format
+msgid "{marsha_name} administration"
+msgstr ""
+
+#: marsha/core/admin.py:88 marsha/core/admin.py:111
+#: marsha/core/models/account.py:370 marsha/core/models/account.py:402
+#: marsha/core/models/account.py:449
+msgid "organization"
+msgstr ""
+
+#: marsha/core/admin.py:89 marsha/core/admin.py:112
+#: marsha/core/models/account.py:371
+msgid "organizations"
+msgstr ""
+
+#: marsha/core/admin.py:103 marsha/core/admin.py:154
+#: marsha/core/models/account.py:44 marsha/core/models/account.py:305
+#: marsha/core/models/account.py:441 marsha/core/models/video.py:102
+msgid "user"
+msgstr ""
+
+#: marsha/core/admin.py:104 marsha/core/admin.py:155
+#: marsha/core/models/account.py:45 marsha/core/models/account.py:205
+#: marsha/core/models/account.py:362 marsha/core/models/video.py:67
+msgid "users"
+msgstr ""
+
+#: marsha/core/admin.py:120 marsha/core/admin.py:121
+#: marsha/core/models/account.py:196
+msgid "portable to"
+msgstr ""
+
+#: marsha/core/admin.py:162 marsha/core/models/account.py:242
+msgid "consumer site"
+msgstr ""
+
+#: marsha/core/admin.py:163 marsha/core/models/account.py:243
+msgid "consumer sites"
+msgstr ""
+
+#: marsha/core/admin.py:248 marsha/core/admin.py:342
+msgid "Video"
+msgstr ""
+
+#: marsha/core/admin.py:255 marsha/core/models/video.py:202
+#: marsha/core/models/video.py:256 marsha/core/models/video.py:391
+msgid "video"
+msgstr ""
+
+#: marsha/core/admin.py:256 marsha/core/models/video.py:203
+msgid "videos"
+msgstr ""
+
+#: marsha/core/admin.py:283
+msgid "user access"
+msgstr ""
+
+#: marsha/core/admin.py:284
+msgid "users accesses"
+msgstr ""
+
+#: marsha/core/admin.py:380 marsha/core/models/account.py:124
+msgid "LTI passport"
+msgstr ""
+
+#: marsha/core/apps.py:11
+msgid "Marsha"
+msgstr ""
+
+#: marsha/core/defaults.py:18
+msgid "pending"
+msgstr ""
+
+#: marsha/core/defaults.py:19
+msgid "processing"
+msgstr ""
+
+#: marsha/core/defaults.py:20
+msgid "error"
+msgstr ""
+
+#: marsha/core/defaults.py:21
+msgid "ready"
+msgstr ""
+
+#: marsha/core/models/account.py:29
+msgid "administrator"
+msgstr ""
+
+#: marsha/core/models/account.py:30
+msgid "instructor"
+msgstr ""
+
+#: marsha/core/models/account.py:31
+msgid "student"
+msgstr ""
+
+#: marsha/core/models/account.py:53 marsha/core/models/account.py:377
+msgid " [deleted]"
+msgstr ""
+
+#: marsha/core/models/account.py:76
+msgid "oauth consumer key"
+msgstr ""
+
+#: marsha/core/models/account.py:79
+msgid "oauth consumer key to authenticate an LTI consumer on the LTI provider"
+msgstr ""
+
+#: marsha/core/models/account.py:85
+msgid "shared secret"
+msgstr ""
+
+#: marsha/core/models/account.py:86
+msgid "LTI Shared secret"
+msgstr ""
+
+#: marsha/core/models/account.py:115
+msgid "is enabled"
+msgstr ""
+
+#: marsha/core/models/account.py:116
+msgid "whether the passport is enabled"
+msgstr ""
+
+#: marsha/core/models/account.py:125
+msgid "LTI passports"
+msgstr ""
+
+#: marsha/core/models/account.py:138
+msgid "{:s}[deleted]"
+msgstr ""
+
+#: marsha/core/models/account.py:145
+msgid "You should set either a Consumer Site or a Playlist, but not both."
+msgstr ""
+
+#: marsha/core/models/account.py:150
+msgid "You must set either a Consumer Site or a Playlist."
+msgstr ""
+
+#: marsha/core/models/account.py:184
+msgid "display name"
+msgstr ""
+
+#: marsha/core/models/account.py:185
+msgid "name of the consumer site."
+msgstr ""
+
+#: marsha/core/models/account.py:189
+msgid "domain name"
+msgstr ""
+
+#: marsha/core/models/account.py:190
+msgid "base domain allowed for consumer site."
+msgstr ""
+
+#: marsha/core/models/account.py:197
+msgid "consumer sites to which this site is automatically portable."
+msgstr ""
+
+#: marsha/core/models/account.py:206
+msgid "users who have been granted access to this consumer site."
+msgstr ""
+
+#: marsha/core/models/account.py:210
+msgid "LRS authentication token"
+msgstr ""
+
+#: marsha/core/models/account.py:211
+msgid "LRS authentication token used to communicate with a remote LRS"
+msgstr ""
+
+#: marsha/core/models/account.py:217
+msgid "LRS url"
+msgstr ""
+
+#: marsha/core/models/account.py:218
+msgid "LRS url used to communicate with a remote LRS"
+msgstr ""
+
+#: marsha/core/models/account.py:224
+msgid "xAPI version"
+msgstr ""
+
+#: marsha/core/models/account.py:225
+msgid "xAPI version used by the remote LRS server"
+msgstr ""
+
+#: marsha/core/models/account.py:231
+msgid "show video download"
+msgstr ""
+
+#: marsha/core/models/account.py:233
+msgid "default value used for every newly created video to determine if the links to download a video are shown by default."
+msgstr ""
+
+#: marsha/core/models/account.py:249 marsha/core/models/video.py:85
+#: marsha/core/models/video.py:210
+msgid "{:s} [deleted]"
+msgstr ""
+
+#: marsha/core/models/account.py:266
+msgid "source site"
+msgstr ""
+
+#: marsha/core/models/account.py:267
+msgid "consumer site that is portable."
+msgstr ""
+
+#: marsha/core/models/account.py:274
+msgid "target site"
+msgstr ""
+
+#: marsha/core/models/account.py:275
+msgid "consumer site to which portability is automatic."
+msgstr ""
+
+#: marsha/core/models/account.py:284
+msgid "consumer site portability"
+msgstr ""
+
+#: marsha/core/models/account.py:285
+msgid "consumer site portabilities"
+msgstr ""
+
+#: marsha/core/models/account.py:292
+#, python-brace-format
+msgid "{source} was portable to {target}"
+msgstr ""
+
+#: marsha/core/models/account.py:293
+#, python-brace-format
+msgid "{source} is portable to {target}"
+msgstr ""
+
+#: marsha/core/models/account.py:306
+msgid "user with access to the consumer site"
+msgstr ""
+
+#: marsha/core/models/account.py:313 marsha/core/models/account.py:394
+msgid "site"
+msgstr ""
+
+#: marsha/core/models/account.py:314
+msgid "consumer site to which the user has access"
+msgstr ""
+
+#: marsha/core/models/account.py:321 marsha/core/models/account.py:457
+#: marsha/core/models/video.py:118
+msgid "role"
+msgstr ""
+
+#: marsha/core/models/account.py:322 marsha/core/models/account.py:458
+#: marsha/core/models/video.py:119
+msgid "role granted to the user on the consumer site"
+msgstr ""
+
+#: marsha/core/models/account.py:330
+msgid "consumer site access"
+msgstr ""
+
+#: marsha/core/models/account.py:331
+msgid "consumer site accesses"
+msgstr ""
+
+#: marsha/core/models/account.py:342
+#, python-brace-format
+msgid "{user} was {role} of {consumer_site}"
+msgstr ""
+
+#: marsha/core/models/account.py:343
+#, python-brace-format
+msgid "{user} is {role} of {consumer_site}"
+msgstr ""
+
+#: marsha/core/models/account.py:350
+msgid "name"
+msgstr ""
+
+#: marsha/core/models/account.py:350
+msgid "name of the organization"
+msgstr ""
+
+#: marsha/core/models/account.py:357
+msgid "consumer sites on which this organization is present"
+msgstr ""
+
+#: marsha/core/models/account.py:363
+msgid "users who have been granted access to this organization"
+msgstr ""
+
+#: marsha/core/models/account.py:395
+msgid "consumer site having this organization"
+msgstr ""
+
+#: marsha/core/models/account.py:403
+msgid "organization in this consumer site"
+msgstr ""
+
+#: marsha/core/models/account.py:412
+msgid "organization in consumer site"
+msgstr ""
+
+#: marsha/core/models/account.py:413
+msgid "organizations in consumer sites"
+msgstr ""
+
+#: marsha/core/models/account.py:423
+#, python-brace-format
+msgid "{organization} was in {consumer_site}"
+msgstr ""
+
+#: marsha/core/models/account.py:424
+#, python-brace-format
+msgid "{organization} is in {consumer_site}"
+msgstr ""
+
+#: marsha/core/models/account.py:442
+msgid "user who has access to the organization"
+msgstr ""
+
+#: marsha/core/models/account.py:450
+msgid "organization to which the user has access"
+msgstr ""
+
+#: marsha/core/models/account.py:466
+msgid "organization access"
+msgstr ""
+
+#: marsha/core/models/account.py:467
+msgid "organization accesses"
+msgstr ""
+
+#: marsha/core/models/account.py:478
+#, python-brace-format
+msgid "{user} was {role} of {organization}"
+msgstr ""
+
+#: marsha/core/models/account.py:480
+#, python-brace-format
+msgid "{user} is {role} of {organization}"
+msgstr ""
+
+#: marsha/core/models/base.py:93
+msgid "id"
+msgstr ""
+
+#: marsha/core/models/base.py:94
+msgid "primary key for the record as UUID"
+msgstr ""
+
+#: marsha/core/models/base.py:100
+msgid "created on"
+msgstr ""
+
+#: marsha/core/models/base.py:101
+msgid "date and time at which a record was created"
+msgstr ""
+
+#: marsha/core/models/base.py:106
+msgid "updated on"
+msgstr ""
+
+#: marsha/core/models/base.py:107
+msgid "date and time at which a record was last updated"
+msgstr ""
+
+#: marsha/core/models/base.py:355 marsha/core/models/video.py:183
+#: marsha/core/models/video.py:268
+msgid "uploaded on"
+msgstr ""
+
+#: marsha/core/models/base.py:357
+msgid "datetime at which the active version of the resource was uploaded."
+msgstr ""
+
+#: marsha/core/models/base.py:364 marsha/core/models/video.py:190
+#: marsha/core/models/video.py:275
+msgid "upload state"
+msgstr ""
+
+#: marsha/core/models/base.py:365
+msgid "state of the upload in AWS."
+msgstr ""
+
+#: marsha/core/models/video.py:19 marsha/core/models/video.py:136
+msgid "title"
+msgstr ""
+
+#: marsha/core/models/video.py:19
+msgid "title of the playlist"
+msgstr ""
+
+#: marsha/core/models/video.py:23 marsha/core/models/video.py:146
+msgid "lti id"
+msgstr ""
+
+#: marsha/core/models/video.py:24 marsha/core/models/video.py:147
+msgid "ID for synchronization with an external LTI tool"
+msgstr ""
+
+#: marsha/core/models/video.py:50
+msgid "is public"
+msgstr ""
+
+#: marsha/core/models/video.py:51
+msgid "if this playlist can be viewed without any access control"
+msgstr ""
+
+#: marsha/core/models/video.py:56 marsha/core/models/video.py:175
+msgid "duplicated from"
+msgstr ""
+
+#: marsha/core/models/video.py:57
+msgid "original playlist this one was duplicated from"
+msgstr ""
+
+#: marsha/core/models/video.py:68
+msgid "users who have been granted access to this playlist"
+msgstr ""
+
+#: marsha/core/models/video.py:77 marsha/core/models/video.py:110
+#: marsha/core/models/video.py:162
+msgid "playlist"
+msgstr ""
+
+#: marsha/core/models/video.py:78
+msgid "playlists"
+msgstr ""
+
+#: marsha/core/models/video.py:103
+msgid "user who has access to the playlist"
+msgstr ""
+
+#: marsha/core/models/video.py:111
+msgid "playlist to which the user has access"
+msgstr ""
+
+#: marsha/core/models/video.py:127
+msgid "playlist access"
+msgstr ""
+
+#: marsha/core/models/video.py:128
+msgid "playlist accesses"
+msgstr ""
+
+#: marsha/core/models/video.py:136
+msgid "title of the video"
+msgstr ""
+
+#: marsha/core/models/video.py:139
+msgid "description"
+msgstr ""
+
+#: marsha/core/models/video.py:140
+msgid "description of the video"
+msgstr ""
+
+#: marsha/core/models/video.py:152
+msgid "author"
+msgstr ""
+
+#: marsha/core/models/video.py:153
+msgid "author of the video"
+msgstr ""
+
+#: marsha/core/models/video.py:163
+msgid "playlist to which this video belongs"
+msgstr ""
+
+#: marsha/core/models/video.py:168
+msgid "position"
+msgstr ""
+
+#: marsha/core/models/video.py:169
+msgid "position of this video in the playlist"
+msgstr ""
+
+#: marsha/core/models/video.py:176
+msgid "original video this one was duplicated from"
+msgstr ""
+
+#: marsha/core/models/video.py:184 marsha/core/models/video.py:269
+msgid "datetime at which the active version of the video was uploaded."
+msgstr ""
+
+#: marsha/core/models/video.py:191 marsha/core/models/video.py:276
+msgid "state of the upload and transcoding pipeline in AWS."
+msgstr ""
+
+#: marsha/core/models/video.py:257
+msgid "video for which this track is"
+msgstr ""
+
+#: marsha/core/models/video.py:264
+msgid "language"
+msgstr ""
+
+#: marsha/core/models/video.py:265
+msgid "language of this track"
+msgstr ""
+
+#: marsha/core/models/video.py:303
+msgid "audio track"
+msgstr ""
+
+#: marsha/core/models/video.py:304
+msgid "audio tracks"
+msgstr ""
+
+#: marsha/core/models/video.py:316
+msgid "Subtitle"
+msgstr ""
+
+#: marsha/core/models/video.py:317
+msgid "Transcript"
+msgstr ""
+
+#: marsha/core/models/video.py:318
+msgid "Closed captioning"
+msgstr ""
+
+#: marsha/core/models/video.py:322
+msgid "mode"
+msgstr ""
+
+#: marsha/core/models/video.py:326
+msgid "Activate a special mode for this timed text track: simple subtitles, closed captioning (for deaf or hard of hearing viewers) or transcription (complete text below aside of the player)."
+msgstr ""
+
+#: marsha/core/models/video.py:337
+msgid "timed text track"
+msgstr ""
+
+#: marsha/core/models/video.py:338
+msgid "timed text tracks"
+msgstr ""
+
+#: marsha/core/models/video.py:380
+msgid "signs language track"
+msgstr ""
+
+#: marsha/core/models/video.py:381
+msgid "signs language tracks"
+msgstr ""
+
+#: marsha/core/models/video.py:392
+msgid "video for which this thumbnail is"
+msgstr ""
+
+#: marsha/core/models/video.py:401
+msgid "thumbnail"
+msgstr ""
+
+#: marsha/settings.py:160
+msgid "english"
+msgstr ""
+
+#: marsha/settings.py:160
+msgid "french"
+msgstr ""
+

--- a/src/backend/locale/fr_CA/LC_MESSAGES/django.po
+++ b/src/backend/locale/fr_CA/LC_MESSAGES/django.po
@@ -1,0 +1,582 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: marsha\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-04-18 13:21+0000\n"
+"PO-Revision-Date: 2019-04-24 09:49\n"
+"Last-Translator: Manuel Raynaud (lunika)\n"
+"Language-Team: French, Canada\n"
+"Language: fr_CA\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: crowdin.com\n"
+"X-Crowdin-Project: marsha\n"
+"X-Crowdin-Language: fr-CA\n"
+"X-Crowdin-File: backend.pot\n"
+
+#: marsha/core/admin.py:77
+#, python-brace-format
+msgid "{marsha_name} administration"
+msgstr ""
+
+#: marsha/core/admin.py:88 marsha/core/admin.py:111
+#: marsha/core/models/account.py:370 marsha/core/models/account.py:402
+#: marsha/core/models/account.py:449
+msgid "organization"
+msgstr ""
+
+#: marsha/core/admin.py:89 marsha/core/admin.py:112
+#: marsha/core/models/account.py:371
+msgid "organizations"
+msgstr ""
+
+#: marsha/core/admin.py:103 marsha/core/admin.py:154
+#: marsha/core/models/account.py:44 marsha/core/models/account.py:305
+#: marsha/core/models/account.py:441 marsha/core/models/video.py:102
+msgid "user"
+msgstr ""
+
+#: marsha/core/admin.py:104 marsha/core/admin.py:155
+#: marsha/core/models/account.py:45 marsha/core/models/account.py:205
+#: marsha/core/models/account.py:362 marsha/core/models/video.py:67
+msgid "users"
+msgstr ""
+
+#: marsha/core/admin.py:120 marsha/core/admin.py:121
+#: marsha/core/models/account.py:196
+msgid "portable to"
+msgstr ""
+
+#: marsha/core/admin.py:162 marsha/core/models/account.py:242
+msgid "consumer site"
+msgstr ""
+
+#: marsha/core/admin.py:163 marsha/core/models/account.py:243
+msgid "consumer sites"
+msgstr ""
+
+#: marsha/core/admin.py:248 marsha/core/admin.py:342
+msgid "Video"
+msgstr ""
+
+#: marsha/core/admin.py:255 marsha/core/models/video.py:202
+#: marsha/core/models/video.py:256 marsha/core/models/video.py:391
+msgid "video"
+msgstr ""
+
+#: marsha/core/admin.py:256 marsha/core/models/video.py:203
+msgid "videos"
+msgstr ""
+
+#: marsha/core/admin.py:283
+msgid "user access"
+msgstr ""
+
+#: marsha/core/admin.py:284
+msgid "users accesses"
+msgstr ""
+
+#: marsha/core/admin.py:380 marsha/core/models/account.py:124
+msgid "LTI passport"
+msgstr ""
+
+#: marsha/core/apps.py:11
+msgid "Marsha"
+msgstr ""
+
+#: marsha/core/defaults.py:18
+msgid "pending"
+msgstr ""
+
+#: marsha/core/defaults.py:19
+msgid "processing"
+msgstr ""
+
+#: marsha/core/defaults.py:20
+msgid "error"
+msgstr ""
+
+#: marsha/core/defaults.py:21
+msgid "ready"
+msgstr ""
+
+#: marsha/core/models/account.py:29
+msgid "administrator"
+msgstr ""
+
+#: marsha/core/models/account.py:30
+msgid "instructor"
+msgstr ""
+
+#: marsha/core/models/account.py:31
+msgid "student"
+msgstr ""
+
+#: marsha/core/models/account.py:53 marsha/core/models/account.py:377
+msgid " [deleted]"
+msgstr ""
+
+#: marsha/core/models/account.py:76
+msgid "oauth consumer key"
+msgstr ""
+
+#: marsha/core/models/account.py:79
+msgid "oauth consumer key to authenticate an LTI consumer on the LTI provider"
+msgstr ""
+
+#: marsha/core/models/account.py:85
+msgid "shared secret"
+msgstr ""
+
+#: marsha/core/models/account.py:86
+msgid "LTI Shared secret"
+msgstr ""
+
+#: marsha/core/models/account.py:115
+msgid "is enabled"
+msgstr ""
+
+#: marsha/core/models/account.py:116
+msgid "whether the passport is enabled"
+msgstr ""
+
+#: marsha/core/models/account.py:125
+msgid "LTI passports"
+msgstr ""
+
+#: marsha/core/models/account.py:138
+msgid "{:s}[deleted]"
+msgstr ""
+
+#: marsha/core/models/account.py:145
+msgid "You should set either a Consumer Site or a Playlist, but not both."
+msgstr ""
+
+#: marsha/core/models/account.py:150
+msgid "You must set either a Consumer Site or a Playlist."
+msgstr ""
+
+#: marsha/core/models/account.py:184
+msgid "display name"
+msgstr ""
+
+#: marsha/core/models/account.py:185
+msgid "name of the consumer site."
+msgstr ""
+
+#: marsha/core/models/account.py:189
+msgid "domain name"
+msgstr ""
+
+#: marsha/core/models/account.py:190
+msgid "base domain allowed for consumer site."
+msgstr ""
+
+#: marsha/core/models/account.py:197
+msgid "consumer sites to which this site is automatically portable."
+msgstr ""
+
+#: marsha/core/models/account.py:206
+msgid "users who have been granted access to this consumer site."
+msgstr ""
+
+#: marsha/core/models/account.py:210
+msgid "LRS authentication token"
+msgstr ""
+
+#: marsha/core/models/account.py:211
+msgid "LRS authentication token used to communicate with a remote LRS"
+msgstr ""
+
+#: marsha/core/models/account.py:217
+msgid "LRS url"
+msgstr ""
+
+#: marsha/core/models/account.py:218
+msgid "LRS url used to communicate with a remote LRS"
+msgstr ""
+
+#: marsha/core/models/account.py:224
+msgid "xAPI version"
+msgstr ""
+
+#: marsha/core/models/account.py:225
+msgid "xAPI version used by the remote LRS server"
+msgstr ""
+
+#: marsha/core/models/account.py:231
+msgid "show video download"
+msgstr ""
+
+#: marsha/core/models/account.py:233
+msgid "default value used for every newly created video to determine if the links to download a video are shown by default."
+msgstr ""
+
+#: marsha/core/models/account.py:249 marsha/core/models/video.py:85
+#: marsha/core/models/video.py:210
+msgid "{:s} [deleted]"
+msgstr ""
+
+#: marsha/core/models/account.py:266
+msgid "source site"
+msgstr ""
+
+#: marsha/core/models/account.py:267
+msgid "consumer site that is portable."
+msgstr ""
+
+#: marsha/core/models/account.py:274
+msgid "target site"
+msgstr ""
+
+#: marsha/core/models/account.py:275
+msgid "consumer site to which portability is automatic."
+msgstr ""
+
+#: marsha/core/models/account.py:284
+msgid "consumer site portability"
+msgstr ""
+
+#: marsha/core/models/account.py:285
+msgid "consumer site portabilities"
+msgstr ""
+
+#: marsha/core/models/account.py:292
+#, python-brace-format
+msgid "{source} was portable to {target}"
+msgstr ""
+
+#: marsha/core/models/account.py:293
+#, python-brace-format
+msgid "{source} is portable to {target}"
+msgstr ""
+
+#: marsha/core/models/account.py:306
+msgid "user with access to the consumer site"
+msgstr ""
+
+#: marsha/core/models/account.py:313 marsha/core/models/account.py:394
+msgid "site"
+msgstr ""
+
+#: marsha/core/models/account.py:314
+msgid "consumer site to which the user has access"
+msgstr ""
+
+#: marsha/core/models/account.py:321 marsha/core/models/account.py:457
+#: marsha/core/models/video.py:118
+msgid "role"
+msgstr ""
+
+#: marsha/core/models/account.py:322 marsha/core/models/account.py:458
+#: marsha/core/models/video.py:119
+msgid "role granted to the user on the consumer site"
+msgstr ""
+
+#: marsha/core/models/account.py:330
+msgid "consumer site access"
+msgstr ""
+
+#: marsha/core/models/account.py:331
+msgid "consumer site accesses"
+msgstr ""
+
+#: marsha/core/models/account.py:342
+#, python-brace-format
+msgid "{user} was {role} of {consumer_site}"
+msgstr ""
+
+#: marsha/core/models/account.py:343
+#, python-brace-format
+msgid "{user} is {role} of {consumer_site}"
+msgstr ""
+
+#: marsha/core/models/account.py:350
+msgid "name"
+msgstr ""
+
+#: marsha/core/models/account.py:350
+msgid "name of the organization"
+msgstr ""
+
+#: marsha/core/models/account.py:357
+msgid "consumer sites on which this organization is present"
+msgstr ""
+
+#: marsha/core/models/account.py:363
+msgid "users who have been granted access to this organization"
+msgstr ""
+
+#: marsha/core/models/account.py:395
+msgid "consumer site having this organization"
+msgstr ""
+
+#: marsha/core/models/account.py:403
+msgid "organization in this consumer site"
+msgstr ""
+
+#: marsha/core/models/account.py:412
+msgid "organization in consumer site"
+msgstr ""
+
+#: marsha/core/models/account.py:413
+msgid "organizations in consumer sites"
+msgstr ""
+
+#: marsha/core/models/account.py:423
+#, python-brace-format
+msgid "{organization} was in {consumer_site}"
+msgstr ""
+
+#: marsha/core/models/account.py:424
+#, python-brace-format
+msgid "{organization} is in {consumer_site}"
+msgstr ""
+
+#: marsha/core/models/account.py:442
+msgid "user who has access to the organization"
+msgstr ""
+
+#: marsha/core/models/account.py:450
+msgid "organization to which the user has access"
+msgstr ""
+
+#: marsha/core/models/account.py:466
+msgid "organization access"
+msgstr ""
+
+#: marsha/core/models/account.py:467
+msgid "organization accesses"
+msgstr ""
+
+#: marsha/core/models/account.py:478
+#, python-brace-format
+msgid "{user} was {role} of {organization}"
+msgstr ""
+
+#: marsha/core/models/account.py:480
+#, python-brace-format
+msgid "{user} is {role} of {organization}"
+msgstr ""
+
+#: marsha/core/models/base.py:93
+msgid "id"
+msgstr ""
+
+#: marsha/core/models/base.py:94
+msgid "primary key for the record as UUID"
+msgstr ""
+
+#: marsha/core/models/base.py:100
+msgid "created on"
+msgstr ""
+
+#: marsha/core/models/base.py:101
+msgid "date and time at which a record was created"
+msgstr ""
+
+#: marsha/core/models/base.py:106
+msgid "updated on"
+msgstr ""
+
+#: marsha/core/models/base.py:107
+msgid "date and time at which a record was last updated"
+msgstr ""
+
+#: marsha/core/models/base.py:355 marsha/core/models/video.py:183
+#: marsha/core/models/video.py:268
+msgid "uploaded on"
+msgstr ""
+
+#: marsha/core/models/base.py:357
+msgid "datetime at which the active version of the resource was uploaded."
+msgstr ""
+
+#: marsha/core/models/base.py:364 marsha/core/models/video.py:190
+#: marsha/core/models/video.py:275
+msgid "upload state"
+msgstr ""
+
+#: marsha/core/models/base.py:365
+msgid "state of the upload in AWS."
+msgstr ""
+
+#: marsha/core/models/video.py:19 marsha/core/models/video.py:136
+msgid "title"
+msgstr ""
+
+#: marsha/core/models/video.py:19
+msgid "title of the playlist"
+msgstr ""
+
+#: marsha/core/models/video.py:23 marsha/core/models/video.py:146
+msgid "lti id"
+msgstr ""
+
+#: marsha/core/models/video.py:24 marsha/core/models/video.py:147
+msgid "ID for synchronization with an external LTI tool"
+msgstr ""
+
+#: marsha/core/models/video.py:50
+msgid "is public"
+msgstr ""
+
+#: marsha/core/models/video.py:51
+msgid "if this playlist can be viewed without any access control"
+msgstr ""
+
+#: marsha/core/models/video.py:56 marsha/core/models/video.py:175
+msgid "duplicated from"
+msgstr ""
+
+#: marsha/core/models/video.py:57
+msgid "original playlist this one was duplicated from"
+msgstr ""
+
+#: marsha/core/models/video.py:68
+msgid "users who have been granted access to this playlist"
+msgstr ""
+
+#: marsha/core/models/video.py:77 marsha/core/models/video.py:110
+#: marsha/core/models/video.py:162
+msgid "playlist"
+msgstr ""
+
+#: marsha/core/models/video.py:78
+msgid "playlists"
+msgstr ""
+
+#: marsha/core/models/video.py:103
+msgid "user who has access to the playlist"
+msgstr ""
+
+#: marsha/core/models/video.py:111
+msgid "playlist to which the user has access"
+msgstr ""
+
+#: marsha/core/models/video.py:127
+msgid "playlist access"
+msgstr ""
+
+#: marsha/core/models/video.py:128
+msgid "playlist accesses"
+msgstr ""
+
+#: marsha/core/models/video.py:136
+msgid "title of the video"
+msgstr ""
+
+#: marsha/core/models/video.py:139
+msgid "description"
+msgstr ""
+
+#: marsha/core/models/video.py:140
+msgid "description of the video"
+msgstr ""
+
+#: marsha/core/models/video.py:152
+msgid "author"
+msgstr ""
+
+#: marsha/core/models/video.py:153
+msgid "author of the video"
+msgstr ""
+
+#: marsha/core/models/video.py:163
+msgid "playlist to which this video belongs"
+msgstr ""
+
+#: marsha/core/models/video.py:168
+msgid "position"
+msgstr ""
+
+#: marsha/core/models/video.py:169
+msgid "position of this video in the playlist"
+msgstr ""
+
+#: marsha/core/models/video.py:176
+msgid "original video this one was duplicated from"
+msgstr ""
+
+#: marsha/core/models/video.py:184 marsha/core/models/video.py:269
+msgid "datetime at which the active version of the video was uploaded."
+msgstr ""
+
+#: marsha/core/models/video.py:191 marsha/core/models/video.py:276
+msgid "state of the upload and transcoding pipeline in AWS."
+msgstr ""
+
+#: marsha/core/models/video.py:257
+msgid "video for which this track is"
+msgstr ""
+
+#: marsha/core/models/video.py:264
+msgid "language"
+msgstr ""
+
+#: marsha/core/models/video.py:265
+msgid "language of this track"
+msgstr ""
+
+#: marsha/core/models/video.py:303
+msgid "audio track"
+msgstr ""
+
+#: marsha/core/models/video.py:304
+msgid "audio tracks"
+msgstr ""
+
+#: marsha/core/models/video.py:316
+msgid "Subtitle"
+msgstr ""
+
+#: marsha/core/models/video.py:317
+msgid "Transcript"
+msgstr ""
+
+#: marsha/core/models/video.py:318
+msgid "Closed captioning"
+msgstr ""
+
+#: marsha/core/models/video.py:322
+msgid "mode"
+msgstr ""
+
+#: marsha/core/models/video.py:326
+msgid "Activate a special mode for this timed text track: simple subtitles, closed captioning (for deaf or hard of hearing viewers) or transcription (complete text below aside of the player)."
+msgstr ""
+
+#: marsha/core/models/video.py:337
+msgid "timed text track"
+msgstr ""
+
+#: marsha/core/models/video.py:338
+msgid "timed text tracks"
+msgstr ""
+
+#: marsha/core/models/video.py:380
+msgid "signs language track"
+msgstr ""
+
+#: marsha/core/models/video.py:381
+msgid "signs language tracks"
+msgstr ""
+
+#: marsha/core/models/video.py:392
+msgid "video for which this thumbnail is"
+msgstr ""
+
+#: marsha/core/models/video.py:401
+msgid "thumbnail"
+msgstr ""
+
+#: marsha/settings.py:160
+msgid "english"
+msgstr ""
+
+#: marsha/settings.py:160
+msgid "french"
+msgstr ""
+

--- a/src/backend/locale/fr_FR/LC_MESSAGES/django.po
+++ b/src/backend/locale/fr_FR/LC_MESSAGES/django.po
@@ -1,0 +1,582 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: marsha\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-04-18 13:21+0000\n"
+"PO-Revision-Date: 2019-04-24 09:49\n"
+"Last-Translator: Manuel Raynaud (lunika)\n"
+"Language-Team: French\n"
+"Language: fr_FR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: crowdin.com\n"
+"X-Crowdin-Project: marsha\n"
+"X-Crowdin-Language: fr\n"
+"X-Crowdin-File: backend.pot\n"
+
+#: marsha/core/admin.py:77
+#, python-brace-format
+msgid "{marsha_name} administration"
+msgstr ""
+
+#: marsha/core/admin.py:88 marsha/core/admin.py:111
+#: marsha/core/models/account.py:370 marsha/core/models/account.py:402
+#: marsha/core/models/account.py:449
+msgid "organization"
+msgstr ""
+
+#: marsha/core/admin.py:89 marsha/core/admin.py:112
+#: marsha/core/models/account.py:371
+msgid "organizations"
+msgstr ""
+
+#: marsha/core/admin.py:103 marsha/core/admin.py:154
+#: marsha/core/models/account.py:44 marsha/core/models/account.py:305
+#: marsha/core/models/account.py:441 marsha/core/models/video.py:102
+msgid "user"
+msgstr ""
+
+#: marsha/core/admin.py:104 marsha/core/admin.py:155
+#: marsha/core/models/account.py:45 marsha/core/models/account.py:205
+#: marsha/core/models/account.py:362 marsha/core/models/video.py:67
+msgid "users"
+msgstr ""
+
+#: marsha/core/admin.py:120 marsha/core/admin.py:121
+#: marsha/core/models/account.py:196
+msgid "portable to"
+msgstr ""
+
+#: marsha/core/admin.py:162 marsha/core/models/account.py:242
+msgid "consumer site"
+msgstr ""
+
+#: marsha/core/admin.py:163 marsha/core/models/account.py:243
+msgid "consumer sites"
+msgstr ""
+
+#: marsha/core/admin.py:248 marsha/core/admin.py:342
+msgid "Video"
+msgstr ""
+
+#: marsha/core/admin.py:255 marsha/core/models/video.py:202
+#: marsha/core/models/video.py:256 marsha/core/models/video.py:391
+msgid "video"
+msgstr ""
+
+#: marsha/core/admin.py:256 marsha/core/models/video.py:203
+msgid "videos"
+msgstr ""
+
+#: marsha/core/admin.py:283
+msgid "user access"
+msgstr ""
+
+#: marsha/core/admin.py:284
+msgid "users accesses"
+msgstr ""
+
+#: marsha/core/admin.py:380 marsha/core/models/account.py:124
+msgid "LTI passport"
+msgstr ""
+
+#: marsha/core/apps.py:11
+msgid "Marsha"
+msgstr ""
+
+#: marsha/core/defaults.py:18
+msgid "pending"
+msgstr ""
+
+#: marsha/core/defaults.py:19
+msgid "processing"
+msgstr ""
+
+#: marsha/core/defaults.py:20
+msgid "error"
+msgstr ""
+
+#: marsha/core/defaults.py:21
+msgid "ready"
+msgstr ""
+
+#: marsha/core/models/account.py:29
+msgid "administrator"
+msgstr ""
+
+#: marsha/core/models/account.py:30
+msgid "instructor"
+msgstr ""
+
+#: marsha/core/models/account.py:31
+msgid "student"
+msgstr ""
+
+#: marsha/core/models/account.py:53 marsha/core/models/account.py:377
+msgid " [deleted]"
+msgstr ""
+
+#: marsha/core/models/account.py:76
+msgid "oauth consumer key"
+msgstr ""
+
+#: marsha/core/models/account.py:79
+msgid "oauth consumer key to authenticate an LTI consumer on the LTI provider"
+msgstr ""
+
+#: marsha/core/models/account.py:85
+msgid "shared secret"
+msgstr ""
+
+#: marsha/core/models/account.py:86
+msgid "LTI Shared secret"
+msgstr ""
+
+#: marsha/core/models/account.py:115
+msgid "is enabled"
+msgstr ""
+
+#: marsha/core/models/account.py:116
+msgid "whether the passport is enabled"
+msgstr ""
+
+#: marsha/core/models/account.py:125
+msgid "LTI passports"
+msgstr ""
+
+#: marsha/core/models/account.py:138
+msgid "{:s}[deleted]"
+msgstr ""
+
+#: marsha/core/models/account.py:145
+msgid "You should set either a Consumer Site or a Playlist, but not both."
+msgstr ""
+
+#: marsha/core/models/account.py:150
+msgid "You must set either a Consumer Site or a Playlist."
+msgstr ""
+
+#: marsha/core/models/account.py:184
+msgid "display name"
+msgstr ""
+
+#: marsha/core/models/account.py:185
+msgid "name of the consumer site."
+msgstr ""
+
+#: marsha/core/models/account.py:189
+msgid "domain name"
+msgstr ""
+
+#: marsha/core/models/account.py:190
+msgid "base domain allowed for consumer site."
+msgstr ""
+
+#: marsha/core/models/account.py:197
+msgid "consumer sites to which this site is automatically portable."
+msgstr ""
+
+#: marsha/core/models/account.py:206
+msgid "users who have been granted access to this consumer site."
+msgstr ""
+
+#: marsha/core/models/account.py:210
+msgid "LRS authentication token"
+msgstr ""
+
+#: marsha/core/models/account.py:211
+msgid "LRS authentication token used to communicate with a remote LRS"
+msgstr ""
+
+#: marsha/core/models/account.py:217
+msgid "LRS url"
+msgstr ""
+
+#: marsha/core/models/account.py:218
+msgid "LRS url used to communicate with a remote LRS"
+msgstr ""
+
+#: marsha/core/models/account.py:224
+msgid "xAPI version"
+msgstr ""
+
+#: marsha/core/models/account.py:225
+msgid "xAPI version used by the remote LRS server"
+msgstr ""
+
+#: marsha/core/models/account.py:231
+msgid "show video download"
+msgstr ""
+
+#: marsha/core/models/account.py:233
+msgid "default value used for every newly created video to determine if the links to download a video are shown by default."
+msgstr ""
+
+#: marsha/core/models/account.py:249 marsha/core/models/video.py:85
+#: marsha/core/models/video.py:210
+msgid "{:s} [deleted]"
+msgstr ""
+
+#: marsha/core/models/account.py:266
+msgid "source site"
+msgstr ""
+
+#: marsha/core/models/account.py:267
+msgid "consumer site that is portable."
+msgstr ""
+
+#: marsha/core/models/account.py:274
+msgid "target site"
+msgstr ""
+
+#: marsha/core/models/account.py:275
+msgid "consumer site to which portability is automatic."
+msgstr ""
+
+#: marsha/core/models/account.py:284
+msgid "consumer site portability"
+msgstr ""
+
+#: marsha/core/models/account.py:285
+msgid "consumer site portabilities"
+msgstr ""
+
+#: marsha/core/models/account.py:292
+#, python-brace-format
+msgid "{source} was portable to {target}"
+msgstr ""
+
+#: marsha/core/models/account.py:293
+#, python-brace-format
+msgid "{source} is portable to {target}"
+msgstr ""
+
+#: marsha/core/models/account.py:306
+msgid "user with access to the consumer site"
+msgstr ""
+
+#: marsha/core/models/account.py:313 marsha/core/models/account.py:394
+msgid "site"
+msgstr ""
+
+#: marsha/core/models/account.py:314
+msgid "consumer site to which the user has access"
+msgstr ""
+
+#: marsha/core/models/account.py:321 marsha/core/models/account.py:457
+#: marsha/core/models/video.py:118
+msgid "role"
+msgstr ""
+
+#: marsha/core/models/account.py:322 marsha/core/models/account.py:458
+#: marsha/core/models/video.py:119
+msgid "role granted to the user on the consumer site"
+msgstr ""
+
+#: marsha/core/models/account.py:330
+msgid "consumer site access"
+msgstr ""
+
+#: marsha/core/models/account.py:331
+msgid "consumer site accesses"
+msgstr ""
+
+#: marsha/core/models/account.py:342
+#, python-brace-format
+msgid "{user} was {role} of {consumer_site}"
+msgstr ""
+
+#: marsha/core/models/account.py:343
+#, python-brace-format
+msgid "{user} is {role} of {consumer_site}"
+msgstr ""
+
+#: marsha/core/models/account.py:350
+msgid "name"
+msgstr ""
+
+#: marsha/core/models/account.py:350
+msgid "name of the organization"
+msgstr ""
+
+#: marsha/core/models/account.py:357
+msgid "consumer sites on which this organization is present"
+msgstr ""
+
+#: marsha/core/models/account.py:363
+msgid "users who have been granted access to this organization"
+msgstr ""
+
+#: marsha/core/models/account.py:395
+msgid "consumer site having this organization"
+msgstr ""
+
+#: marsha/core/models/account.py:403
+msgid "organization in this consumer site"
+msgstr ""
+
+#: marsha/core/models/account.py:412
+msgid "organization in consumer site"
+msgstr ""
+
+#: marsha/core/models/account.py:413
+msgid "organizations in consumer sites"
+msgstr ""
+
+#: marsha/core/models/account.py:423
+#, python-brace-format
+msgid "{organization} was in {consumer_site}"
+msgstr ""
+
+#: marsha/core/models/account.py:424
+#, python-brace-format
+msgid "{organization} is in {consumer_site}"
+msgstr ""
+
+#: marsha/core/models/account.py:442
+msgid "user who has access to the organization"
+msgstr ""
+
+#: marsha/core/models/account.py:450
+msgid "organization to which the user has access"
+msgstr ""
+
+#: marsha/core/models/account.py:466
+msgid "organization access"
+msgstr ""
+
+#: marsha/core/models/account.py:467
+msgid "organization accesses"
+msgstr ""
+
+#: marsha/core/models/account.py:478
+#, python-brace-format
+msgid "{user} was {role} of {organization}"
+msgstr ""
+
+#: marsha/core/models/account.py:480
+#, python-brace-format
+msgid "{user} is {role} of {organization}"
+msgstr ""
+
+#: marsha/core/models/base.py:93
+msgid "id"
+msgstr ""
+
+#: marsha/core/models/base.py:94
+msgid "primary key for the record as UUID"
+msgstr ""
+
+#: marsha/core/models/base.py:100
+msgid "created on"
+msgstr ""
+
+#: marsha/core/models/base.py:101
+msgid "date and time at which a record was created"
+msgstr ""
+
+#: marsha/core/models/base.py:106
+msgid "updated on"
+msgstr ""
+
+#: marsha/core/models/base.py:107
+msgid "date and time at which a record was last updated"
+msgstr ""
+
+#: marsha/core/models/base.py:355 marsha/core/models/video.py:183
+#: marsha/core/models/video.py:268
+msgid "uploaded on"
+msgstr ""
+
+#: marsha/core/models/base.py:357
+msgid "datetime at which the active version of the resource was uploaded."
+msgstr ""
+
+#: marsha/core/models/base.py:364 marsha/core/models/video.py:190
+#: marsha/core/models/video.py:275
+msgid "upload state"
+msgstr ""
+
+#: marsha/core/models/base.py:365
+msgid "state of the upload in AWS."
+msgstr ""
+
+#: marsha/core/models/video.py:19 marsha/core/models/video.py:136
+msgid "title"
+msgstr ""
+
+#: marsha/core/models/video.py:19
+msgid "title of the playlist"
+msgstr ""
+
+#: marsha/core/models/video.py:23 marsha/core/models/video.py:146
+msgid "lti id"
+msgstr ""
+
+#: marsha/core/models/video.py:24 marsha/core/models/video.py:147
+msgid "ID for synchronization with an external LTI tool"
+msgstr ""
+
+#: marsha/core/models/video.py:50
+msgid "is public"
+msgstr ""
+
+#: marsha/core/models/video.py:51
+msgid "if this playlist can be viewed without any access control"
+msgstr ""
+
+#: marsha/core/models/video.py:56 marsha/core/models/video.py:175
+msgid "duplicated from"
+msgstr ""
+
+#: marsha/core/models/video.py:57
+msgid "original playlist this one was duplicated from"
+msgstr ""
+
+#: marsha/core/models/video.py:68
+msgid "users who have been granted access to this playlist"
+msgstr ""
+
+#: marsha/core/models/video.py:77 marsha/core/models/video.py:110
+#: marsha/core/models/video.py:162
+msgid "playlist"
+msgstr ""
+
+#: marsha/core/models/video.py:78
+msgid "playlists"
+msgstr ""
+
+#: marsha/core/models/video.py:103
+msgid "user who has access to the playlist"
+msgstr ""
+
+#: marsha/core/models/video.py:111
+msgid "playlist to which the user has access"
+msgstr ""
+
+#: marsha/core/models/video.py:127
+msgid "playlist access"
+msgstr ""
+
+#: marsha/core/models/video.py:128
+msgid "playlist accesses"
+msgstr ""
+
+#: marsha/core/models/video.py:136
+msgid "title of the video"
+msgstr ""
+
+#: marsha/core/models/video.py:139
+msgid "description"
+msgstr ""
+
+#: marsha/core/models/video.py:140
+msgid "description of the video"
+msgstr ""
+
+#: marsha/core/models/video.py:152
+msgid "author"
+msgstr ""
+
+#: marsha/core/models/video.py:153
+msgid "author of the video"
+msgstr ""
+
+#: marsha/core/models/video.py:163
+msgid "playlist to which this video belongs"
+msgstr ""
+
+#: marsha/core/models/video.py:168
+msgid "position"
+msgstr ""
+
+#: marsha/core/models/video.py:169
+msgid "position of this video in the playlist"
+msgstr ""
+
+#: marsha/core/models/video.py:176
+msgid "original video this one was duplicated from"
+msgstr ""
+
+#: marsha/core/models/video.py:184 marsha/core/models/video.py:269
+msgid "datetime at which the active version of the video was uploaded."
+msgstr ""
+
+#: marsha/core/models/video.py:191 marsha/core/models/video.py:276
+msgid "state of the upload and transcoding pipeline in AWS."
+msgstr ""
+
+#: marsha/core/models/video.py:257
+msgid "video for which this track is"
+msgstr ""
+
+#: marsha/core/models/video.py:264
+msgid "language"
+msgstr ""
+
+#: marsha/core/models/video.py:265
+msgid "language of this track"
+msgstr ""
+
+#: marsha/core/models/video.py:303
+msgid "audio track"
+msgstr ""
+
+#: marsha/core/models/video.py:304
+msgid "audio tracks"
+msgstr ""
+
+#: marsha/core/models/video.py:316
+msgid "Subtitle"
+msgstr ""
+
+#: marsha/core/models/video.py:317
+msgid "Transcript"
+msgstr ""
+
+#: marsha/core/models/video.py:318
+msgid "Closed captioning"
+msgstr ""
+
+#: marsha/core/models/video.py:322
+msgid "mode"
+msgstr ""
+
+#: marsha/core/models/video.py:326
+msgid "Activate a special mode for this timed text track: simple subtitles, closed captioning (for deaf or hard of hearing viewers) or transcription (complete text below aside of the player)."
+msgstr ""
+
+#: marsha/core/models/video.py:337
+msgid "timed text track"
+msgstr ""
+
+#: marsha/core/models/video.py:338
+msgid "timed text tracks"
+msgstr ""
+
+#: marsha/core/models/video.py:380
+msgid "signs language track"
+msgstr ""
+
+#: marsha/core/models/video.py:381
+msgid "signs language tracks"
+msgstr ""
+
+#: marsha/core/models/video.py:392
+msgid "video for which this thumbnail is"
+msgstr ""
+
+#: marsha/core/models/video.py:401
+msgid "thumbnail"
+msgstr ""
+
+#: marsha/settings.py:160
+msgid "english"
+msgstr ""
+
+#: marsha/settings.py:160
+msgid "french"
+msgstr ""
+

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -2,7 +2,7 @@
 name = marsha
 description = A FUN video provider for Open edX
 long_description = file:README.rst
-version = 2.6.0
+version = 2.7.0
 author = Open FUN (France Universite Numerique)
 author_email = fun.dev@fun-mooc.fr
 license = MIT

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marsha",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "🐠 a FUN LTI video provider",
   "main": "front/index.tsx",
   "scripts": {

--- a/src/frontend/translations/es_ES.po
+++ b/src/frontend/translations/es_ES.po
@@ -5,14 +5,14 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "MIME-Version: 1.0\n"
 "X-Generator: crowdin.com\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Crowdin-Project: marsha\n"
-"X-Crowdin-Language: fr\n"
+"X-Crowdin-Language: es-ES\n"
 "X-Crowdin-File: frontend.pot\n"
 "Project-Id-Version: marsha\n"
 "Last-Translator: Manuel Raynaud (lunika)\n"
-"Language-Team: French\n"
-"Language: fr_FR\n"
+"Language-Team: Spanish\n"
+"Language: es_ES\n"
 "PO-Revision-Date: 2019-04-24 09:49\n"
 
 #. [components.DownloadVideo.1080] - High quality video
@@ -20,63 +20,63 @@ msgstr ""
 #. 1080p: FullHD (high quality)
 #: i18n/components/DowloadVideo/DownloadVideo.json
 msgid "1080p: FullHD (high quality)"
-msgstr "1080p: FullHD (haute qualité)"
+msgstr "1080p: FullHD (alta calidad)"
 
 #. [components.DownloadVideo.480] - Mobile quality video
 #. defaultMessage is:
 #. 480p: SD (Mobile)
 #: i18n/components/DowloadVideo/DownloadVideo.json
 msgid "480p: SD (Mobile)"
-msgstr "480p: SD (mobile)"
+msgstr "480p: SD (Móvil)"
 
 #. [components.DownloadVideo.720] - Normal quality video
 #. defaultMessage is:
 #. 720p: HD (standard)
 #: i18n/components/DowloadVideo/DownloadVideo.json
 msgid "720p: HD (standard)"
-msgstr "720p: HD (normal)"
+msgstr "720p: HD (estándar)"
 
 #. [components.TimedTextCreationForm.addTrackLabel] - Label for the form that lets the instructor add a new timed text track.
 #. defaultMessage is:
 #. Add a language
 #: i18n/components/TimedTextCreationForm/TimedTextCreationForm.json
 msgid "Add a language"
-msgstr "Ajouter une langue"
+msgstr "Añadir un idioma"
 
 #. [component.DashboardVideoPaneDownloadOption.allowDownload]
 #. defaultMessage is:
 #. Allow video download
 #: i18n/components/DashboardVideoPaneDownloadOption/DashboardVideoPaneDownloadOption.json
 msgid "Allow video download"
-msgstr "Autoriser le téléchargement de la vidéo"
+msgstr "Permitir descarga de vídeos"
 
 #. [components.UploadForm.linkToDashboard] - Text for the link to the dashboard in the upload form.
 #. defaultMessage is:
 #. Back to dashboard
 #: i18n/components/UploadForm/UploadForm.json
 msgid "Back to dashboard"
-msgstr "Revenir au tableau de bord"
+msgstr "Volver al panel de control"
 
 #. [components.Transcripts.transcriptSelect] - Placeholder for the transcript select box
 #. defaultMessage is:
 #. Choose a language
 #: i18n/components/Transcripts/Transcripts.json
 msgid "Choose a language"
-msgstr "Choisir une langue"
+msgstr "Elegir un idioma"
 
 #. [components.DashboardTimedTextPane.closedCaptions] - Title for the closed captions management in the dashboard.
 #. defaultMessage is:
 #. Closed captions
 #: i18n/components/DashboardTimedTextPane/DashboardTimedTextPane.json
 msgid "Closed captions"
-msgstr "Sous-titres"
+msgstr "Subtítulos"
 
 #. [components.UploadForm.title-videos] - Title for the video upload form
 #. defaultMessage is:
 #. Create a new video
 #: i18n/components/UploadForm/UploadForm.json
 msgid "Create a new video"
-msgstr "Créer une nouvelle vidéo"
+msgstr "Crear un nuevo vídeo"
 
 #. [components.Dashboard.title] - Title for the dashboard, where the user can see the status of the video/audio/timed text upload
 #.       & processing, and will be able to manage them.
@@ -84,63 +84,63 @@ msgstr "Créer une nouvelle vidéo"
 #. Dashboard
 #: i18n/components/Dashboard/Dashboard.json
 msgid "Dashboard"
-msgstr "Tableau de bord"
+msgstr "Panel de control"
 
 #. [components.TimedTextListItem.delete] - Link text to delete a subtitle/transcript/captions item.
 #. defaultMessage is:
 #. Delete
 #: i18n/components/TimedTextListItem/TimedTextListItem.json
 msgid "Delete"
-msgstr "Supprimer"
+msgstr "Eliminar"
 
 #. [components.DownloadVideo.downloadVideo] - Text to download the video
 #. defaultMessage is:
 #. Download this video:
 #: i18n/components/DowloadVideo/DownloadVideo.json
 msgid "Download this video:"
-msgstr "Télécharger cette vidéo :"
+msgstr "Descargar este vídeo:"
 
 #. [components.UploadStatusPicker.ERROR] - Status information for a video/audio/timed text track
 #. defaultMessage is:
 #. Error
 #: i18n/components/UploadStatusPicker/UploadStatusPicker.json
 msgid "Error"
-msgstr "Erreur"
+msgstr "Error"
 
 #. [components.ErrorComponent.policy.title] - Helpful text for the upload permission error page
 #. defaultMessage is:
 #. Failed to authenticate your permission to upload
 #: i18n/components/ErrorComponent/ErrorComponent.json
 msgid "Failed to authenticate your permission to upload"
-msgstr "Impossible de vérifier vos droits pour téléverser le fichier"
+msgstr "Error al autenticar su permiso para subir vídeos"
 
 #. [component.DashboardVideoPaneDownloadOption.updateVideoFail] - Failed to update download permission on your video.
 #. defaultMessage is:
 #. Failed to update your video. Please try again later.
 #: i18n/components/DashboardVideoPaneDownloadOption/DashboardVideoPaneDownloadOption.json
 msgid "Failed to update your video. Please try again later."
-msgstr "Impossible de mettre à jour la vidéo. Merci de réessayer plus tard."
+msgstr "Error al actualizar el vídeo. Por favor, inténtelo de nuevo más tarde."
 
 #. [components.ErrorComponent.upload.title] - Title for the video upload error page
 #. defaultMessage is:
 #. Failed to upload your video file
 #: i18n/components/ErrorComponent/ErrorComponent.json
 msgid "Failed to upload your video file"
-msgstr "Erreur lors du téléversement du fichier vidéo"
+msgstr "Error al subir el archivo de vídeo"
 
 #. [components.InstructorView.btnDashboard] - Text for the button in the instructor view that allows the instructor to go to the dashboard.
 #. defaultMessage is:
 #. Go to Dashboard
 #: i18n/components/InstructorView/InstructorView.json
 msgid "Go to Dashboard"
-msgstr "Aller au tableau de bord"
+msgstr "Ir al panel de control"
 
 #. [components.Transcripts.hideTranscript] - Text to hide a displayed transcript
 #. defaultMessage is:
 #. Hide transcript
 #: i18n/components/Transcripts/Transcripts.json
 msgid "Hide transcript"
-msgstr "Masquer le transcrit"
+msgstr "Ocultar transcripción"
 
 #. [components.InstructorView.title] - Title for the Instructor View. Describes the area appearing right above, which is a preview
 #.       of what the student will see there.
@@ -148,49 +148,49 @@ msgstr "Masquer le transcrit"
 #. Instructor Preview 👆
 #: i18n/components/InstructorView/InstructorView.json
 msgid "Instructor Preview 👆"
-msgstr "Aperçu instructeur 👆"
+msgstr "Vista previa del instructor"
 
 #. [components.UploadStatusPicker.PENDING] - Status information for a video/audio/timed text track
 #. defaultMessage is:
 #. Missing
 #: i18n/components/UploadStatusPicker/UploadStatusPicker.json
 msgid "Missing"
-msgstr "Absent"
+msgstr "Desaparecido"
 
 #. [components.UploadStatusPicker.PROCESSING] - Status information for a video/audio/timed text track
 #. defaultMessage is:
 #. Processing
 #: i18n/components/UploadStatusPicker/UploadStatusPicker.json
 msgid "Processing"
-msgstr "En cours de traitement"
+msgstr "Procesando"
 
 #. [components.UploadStatusPicker.READY] - Status information for a video/audio/timed text track
 #. defaultMessage is:
 #. Ready
 #: i18n/components/UploadStatusPicker/UploadStatusPicker.json
 msgid "Ready"
-msgstr "Disponible"
+msgstr "Listo"
 
 #. [components.TimedTextListItem.replace] - Link text to replace a subtitle/transcript/captions item with a new file (for the same language).
 #. defaultMessage is:
 #. Replace
 #: i18n/components/TimedTextListItem/TimedTextListItem.json
 msgid "Replace"
-msgstr "Remplacer"
+msgstr "Reemplazar"
 
 #. [components.Dashboard.DashboardVideoPaneButtons.btnReplaceVideo] - Dashboard button to upload a video to replace the existing one, when there *is* an existing video.
 #. defaultMessage is:
 #. Replace the video
 #: i18n/components/DashboardVideoPaneButtons/DashboardVideoPaneButtons.json
 msgid "Replace the video"
-msgstr "Remplacer la vidéo"
+msgstr "Reemplazar este vídeo"
 
 #. [components.dashboardThumbnail.replaceThumbnailButton]
 #. defaultMessage is:
 #. Replace this thumbnail
 #: i18n/components/DashboardThumbnail/DashboardThumbnail.json
 msgid "Replace this thumbnail"
-msgstr "Remplacer cette vignette"
+msgstr "Reemplazar esta miniatura"
 
 #. [components.UploadForm.dropzoneButtonPick] - File upload dropzone: button to choose a file to upload,
 #.       has the drag text next to it (components.UploadForm.dropzoneDragText)
@@ -198,63 +198,63 @@ msgstr "Remplacer cette vignette"
 #. Select a file to upload
 #: i18n/components/UploadField/DropzonePlaceholder.json
 msgid "Select a file to upload"
-msgstr "Sélectionner un fichier à téléverser"
+msgstr "Eligir un archivo para subir"
 
 #. [components.Transcripts.transcriptLabel] - Text indicated to choose an available transcript language
 #. defaultMessage is:
 #. Show a transcript
 #: i18n/components/Transcripts/Transcripts.json
 msgid "Show a transcript"
-msgstr "Choisir un transcrit"
+msgstr "Eligir una transcripción"
 
 #. [components.DashboardTimedTextPane.subtitles] - Title for the subtitles management in the dashboard.
 #. defaultMessage is:
 #. Subtitles
 #: i18n/components/DashboardTimedTextPane/DashboardTimedTextPane.json
 msgid "Subtitles"
-msgstr "Sous-titres"
+msgstr "Subtítulos"
 
 #. [components.ErrorComponent.notFound.title] - Title for the 404 Not Found error page
 #. defaultMessage is:
 #. The video you are looking for could not be found
 #: i18n/components/ErrorComponent/ErrorComponent.json
 msgid "The video you are looking for could not be found"
-msgstr "Cette vidéo n'est pas disponible"
+msgstr "El vídeo que está buscando no ha sido encontrado"
 
 #. [components.Dashboard.DashboardVideoPaneHelptext.helptextPending] - Dashboard helptext for the case when there is no existing video nor anything in progress.
 #. defaultMessage is:
 #. There is currently no video to display.
 #: i18n/components/DashboardVideoPaneHelptext/DashboardVideoPaneHelptext.json
 msgid "There is currently no video to display."
-msgstr "Il n'y a pas encore de vidéo à afficher."
+msgstr "Actualmente no hay ningún vídeo para mostrar."
 
 #. [components.DashboardThumbnail.error] - Generic error message when we fail to create a thumbnail.
 #. defaultMessage is:
 #. There was an error during thumbnail creation.
 #: i18n/components/DashboardThumbnail/DashboardThumbnail.json
 msgid "There was an error during thumbnail creation."
-msgstr "Une erreur s'est produite durant la création de la vignette."
+msgstr "Se produjo un error durante la creación de miniaturas."
 
 #. [components.TimedTextCreationForm.error] - Generic error message when we fail to create a subtitle/transcript/caption track.
 #. defaultMessage is:
 #. There was an error during track creation.
 #: i18n/components/TimedTextCreationForm/TimedTextCreationForm.json
 msgid "There was an error during track creation."
-msgstr "Une erreur s'est produite pendant la création de cette piste."
+msgstr "Se produjo un error durante la creación de pistas."
 
 #. [components.ErrorComponent.lti.title] - Title for the LTI error page
 #. defaultMessage is:
 #. There was an error loading this video
 #: i18n/components/ErrorComponent/ErrorComponent.json
 msgid "There was an error loading this video"
-msgstr "Une erreur s'est produite pendant le chargement de la vidéo"
+msgstr "Se produjo un error al cargar este video"
 
 #. [components.Dashboard.DashboardVideoPaneHelptext.helptextError] - Dashboard helptext for when the video failed to upload or get processed.
 #. defaultMessage is:
 #. There was an error with your video. Retry or upload another one.
 #: i18n/components/DashboardVideoPaneHelptext/DashboardVideoPaneHelptext.json
 msgid "There was an error with your video. Retry or upload another one."
-msgstr "Une erreur s'est produite avec cette vidéo. Réessayez ou choisissez une autre vidéo."
+msgstr "Se produjo un error con el vídeo. Vuelva a intentarlo o suba otro."
 
 #. [components.ErrorComponent.notFound.text] - Helpful text for the 404 Not Found error page
 #. defaultMessage is:
@@ -263,119 +263,120 @@ msgstr "Une erreur s'est produite avec cette vidéo. Réessayez ou choisissez un
 #: i18n/components/ErrorComponent/ErrorComponent.json
 msgid "This video does not exist or has not been published yet.\n"
 "      If you are an instructor, please make sure you are properly authenticated."
-msgstr "La vidéo n'existe pas ou n'a pas encore été publiée. Si vous êtes un instructeur assurez vous d'être correctement authentifié."
+msgstr "Este video no existe o no ha sido publicado todavía.\n"
+"      Si usted es un instructor, por favor asegúrese de que está autenticado correctamente."
 
 #. [components.InstructorView.disabledDashboard] - Text explaining that the ivdeo is in read_only mode and the dashboard is not available
 #. defaultMessage is:
 #. This video is imported from another playlist. You can go to the original playlist to directly modify this video, or delete it from the current playlist and replace it by a new video.
 #: i18n/components/InstructorView/InstructorView.json
 msgid "This video is imported from another playlist. You can go to the original playlist to directly modify this video, or delete it from the current playlist and replace it by a new video."
-msgstr "Cette vidéo a été importé depuis un autre cours. Pour la modifier vous devez le faire depuis le cours d'origine ou bien supprimer ce block et en recréer un nouveau avec cette vidéo."
+msgstr ""
 
 #. [components.DashboardTimedTextPane.transcripts] - Title for the transcripts management in the dashboard.
 #. defaultMessage is:
 #. Transcripts
 #: i18n/components/DashboardTimedTextPane/DashboardTimedTextPane.json
 msgid "Transcripts"
-msgstr "Transcrits"
+msgstr "Transcripción"
 
 #. [components.TimedTextListItem.upload] - Link text to upload a missing subtitle/transcript/captions item file.
 #. defaultMessage is:
 #. Upload
 #: i18n/components/TimedTextListItem/TimedTextListItem.json
 msgid "Upload"
-msgstr "Téléverser"
+msgstr "Subir"
 
 #. [components.UploadForm.title-timedtexttracks-cc] - Title for the timed text file upload form
 #. defaultMessage is:
 #. Upload a new closed captions file
 #: i18n/components/UploadForm/UploadForm.json
 msgid "Upload a new closed captions file"
-msgstr "Téléverser un nouveau fichier de sous-titres codés (sourds et malentendants)"
+msgstr "Subir un nuevo archivo de subtítulos"
 
 #. [components.UploadForm.title-timedtexttracks-st] - Title for the timed text file upload form
 #. defaultMessage is:
 #. Upload a new subtitles file
 #: i18n/components/UploadForm/UploadForm.json
 msgid "Upload a new subtitles file"
-msgstr "Téléverser un nouveau fichier de sous-titres"
+msgstr "Subir un nuevo archivo de subtítulos"
 
 #. [components.UploadForm.title-thumbnail] - Title for the thumbnail upload form
 #. defaultMessage is:
 #. Upload a new thumbnail
 #: i18n/components/UploadForm/UploadForm.json
 msgid "Upload a new thumbnail"
-msgstr "Téléverser une nouvelle vignette"
+msgstr "Subir una nueva miniatura"
 
 #. [components.UploadForm.title-timedtexttracks-ts] - Title for the timed text file upload form
 #. defaultMessage is:
 #. Upload a new transcript file
 #: i18n/components/UploadForm/UploadForm.json
 msgid "Upload a new transcript file"
-msgstr "Téléverser un nouveau transcrit"
+msgstr "Subir un nuevo archivo de transcripción"
 
 #. [components.Dashboard.DashboardVideoPaneButtons.btnUploadFirstVideo] - Dashboard button to upload a video, when there is no existing video.
 #. defaultMessage is:
 #. Upload a video
 #: i18n/components/DashboardVideoPaneButtons/DashboardVideoPaneButtons.json
 msgid "Upload a video"
-msgstr "Téléverser une vidéo"
+msgstr "Subir un vídeo"
 
 #. [components.Dashboard.DashboardVideoPaneHelptext.helptextUploading] - Dashboard helptext to warn user not to navigate away during video upload.
 #. defaultMessage is:
 #. Upload in progress... Please do not close or reload this page.
 #: i18n/components/DashboardVideoPaneHelptext/DashboardVideoPaneHelptext.json
 msgid "Upload in progress... Please do not close or reload this page."
-msgstr "Téléversement en cours... Merci de ne pas fermer ni recharger la page."
+msgstr "Carga en curso... Por favor no cierre o vuelva a cargar esta página."
 
 #. [components.DashboardVideoPaneProgress.progressLabel] - Accessibility message for the upload progress bar.
 #. defaultMessage is:
 #. Upload progress
 #: i18n/components/DashboardObjectProgress/DashboardObjectProgress.json
 msgid "Upload progress"
-msgstr "Progression du téléversement"
+msgstr "Progreso de carga"
 
 #. [components.TimedTextCreationForm.addTrackBtn] - Text for the button in the dashboard to go upload a new timed text file.
 #. defaultMessage is:
 #. Upload the file
 #: i18n/components/TimedTextCreationForm/TimedTextCreationForm.json
 msgid "Upload the file"
-msgstr "Téléverser le fichier"
+msgstr "Subir el archivo"
 
 #. [components.UploadStatusPicker.UPLOADING] - Status information for a video/audio/timed text track
 #. defaultMessage is:
 #. Uploading
 #: i18n/components/UploadStatusPicker/UploadStatusPicker.json
 msgid "Uploading"
-msgstr "Téléversement en cours"
+msgstr "Subiendo"
 
 #. [components.DashboardVideoPane.title] - Subtitle for the video part of the dashboard (right now the only part until we add timed text tracks).
 #. defaultMessage is:
 #. Video status
 #: i18n/components/DashboardVideoPane/DashboardVideoPane.json
 msgid "Video status"
-msgstr "Statut de la vidéo"
+msgstr "Estado del vídeo"
 
 #. [components.DashboardVideoPane.thumbnailAlt] - Accessibility text for the video thumbnail in the Dashboard.
 #. defaultMessage is:
 #. Video thumbnail preview image.
 #: i18n/components/DashboardThumbnailDisplay/DashboardThumbnailDisplay.json
 msgid "Video thumbnail preview image."
-msgstr "Vignette de prévisualisation de la vidéo."
+msgstr "Imagen previa de la miniatura del vídeo."
 
 #. [components.Dashboard.DashboardVideoPaneButtons.btnPlayVideo] - Dashboard button to play the existing video, if there is one.
 #. defaultMessage is:
 #. Watch
 #: i18n/components/DashboardVideoPaneButtons/DashboardVideoPaneButtons.json
 msgid "Watch"
-msgstr "Regarder"
+msgstr "Ver"
 
 #. [components.ErrorComponent.policy.text] - Title for the upload permission error page
 #. defaultMessage is:
 #. We could not make sure you are allowed to upload a video file. Please check your settings and/or try again.
 #: i18n/components/ErrorComponent/ErrorComponent.json
 msgid "We could not make sure you are allowed to upload a video file. Please check your settings and/or try again."
-msgstr "Nous ne pouvons vérifier si vous avez les droits nécessaires pour téléverser un fichier. Vérifiez vos paramètres et/ou réessayez."
+msgstr "No pudimos asegurarnos que usted está autorizado a subir un archivo de vídeo. Por favor, compruebe su configuración y/o vuelva a intentarlo."
 
 #. [components.ErrorComponent.lti.text] - Helpful text for the LTI error page
 #. defaultMessage is:
@@ -384,35 +385,36 @@ msgstr "Nous ne pouvons vérifier si vous avez les droits nécessaires pour tél
 #: i18n/components/ErrorComponent/ErrorComponent.json
 msgid "We could not validate your access to this video. Please contact your instructor.\n"
 "      If you are the instructor, please check your settings."
-msgstr "Nous ne pouvons vérifier vos droits pour accéder à cette vidéo. Merci de prendre contact avec votre instructeur. Si vous êtes l'instructeur, merci de vérifier vos paramètres."
+msgstr "No hemos podido validar su acceso a este vídeo. Por favor, póngase en contacto con su instructor.\n"
+"      Si usted es el instructor, por favor, revise su configuración."
 
 #. [components.ErrorComponent.upload.text] - Helpful text for the Upload error page
 #. defaultMessage is:
 #. You can try again later. You may want to check your Internet connection quality.
 #: i18n/components/ErrorComponent/ErrorComponent.json
 msgid "You can try again later. You may want to check your Internet connection quality."
-msgstr "Vous pouvez réessayer dans quelques instants. Vous devriez vérifier la qualité de votre connexion internet."
+msgstr "Puede intentarlo más tarde. Comprobe la calidad de su conexión a internet."
 
 #. [components.DashboardThumbnail.helptextProcessing] - Thumbnail help text informing that the thumbnail is processing and will be available soon.
 #. defaultMessage is:
 #. Your thumbnail is currently processing. This may take several minutes. It will appear here once done.
 #: i18n/components/DashboardThumbnail/DashboardThumbnail.json
 msgid "Your thumbnail is currently processing. This may take several minutes. It will appear here once done."
-msgstr "Votre vignette est en cours de traitement. Le traitement peut prendre quelques minutes. La vignette apparaîtra une fois le traitement terminé."
+msgstr "Su miniatura está siendo procesada. Esto puede tardar varios minutos. Aparecerá aquí una vez este proceso terminado."
 
 #. [components.Dashboard.DashboardVideoPaneHelptext.helptextProcessing] - Dashboard helptext to warn users not to wait for video processing in front of this page.
 #. defaultMessage is:
 #. Your video is currently processing. This may take up to an hour. Please come back later.
 #: i18n/components/DashboardVideoPaneHelptext/DashboardVideoPaneHelptext.json
 msgid "Your video is currently processing. This may take up to an hour. Please come back later."
-msgstr "Votre vidéo est en cours de traitement. Le traitement peut prendre jusqu'à une heure. Nous vous conseillons de revenir plus tard."
+msgstr "El vídeo está siendo procesado. Esto puede tomar hasta una hora. Por favor, vuelva más tarde."
 
 #. [components.Dashboard.DashboardVideoPaneHelptext.helptextReady] - Dashboard helptext for ready-to-play videos.
 #. defaultMessage is:
 #. Your video is ready to play.
 #: i18n/components/DashboardVideoPaneHelptext/DashboardVideoPaneHelptext.json
 msgid "Your video is ready to play."
-msgstr "Votre vidéo est prête à être visionnée."
+msgstr "El vídeo está listo para ser reproducido."
 
 #. [components.UploadForm.dropzoneDragText] - File upload dropzone: helptext on the dropzone,
 #.       goes along with the button (components.UploadForm.dropzoneButtonPick)
@@ -420,5 +422,5 @@ msgstr "Votre vidéo est prête à être visionnée."
 #. or drop it here
 #: i18n/components/UploadField/DropzonePlaceholder.json
 msgid "or drop it here"
-msgstr "ou le glisser ici"
+msgstr "o arrastrarlo aquí"
 

--- a/src/frontend/translations/fr_CA.po
+++ b/src/frontend/translations/fr_CA.po
@@ -7,12 +7,12 @@ msgstr ""
 "X-Generator: crowdin.com\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Crowdin-Project: marsha\n"
-"X-Crowdin-Language: fr\n"
+"X-Crowdin-Language: fr-CA\n"
 "X-Crowdin-File: frontend.pot\n"
 "Project-Id-Version: marsha\n"
 "Last-Translator: Manuel Raynaud (lunika)\n"
-"Language-Team: French\n"
-"Language: fr_FR\n"
+"Language-Team: French, Canada\n"
+"Language: fr_CA\n"
 "PO-Revision-Date: 2019-04-24 09:49\n"
 
 #. [components.DownloadVideo.1080] - High quality video
@@ -20,63 +20,63 @@ msgstr ""
 #. 1080p: FullHD (high quality)
 #: i18n/components/DowloadVideo/DownloadVideo.json
 msgid "1080p: FullHD (high quality)"
-msgstr "1080p: FullHD (haute qualité)"
+msgstr ""
 
 #. [components.DownloadVideo.480] - Mobile quality video
 #. defaultMessage is:
 #. 480p: SD (Mobile)
 #: i18n/components/DowloadVideo/DownloadVideo.json
 msgid "480p: SD (Mobile)"
-msgstr "480p: SD (mobile)"
+msgstr ""
 
 #. [components.DownloadVideo.720] - Normal quality video
 #. defaultMessage is:
 #. 720p: HD (standard)
 #: i18n/components/DowloadVideo/DownloadVideo.json
 msgid "720p: HD (standard)"
-msgstr "720p: HD (normal)"
+msgstr ""
 
 #. [components.TimedTextCreationForm.addTrackLabel] - Label for the form that lets the instructor add a new timed text track.
 #. defaultMessage is:
 #. Add a language
 #: i18n/components/TimedTextCreationForm/TimedTextCreationForm.json
 msgid "Add a language"
-msgstr "Ajouter une langue"
+msgstr ""
 
 #. [component.DashboardVideoPaneDownloadOption.allowDownload]
 #. defaultMessage is:
 #. Allow video download
 #: i18n/components/DashboardVideoPaneDownloadOption/DashboardVideoPaneDownloadOption.json
 msgid "Allow video download"
-msgstr "Autoriser le téléchargement de la vidéo"
+msgstr ""
 
 #. [components.UploadForm.linkToDashboard] - Text for the link to the dashboard in the upload form.
 #. defaultMessage is:
 #. Back to dashboard
 #: i18n/components/UploadForm/UploadForm.json
 msgid "Back to dashboard"
-msgstr "Revenir au tableau de bord"
+msgstr ""
 
 #. [components.Transcripts.transcriptSelect] - Placeholder for the transcript select box
 #. defaultMessage is:
 #. Choose a language
 #: i18n/components/Transcripts/Transcripts.json
 msgid "Choose a language"
-msgstr "Choisir une langue"
+msgstr ""
 
 #. [components.DashboardTimedTextPane.closedCaptions] - Title for the closed captions management in the dashboard.
 #. defaultMessage is:
 #. Closed captions
 #: i18n/components/DashboardTimedTextPane/DashboardTimedTextPane.json
 msgid "Closed captions"
-msgstr "Sous-titres"
+msgstr ""
 
 #. [components.UploadForm.title-videos] - Title for the video upload form
 #. defaultMessage is:
 #. Create a new video
 #: i18n/components/UploadForm/UploadForm.json
 msgid "Create a new video"
-msgstr "Créer une nouvelle vidéo"
+msgstr ""
 
 #. [components.Dashboard.title] - Title for the dashboard, where the user can see the status of the video/audio/timed text upload
 #.       & processing, and will be able to manage them.
@@ -84,63 +84,63 @@ msgstr "Créer une nouvelle vidéo"
 #. Dashboard
 #: i18n/components/Dashboard/Dashboard.json
 msgid "Dashboard"
-msgstr "Tableau de bord"
+msgstr ""
 
 #. [components.TimedTextListItem.delete] - Link text to delete a subtitle/transcript/captions item.
 #. defaultMessage is:
 #. Delete
 #: i18n/components/TimedTextListItem/TimedTextListItem.json
 msgid "Delete"
-msgstr "Supprimer"
+msgstr ""
 
 #. [components.DownloadVideo.downloadVideo] - Text to download the video
 #. defaultMessage is:
 #. Download this video:
 #: i18n/components/DowloadVideo/DownloadVideo.json
 msgid "Download this video:"
-msgstr "Télécharger cette vidéo :"
+msgstr ""
 
 #. [components.UploadStatusPicker.ERROR] - Status information for a video/audio/timed text track
 #. defaultMessage is:
 #. Error
 #: i18n/components/UploadStatusPicker/UploadStatusPicker.json
 msgid "Error"
-msgstr "Erreur"
+msgstr ""
 
 #. [components.ErrorComponent.policy.title] - Helpful text for the upload permission error page
 #. defaultMessage is:
 #. Failed to authenticate your permission to upload
 #: i18n/components/ErrorComponent/ErrorComponent.json
 msgid "Failed to authenticate your permission to upload"
-msgstr "Impossible de vérifier vos droits pour téléverser le fichier"
+msgstr ""
 
 #. [component.DashboardVideoPaneDownloadOption.updateVideoFail] - Failed to update download permission on your video.
 #. defaultMessage is:
 #. Failed to update your video. Please try again later.
 #: i18n/components/DashboardVideoPaneDownloadOption/DashboardVideoPaneDownloadOption.json
 msgid "Failed to update your video. Please try again later."
-msgstr "Impossible de mettre à jour la vidéo. Merci de réessayer plus tard."
+msgstr ""
 
 #. [components.ErrorComponent.upload.title] - Title for the video upload error page
 #. defaultMessage is:
 #. Failed to upload your video file
 #: i18n/components/ErrorComponent/ErrorComponent.json
 msgid "Failed to upload your video file"
-msgstr "Erreur lors du téléversement du fichier vidéo"
+msgstr ""
 
 #. [components.InstructorView.btnDashboard] - Text for the button in the instructor view that allows the instructor to go to the dashboard.
 #. defaultMessage is:
 #. Go to Dashboard
 #: i18n/components/InstructorView/InstructorView.json
 msgid "Go to Dashboard"
-msgstr "Aller au tableau de bord"
+msgstr ""
 
 #. [components.Transcripts.hideTranscript] - Text to hide a displayed transcript
 #. defaultMessage is:
 #. Hide transcript
 #: i18n/components/Transcripts/Transcripts.json
 msgid "Hide transcript"
-msgstr "Masquer le transcrit"
+msgstr ""
 
 #. [components.InstructorView.title] - Title for the Instructor View. Describes the area appearing right above, which is a preview
 #.       of what the student will see there.
@@ -148,49 +148,49 @@ msgstr "Masquer le transcrit"
 #. Instructor Preview 👆
 #: i18n/components/InstructorView/InstructorView.json
 msgid "Instructor Preview 👆"
-msgstr "Aperçu instructeur 👆"
+msgstr ""
 
 #. [components.UploadStatusPicker.PENDING] - Status information for a video/audio/timed text track
 #. defaultMessage is:
 #. Missing
 #: i18n/components/UploadStatusPicker/UploadStatusPicker.json
 msgid "Missing"
-msgstr "Absent"
+msgstr ""
 
 #. [components.UploadStatusPicker.PROCESSING] - Status information for a video/audio/timed text track
 #. defaultMessage is:
 #. Processing
 #: i18n/components/UploadStatusPicker/UploadStatusPicker.json
 msgid "Processing"
-msgstr "En cours de traitement"
+msgstr ""
 
 #. [components.UploadStatusPicker.READY] - Status information for a video/audio/timed text track
 #. defaultMessage is:
 #. Ready
 #: i18n/components/UploadStatusPicker/UploadStatusPicker.json
 msgid "Ready"
-msgstr "Disponible"
+msgstr ""
 
 #. [components.TimedTextListItem.replace] - Link text to replace a subtitle/transcript/captions item with a new file (for the same language).
 #. defaultMessage is:
 #. Replace
 #: i18n/components/TimedTextListItem/TimedTextListItem.json
 msgid "Replace"
-msgstr "Remplacer"
+msgstr ""
 
 #. [components.Dashboard.DashboardVideoPaneButtons.btnReplaceVideo] - Dashboard button to upload a video to replace the existing one, when there *is* an existing video.
 #. defaultMessage is:
 #. Replace the video
 #: i18n/components/DashboardVideoPaneButtons/DashboardVideoPaneButtons.json
 msgid "Replace the video"
-msgstr "Remplacer la vidéo"
+msgstr ""
 
 #. [components.dashboardThumbnail.replaceThumbnailButton]
 #. defaultMessage is:
 #. Replace this thumbnail
 #: i18n/components/DashboardThumbnail/DashboardThumbnail.json
 msgid "Replace this thumbnail"
-msgstr "Remplacer cette vignette"
+msgstr ""
 
 #. [components.UploadForm.dropzoneButtonPick] - File upload dropzone: button to choose a file to upload,
 #.       has the drag text next to it (components.UploadForm.dropzoneDragText)
@@ -198,63 +198,63 @@ msgstr "Remplacer cette vignette"
 #. Select a file to upload
 #: i18n/components/UploadField/DropzonePlaceholder.json
 msgid "Select a file to upload"
-msgstr "Sélectionner un fichier à téléverser"
+msgstr ""
 
 #. [components.Transcripts.transcriptLabel] - Text indicated to choose an available transcript language
 #. defaultMessage is:
 #. Show a transcript
 #: i18n/components/Transcripts/Transcripts.json
 msgid "Show a transcript"
-msgstr "Choisir un transcrit"
+msgstr ""
 
 #. [components.DashboardTimedTextPane.subtitles] - Title for the subtitles management in the dashboard.
 #. defaultMessage is:
 #. Subtitles
 #: i18n/components/DashboardTimedTextPane/DashboardTimedTextPane.json
 msgid "Subtitles"
-msgstr "Sous-titres"
+msgstr ""
 
 #. [components.ErrorComponent.notFound.title] - Title for the 404 Not Found error page
 #. defaultMessage is:
 #. The video you are looking for could not be found
 #: i18n/components/ErrorComponent/ErrorComponent.json
 msgid "The video you are looking for could not be found"
-msgstr "Cette vidéo n'est pas disponible"
+msgstr ""
 
 #. [components.Dashboard.DashboardVideoPaneHelptext.helptextPending] - Dashboard helptext for the case when there is no existing video nor anything in progress.
 #. defaultMessage is:
 #. There is currently no video to display.
 #: i18n/components/DashboardVideoPaneHelptext/DashboardVideoPaneHelptext.json
 msgid "There is currently no video to display."
-msgstr "Il n'y a pas encore de vidéo à afficher."
+msgstr ""
 
 #. [components.DashboardThumbnail.error] - Generic error message when we fail to create a thumbnail.
 #. defaultMessage is:
 #. There was an error during thumbnail creation.
 #: i18n/components/DashboardThumbnail/DashboardThumbnail.json
 msgid "There was an error during thumbnail creation."
-msgstr "Une erreur s'est produite durant la création de la vignette."
+msgstr ""
 
 #. [components.TimedTextCreationForm.error] - Generic error message when we fail to create a subtitle/transcript/caption track.
 #. defaultMessage is:
 #. There was an error during track creation.
 #: i18n/components/TimedTextCreationForm/TimedTextCreationForm.json
 msgid "There was an error during track creation."
-msgstr "Une erreur s'est produite pendant la création de cette piste."
+msgstr ""
 
 #. [components.ErrorComponent.lti.title] - Title for the LTI error page
 #. defaultMessage is:
 #. There was an error loading this video
 #: i18n/components/ErrorComponent/ErrorComponent.json
 msgid "There was an error loading this video"
-msgstr "Une erreur s'est produite pendant le chargement de la vidéo"
+msgstr ""
 
 #. [components.Dashboard.DashboardVideoPaneHelptext.helptextError] - Dashboard helptext for when the video failed to upload or get processed.
 #. defaultMessage is:
 #. There was an error with your video. Retry or upload another one.
 #: i18n/components/DashboardVideoPaneHelptext/DashboardVideoPaneHelptext.json
 msgid "There was an error with your video. Retry or upload another one."
-msgstr "Une erreur s'est produite avec cette vidéo. Réessayez ou choisissez une autre vidéo."
+msgstr ""
 
 #. [components.ErrorComponent.notFound.text] - Helpful text for the 404 Not Found error page
 #. defaultMessage is:
@@ -263,119 +263,119 @@ msgstr "Une erreur s'est produite avec cette vidéo. Réessayez ou choisissez un
 #: i18n/components/ErrorComponent/ErrorComponent.json
 msgid "This video does not exist or has not been published yet.\n"
 "      If you are an instructor, please make sure you are properly authenticated."
-msgstr "La vidéo n'existe pas ou n'a pas encore été publiée. Si vous êtes un instructeur assurez vous d'être correctement authentifié."
+msgstr ""
 
 #. [components.InstructorView.disabledDashboard] - Text explaining that the ivdeo is in read_only mode and the dashboard is not available
 #. defaultMessage is:
 #. This video is imported from another playlist. You can go to the original playlist to directly modify this video, or delete it from the current playlist and replace it by a new video.
 #: i18n/components/InstructorView/InstructorView.json
 msgid "This video is imported from another playlist. You can go to the original playlist to directly modify this video, or delete it from the current playlist and replace it by a new video."
-msgstr "Cette vidéo a été importé depuis un autre cours. Pour la modifier vous devez le faire depuis le cours d'origine ou bien supprimer ce block et en recréer un nouveau avec cette vidéo."
+msgstr ""
 
 #. [components.DashboardTimedTextPane.transcripts] - Title for the transcripts management in the dashboard.
 #. defaultMessage is:
 #. Transcripts
 #: i18n/components/DashboardTimedTextPane/DashboardTimedTextPane.json
 msgid "Transcripts"
-msgstr "Transcrits"
+msgstr ""
 
 #. [components.TimedTextListItem.upload] - Link text to upload a missing subtitle/transcript/captions item file.
 #. defaultMessage is:
 #. Upload
 #: i18n/components/TimedTextListItem/TimedTextListItem.json
 msgid "Upload"
-msgstr "Téléverser"
+msgstr ""
 
 #. [components.UploadForm.title-timedtexttracks-cc] - Title for the timed text file upload form
 #. defaultMessage is:
 #. Upload a new closed captions file
 #: i18n/components/UploadForm/UploadForm.json
 msgid "Upload a new closed captions file"
-msgstr "Téléverser un nouveau fichier de sous-titres codés (sourds et malentendants)"
+msgstr ""
 
 #. [components.UploadForm.title-timedtexttracks-st] - Title for the timed text file upload form
 #. defaultMessage is:
 #. Upload a new subtitles file
 #: i18n/components/UploadForm/UploadForm.json
 msgid "Upload a new subtitles file"
-msgstr "Téléverser un nouveau fichier de sous-titres"
+msgstr ""
 
 #. [components.UploadForm.title-thumbnail] - Title for the thumbnail upload form
 #. defaultMessage is:
 #. Upload a new thumbnail
 #: i18n/components/UploadForm/UploadForm.json
 msgid "Upload a new thumbnail"
-msgstr "Téléverser une nouvelle vignette"
+msgstr ""
 
 #. [components.UploadForm.title-timedtexttracks-ts] - Title for the timed text file upload form
 #. defaultMessage is:
 #. Upload a new transcript file
 #: i18n/components/UploadForm/UploadForm.json
 msgid "Upload a new transcript file"
-msgstr "Téléverser un nouveau transcrit"
+msgstr ""
 
 #. [components.Dashboard.DashboardVideoPaneButtons.btnUploadFirstVideo] - Dashboard button to upload a video, when there is no existing video.
 #. defaultMessage is:
 #. Upload a video
 #: i18n/components/DashboardVideoPaneButtons/DashboardVideoPaneButtons.json
 msgid "Upload a video"
-msgstr "Téléverser une vidéo"
+msgstr ""
 
 #. [components.Dashboard.DashboardVideoPaneHelptext.helptextUploading] - Dashboard helptext to warn user not to navigate away during video upload.
 #. defaultMessage is:
 #. Upload in progress... Please do not close or reload this page.
 #: i18n/components/DashboardVideoPaneHelptext/DashboardVideoPaneHelptext.json
 msgid "Upload in progress... Please do not close or reload this page."
-msgstr "Téléversement en cours... Merci de ne pas fermer ni recharger la page."
+msgstr ""
 
 #. [components.DashboardVideoPaneProgress.progressLabel] - Accessibility message for the upload progress bar.
 #. defaultMessage is:
 #. Upload progress
 #: i18n/components/DashboardObjectProgress/DashboardObjectProgress.json
 msgid "Upload progress"
-msgstr "Progression du téléversement"
+msgstr ""
 
 #. [components.TimedTextCreationForm.addTrackBtn] - Text for the button in the dashboard to go upload a new timed text file.
 #. defaultMessage is:
 #. Upload the file
 #: i18n/components/TimedTextCreationForm/TimedTextCreationForm.json
 msgid "Upload the file"
-msgstr "Téléverser le fichier"
+msgstr ""
 
 #. [components.UploadStatusPicker.UPLOADING] - Status information for a video/audio/timed text track
 #. defaultMessage is:
 #. Uploading
 #: i18n/components/UploadStatusPicker/UploadStatusPicker.json
 msgid "Uploading"
-msgstr "Téléversement en cours"
+msgstr ""
 
 #. [components.DashboardVideoPane.title] - Subtitle for the video part of the dashboard (right now the only part until we add timed text tracks).
 #. defaultMessage is:
 #. Video status
 #: i18n/components/DashboardVideoPane/DashboardVideoPane.json
 msgid "Video status"
-msgstr "Statut de la vidéo"
+msgstr ""
 
 #. [components.DashboardVideoPane.thumbnailAlt] - Accessibility text for the video thumbnail in the Dashboard.
 #. defaultMessage is:
 #. Video thumbnail preview image.
 #: i18n/components/DashboardThumbnailDisplay/DashboardThumbnailDisplay.json
 msgid "Video thumbnail preview image."
-msgstr "Vignette de prévisualisation de la vidéo."
+msgstr ""
 
 #. [components.Dashboard.DashboardVideoPaneButtons.btnPlayVideo] - Dashboard button to play the existing video, if there is one.
 #. defaultMessage is:
 #. Watch
 #: i18n/components/DashboardVideoPaneButtons/DashboardVideoPaneButtons.json
 msgid "Watch"
-msgstr "Regarder"
+msgstr ""
 
 #. [components.ErrorComponent.policy.text] - Title for the upload permission error page
 #. defaultMessage is:
 #. We could not make sure you are allowed to upload a video file. Please check your settings and/or try again.
 #: i18n/components/ErrorComponent/ErrorComponent.json
 msgid "We could not make sure you are allowed to upload a video file. Please check your settings and/or try again."
-msgstr "Nous ne pouvons vérifier si vous avez les droits nécessaires pour téléverser un fichier. Vérifiez vos paramètres et/ou réessayez."
+msgstr ""
 
 #. [components.ErrorComponent.lti.text] - Helpful text for the LTI error page
 #. defaultMessage is:
@@ -384,35 +384,35 @@ msgstr "Nous ne pouvons vérifier si vous avez les droits nécessaires pour tél
 #: i18n/components/ErrorComponent/ErrorComponent.json
 msgid "We could not validate your access to this video. Please contact your instructor.\n"
 "      If you are the instructor, please check your settings."
-msgstr "Nous ne pouvons vérifier vos droits pour accéder à cette vidéo. Merci de prendre contact avec votre instructeur. Si vous êtes l'instructeur, merci de vérifier vos paramètres."
+msgstr ""
 
 #. [components.ErrorComponent.upload.text] - Helpful text for the Upload error page
 #. defaultMessage is:
 #. You can try again later. You may want to check your Internet connection quality.
 #: i18n/components/ErrorComponent/ErrorComponent.json
 msgid "You can try again later. You may want to check your Internet connection quality."
-msgstr "Vous pouvez réessayer dans quelques instants. Vous devriez vérifier la qualité de votre connexion internet."
+msgstr ""
 
 #. [components.DashboardThumbnail.helptextProcessing] - Thumbnail help text informing that the thumbnail is processing and will be available soon.
 #. defaultMessage is:
 #. Your thumbnail is currently processing. This may take several minutes. It will appear here once done.
 #: i18n/components/DashboardThumbnail/DashboardThumbnail.json
 msgid "Your thumbnail is currently processing. This may take several minutes. It will appear here once done."
-msgstr "Votre vignette est en cours de traitement. Le traitement peut prendre quelques minutes. La vignette apparaîtra une fois le traitement terminé."
+msgstr ""
 
 #. [components.Dashboard.DashboardVideoPaneHelptext.helptextProcessing] - Dashboard helptext to warn users not to wait for video processing in front of this page.
 #. defaultMessage is:
 #. Your video is currently processing. This may take up to an hour. Please come back later.
 #: i18n/components/DashboardVideoPaneHelptext/DashboardVideoPaneHelptext.json
 msgid "Your video is currently processing. This may take up to an hour. Please come back later."
-msgstr "Votre vidéo est en cours de traitement. Le traitement peut prendre jusqu'à une heure. Nous vous conseillons de revenir plus tard."
+msgstr ""
 
 #. [components.Dashboard.DashboardVideoPaneHelptext.helptextReady] - Dashboard helptext for ready-to-play videos.
 #. defaultMessage is:
 #. Your video is ready to play.
 #: i18n/components/DashboardVideoPaneHelptext/DashboardVideoPaneHelptext.json
 msgid "Your video is ready to play."
-msgstr "Votre vidéo est prête à être visionnée."
+msgstr ""
 
 #. [components.UploadForm.dropzoneDragText] - File upload dropzone: helptext on the dropzone,
 #.       goes along with the button (components.UploadForm.dropzoneButtonPick)
@@ -420,5 +420,5 @@ msgstr "Votre vidéo est prête à être visionnée."
 #. or drop it here
 #: i18n/components/UploadField/DropzonePlaceholder.json
 msgid "or drop it here"
-msgstr "ou le glisser ici"
+msgstr ""
 


### PR DESCRIPTION
### Added

- LRS credentials can be configured at the consumer site level.
- Configure in the consumer site admin panel if by default videos can show a download link.
- Do not allow video modification when the consumer site used is not the one used
  to create the video.


