### PR TITLE
♻️(front) shorten plyr seek time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Reactivate HLS support.
 - Only one play button in the plyr is active for a screen reader.
 - Remove usage of react-redux
+- Change seek time to 5 seconds in plyr configuration.
 
 ### Fixed
 

--- a/src/frontend/Player/createPlyrPlayer.ts
+++ b/src/frontend/Player/createPlyrPlayer.ts
@@ -86,6 +86,7 @@ export const createPlyrPlayer = async (
       unmute: intl.formatMessage(i18nMessages.unmute),
       volume: intl.formatMessage(i18nMessages.volume),
     },
+    seekTime: 5,
     settings,
   });
 


### PR DESCRIPTION
## Purpose

By default plyr has seek time configured to 10 seconds when you use
keyboard shorcuts. This time is too long and we decided to set it to 5
seconds like on youtube.

## Proposal

- [x] change `seekTime` value to `5`

