### PR TITLE
🐛(backend) workaround allowing to use newer version of django-storages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow to use newer version of django-storages
+
 ## [2.8.0] - 2019-05-15
 
 ### Added

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -397,7 +397,7 @@ class Production(Base):
 
     # folder where static will be stored. It matches the path_pattern used
     # in the cloudfront configuration.
-    AWS_LOCATION = Base.STATIC_URL
+    AWS_LOCATION = Base.STATIC_URL.lstrip("/")
 
     # pattern matching files to ignore when hashing file names and exclude from the
     # static files manifest

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -26,7 +26,7 @@ requires-python = >=3.6
 
 [options]
 install_requires =
-    boto3==1.9.96 # pyup: <=1.9.96
+    boto3==1.9.150
     chardet==3.0.4 # puyup: >=3.0.2,<3.1.0
     coreapi==2.3.3
     cryptography==2.6.1
@@ -38,7 +38,7 @@ install_requires =
     djangorestframework_simplejwt==4.3.0
     django-safedelete==0.5.1
     # superior versions of django-storages are not compatible with ManifestStaticFilesStorage
-    django-storages==1.6.3 # pyup: <=1.6.3
+    django-storages==1.7.1
     dockerflow==2018.4.0
     gunicorn==19.9.0
     # Warning from psycopg2 "The psycopg2 wheel package will be renamed from release 2.8" => psyopg2-binary


### PR DESCRIPTION
## Purpose

Django-storages version we use has a security issue but it was
impossible to upgrade it because newer version are not compatible with
boto3. Hopefully a workarounf exists allowing us ti use newer versions.
The workaround can be fount in the issue reporting the bug:
https://github.com/jschneier/django-storages/issues/382#issuecomment-377174808

## Proposal

- [x] Apply the solution in our custom storage class

