### PR TITLE
✨(back) manage administrator role like an instructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Manage administrator role like an instructor.
+
 ## [2.10.1] - 2019-08-13
 
 ### Fixed

--- a/src/backend/marsha/core/lti.py
+++ b/src/backend/marsha/core/lti.py
@@ -11,7 +11,7 @@ from pylti.common import LTIException, verify_request_common
 
 from .defaults import PENDING, READY
 from .models import ConsumerSite, Playlist, Video
-from .models.account import INSTRUCTOR, LTI_ROLES, STUDENT, LTIPassport
+from .models.account import ADMINISTRATOR, INSTRUCTOR, LTI_ROLES, STUDENT, LTIPassport
 
 
 class LTI:
@@ -236,7 +236,9 @@ class LTI:
             True if the user is an instructor, False otherwise
 
         """
-        return bool(LTI_ROLES[INSTRUCTOR] & set(self.roles))
+        return bool(LTI_ROLES[INSTRUCTOR] & set(self.roles)) or bool(
+            LTI_ROLES[ADMINISTRATOR] & set(self.roles)
+        )
 
     @property
     def is_student(self):

--- a/src/backend/marsha/core/models/account.py
+++ b/src/backend/marsha/core/models/account.py
@@ -22,6 +22,7 @@ SHARED_SECRET_SIZE = 40
 
 ADMINISTRATOR, INSTRUCTOR, STUDENT = ("administrator", "instructor", "student")
 LTI_ROLES = {
+    ADMINISTRATOR: {"administrator"},
     INSTRUCTOR: {"instructor", "teacher", "staff"},
     STUDENT: {"student", "learner"},
 }

--- a/src/backend/marsha/core/permissions.py
+++ b/src/backend/marsha/core/permissions.py
@@ -2,7 +2,7 @@
 from rest_framework import exceptions, permissions
 from rest_framework_simplejwt.models import TokenUser
 
-from .models.account import INSTRUCTOR, LTI_ROLES
+from .models.account import ADMINISTRATOR, INSTRUCTOR, LTI_ROLES
 
 
 class IsVideoInstructorTokenOrAdminUser(permissions.IsAdminUser):
@@ -35,7 +35,10 @@ class IsVideoInstructorTokenOrAdminUser(permissions.IsAdminUser):
         user = request.user
         if (
             isinstance(user, TokenUser)
-            and LTI_ROLES[INSTRUCTOR] & set(user.token.payload.get("roles", []))
+            and (
+                LTI_ROLES[INSTRUCTOR] & set(user.token.payload.get("roles", []))
+                or LTI_ROLES[ADMINISTRATOR] & set(user.token.payload.get("roles", []))
+            )
             and user.token.payload.get("read_only", True) is False
         ):
             return True
@@ -87,7 +90,10 @@ class IsVideoInstructorTokenOrAdminUser(permissions.IsAdminUser):
         user = request.user
         if (
             isinstance(user, TokenUser)
-            and LTI_ROLES[INSTRUCTOR] & set(user.token.payload.get("roles", []))
+            and (
+                LTI_ROLES[INSTRUCTOR] & set(user.token.payload.get("roles", []))
+                or LTI_ROLES[ADMINISTRATOR] & set(user.token.payload.get("roles", []))
+            )
             and str(self.get_video_id(obj)) != user.id
         ):
             raise exceptions.PermissionDenied()

--- a/src/backend/marsha/core/tests/test_lti.py
+++ b/src/backend/marsha/core/tests/test_lti.py
@@ -94,6 +94,7 @@ class VideoLTITestCase(TestCase):
         """The instructor role should be identified even when a synonym is used."""
         for roles_string in [
             "instructor",
+            "administrator",
             "Teacher",  # upper case letters should be normalized
             "student,instructor",  # two roles separated by comma
             "student, Instructor",  # a space after the comma is allowed
@@ -104,7 +105,7 @@ class VideoLTITestCase(TestCase):
             lti = LTI(request, uuid.uuid4())
             self.assertTrue(lti.is_instructor)
 
-        for roles_string in ["", "instructori", "student", "administrator,student"]:
+        for roles_string in ["", "instructori", "student", "student"]:
             request = self.factory.post("/", {"roles": roles_string})
             lti = LTI(request, uuid.uuid4())
             self.assertFalse(lti.is_instructor)


### PR DESCRIPTION
## Purpose

A pedagogic member has an administrator role and we don't take care of
this role. This role should have the same permission as an instructor.
He should be able to access the dashboard and then use every marsha's
features.

## Proposal

- [x] add new administrator and use it like an instructor.

Closes #447