### PR TITLE
🚸(video) add the `show_download` flag to the video admin view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Add the `show_download` flag to the video admin view.
+
 ### Changed
 
 - Hide dashboard button in instructor view when a video is in read only.

--- a/src/backend/marsha/core/admin.py
+++ b/src/backend/marsha/core/admin.py
@@ -206,6 +206,7 @@ class VideoAdmin(admin.ModelAdmin):
         link_field("consumer_site"),
         "lti_id",
         "upload_state",
+        "show_download",
         "uploaded_on",
         "updated_on",
         "created_on",
@@ -218,6 +219,7 @@ class VideoAdmin(admin.ModelAdmin):
         "playlist",
         "lti_id",
         "upload_state",
+        "show_download",
         "created_by",
         "duplicated_from",
         "uploaded_on",
@@ -233,7 +235,7 @@ class VideoAdmin(admin.ModelAdmin):
         "uploaded_on",
         "updated_on",
     ]
-    list_filter = ("upload_state", "playlist__consumer_site__domain")
+    list_filter = ("upload_state", "show_download", "playlist__consumer_site__domain")
     search_fields = (
         "id",
         "lti_id",
@@ -261,6 +263,7 @@ class VideosInline(admin.TabularInline):
         "playlist",
         "lti_id",
         "upload_state",
+        "show_download",
         "uploaded_on",
         "updated_on",
         "created_on",


### PR DESCRIPTION
## Purpose

When adding this field on the model, we forgot to add it to the admin view. In some cases, it is convenient to be able to modify this flag directly from the admin.

## Proposal

Add the `show_download` field of the:
- [x] Video admin list view
- [x] Video admin change form,
- [x] Inline video admin list view on the playlist admin change form.
