### PR TITLE
🚧(front) reactivate HLS support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Hide dashboard button in instructor view when a video is in read only.
+- Reactivate HLS support.
 
 ### Fixed
 

--- a/src/frontend/components/VideoPlayer/index.tsx
+++ b/src/frontend/components/VideoPlayer/index.tsx
@@ -24,7 +24,7 @@ import {
   videoSize,
 } from '../../types/tracks';
 import { VideoPlayerInterface } from '../../types/VideoPlayerInterface';
-import { isMSESupported } from '../../utils/isAbrSupported';
+import { isHlsSupported, isMSESupported } from '../../utils/isAbrSupported';
 import { Maybe, Nullable } from '../../utils/types';
 import { DownloadVideo } from '../DowloadVideo/DownloadVideo';
 import { ERROR_COMPONENT_ROUTE } from '../ErrorComponent/route';
@@ -139,14 +139,23 @@ class BaseVideoPlayer extends React.Component<
           crossOrigin="anonymous"
           poster={thumbnailUrls[720]}
         >
-          {(Object.keys(video.urls.mp4) as videoSize[]).map(size => (
+          {!!this.videoNodeRef && isHlsSupported(this.videoNodeRef) && (
             <source
-              key={video.urls.mp4[size]}
-              size={size}
-              src={video.urls.mp4[size]}
-              type="video/mp4"
+              src={video.urls.manifests.hls}
+              size="auto"
+              type="application/vnd.apple.mpegURL"
             />
-          ))}
+          )}
+          {!!this.videoNodeRef &&
+            !isHlsSupported(this.videoNodeRef) &&
+            (Object.keys(video.urls.mp4) as videoSize[]).map(size => (
+              <source
+                key={video.urls.mp4[size]}
+                size={size}
+                src={video.urls.mp4[size]}
+                type="video/mp4"
+              />
+            ))}
 
           {/* This is a workaround to force plyr to load its tracks list once
           instantiated. Without this, captions are not loaded correctly, at least, on firefox.

--- a/src/frontend/utils/isAbrSupported.ts
+++ b/src/frontend/utils/isAbrSupported.ts
@@ -5,3 +5,6 @@
 export const isMSESupported = () =>
   !!(window as { MediaSource?: MediaSource }).MediaSource &&
   !!MediaSource.isTypeSupported;
+
+export const isHlsSupported = (video: HTMLVideoElement): boolean =>
+  !!video.canPlayType('application/vnd.apple.mpegurl');


### PR DESCRIPTION
## Purpose

We have file to be used by iOS base on the HLS spec but we remove them
in version 2.5.0. We noticed that when both HLS and mp4 are used, the
ios player will not used the HLS file. Here we only used the HLS file if
the browser can play it, we use mp4 file otherwise.

## Proposal

- [x] check if browser can play HLS videos

