### PR TITLE
🐛(xAPI) add time in interacted xapi payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Add time in interacted xapi payload.
+
 ## [2.9.0] - 2019-06-11
 
 ### Added

--- a/src/frontend/Player/createPlyrPlayer.ts
+++ b/src/frontend/Player/createPlyrPlayer.ts
@@ -130,7 +130,7 @@ export const createPlyrPlayer = (
         contextExtensions.ccSubtitleLanguage = track.srcLang;
       }
     }
-    xapiStatement.interacted(contextExtensions);
+    xapiStatement.interacted({ time: plyr.currentTime }, contextExtensions);
   };
 
   player.on('captionsdisabled', event => interacted(event));

--- a/src/frontend/XAPI/XAPIStatement.spec.ts
+++ b/src/frontend/XAPI/XAPIStatement.spec.ts
@@ -435,17 +435,22 @@ describe('XAPIStatement', () => {
         overwriteRoutes: true,
       });
       const xapiStatement = new XAPIStatement('jwt', 'abcd');
-      xapiStatement.interacted({
-        ccSubtitleEnabled: true,
-        ccSubtitleLanguage: 'en',
-        frameRate: 29.97,
-        fullScreen: true,
-        quality: '480',
-        speed: '1x',
-        track: 'foo',
-        videoPlaybackSize: '640x480',
-        volume: 1,
-      });
+      xapiStatement.interacted(
+        {
+          time: 50,
+        },
+        {
+          ccSubtitleEnabled: true,
+          ccSubtitleLanguage: 'en',
+          frameRate: 29.97,
+          fullScreen: true,
+          quality: '480',
+          speed: '1x',
+          track: 'foo',
+          videoPlaybackSize: '640x480',
+          volume: 1,
+        },
+      );
 
       const lastCall = fetchMock.lastCall(`${XAPI_ENDPOINT}/`);
 
@@ -473,6 +478,9 @@ describe('XAPIStatement', () => {
         'https://w3id.org/xapi/video/extensions/track': 'foo',
         'https://w3id.org/xapi/video/extensions/video-playback-size': '640x480',
         'https://w3id.org/xapi/video/extensions/volume': 1,
+      });
+      expect(body.result.extensions).toEqual({
+        'https://w3id.org/xapi/video/extensions/time': 50,
       });
       expect(body).toHaveProperty('id');
       expect(body).toHaveProperty('timestamp');

--- a/src/frontend/XAPI/XAPIStatement.ts
+++ b/src/frontend/XAPI/XAPIStatement.ts
@@ -9,6 +9,7 @@ import {
   DataPayload,
   InitializedContextExtensions,
   InteractedContextExtensions,
+  InteractedResultExtensions,
   PausedResultExtensions,
   PlayedResultExtensions,
   ResultExtensionsDefinition,
@@ -335,7 +336,10 @@ export class XAPIStatement {
     this.send(data);
   }
 
-  interacted(contextExtensions: InteractedContextExtensions): void {
+  interacted(
+    resultExtensions: InteractedResultExtensions,
+    contextExtensions: InteractedContextExtensions,
+  ): void {
     // find a way to remove this undefined type. There is no undefined value
     const extensions: {
       [key: string]: string | boolean | number | undefined;
@@ -351,6 +355,13 @@ export class XAPIStatement {
     const data: DataPayload = {
       context: {
         extensions,
+      },
+      result: {
+        extensions: {
+          [ResultExtensionsDefinition.time]: truncateDecimalDigits(
+            resultExtensions.time,
+          ),
+        },
       },
       verb: {
         display: {

--- a/src/frontend/types/XAPI.ts
+++ b/src/frontend/types/XAPI.ts
@@ -104,6 +104,10 @@ export interface TerminatedResultExtensions {
 
 /************* Interacted event  *************/
 
+export interface InteractedResultExtensions {
+  time: number;
+}
+
 export interface InteractedContextExtensions {
   ccSubtitleEnabled?: boolean;
   ccSubtitleLanguage?: string;


### PR DESCRIPTION
## Purpose

There is a confusion in the video xapi documentation. In one place time
should be added in the interacted payload and in the summary it doesn't
appear. we think we should add it, it can be good to know at what time
the interaction was made.

## Proposal

- [x] Add time in interacted payload.

