### PR TITLE
🐛(backend) use secure cookie only in production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- use secure cookie only in production.
+
 ## [2.8.2] - 2019-05-21
 
 ### Changed

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -74,9 +74,7 @@ class Base(Configuration):
     SITE_ID = 1
 
     SECURE_BROWSER_XSS_FILTER = True
-    SESSION_COOKIE_SECURE = True
     SECURE_CONTENT_TYPE_NOSNIFF = True
-    CSRF_COOKIE_SECURE = True
     X_FRAME_OPTIONS = "DENY"
     SILENCED_SYSTEM_CHECKS = values.ListValue([])
 
@@ -409,6 +407,9 @@ class Production(Base):
     # pattern matching files to ignore when hashing file names and exclude from the
     # static files manifest
     STATIC_POSTPROCESS_IGNORE_REGEX = values.Value(r"^js\/[0-9]*\..*\.index\.js$")
+
+    SESSION_COOKIE_SECURE = True
+    CSRF_COOKIE_SECURE = True
 
 
 class Staging(Production):


### PR DESCRIPTION
## Purpose

In development we cannot use all secure cookie settings because we
don't use https certificate. These settings should be used only in
production.

## Proposal

- [x] modify settings to use secured cookie only in production.