### PR TITLE
🐛(front) force to display captions on firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Allow to use newer version of django-storages
+- Force to display captions on firefox.
 
 ## [2.8.0] - 2019-05-15
 

--- a/src/frontend/Player/createPlyrPlayer.ts
+++ b/src/frontend/Player/createPlyrPlayer.ts
@@ -8,6 +8,7 @@ import {
   InitializedContextExtensions,
   InteractedContextExtensions,
 } from '../types/XAPI';
+import { isMSESupported } from '../utils/isAbrSupported';
 import { XAPIStatement } from '../XAPI/XAPIStatement';
 
 export const createPlyrPlayer = (
@@ -15,11 +16,16 @@ export const createPlyrPlayer = (
   jwt: string,
   dispatch: Dispatch,
 ): Plyr => {
+  const settings = ['captions', 'speed', 'loop'];
+  if (!isMSESupported()) {
+    settings.push('quality');
+  }
   const player = new Plyr(ref, {
     captions: {
       active: true,
       update: true,
     },
+    settings,
   });
   const decodedToken: DecodedJwt = jwt_decode(jwt);
 

--- a/src/frontend/components/VideoPlayer/index.spec.tsx
+++ b/src/frontend/components/VideoPlayer/index.spec.tsx
@@ -127,6 +127,15 @@ describe('VideoPlayer', () => {
     expect(queryByText(/Download this video/i)).toEqual(null);
     getByText('Show a transcript');
     expect(container.querySelectorAll('track')).toHaveLength(2);
+    expect(
+      container.querySelector('source[src="https://example.com/144p.mp4"]'),
+    ).not.toBeNull();
+    expect(
+      container.querySelector('source[src="https://example.com/1080p.mp4"]'),
+    ).not.toBeNull();
+    expect(container.querySelectorAll('source[type="video/mp4"]')).toHaveLength(
+      2,
+    );
   });
 
   it('allows video download when the video object specifies it', () => {

--- a/src/frontend/components/VideoPlayer/index.tsx
+++ b/src/frontend/components/VideoPlayer/index.tsx
@@ -139,15 +139,14 @@ class BaseVideoPlayer extends React.Component<
           crossOrigin="anonymous"
           poster={thumbnailUrls[720]}
         >
-          {!this.state.isDashSupported &&
-            (Object.keys(video.urls.mp4) as videoSize[]).map(size => (
-              <source
-                key={video.urls.mp4[size]}
-                size={size}
-                src={video.urls.mp4[size]}
-                type="video/mp4"
-              />
-            ))}
+          {(Object.keys(video.urls.mp4) as videoSize[]).map(size => (
+            <source
+              key={video.urls.mp4[size]}
+              size={size}
+              src={video.urls.mp4[size]}
+              type="video/mp4"
+            />
+          ))}
 
           {/* This is a workaround to force plyr to load its tracks list once
           instantiated. Without this, captions are not loaded correctly, at least, on firefox.


### PR DESCRIPTION
## Purpose

On firefox, if there is no video source the captions are not loaded. To
fix this issue we always add the source tags even if dashjs is used and
we don't need them.

## Proposal

- [x] remove test to know if dashjs is supported and always add `source` tags.

