### PR TITLE
Rename permissions

### DIFF
--- a/src/backend/marsha/core/api.py
+++ b/src/backend/marsha/core/api.py
@@ -27,7 +27,7 @@ from .models import Thumbnail, TimedTextTrack, Video
 from .permissions import (
     IsRelatedVideoTokenOrAdminUser,
     IsVideoToken,
-    IsVideoTokenOrAdminUser,
+    IsVideoInstructorTokenOrAdminUser,
 )
 from .serializers import (
     ThumbnailSerializer,
@@ -116,7 +116,7 @@ class VideoViewSet(
 
     queryset = Video.objects.all()
     serializer_class = VideoSerializer
-    permission_classes = [IsVideoTokenOrAdminUser]
+    permission_classes = [IsVideoInstructorTokenOrAdminUser]
 
     @action(methods=["post"], detail=True, url_path="initiate-upload")
     # pylint: disable=unused-argument

--- a/src/backend/marsha/core/api.py
+++ b/src/backend/marsha/core/api.py
@@ -25,9 +25,9 @@ from .exceptions import MissingUserIdError
 from .lti import LTIUser
 from .models import Thumbnail, TimedTextTrack, Video
 from .permissions import (
-    IsRelatedVideoTokenOrAdminUser,
-    IsVideoToken,
     IsVideoInstructorTokenOrAdminUser,
+    IsVideoRelatedInstructorTokenOrAdminUser,
+    IsVideoToken,
 )
 from .serializers import (
     ThumbnailSerializer,
@@ -181,7 +181,7 @@ class TimedTextTrackViewSet(
         if self.action == "metadata":
             permission_classes = [IsVideoToken]
         else:
-            permission_classes = [IsRelatedVideoTokenOrAdminUser]
+            permission_classes = [IsVideoRelatedInstructorTokenOrAdminUser]
         return [permission() for permission in permission_classes]
 
     def get_queryset(self):
@@ -240,7 +240,7 @@ class ThumbnailViewSet(
 ):
     """Viewset for the API of the Thumbnail object."""
 
-    permission_classes = [IsRelatedVideoTokenOrAdminUser]
+    permission_classes = [IsVideoRelatedInstructorTokenOrAdminUser]
     serializer_class = ThumbnailSerializer
 
     def get_queryset(self):

--- a/src/backend/marsha/core/permissions.py
+++ b/src/backend/marsha/core/permissions.py
@@ -5,7 +5,7 @@ from rest_framework_simplejwt.models import TokenUser
 from .models.account import INSTRUCTOR, LTI_ROLES
 
 
-class IsVideoTokenOrAdminUser(permissions.IsAdminUser):
+class IsVideoInstructorTokenOrAdminUser(permissions.IsAdminUser):
     """A custom permission class for JWT Tokens related to a video object.
 
     These permissions build on the `IsAdminUser` class but grants additional specific accesses
@@ -95,7 +95,7 @@ class IsVideoTokenOrAdminUser(permissions.IsAdminUser):
         return super().has_object_permission(request, view, obj)
 
 
-class IsRelatedVideoTokenOrAdminUser(IsVideoTokenOrAdminUser):
+class IsRelatedVideoTokenOrAdminUser(IsVideoInstructorTokenOrAdminUser):
     """A custom permission class for JWT Tokens related to objects linked to a video.
 
     These permissions build on the `IsAdminUser` class but grants additional specific accesses

--- a/src/backend/marsha/core/permissions.py
+++ b/src/backend/marsha/core/permissions.py
@@ -95,7 +95,7 @@ class IsVideoInstructorTokenOrAdminUser(permissions.IsAdminUser):
         return super().has_object_permission(request, view, obj)
 
 
-class IsRelatedVideoTokenOrAdminUser(IsVideoInstructorTokenOrAdminUser):
+class IsVideoRelatedInstructorTokenOrAdminUser(IsVideoInstructorTokenOrAdminUser):
     """A custom permission class for JWT Tokens related to objects linked to a video.
 
     These permissions build on the `IsAdminUser` class but grants additional specific accesses


### PR DESCRIPTION
## Purpose

`IsRelatedVideoTokenOrAdminUser` and `IsVideoTokenOrAdminUser` have bad names. They are looking for Instructor tokens as opposed to the IsVideoToken class which accepts students.

## Proposal

rename then in `IsVideoInstructorTokenOrAdminUser` and `IsVideoRelatedInstructorTokenOrAdminUser`

Closes #248 
