### PR TITLE
manage document resource on AWS

### DIFF
--- a/src/aws/lambda-encode/index.js
+++ b/src/aws/lambda-encode/index.js
@@ -4,6 +4,10 @@ const encodeTimedTextTrack = require('./src/encodeTimedTextTrack');
 const encodeVideo = require('./src/encodeVideo');
 const updateState = require('./src/updateState');
 const resizeThumbnails = require('./src/resizeThumbnails');
+const copyDocument = require('./src/copyDocument');
+
+const READY = 'ready';
+const PROCESSING = 'processing';
 
 exports.handler = async (event, context, callback) => {
   console.log('Received event:', JSON.stringify(event, null, 2));
@@ -15,24 +19,29 @@ exports.handler = async (event, context, callback) => {
   const [resourceId, kind, recordId, extendedStamp] = parts;
   if (
     parts.length != 4 ||
-    !['timedtexttrack', 'video', 'thumbnail'].includes(kind)
+    !['document', 'thumbnail', 'timedtexttrack', 'video'].includes(kind)
   ) {
     let error;
     switch (kind) {
-      case 'video':
+      case 'document':
         error =
-          'Source videos should be uploaded in a folder of the form ' +
-          '"{playlist_id}/videos/{video_id}/{stamp}".';
+          'Source document should be uploaded to a folder of the form ' +
+          '"{document_id}/document/{document_id}/{stamp}".';
+        break;
+      case 'thumbnail':
+        error =
+          'Source thumbnails should be uploaded in a folder of the form ' +
+          '"{playlist_id}/thumbnail/{thumbnail_id}/{stamp}".';
         break;
       case 'timedtexttrack':
         error =
           'Source timed text files should be uploaded to a folder of the form ' +
           '"{playlist_id}/timedtexttrack/{timedtext_id}/{stamp}_{language}[_{has_closed_caption}]".';
         break;
-      case 'thumbnail':
+      case 'video':
         error =
-          'Source thumbnails should be uploaded in a folder of the form ' +
-          '"{playlist_id}/thumbnail/{thumbnail_id}/{stamp}".';
+          'Source videos should be uploaded in a folder of the form ' +
+          '"{video_id}/video/{video_id}/{stamp}".';
         break;
       default:
         error = kind
@@ -45,10 +54,34 @@ exports.handler = async (event, context, callback) => {
   }
 
   switch (kind) {
+    case 'document':
+      try {
+        await copyDocument(objectKey, sourceBucket);
+        await updateState(objectKey, READY);
+      } catch (error) {
+        return callback(error);
+      }
+      console.log(
+        `Successfully received and copy document ${objectKey} from ${sourceBucket}.`,
+      );
+      break;
+
+    case 'thumbnail':
+      try {
+        await resizeThumbnails(objectKey, sourceBucket);
+        await updateState(objectKey, READY);
+      } catch (error) {
+        return callback(error);
+      }
+      console.log(
+        `Successfully received and resized thumbnail ${objectKey} from ${sourceBucket}.`,
+      );
+      break;
+
     case 'timedtexttrack':
       try {
         await encodeTimedTextTrack(objectKey, sourceBucket);
-        await updateState(objectKey, 'ready');
+        await updateState(objectKey, READY);
       } catch (error) {
         return callback(error);
       }
@@ -61,24 +94,12 @@ exports.handler = async (event, context, callback) => {
       let jobData;
       try {
         jobData = await encodeVideo(objectKey, sourceBucket);
-        await updateState(objectKey, 'processing');
+        await updateState(objectKey, PROCESSING);
       } catch (error) {
         return callback(error);
       }
       console.log(JSON.stringify(jobData, null, 2));
       callback(null, { Job: jobData.Job.Id });
-      break;
-
-    case 'thumbnail':
-      try {
-        await resizeThumbnails(objectKey, sourceBucket);
-        await updateState(objectKey, 'ready');
-      } catch (error) {
-        return callback(error);
-      }
-      console.log(
-        `Successfully received and resized thumbnail ${objectKey} from ${sourceBucket}.`,
-      );
       break;
   }
 };

--- a/src/aws/lambda-encode/src/copyDocument.js
+++ b/src/aws/lambda-encode/src/copyDocument.js
@@ -1,0 +1,24 @@
+// Copy a document from a source to a destination bucket
+const AWS = require('aws-sdk');
+const s3 = new AWS.S3({ apiVersion: '2006-03-01' });
+
+module.exports = async (objectKey, sourceBucket) => {
+  const destinationBucket = process.env.S3_DESTINATION_BUCKET;
+
+  console.log(`Copying document ${objectKey} to destination bucket.`);
+
+  const sourceDocument = await s3
+    .getObject({ Bucket: sourceBucket, Key: objectKey })
+    .promise();
+
+
+  const parts = objectKey.split('/');
+  await s3
+    .putObject({
+      Body: sourceDocument.Body,
+      Bucket: destinationBucket,
+      Key: `${parts[0]}/document/${parts[3]}`,
+      ContentType: 'binary/octet-stream',
+    })
+    .promise();
+};

--- a/src/aws/lambda-encode/src/copyDocument.spec.js
+++ b/src/aws/lambda-encode/src/copyDocument.spec.js
@@ -1,0 +1,42 @@
+process.env.S3_DESTINATION_BUCKET = 'destination bucket';
+
+// Don't pollute tests with logs intended for CloudWatch
+jest.spyOn(console, 'log');
+
+// Mock the AWS SDK calls used in encodeTimedTextTrack
+const mockGetObject = jest.fn();
+const mockPutObject = jest.fn();
+jest.mock('aws-sdk', () => ({
+  S3: function() {
+    this.getObject = mockGetObject;
+    this.putObject = mockPutObject;
+  },
+}));
+
+const copyDocument = require('./copyDocument');
+
+describe('lambda-encore/src/copyDocument', () => {
+  beforeEach(() => {
+    console.log.mockReset();
+    jest.resetAllMocks();
+  });
+
+  it('copy a document from a source to a destination bucket', async () => {
+    mockGetObject.mockReturnValue({
+      promise: () =>
+        new Promise(resolve => resolve({ Body: 'input timed text' })),
+    });
+    mockPutObject.mockReturnValue({
+      promise: () => new Promise(resolve => resolve()),
+    });
+
+    await copyDocument('foo/document/foo/bar', 'source bucket')
+
+    expect(mockPutObject).toHaveBeenCalledWith({
+      Body: 'input timed text',
+      Bucket: 'destination bucket',
+      Key: 'foo/document/bar',
+      ContentType: 'binary/octet-stream',
+    })
+  });
+})


### PR DESCRIPTION
## Purpose

New `document` resource needs to be manage on AWS. We only need to copy it from the source to the destination bucket.

## Proposal

- [x] update `lambda-encode` to manage `document` resource.

Note: we need to change this lambda name now.

