### PR TITLE
♻️(front) hide dashboard button when a video is in read only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Hide dashboard button in instructor view when a video is in read only.
+
 ### Fixed
 
 - Add time in interacted xapi payload.

--- a/src/frontend/components/InstructorView/InstructorView.spec.tsx
+++ b/src/frontend/components/InstructorView/InstructorView.spec.tsx
@@ -49,7 +49,7 @@ describe('<InstructorView />', () => {
     expect(wrapper.prop('to')).toEqual(ERROR_COMPONENT_ROUTE('lti'));
   });
 
-  it('disable the button when read_only is true', () => {
+  it('remove the button when read_only is true', () => {
     const wrapper = shallow(
       <InstructorView videoId={'42'} readOnly={true}>
         <div />
@@ -59,6 +59,6 @@ describe('<InstructorView />', () => {
     expect(wrapper.html()).toContain(
       'This video is imported from another playlist. You can go to the original playlist to directly modify this video, or delete it from the current playlist and replace it by a new video.',
     );
-    expect(wrapper.find(Button).prop('disabled')).toEqual(true);
+    expect(wrapper.exists(Button)).toEqual(false);
   });
 });

--- a/src/frontend/components/InstructorView/InstructorView.tsx
+++ b/src/frontend/components/InstructorView/InstructorView.tsx
@@ -70,12 +70,13 @@ export const InstructorView = ({
       </PreviewWrapper>
       <InstructorControls>
         <FormattedMessage {...message} />
-        <BtnWithLink
-          color={'brand'}
-          label={<FormattedMessage {...messages.btnDashboard} />}
-          to={DASHBOARD_ROUTE()}
-          disabled={readOnly}
-        />
+        {!readOnly && (
+          <BtnWithLink
+            color={'brand'}
+            label={<FormattedMessage {...messages.btnDashboard} />}
+            to={DASHBOARD_ROUTE()}
+          />
+        )}
       </InstructorControls>
     </React.Fragment>
   ) : (


### PR DESCRIPTION
## Purpose
When an instructor view one of its video but in an other playlist the
`Go to dashboard` should be hide.

## Proposal

- [x] Hide dashboard button when a video is in read only.

Closes #402 