### PR TITLE
🔖(patch) bump release to 2.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.7.1] - 2019-04-29
+
 ### Fixed
 
 - Correctly load static js chunks from cloud-front CDN
@@ -213,7 +215,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Minor fixes and improvements on features and tests
 
-[unreleased]: https://github.com/openfun/marsha/compare/v2.7.0...master
+[unreleased]: https://github.com/openfun/marsha/compare/v2.7.1...master
+[2.7.1]: https://github.com/openfun/marsha/compare/v2.7.0...v2.7.1
 [2.7.0]: https://github.com/openfun/marsha/compare/v2.6.0...v2.7.0
 [2.6.0]: https://github.com/openfun/marsha/compare/v2.5.0...v2.6.0
 [2.5.0]: https://github.com/openfun/marsha/compare/v2.4.0...v2.5.0

--- a/src/aws/lambda-configure/package.json
+++ b/src/aws/lambda-configure/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-configure",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "engines": {
     "node": ">8.10"
   },

--- a/src/aws/lambda-encode/package.json
+++ b/src/aws/lambda-encode/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-convert",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "engines": {
     "node": ">8.10"
   },

--- a/src/aws/lambda-update-state/package.json
+++ b/src/aws/lambda-update-state/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-update-state",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "engines": {
     "node": ">8.10"
   },

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -2,7 +2,7 @@
 name = marsha
 description = A FUN video provider for Open edX
 long_description = file:README.rst
-version = 2.7.0
+version = 2.7.1
 author = Open FUN (France Universite Numerique)
 author_email = fun.dev@fun-mooc.fr
 license = MIT

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marsha",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "🐠 a FUN LTI video provider",
   "main": "front/index.tsx",
   "scripts": {


### PR DESCRIPTION
Fixed
- Correctly load static js chunks from cloud-front CDN