### PR TITLE
🔖(patch) bump release to 2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.8.0] - 2019-05-15
+
 ### Added
 
 - Automate python dependencies upgrade with pyup.
@@ -16,7 +18,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Use pytest to run backend tests.
-- Rename lambda-update-state lambda in lambda-complete.
+- Rename lambda-update-state lambda to lambda-complete.
 - Keep only one docker-compose file.
 - Move gitlint directory into lib directory.
 - Upgrade to django 2.2
@@ -232,7 +234,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Minor fixes and improvements on features and tests
 
-[unreleased]: https://github.com/openfun/marsha/compare/v2.7.1...master
+[unreleased]: https://github.com/openfun/marsha/compare/v2.8.0...master
+[2.8.0]: https://github.com/openfun/marsha/compare/v2.7.1...v2.8.0
 [2.7.1]: https://github.com/openfun/marsha/compare/v2.7.0...v2.7.1
 [2.7.0]: https://github.com/openfun/marsha/compare/v2.6.0...v2.7.0
 [2.6.0]: https://github.com/openfun/marsha/compare/v2.5.0...v2.6.0

--- a/src/aws/lambda-complete/package.json
+++ b/src/aws/lambda-complete/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-complete",
-  "version": "2.7.1",
+  "version": "2.8.0",
   "engines": {
     "node": ">8.10"
   },

--- a/src/aws/lambda-configure/package.json
+++ b/src/aws/lambda-configure/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-configure",
-  "version": "2.7.1",
+  "version": "2.8.0",
   "engines": {
     "node": ">8.10"
   },

--- a/src/aws/lambda-encode/package.json
+++ b/src/aws/lambda-encode/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-convert",
-  "version": "2.7.1",
+  "version": "2.8.0",
   "engines": {
     "node": ">8.10"
   },

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = marsha
 description = A FUN video provider for Open edX
-version = 2.7.1
+version = 2.8.0
 author = Open FUN (France Universite Numerique)
 author_email = fun.dev@fun-mooc.fr
 license = MIT

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marsha",
-  "version": "2.7.1",
+  "version": "2.8.0",
   "description": "🐠 a FUN LTI video provider",
   "main": "front/index.tsx",
   "scripts": {


### PR DESCRIPTION
### Added

- Automate python dependencies upgrade with pyup.
- Create command bin/pytest.

### Changed

- Use pytest to run backend tests.
- Rename lambda-update-state lambda in lambda-complete.
- Keep only one docker-compose file.
- Move gitlint directory into lib directory.
- Upgrade to django 2.2
- Remove docker alpine images
- Standardize the project's `Makefile` to make it more easily maintainable by
  our peers
- Copy pylint config from Richie project.

