### PR TITLE
🐛(xAPI) be sure to send completed event when progress has reached 100%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- xapi: be sure to send completed event when progress has reached 100%
+
 ## [2.8.3] - 2019-06-05
 
 ### Changed


### PR DESCRIPTION
## Purpose

In some cases the time code sent in the last paused event, when the video
ended, can be higher than the duration sent by plyr itself. In this case
the progression is higher than 100% and if we return it the completed event
is not sent because the progression is not strictly equal to 100%.

## Proposal

- [x] return no more than 1 in the progress method.

