### PR TITLE
✨(xAPI) prevent to lose an upload when a page is leaved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Compute a completion threshold when xapi is initialized.
 - Detect when a user leaves the page to send terminated statement.
+- Avoid losing an upload by asking to the user if he really
+  wants to leave the page.
 
 ## [2.8.4] - 2019-06-06
 

--- a/src/frontend/components/UploadForm/UploadForm.spec.tsx
+++ b/src/frontend/components/UploadForm/UploadForm.spec.tsx
@@ -253,5 +253,28 @@ describe('UploadForm', () => {
         upload_state: uploadState.ERROR,
       });
     });
+
+    it('should call beforeUnload if user leave the page', () => {
+      const wrapper = shallow(
+        <UploadForm
+          jwt={'some token'}
+          notifyObjectUploadProgress={mockNotifyUploadProgress}
+          object={object}
+          objectType={modelName.VIDEOS}
+          updateObject={mockUpdateObject}
+        />,
+      );
+      const event = {
+        preventDefault: jest.fn(),
+      };
+      (wrapper.instance() as UploadForm).beforeUnload(event as any);
+
+      expect(event.preventDefault).not.toHaveBeenCalled();
+
+      wrapper.setState({ status: 'uploading' });
+      (wrapper.instance() as UploadForm).beforeUnload(event as any);
+
+      expect(event.preventDefault).toHaveBeenCalled();
+    });
   });
 });

--- a/src/frontend/components/UploadForm/UploadForm.tsx
+++ b/src/frontend/components/UploadForm/UploadForm.tsx
@@ -112,6 +112,28 @@ export class UploadForm extends React.Component<
   UploadFormProps,
   UploadFormState
 > {
+  constructor(props: UploadFormProps) {
+    super(props);
+    this.state = {
+      status: undefined,
+    };
+  }
+
+  componentDidMount() {
+    window.addEventListener('beforeunload', this.beforeUnload);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('beforeunload', this.beforeUnload);
+  }
+
+  beforeUnload(event: BeforeUnloadEvent) {
+    if (this.state.status === 'uploading') {
+      event.preventDefault();
+      event.returnValue = '';
+    }
+  }
+
   async upload(file: Maybe<File>) {
     const {
       jwt,


### PR DESCRIPTION
## Purpose

When an upload is on going, this upload can be lost if the user leaves
the page. To be sure this is what he wants, we stop event
propagation in the beforeunload event and the browser will asks
confirmation to leave the page.

## Proposal

- [x] ask user confirmation before leaving an upload in progress. 

This PR closes #157 

