### PR TITLE
✨(backend) allow to configure SILENCED_SYSTEM_CHECKS setting

### DIFF
--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -77,9 +77,7 @@ class Base(Configuration):
     SESSION_COOKIE_SECURE = True
     SECURE_CONTENT_TYPE_NOSNIFF = True
     CSRF_COOKIE_SECURE = True
-    SILENCED_SYSTEM_CHECKS = [
-        "security.W019"  # Disable because we want to use SAMEORIGIN as value for X_FRAME_OPTIONS
-    ]
+    SILENCED_SYSTEM_CHECKS = values.ListValue([])
 
     # Application definition
 
@@ -379,12 +377,6 @@ class Production(Base):
 
     ALLOWED_HOSTS = values.ListValue(None)
     AWS_SOURCE_BUCKET_NAME = values.Value("production-marsha-source")
-    # Force to redirect traffic to HTTPS protocol
-    SECURE_SSL_REDIRECT = True
-
-    # Configure HSTS
-    # https://docs.djangoproject.com/en/2.2/ref/middleware/#http-strict-transport-security
-    SECURE_HSTS_SECONDS = 3600
 
     # Helper to easily know if static files in AWS is activated
     STATICFILES_AWS_ENABLED = True

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -77,6 +77,7 @@ class Base(Configuration):
     SESSION_COOKIE_SECURE = True
     SECURE_CONTENT_TYPE_NOSNIFF = True
     CSRF_COOKIE_SECURE = True
+    X_FRAME_OPTIONS = "DENY"
     SILENCED_SYSTEM_CHECKS = values.ListValue([])
 
     # Application definition


### PR DESCRIPTION
## Purpose

~~Django should not be responsible to apply SECURE_HSTS_SECONDS and
SECURE_HSTS_SECONDS rules. It should be the nginx or other reverse proxy
responsibility. The https connection will be made with it, not with
django.~~

In a first time this PR "harcoded" a list of silenced system checks. We finally choose to just allow to configure this setting freely using environment variable.

## Proposal

- ~~[x] Add SECURE_HSTS_SECONDS and SECURE_HSTS_SECONDS checks in SILENCED_SYSTEM_CHECKS list~~
- [x] Add SILENCED_SYSTEM_CHECKS configurable in settings.

