### PR TITLE
🚨(backend) configure django core settings to pass all heartbeat checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Configure django core settings to pass all heartbeat checks
+
 ## [2.8.1] - 2019-05-17
 
 ### Fixed

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -73,6 +73,14 @@ class Base(Configuration):
 
     SITE_ID = 1
 
+    SECURE_BROWSER_XSS_FILTER = True
+    SESSION_COOKIE_SECURE = True
+    SECURE_CONTENT_TYPE_NOSNIFF = True
+    CSRF_COOKIE_SECURE = True
+    SILENCED_SYSTEM_CHECKS = [
+        "security.W019"  # Disable because we want to use SAMEORIGIN as value for X_FRAME_OPTIONS
+    ]
+
     # Application definition
 
     INSTALLED_APPS = [
@@ -371,6 +379,12 @@ class Production(Base):
 
     ALLOWED_HOSTS = values.ListValue(None)
     AWS_SOURCE_BUCKET_NAME = values.Value("production-marsha-source")
+    # Force to redirect traffic to HTTPS protocol
+    SECURE_SSL_REDIRECT = True
+
+    # Configure HSTS
+    # https://docs.djangoproject.com/en/2.2/ref/middleware/#http-strict-transport-security
+    SECURE_HSTS_SECONDS = 3600
 
     # Helper to easily know if static files in AWS is activated
     STATICFILES_AWS_ENABLED = True


### PR DESCRIPTION
## Purpose

Heartbeat endpoint warns us that some settings are not well configured,
we have to set them in the settings:
- SECURE_BROWSER_XSS_FILTER
- SESSION_COOKIE_SECURE
- SECURE_CONTENT_TYPE_NOSNIFF
- CSRF_COOKIE_SECURE
Some settings are only changed in production, they will not work in
Development and Test:
- SECURE_SSL_REDIRECT
- SECURE_HSTS_SECONDS
We also disable check of X_FRAME_OPTIONS because we want to use the
value SAMEORIGIN, without this value it is not possible to serve the
site in a frame.

## Proposal

- [x] Update settings

This PR will also closes #146 