### PR TITLE
✨(xAPI) send terminated statement when use leave the page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Compute a completion threshold when xapi is initialized.
+- Detect when a user leaves the page to send terminated statement.
 
 ## [2.8.4] - 2019-06-06
 

--- a/src/frontend/Player/createPlyrPlayer.ts
+++ b/src/frontend/Player/createPlyrPlayer.ts
@@ -34,7 +34,7 @@ export const createPlyrPlayer = (
   let currentTime: number = 0;
   let seekingAt: number = 0;
   let hasSeeked: boolean = false;
-  let isInitialized = false;
+  let isInitialized: boolean = false;
 
   // canplay is the event when the video is really initialized and
   // information can be found in plyr object. Don't use ready event
@@ -148,6 +148,14 @@ export const createPlyrPlayer = (
     dispatch(notifyPlayerTimeUpdate(event.detail.plyr.currentTime));
   });
   /**************** End dispatch time updated *********************/
+
+  window.addEventListener('unload', () => {
+    if (false === isInitialized) {
+      return;
+    }
+
+    xapiStatement.terminated({ time: player.currentTime });
+  });
 
   return player;
 };

--- a/src/frontend/XAPI/XAPIStatement.ts
+++ b/src/frontend/XAPI/XAPIStatement.ts
@@ -20,9 +20,6 @@ import { truncateDecimalDigits } from '../utils/truncateDecimalDigits';
 import { Nullable } from '../utils/types';
 
 export class XAPIStatement {
-  // segments are saved in two different arrays
-  // we need to save to follow each segments played by the user.
-  // https://liveaspankaj.gitbooks.io/xapi-video-profile/content/statement_data_model.html#2545-played-segments
   private playedSegments: string = '';
   private startSegment: Nullable<number> = null;
   private duration: number = 0;
@@ -304,6 +301,10 @@ export class XAPIStatement {
   }
 
   terminated(resultExtensions: TerminatedResultExtensions): void {
+    if (this.startSegment !== null) {
+      this.paused({ time: resultExtensions.time });
+    }
+
     const time = truncateDecimalDigits(resultExtensions.time);
 
     const data: DataPayload = {


### PR DESCRIPTION
## Purpose

The terminated statement should be sent when a user leave the page
containing the played video. This statement will be also responsible to
send a paused statement if the video is still playing.

## Proposal

- [x] Detect when a user leave the page to send terminated statement.

