### PR TITLE
🐛(frontend) fix an issue with video polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Fix an issue that prevented replacement videos from being shown as "ready"
+  in the dashboard.
 - Add time in interacted xapi payload.
 - Pin Terraform to version 0.11.14.
 - Change arial-label on play button when its state changes.

--- a/src/frontend/data/sideEffects/upload/index.ts
+++ b/src/frontend/data/sideEffects/upload/index.ts
@@ -30,8 +30,6 @@ export const upload = (
     return setStatus('policy_error');
   }
 
-  setStatus('uploading');
-
   // Use FormData to meet the requirement of a multi-part POST request for s3
   // NB: order of keys is important here, which is why we do not iterate over an object
   const formData = makeFormData.apply(null, [
@@ -56,6 +54,11 @@ export const upload = (
       ...object,
       upload_state: uploadState.UPLOADING,
     });
+
+    // This `setStatus` call, which results in a redirection from the upload form to the dashboard, needs to
+    // happen **after** the video object has been updated. This is necessary to avoid an initial render of the
+    // dashboard with outdated data (a "READY" video, instead of a "PROCESSING"/"UPLOADING" one).
+    setStatus('uploading');
 
     await uploadFile(
       `https://${policy.s3_endpoint}/${policy.bucket}`,


### PR DESCRIPTION
## Purpose

The Dashboard video pane component is supposed to poll the video until it is ready, when it renders a non-ready video. 

This was not happening when uploading a new video to replace an existing, ready one, because the dashboard was first called with outdated data pertaining to the ready video.

## Proposal

We just had to move around the redirection to the dashboard video pane when the user picks the replacement video, to make sure it happens after the video object has been updated to its new state.
