### PR TITLE
📌(AWS) pin terraform to version 0.11.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Add time in interacted xapi payload.
+- pin Terraform to version 0.11.14
 
 ## [2.9.0] - 2019-06-11
 

--- a/src/aws/bin/state
+++ b/src/aws/bin/state
@@ -10,5 +10,5 @@ docker run --rm -it \
     -v "${PWD}/create_state_bucket:/app" \
     -w "/app" \
     --env-file ./env.d/development \
-    "hashicorp/terraform:light" \
+    "hashicorp/terraform:0.11.14" \
     "$@"

--- a/src/aws/bin/terraform
+++ b/src/aws/bin/terraform
@@ -9,5 +9,5 @@ docker run --rm -it \
     -v "${PWD}/:/app" \
     -w "/app" \
     --env-file ./env.d/development \
-    "hashicorp/terraform:light" \
+    "hashicorp/terraform:0.11.14" \
     "$@"


### PR DESCRIPTION
## Purpose

We must pin the terraform version we use to version 0.11.14. There are
breaking changes in version 0.12 and we have to do a migration. Moreover,
we also need to migrate the AWS version which also contains breaking
changes. In a first time we will use a version we know and compatible
with our existing configuration, workspaces and states.

## Proposal

Description...

- [x] pin terraform to version 0.11.14

