### PR TITLE
rework on xAPI played segments and completed event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - use secure cookie only in production.
 
+### Fixed
+
+- xapi: played segments list should not contain skipped segments (seek event)
+- xapi: completed event is sent when the progression reaches 100%
+
 ## [2.8.2] - 2019-05-21
 
 ### Changed

--- a/src/frontend/Player/createPlyrPlayer.spec.ts
+++ b/src/frontend/Player/createPlyrPlayer.spec.ts
@@ -44,44 +44,43 @@ describe('createPlyrPlayer', () => {
       'seeked',
       expect.any(Function),
     );
-    expect(player.on).toHaveBeenNthCalledWith(7, 'ended', expect.any(Function));
     expect(player.on).toHaveBeenNthCalledWith(
-      8,
+      7,
       'captionsdisabled',
       expect.any(Function),
     );
     expect(player.on).toHaveBeenNthCalledWith(
-      9,
+      8,
       'captionsenabled',
       expect.any(Function),
     );
     expect(player.on).toHaveBeenNthCalledWith(
-      10,
+      9,
       'enterfullscreen',
       expect.any(Function),
     );
     expect(player.on).toHaveBeenNthCalledWith(
-      11,
+      10,
       'exitfullscreen',
       expect.any(Function),
     );
     expect(player.on).toHaveBeenNthCalledWith(
-      12,
+      11,
       'languagechange',
       expect.any(Function),
     );
     expect(player.on).toHaveBeenNthCalledWith(
-      13,
+      12,
       'qualitychange',
       expect.any(Function),
     );
     expect(player.on).toHaveBeenNthCalledWith(
-      14,
+      13,
       'ratechange',
       expect.any(Function),
     );
     expect(player.on).toHaveBeenNthCalledWith(
-      15,
+      14,
       'volumechange',
       expect.any(Function),
     );

--- a/src/frontend/Player/createPlyrPlayer.ts
+++ b/src/frontend/Player/createPlyrPlayer.ts
@@ -110,11 +110,6 @@ export const createPlyrPlayer = (
       timeTo: event.detail.plyr.currentTime,
     });
   });
-  /**************** End seeked statement *********************/
-
-  player.on('ended', event => {
-    xapiStatement.completed({});
-  });
 
   /**************** Interacted event *************************/
   const interacted = (event: Plyr.PlyrEvent): void => {

--- a/src/frontend/XAPI/XAPIStatement.spec.ts
+++ b/src/frontend/XAPI/XAPIStatement.spec.ts
@@ -259,7 +259,7 @@ describe('XAPIStatement', () => {
       });
       expect(body.result.extensions).toEqual({
         'https://w3id.org/xapi/video/extensions/length': 100,
-        'https://w3id.org/xapi/video/extensions/played-segments': '0[.]10',
+        'https://w3id.org/xapi/video/extensions/played-segments': '10',
         'https://w3id.org/xapi/video/extensions/progress': 0.1,
         'https://w3id.org/xapi/video/extensions/time-from': 0,
         'https://w3id.org/xapi/video/extensions/time-to': 10,
@@ -387,7 +387,7 @@ describe('XAPIStatement', () => {
         'https://w3id.org/xapi/video/extensions/session-id': 'abcd',
       });
       expect(body.result.extensions).toEqual({
-        'https://w3id.org/xapi/video/extensions/played-segments': '0[.]50',
+        'https://w3id.org/xapi/video/extensions/played-segments': '',
         'https://w3id.org/xapi/video/extensions/progress': 0.5,
         'https://w3id.org/xapi/video/extensions/time': 50,
       });
@@ -430,7 +430,7 @@ describe('XAPIStatement', () => {
         'https://w3id.org/xapi/video/extensions/session-id': 'abcd',
       });
       expect(body.result.extensions).toEqual({
-        'https://w3id.org/xapi/video/extensions/played-segments': '0[.]50',
+        'https://w3id.org/xapi/video/extensions/played-segments': '',
         'https://w3id.org/xapi/video/extensions/progress': 0.5,
         'https://w3id.org/xapi/video/extensions/time': 50,
       });
@@ -505,31 +505,33 @@ describe('XAPIStatement', () => {
         timeFrom: 5,
         timeTo: 12,
       });
-      expect(xapiStatement.getPlayedSegment()).toBe('0[.]5[,]5[.]12');
+      expect(xapiStatement.getPlayedSegment()).toBe('0[.]5[,]12');
       xapiStatement.paused({}, { time: 22 });
-      expect(xapiStatement.getPlayedSegment()).toBe('0[.]5[,]5[.]12[,]12[.]22');
+      expect(xapiStatement.getPlayedSegment()).toBe('0[.]5[,]12[.]22');
       xapiStatement.seeked({
         timeFrom: 22,
         timeTo: 15,
       });
-      expect(xapiStatement.getPlayedSegment()).toBe(
-        '0[.]5[,]5[.]12[,]12[.]22[,]22[.]15',
-      );
-      xapiStatement.played({ time: 15 });
-      expect(xapiStatement.getPlayedSegment()).toBe(
-        '0[.]5[,]5[.]12[,]12[.]22[,]22[.]15[,]15',
-      );
+      expect(xapiStatement.getPlayedSegment()).toBe('0[.]5[,]12[.]22[,]15');
       xapiStatement.paused({}, { time: 55 });
       expect(xapiStatement.getPlayedSegment()).toBe(
-        '0[.]5[,]5[.]12[,]12[.]22[,]22[.]15[,]15[.]55',
+        '0[.]5[,]12[.]22[,]15[.]55',
       );
       xapiStatement.played({ time: 55 });
       expect(xapiStatement.getPlayedSegment()).toBe(
-        '0[.]5[,]5[.]12[,]12[.]22[,]22[.]15[,]15[.]55[,]55',
+        '0[.]5[,]12[.]22[,]15[.]55[,]55',
       );
       xapiStatement.paused({}, { time: 99.33 });
       expect(xapiStatement.getPlayedSegment()).toBe(
-        '0[.]5[,]5[.]12[,]12[.]22[,]22[.]15[,]15[.]55[,]55[.]99.33',
+        '0[.]5[,]12[.]22[,]15[.]55[,]55[.]99.33',
+      );
+      xapiStatement.played({ time: 99.33 });
+      expect(xapiStatement.getPlayedSegment()).toBe(
+        '0[.]5[,]12[.]22[,]15[.]55[,]55[.]99.33[,]99.33',
+      );
+      xapiStatement.paused({}, { time: 100 });
+      expect(xapiStatement.getPlayedSegment()).toBe(
+        '0[.]5[,]12[.]22[,]15[.]55[,]55[.]99.33[,]99.33[.]100',
       );
       xapiStatement.completed({});
       expect(xapiStatement.getPlayedSegment()).toBe(

--- a/src/frontend/XAPI/XAPIStatement.spec.ts
+++ b/src/frontend/XAPI/XAPIStatement.spec.ts
@@ -262,7 +262,7 @@ describe('XAPIStatement', () => {
       expect(body.result.extensions).toEqual({
         'https://w3id.org/xapi/video/extensions/length': 100,
         'https://w3id.org/xapi/video/extensions/played-segments': '10',
-        'https://w3id.org/xapi/video/extensions/progress': 0.1,
+        'https://w3id.org/xapi/video/extensions/progress': 0,
         'https://w3id.org/xapi/video/extensions/time-from': 0,
         'https://w3id.org/xapi/video/extensions/time-to': 10,
       });
@@ -349,7 +349,7 @@ describe('XAPIStatement', () => {
       });
       expect(body.result.extensions).toEqual({
         'https://w3id.org/xapi/video/extensions/played-segments': '',
-        'https://w3id.org/xapi/video/extensions/progress': 0.5,
+        'https://w3id.org/xapi/video/extensions/progress': 0,
         'https://w3id.org/xapi/video/extensions/time': 50,
       });
       expect(body).toHaveProperty('id');
@@ -393,7 +393,7 @@ describe('XAPIStatement', () => {
       });
       expect(body.result.extensions).toEqual({
         'https://w3id.org/xapi/video/extensions/played-segments': '',
-        'https://w3id.org/xapi/video/extensions/progress': 0.5,
+        'https://w3id.org/xapi/video/extensions/progress': 0,
         'https://w3id.org/xapi/video/extensions/time': 50,
       });
       expect(body).toHaveProperty('id');

--- a/src/frontend/XAPI/XAPIStatement.spec.ts
+++ b/src/frontend/XAPI/XAPIStatement.spec.ts
@@ -178,6 +178,7 @@ describe('XAPIStatement', () => {
         'en-US': 'paused',
       });
       expect(body.context.extensions).toEqual({
+        'https://w3id.org/xapi/video/extensions/length': 100,
         'https://w3id.org/xapi/video/extensions/session-id': 'abcd',
       });
       expect(body.result.extensions).toEqual({
@@ -215,6 +216,7 @@ describe('XAPIStatement', () => {
       });
       expect(body.context.extensions).toEqual({
         'https://w3id.org/xapi/video/extensions/completion-threshold': 0.5,
+        'https://w3id.org/xapi/video/extensions/length': 100,
         'https://w3id.org/xapi/video/extensions/session-id': 'abcd',
       });
       expect(body.result.extensions).toEqual({
@@ -279,7 +281,7 @@ describe('XAPIStatement', () => {
       xapiStatement.played({ time: 0 });
       // completed is delayed to have a realistic duration
       setTimeout(() => {
-        xapiStatement.completed({});
+        xapiStatement.completed();
 
         const lastCall = fetchMock.lastCall(`${XAPI_ENDPOINT}/`);
 
@@ -297,48 +299,6 @@ describe('XAPIStatement', () => {
           'en-US': 'completed',
         });
         expect(body.context.extensions).toEqual({
-          'https://w3id.org/xapi/video/extensions/session-id': 'abcd',
-        });
-        expect(body.result.extensions).toEqual({
-          'https://w3id.org/xapi/video/extensions/played-segments': '0[.]100',
-          'https://w3id.org/xapi/video/extensions/progress': 1,
-          'https://w3id.org/xapi/video/extensions/time': 100,
-        });
-        expect(body.result.completion).toBe(true);
-        expect(body.result.duration).toMatch(/^PT[0-9]*.?[0-9]*S$/);
-        expect(body).toHaveProperty('id');
-        expect(body).toHaveProperty('timestamp');
-      }, 500);
-    });
-
-    it('sends a completed statement with completion threshold', () => {
-      fetchMock.mock(`${XAPI_ENDPOINT}/`, 204, {
-        overwriteRoutes: true,
-      });
-      const xapiStatement = new XAPIStatement('jwt', 'abcd');
-      xapiStatement.initialized({ length: 100 });
-      xapiStatement.played({ time: 0 });
-      // completed is delayed to have a realistic duration
-      setTimeout(() => {
-        xapiStatement.completed({ completionTreshold: 0.5 });
-
-        const lastCall = fetchMock.lastCall(`${XAPI_ENDPOINT}/`);
-
-        const requestParameters = lastCall![1]!;
-
-        expect(requestParameters.headers).toEqual({
-          Authorization: 'Bearer jwt',
-          'Content-Type': 'application/json',
-        });
-
-        const body = JSON.parse(requestParameters.body as string);
-
-        expect(body.verb.id).toEqual(VerbDefinition.completed);
-        expect(body.verb.display).toEqual({
-          'en-US': 'completed',
-        });
-        expect(body.context.extensions).toEqual({
-          'https://w3id.org/xapi/video/extensions/completion-threshold': 0.5,
           'https://w3id.org/xapi/video/extensions/session-id': 'abcd',
         });
         expect(body.result.extensions).toEqual({
@@ -384,6 +344,7 @@ describe('XAPIStatement', () => {
         'en-US': 'terminated',
       });
       expect(body.context.extensions).toEqual({
+        'https://w3id.org/xapi/video/extensions/length': 100,
         'https://w3id.org/xapi/video/extensions/session-id': 'abcd',
       });
       expect(body.result.extensions).toEqual({
@@ -427,6 +388,7 @@ describe('XAPIStatement', () => {
       });
       expect(body.context.extensions).toEqual({
         'https://w3id.org/xapi/video/extensions/completion-threshold': 0.2,
+        'https://w3id.org/xapi/video/extensions/length': 100,
         'https://w3id.org/xapi/video/extensions/session-id': 'abcd',
       });
       expect(body.result.extensions).toEqual({

--- a/src/frontend/XAPI/XAPIStatement.ts
+++ b/src/frontend/XAPI/XAPIStatement.ts
@@ -167,6 +167,7 @@ export class XAPIStatement {
   ): void {
     const time: number = truncateDecimalDigits(resultExtensions.time);
     this.addEndSegment(time);
+    const progress = this.getProgress();
     const data: DataPayload = {
       context: {
         extensions: {
@@ -178,7 +179,9 @@ export class XAPIStatement {
         extensions: {
           [ResultExtensionsDefinition.time]: time,
           [ResultExtensionsDefinition.playedSegment]: this.getPlayedSegment(),
-          [ResultExtensionsDefinition.progress]: truncateDecimalDigits(resultExtensions.time / this.duration),
+          [ResultExtensionsDefinition.progress]: truncateDecimalDigits(
+            progress,
+          ),
         },
       },
       verb: {
@@ -196,7 +199,7 @@ export class XAPIStatement {
 
     this.send(data);
 
-    if (this.getProgress() >= 1) {
+    if (Math.abs(1.0 - progress) < Number.EPSILON) {
       this.completed();
     }
   }
@@ -221,7 +224,7 @@ export class XAPIStatement {
             this.duration,
           ),
           [ResultExtensionsDefinition.progress]: truncateDecimalDigits(
-            resultExtensions.timeTo / this.duration,
+            this.getProgress(),
           ),
           [ResultExtensionsDefinition.playedSegment]: this.getPlayedSegment(),
         },
@@ -292,7 +295,7 @@ export class XAPIStatement {
         extensions: {
           [ResultExtensionsDefinition.time]: time,
           [ResultExtensionsDefinition.progress]: truncateDecimalDigits(
-            resultExtensions.time / this.duration,
+            this.getProgress(),
           ),
           [ResultExtensionsDefinition.playedSegment]: this.getPlayedSegment(),
         },

--- a/src/frontend/XAPI/XAPIStatement.ts
+++ b/src/frontend/XAPI/XAPIStatement.ts
@@ -5,7 +5,7 @@ import uuid from 'uuid';
 import { XAPI_ENDPOINT } from '../settings';
 import {
   CompletedDataPlayload,
-  ContextExtensionsDefintion,
+  ContextExtensionsDefinition,
   DataPayload,
   InitializedContextExtensions,
   InteractedContextExtensions,
@@ -110,11 +110,11 @@ export class XAPIStatement {
     const extensions: {
       [key: string]: string | boolean | number | undefined;
     } = {
-      [ContextExtensionsDefintion.sessionId]: this.sessionId,
+      [ContextExtensionsDefinition.sessionId]: this.sessionId,
     };
     for (const key of Object.keys(contextExtensions)) {
       extensions[
-        ContextExtensionsDefintion[key as keyof InitializedContextExtensions]
+        ContextExtensionsDefinition[key as keyof InitializedContextExtensions]
       ] = contextExtensions[key as keyof InitializedContextExtensions];
     }
 
@@ -142,7 +142,7 @@ export class XAPIStatement {
     const data: DataPayload = {
       context: {
         extensions: {
-          [ContextExtensionsDefintion.sessionId]: this.sessionId,
+          [ContextExtensionsDefinition.sessionId]: this.sessionId,
         },
       },
       result: {
@@ -171,8 +171,8 @@ export class XAPIStatement {
     const data: DataPayload = {
       context: {
         extensions: {
-          [ContextExtensionsDefintion.length]: this.duration,
-          [ContextExtensionsDefintion.sessionId]: this.sessionId,
+          [ContextExtensionsDefinition.length]: this.duration,
+          [ContextExtensionsDefinition.sessionId]: this.sessionId,
         },
       },
       result: {
@@ -193,7 +193,7 @@ export class XAPIStatement {
     };
 
     if (contextExtensions.completionTreshold) {
-      data.context!.extensions[ContextExtensionsDefintion.completionTreshold] =
+      data.context!.extensions[ContextExtensionsDefinition.completionTreshold] =
         contextExtensions.completionTreshold;
     }
 
@@ -213,14 +213,14 @@ export class XAPIStatement {
     const data: DataPayload = {
       context: {
         extensions: {
-          [ContextExtensionsDefintion.sessionId]: this.sessionId,
+          [ContextExtensionsDefinition.sessionId]: this.sessionId,
         },
       },
       result: {
         extensions: {
           [ResultExtensionsDefinition.timeFrom]: timeFrom,
           [ResultExtensionsDefinition.timeTo]: timeTo,
-          [ContextExtensionsDefintion.length]: truncateDecimalDigits(
+          [ContextExtensionsDefinition.length]: truncateDecimalDigits(
             this.duration,
           ),
           [ResultExtensionsDefinition.progress]: truncateDecimalDigits(
@@ -250,9 +250,9 @@ export class XAPIStatement {
     const data: CompletedDataPlayload = {
       context: {
         extensions: {
-          [ContextExtensionsDefintion.length]: this.duration,
-          [ContextExtensionsDefintion.sessionId]: this.sessionId,
-          [ContextExtensionsDefintion.completionTreshold]: 1,
+          [ContextExtensionsDefinition.length]: this.duration,
+          [ContextExtensionsDefinition.sessionId]: this.sessionId,
+          [ContextExtensionsDefinition.completionTreshold]: 1,
         },
       },
       result: {
@@ -287,8 +287,8 @@ export class XAPIStatement {
     const data: DataPayload = {
       context: {
         extensions: {
-          [ContextExtensionsDefintion.length]: this.duration,
-          [ContextExtensionsDefintion.sessionId]: this.sessionId,
+          [ContextExtensionsDefinition.length]: this.duration,
+          [ContextExtensionsDefinition.sessionId]: this.sessionId,
         },
       },
       result: {
@@ -309,7 +309,7 @@ export class XAPIStatement {
     };
 
     if (contextExtensions.completionTreshold) {
-      data.context!.extensions[ContextExtensionsDefintion.completionTreshold] =
+      data.context!.extensions[ContextExtensionsDefinition.completionTreshold] =
         contextExtensions.completionTreshold;
     }
 
@@ -321,11 +321,11 @@ export class XAPIStatement {
     const extensions: {
       [key: string]: string | boolean | number | undefined;
     } = {
-      [ContextExtensionsDefintion.sessionId]: this.sessionId,
+      [ContextExtensionsDefinition.sessionId]: this.sessionId,
     };
     for (const key of Object.keys(contextExtensions)) {
       extensions[
-        ContextExtensionsDefintion[key as keyof InteractedContextExtensions]
+        ContextExtensionsDefinition[key as keyof InteractedContextExtensions]
       ] = contextExtensions[key as keyof InteractedContextExtensions];
     }
 

--- a/src/frontend/types/XAPI.ts
+++ b/src/frontend/types/XAPI.ts
@@ -27,7 +27,7 @@ export interface CompletedDataPlayload extends DataPayload {
   };
 }
 
-export enum ContextExtensionsDefintion {
+export enum ContextExtensionsDefinition {
   ccSubtitleEnabled = 'https://w3id.org/xapi/video/extensions/cc-subtitle-enabled',
   ccSubtitleLanguage = 'https://w3id.org/xapi/video/extensions/cc-subtitle-lang',
   completionTreshold = 'https://w3id.org/xapi/video/extensions/completion-threshold',

--- a/src/frontend/types/XAPI.ts
+++ b/src/frontend/types/XAPI.ts
@@ -101,12 +101,6 @@ export interface SeekedResultExtensions {
   timeTo: number;
 }
 
-/************* Completed event  *************/
-
-export interface CompletedContextExtensions {
-  completionTreshold?: number;
-}
-
 /************* Terminated event  *************/
 
 export interface TerminatedContextExtensions {


### PR DESCRIPTION
## Purpose

As explained in #400, the `completed` event is not sent at the good time. While working on this fix, we noticed that the played segments were wrong and it was impossible to compute the progression, and thus, impossible to know when the video is completed.

## Proposal

- [x] fix played segments
- [x] create a method to compute the progression
- [x] send the completed statement once the progression reaches 100%

Fixes #400