### PR TITLE
Manage documents in front application

### DIFF
--- a/src/backend/marsha/core/templates/core/lti_development.html
+++ b/src/backend/marsha/core/templates/core/lti_development.html
@@ -40,7 +40,7 @@
     </style>
 
     <script>
-      const baseUrl = "http://localhost:8060/lti/videos/";
+      const baseUrl = "http://localhost:8060/lti";
 
       document.addEventListener('DOMContentLoaded', () => {
         document.querySelectorAll('form').forEach(form => {
@@ -49,8 +49,9 @@
 
             const form = event.target;
             const uuid = form.querySelector('input[name="uuid"]').value;
+            const resource = form.querySelector('select[name="resource"]').value;
 
-            form.action = `${baseUrl}${uuid}`;
+            form.action = `${baseUrl}/${resource}/${uuid}`;
             form.submit();
           });
         });
@@ -67,7 +68,6 @@
         cross-origin call.
       </p>
       <form
-        action="http://localhost:8060/lti/videos/"
         method="post"
         target="lti_iframe"
       >
@@ -79,6 +79,11 @@
           value="course-v1:ufr+mathematics+0001"
         />
         <input type="text" name="roles" value="Instructor" />
+        <select name="resource">
+          <option>Resource</option>
+          <option value="videos" selected>video</option>
+          <option value="documents">document</option>
+        </select>
         <input type="text" name="user_id" value="56255f3807599c377bf0e5bf072359fd" />
         <input type="text" name="lis_person_contact_email_primary" value="contact@openfun.fr" />
         <select name="launch_presentation_locale">
@@ -123,7 +128,7 @@
         Open the `/lti/videos/` view in a regular full-screen page, with a POST
         request.
       </p>
-      <form action="/lti/videos/" method="post">
+      <form method="post">
         <input type="text" name="uuid" value="{{ uuid }}" />
         <input type="text" name="resource_link_id" value="example.com-df7" />
         <input
@@ -132,6 +137,11 @@
           value="course-v1:ufr+mathematics+0001"
         />
         <input type="text" name="roles" value="Instructor" />
+        <select name="resource">
+          <option>Resource</option>
+          <option value="videos" selected>video</option>
+          <option value="documents">document</option>
+        </select>
         <input type="text" name="user_id" value="56255f3807599c377bf0e5bf072359fd" />
         <input type="text" name="lis_person_contact_email_primary" value="contact@openfun.fr" />
         <input type="hidden" name="custom_component_display_name" value="LTI Consumer" />

--- a/src/frontend/appVideo.tsx
+++ b/src/frontend/appVideo.tsx
@@ -1,0 +1,32 @@
+import { Grommet } from 'grommet';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { IntlProvider } from 'react-intl';
+import { Provider } from 'react-redux';
+
+import { AppRoutes } from './components/AppRoutes';
+import { bootstrapStore } from './data/bootstrapStore';
+import { AppData, ResourceType } from './types/AppData';
+// Load our style reboot into the DOM
+import { GlobalStyles } from './utils/theme/baseStyles';
+import { theme } from './utils/theme/theme';
+
+export const appVideo = (
+  appData: AppData<ResourceType.VIDEO>,
+  localeCode: string,
+  translatedMessages: any,
+) => {
+  const store = bootstrapStore(appData);
+
+  ReactDOM.render(
+    <IntlProvider locale={localeCode} messages={translatedMessages}>
+      <Grommet theme={theme}>
+        <Provider store={store}>
+          <AppRoutes />
+          <GlobalStyles />
+        </Provider>
+      </Grommet>
+    </IntlProvider>,
+    document.querySelector('#marsha-frontend-root'),
+  );
+};

--- a/src/frontend/components/Dashboard/index.spec.tsx
+++ b/src/frontend/components/Dashboard/index.spec.tsx
@@ -17,6 +17,9 @@ jest.mock(
     DashboardTimedTextPaneConnected: () => '',
   }),
 );
+jest.mock('../../data/appData', () => ({
+  appData: {},
+}));
 
 describe('<Dashboard />', () => {
   afterEach(cleanup);

--- a/src/frontend/components/DashboardThumbnail/index.spec.tsx
+++ b/src/frontend/components/DashboardThumbnail/index.spec.tsx
@@ -22,6 +22,10 @@ const mockCreateThumbnail: jestMockOf<
   typeof createThumbnail
 > = createThumbnail as any;
 
+jest.mock('../../data/appData', () => ({
+  appData: {},
+}));
+
 describe('<DashboardThumbnail />', () => {
   afterEach(jest.resetAllMocks);
   afterEach(cleanup);
@@ -81,10 +85,9 @@ describe('<DashboardThumbnail />', () => {
       <Provider
         store={bootstrapStore({
           jwt: '',
-          resourceLinkid: '',
           state: appState.INSTRUCTOR,
           video,
-        })}
+        } as any)}
       >
         <DashboardThumbnail video={video} />
       </Provider>,
@@ -116,10 +119,9 @@ describe('<DashboardThumbnail />', () => {
       <Provider
         store={bootstrapStore({
           jwt: '',
-          resourceLinkid: '',
           state: appState.INSTRUCTOR,
           video: videoWithoutThumbnail,
-        })}
+        } as any)}
       >
         <DashboardThumbnail video={videoWithoutThumbnail} />
       </Provider>,
@@ -154,10 +156,9 @@ describe('<DashboardThumbnail />', () => {
       <Provider
         store={bootstrapStore({
           jwt: '',
-          resourceLinkid: '',
           state: appState.INSTRUCTOR,
           video: videoWithLoadingThumbnail,
-        })}
+        } as any)}
       >
         <DashboardThumbnail video={videoWithLoadingThumbnail} />
       </Provider>,
@@ -190,10 +191,9 @@ describe('<DashboardThumbnail />', () => {
       <Provider
         store={bootstrapStore({
           jwt: '',
-          resourceLinkid: '',
           state: appState.INSTRUCTOR,
           video: videoWithProcessingThumbnail,
-        })}
+        } as any)}
       >
         <DashboardThumbnail video={videoWithProcessingThumbnail} />
       </Provider>,
@@ -224,10 +224,9 @@ describe('<DashboardThumbnail />', () => {
       <Provider
         store={bootstrapStore({
           jwt: '',
-          resourceLinkid: '',
           state: appState.INSTRUCTOR,
           video: videoWithErroredThumbnail,
-        })}
+        } as any)}
       >
         <DashboardThumbnail video={videoWithErroredThumbnail} />
       </Provider>,
@@ -258,10 +257,9 @@ describe('<DashboardThumbnail />', () => {
           jwt:
             'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2M' +
             'jM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
-          resourceLinkid: '',
           state: appState.INSTRUCTOR,
           video: videoWithoutThumbnail,
-        })}
+        } as any)}
       >
         <DashboardThumbnail video={videoWithoutThumbnail} />
       </Provider>,

--- a/src/frontend/components/VideoPlayer/index.spec.tsx
+++ b/src/frontend/components/VideoPlayer/index.spec.tsx
@@ -27,6 +27,10 @@ jest.mock('../../utils/isAbrSupported', () => ({
 }));
 const mockIsMSESupported = isMSESupported as jestMockOf<typeof isMSESupported>;
 
+jest.mock('../../data/appData', () => ({
+  appData: {},
+}));
+
 describe('VideoPlayer', () => {
   afterEach(cleanup);
   beforeEach(jest.clearAllMocks);

--- a/src/frontend/data/appData.ts
+++ b/src/frontend/data/appData.ts
@@ -1,8 +1,11 @@
+import { ResourceType } from '../types/AppData';
 import { parseDataElements } from '../utils/parseDataElements/parseDataElements';
 
+// Spread to pass an array instead of a NodeList
+
+const elements = [...document.querySelectorAll('.marsha-frontend-data')];
+const element = document.querySelector('.marsha-frontend-data[id]');
+
 export const appData = {
-  ...parseDataElements(
-    // Spread to pass an array instead of a NodeList
-    [...document.querySelectorAll('.marsha-frontend-data')],
-  ),
+  ...parseDataElements(elements, element!.id as ResourceType),
 };

--- a/src/frontend/data/bootstrapStore.ts
+++ b/src/frontend/data/bootstrapStore.ts
@@ -2,7 +2,7 @@ import { applyMiddleware, compose, createStore } from 'redux';
 import createSagaMiddleware from 'redux-saga';
 
 import { requestStatus } from '../types/api';
-import { AppData } from '../types/AppData';
+import { AppData, ResourceType } from '../types/AppData';
 import { modelName } from '../types/models';
 import { Nullable } from '../utils/types';
 import { buildInitialState } from './context/reducer';
@@ -14,7 +14,7 @@ import { TimedTextTracksState } from './timedtexttracks/reducer';
 
 const sagaMiddleware = createSagaMiddleware();
 
-export const bootstrapStore = (appData: AppData) => {
+export const bootstrapStore = (appData: AppData<ResourceType.VIDEO>) => {
   const composeEnhancers =
     (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 

--- a/src/frontend/data/context/reducer.spec.ts
+++ b/src/frontend/data/context/reducer.spec.ts
@@ -3,6 +3,10 @@ import { DecodedJwt } from '../../types/jwt';
 import { Video } from '../../types/tracks';
 import { context } from './reducer';
 
+jest.mock('../appData', () => ({
+  appData: {},
+}));
+
 describe('Reducer: context', () => {
   const previousState = {
     decodedJwt: {} as DecodedJwt,

--- a/src/frontend/data/context/reducer.ts
+++ b/src/frontend/data/context/reducer.ts
@@ -1,7 +1,7 @@
 import jwt_decode from 'jwt-decode';
 import { AnyAction, Reducer } from 'redux';
 
-import { AppData, appState } from '../../types/AppData';
+import { AppData, appState, ResourceType } from '../../types/AppData';
 import { DecodedJwt } from '../../types/jwt';
 import { UploadableObject, Video } from '../../types/tracks';
 import { appData as initialState } from '../appData';
@@ -17,7 +17,7 @@ export interface ContextState<state> {
   };
 }
 
-export const buildInitialState = (appData: AppData) => ({
+export const buildInitialState = (appData: AppData<ResourceType.VIDEO>) => ({
   decodedJwt: appData.jwt ? (jwt_decode(appData.jwt) as DecodedJwt) : null,
   jwt: appData.jwt || null,
   ltiResourceVideo: appData.video || null,
@@ -26,7 +26,9 @@ export const buildInitialState = (appData: AppData) => ({
 });
 
 export const context: Reducer<ContextState<appState>> = (
-  state: ContextState<appState> = buildInitialState(initialState),
+  state: ContextState<appState> = buildInitialState(initialState as AppData<
+    ResourceType.VIDEO
+  >),
   action?: UploadProgressNotification<UploadableObject> | AnyAction,
 ) => {
   if (!action) {

--- a/src/frontend/index.tsx
+++ b/src/frontend/index.tsx
@@ -1,21 +1,11 @@
 import 'iframe-resizer/js/iframeResizer.contentWindow';
 
-import { Grommet } from 'grommet';
 import jwtDecode from 'jwt-decode';
-import React from 'react';
-import ReactDOM from 'react-dom';
-import { addLocaleData, IntlProvider } from 'react-intl';
-import { Provider } from 'react-redux';
+import { addLocaleData } from 'react-intl';
 
-import { AppRoutes } from './components/AppRoutes';
 import { appData } from './data/appData';
-import { bootstrapStore } from './data/bootstrapStore';
+import { AppData, ResourceType } from './types/AppData';
 import { DecodedJwt } from './types/jwt';
-// Load our style reboot into the DOM
-import { GlobalStyles } from './utils/theme/baseStyles';
-import { theme } from './utils/theme/theme';
-
-const store = bootstrapStore(appData);
 
 const decodedToken: DecodedJwt = jwtDecode(appData.jwt);
 
@@ -38,16 +28,14 @@ document.addEventListener('DOMContentLoaded', async event => {
     );
   } catch (e) {}
 
-  // Render our actual component tree
-  ReactDOM.render(
-    <IntlProvider locale={localeCode} messages={translatedMessages}>
-      <Grommet theme={theme}>
-        <Provider store={store}>
-          <AppRoutes />
-          <GlobalStyles />
-        </Provider>
-      </Grommet>
-    </IntlProvider>,
-    document.querySelector('#marsha-frontend-root'),
-  );
+  switch (appData.resourceType) {
+    case ResourceType.VIDEO:
+      const app = await import('./appVideo');
+      app.appVideo(
+        appData as AppData<ResourceType.VIDEO>,
+        localeCode,
+        translatedMessages,
+      );
+      break;
+  }
 });

--- a/src/frontend/types/AppData.ts
+++ b/src/frontend/types/AppData.ts
@@ -1,5 +1,6 @@
-import { Nullable } from '../utils/types';
+import { Maybe, Nullable } from '../utils/types';
 import { AWSPolicy } from './AWSPolicy';
+import { Document } from './file';
 import { Video } from './tracks';
 
 export enum appState {
@@ -8,14 +9,19 @@ export enum appState {
   STUDENT = 'student',
 }
 
+export enum ResourceType {
+  DOCUMENT = 'document',
+  VIDEO = 'video',
+}
+
 export type appStateSuccess = appState.INSTRUCTOR | appState.STUDENT;
 
-export interface AppData {
+export interface AppData<R extends ResourceType> {
   jwt: string;
-  policy?: AWSPolicy;
-  resourceLinkid: string;
   state: appState;
-  video: Nullable<Video>;
+  video: R extends ResourceType.VIDEO ? Nullable<Video> : undefined;
+  document: R extends ResourceType.DOCUMENT ? Nullable<Document> : undefined;
+  resourceType: R;
 
   updateVideo?: (video: Video) => void;
 }

--- a/src/frontend/types/file.tsx
+++ b/src/frontend/types/file.tsx
@@ -1,0 +1,10 @@
+import { Resource, uploadState } from './tracks';
+
+export interface Document extends Resource {
+  description: string;
+  is_ready_to_display: boolean;
+  title: string;
+  upload_state: uploadState;
+  url: string;
+  show_download: boolean;
+}

--- a/src/frontend/utils/parseDataElements/parseDataElements.spec.ts
+++ b/src/frontend/utils/parseDataElements/parseDataElements.spec.ts
@@ -1,3 +1,4 @@
+import { appState, ResourceType } from '../../types/AppData';
 import { keyFromAttr, parseDataElements } from './parseDataElements';
 
 describe.only('utils/parseDataElements', () => {
@@ -9,71 +10,22 @@ describe.only('utils/parseDataElements', () => {
   });
 
   describe('parseDataElements()', () => {
-    it('returns an object from the key/values of a data-element', () => {
-      // Build some bogus object with string values & lowecase string keys
-      const data: { [key: string]: string } = {
-        keyone: 'valueOne',
-        keytwo: 'valueTwo',
-      };
-      // Set up the element that contains our data as data-attributes
-      const dataElement = document.createElement('div');
-      Object.keys(data).forEach(key =>
-        dataElement.setAttribute(`data-${key}`, data[key]),
-      );
-      // The data is extracted from the data element
-      expect(parseDataElements([dataElement])).toEqual(data);
-    });
+    it('return a AppData object', () => {
+      const element = document.createElement('div');
+      element.setAttribute('data-jwt', 'jwt');
+      element.setAttribute('data-state', appState.INSTRUCTOR);
+      const otherElement = document.createElement('div');
+      otherElement.setAttribute('id', 'video');
+      otherElement.setAttribute('data-video', JSON.stringify({ id: 42 }));
 
-    it('merges data from two separate elements', () => {
-      // Build some bogus objects with string values & lowecase string keys
-      const dataX: { [key: string]: string } = {
-        keythree: 'valueThree',
-      };
-      const dataY: { [key: string]: string } = {
-        keyfour: 'valueFour',
-      };
-      // Set up the elements that contains our data as data-attributes
-      const dataElementX = document.createElement('div');
-      Object.keys(dataX).forEach(key =>
-        dataElementX.setAttribute(`data-${key}`, dataX[key]),
-      );
-      const dataElementY = document.createElement('div');
-      Object.keys(dataY).forEach(key =>
-        dataElementY.setAttribute(`data-${key}`, dataY[key]),
-      ); // The data is extracted from the data element
-      expect(parseDataElements([dataElementX, dataElementY])).toEqual({
-        ...dataX,
-        ...dataY,
-      });
-    });
-
-    it('creates a nested object when an element as an ID attribute', () => {
-      // Build some bogus objects with string values & lowecase string keys
-      const data: { [data: string]: string } = {
-        keyfive: 'valueFive',
-      };
-      // Make a standard AWS S3 policy for illustration purposes
-      const policy: { [key: string]: string } = {
-        acl: 'public-read',
-        awsaccesskeyid: 'MyAWSKey',
-        key: 'file_key_in_s3',
-        policy: 'base64_encoded_policy',
-        signature: 'the_policys_hmac_signature',
-        url: 'my_s3_buckets_url',
-      };
-      // Set up the element that contains our bogus data as data-attributes
-      const dataElement = document.createElement('div');
-      Object.keys(data).forEach(key =>
-        dataElement.setAttribute(`data-${key}`, data[key]),
-      );
-      // Set up the element that contains the policy as data-attributes
-      const policyElement = document.createElement('div');
-      policyElement.id = 'policy'; // triggers the creation of a nested object
-      policyElement.setAttribute('data-policy', JSON.stringify(policy));
-      // The bogus data and policy are extracted from the data elements
-      expect(parseDataElements([dataElement, policyElement])).toEqual({
-        ...data,
-        policy,
+      expect(
+        parseDataElements([element, otherElement], ResourceType.VIDEO),
+      ).toEqual({
+        document: undefined,
+        jwt: 'jwt',
+        resourceType: ResourceType.VIDEO,
+        state: appState.INSTRUCTOR,
+        video: { id: 42 },
       });
     });
   });

--- a/src/frontend/utils/parseDataElements/parseDataElements.ts
+++ b/src/frontend/utils/parseDataElements/parseDataElements.ts
@@ -1,4 +1,4 @@
-import { AppData } from '../../types/AppData';
+import { AppData, appState, ResourceType } from '../../types/AppData';
 
 // Transform a data-attribute into a proper key: drop 'data-' & camel-case it
 // Exported for testing purposes
@@ -16,12 +16,11 @@ export const keyFromAttr = (attribute: string) => {
   );
 };
 
-// Extract all the necessary data the backend passed us through data-attributes on some elements
-export const parseDataElements: (
-  dataElements: Element[],
-) => AppData = dataElements => {
-  // Iterate over the data elements to add their data onto the root accumulator (starting with {})
-  return dataElements.reduce(
+export function parseDataElements<R extends ResourceType>(
+  elements: Element[],
+  resource: R,
+): AppData<R> {
+  const data: any = elements.reduce(
     (rootAcc, element) =>
       Object.keys(element.attributes)
         // Get the actual attribute names from the NamedNodeMap object
@@ -50,5 +49,15 @@ export const parseDataElements: (
           }
         }, rootAcc),
     {},
-  ) as AppData;
-};
+  );
+
+  const appData: AppData<R> = {
+    document: data.document,
+    jwt: data.jwt,
+    resourceType: resource,
+    state: data.state as appState,
+    video: data.video,
+  };
+
+  return appData;
+}


### PR DESCRIPTION
## Purpose

The backend application can manage a new `document` resource. We need to change the front application to manage it too.
This application will allow to upload a document, display a link once uploaded and the dashboard will only allow to replace the current file.

## Proposal

We will create a new "application" but using some existing components like all the upload and progress component. If possible we will not reuse redux, maybe by creating a wrapper component ?
In a first we need yo isolate the existing application and related data.
Then it will possible to create the new components managing `document resource`

- [x] isolate video application and related data.
- [ ] more to come
