### PR TITLE
♻️(front) change message in <InstructorView /> when a video is read only

### DIFF
--- a/src/frontend/__mocks__/react-intl.tsx
+++ b/src/frontend/__mocks__/react-intl.tsx
@@ -20,6 +20,15 @@ Intl.injectIntl = (Node: any) => {
 };
 
 // Patch FormattedMessage to just spit out the default message
-Intl.FormattedMessage = (props: FormattedMessage.Props) => props.defaultMessage;
+Intl.FormattedMessage = (props: FormattedMessage.Props) => {
+  if (props.values && props.defaultMessage) {
+    const keys = Object.keys(props.values);
+    return keys.reduce((message, key) => {
+      return message.replace(`{${key}}`, props.values![key] as any);
+    }, props.defaultMessage);
+  }
+
+  return props.defaultMessage;
+};
 
 module.exports = Intl;

--- a/src/frontend/components/InstructorView/index.spec.tsx
+++ b/src/frontend/components/InstructorView/index.spec.tsx
@@ -1,7 +1,5 @@
 import { render } from '@testing-library/react';
 import React from 'react';
-
-import { uploadState } from '../../types/tracks';
 import { wrapInRouter } from '../../utils/tests/router';
 
 import { InstructorView } from './';
@@ -18,18 +16,6 @@ describe('<InstructorView />', () => {
     mockDecodedJwt = {
       read_only: false,
     };
-    const mockVideo: any = {
-      id: 42,
-      thumbnail: null,
-      timed_text_tracks: [],
-      upload_state: uploadState.PROCESSING,
-    };
-    const state = {
-      jwt: {
-        read_only: false,
-      },
-      video: mockVideo,
-    } as any;
 
     const { getByText } = render(
       wrapInRouter(
@@ -43,33 +29,20 @@ describe('<InstructorView />', () => {
     getByText('Go to Dashboard');
   });
 
-  it('remove the button when read_only is true', () => {
+  it('removes the button when read_only is true', () => {
     mockDecodedJwt = {
+      context_id: 'foo+context_id',
       read_only: true,
     };
-    const mockVideo: any = {
-      id: 42,
-      thumbnail: null,
-      timed_text_tracks: [],
-      upload_state: uploadState.PROCESSING,
-    };
-    const state = {
-      jwt: {
-        read_only: true,
-      },
-      video: mockVideo,
-    } as any;
 
     const { getByText, queryByText } = render(
-      wrapInRouter(
-        <InstructorView>
-          <div className="some-child" />
-        </InstructorView>,
-      ),
+      <InstructorView>
+        <div className="some-child" />
+      </InstructorView>,
     );
 
     getByText(
-      'This video is imported from another playlist. You can go to the original playlist to directly modify this video, or delete it from the current playlist and replace it by a new video.',
+      'This video is read-only because it belongs to another course: foo+context_id',
     );
     expect(queryByText('Go to Dashboard')).toBeNull();
   });

--- a/src/frontend/components/InstructorView/index.tsx
+++ b/src/frontend/components/InstructorView/index.tsx
@@ -17,7 +17,7 @@ const messages = defineMessages({
   },
   disabledDashboard: {
     defaultMessage:
-      'This video is imported from another playlist. You can go to the original playlist to directly modify this video, or delete it from the current playlist and replace it by a new video.',
+      'This video is read-only because it belongs to another course: {context_id}',
     description:
       'Text explaining that the ivdeo is in read_only mode and the dashboard is not available',
     id: 'components.InstructorView.disabledDashboard',
@@ -55,13 +55,16 @@ interface InstructorViewProps {
 export const InstructorView = ({ children }: InstructorViewProps) => {
   const readOnly = getDecodedJwt().read_only;
   const message = readOnly ? messages.disabledDashboard : messages.title;
+  const messagePlaceholder = readOnly
+    ? { context_id: getDecodedJwt().context_id }
+    : {};
   return (
     <React.Fragment>
       <PreviewWrapper>
         <Preview>{children}</Preview>
       </PreviewWrapper>
       <InstructorControls>
-        <FormattedMessage {...message} />
+        <FormattedMessage {...message} values={messagePlaceholder} />
         {!readOnly && (
           <BtnWithLink
             color={'brand'}


### PR DESCRIPTION
## Purpose

In InstructorView component, the message display when a video is read
only is too long and too complicated. We choose to replace to a
reference to the context_id the video belong to.

There was also a problem with the react-intl mock. It was needed to improve it a little bit. We should definitely remove it when possible.

## Proposal

- [x] change message in `<InstructorView />` when video is read-only.
- [x] improve reactIntl mock

Closes #465 