### PR TITLE
✨(front) seek to the cue's start time when a user click on it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Add the `show_download` flag to the video admin view.
 - Translate plyr interface.
+- Seek the video to the time corresponding to a transcript sentence
+  when a user click on it.
 
 ### Changed
 

--- a/src/frontend/Player/createPlyrPlayer.ts
+++ b/src/frontend/Player/createPlyrPlayer.ts
@@ -2,12 +2,12 @@ import Plyr from 'plyr';
 import { IntlProvider } from 'react-intl';
 
 import { appData, getDecodedJwt } from '../data/appData';
+import { useTranscriptTimeSelectorApi } from '../data/stores/useTranscriptTimeSelector';
 import {
   InitializedContextExtensions,
   InteractedContextExtensions,
 } from '../types/XAPI';
 import { isMSESupported } from '../utils/isAbrSupported';
-import { Nullable } from '../utils/types';
 import { XAPIStatement } from '../XAPI/XAPIStatement';
 import { i18nMessages } from './i18n/plyrTranslation';
 
@@ -109,6 +109,13 @@ export const createPlyrPlayer = async (
       }
     }
   }
+
+  useTranscriptTimeSelectorApi.subscribe(
+    time => (player.currentTime = time as number),
+    {
+      selector: state => state.time,
+    },
+  );
 
   const xapiStatement = new XAPIStatement(
     appData.jwt,

--- a/src/frontend/components/TranscriptSentence/index.spec.tsx
+++ b/src/frontend/components/TranscriptSentence/index.spec.tsx
@@ -1,31 +1,38 @@
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
 import { VTTCue } from 'vtt.js';
 
 import { TranscriptSentence } from '.';
 
+const mockSetTime = jest.fn();
+jest.mock('../../data/stores/useTranscriptTimeSelector', () => ({
+  useTranscriptTimeSelector: jest.fn(() => mockSetTime),
+}));
+
 describe('<TranscriptSentence />', () => {
+  afterEach(jest.clearAllMocks);
+
   it('displays a simple <Text /> when not active', () => {
     const cue: VTTCue = {
       endTime: 1,
       id: 'e67ba62e-ec93-4e04-a8da-bdaed3655262',
-      startTime: 0,
+      startTime: 10,
       text: 'Lorem ipsum dolor sit amet.',
     };
 
     const { getByText } = render(
       <TranscriptSentence cue={cue} active={false} />,
     );
-    const sentence = getByText('Lorem ipsum dolor sit amet.');
 
-    expect(sentence.classList).toHaveLength(2);
+    fireEvent.click(getByText('Lorem ipsum dolor sit amet.'));
+    expect(mockSetTime).toHaveBeenCalledWith(10);
   });
 
   it('highlights the text when the sentence is active', () => {
     const cue: VTTCue = {
       endTime: 1,
       id: 'e67ba62e-ec93-4e04-a8da-bdaed3655262',
-      startTime: 0,
+      startTime: 20,
       text: 'Lorem ipsum dolor sit amet.',
     };
 
@@ -33,9 +40,7 @@ describe('<TranscriptSentence />', () => {
       <TranscriptSentence cue={cue} active={true} />,
     );
 
-    const sentence = getByText('Lorem ipsum dolor sit amet.');
-
-    // 2 css rules are added, 2 new class should be added
-    expect(sentence.classList).toHaveLength(4);
+    fireEvent.click(getByText('Lorem ipsum dolor sit amet.'));
+    expect(mockSetTime).toHaveBeenCalledWith(20);
   });
 });

--- a/src/frontend/components/TranscriptSentence/index.tsx
+++ b/src/frontend/components/TranscriptSentence/index.tsx
@@ -3,7 +3,16 @@ import * as React from 'react';
 import styled from 'styled-components';
 import { VTTCue } from 'vtt.js';
 
-export const ActiveSentence = styled(Text)`
+import { useTranscriptTimeSelector } from '../../data/stores/useTranscriptTimeSelector';
+
+const Sentence = styled(Text)`
+  cursor: pointer;
+  :hover {
+    text-decoration: underline;
+  }
+`;
+
+const ActiveSentence = styled(Sentence)`
   background-color: rgba(242, 94, 35, 0.25);
   outline: 1px solid rgba(242, 94, 35, 0.5);
 `;
@@ -13,12 +22,21 @@ interface TranscriptSentenceProps {
   active: boolean;
 }
 
-export const TranscriptSentence = (props: TranscriptSentenceProps) => {
-  const { cue, active } = props;
+export const TranscriptSentence = ({
+  cue,
+  active,
+}: TranscriptSentenceProps) => {
+  const setTime = useTranscriptTimeSelector(state => state.setTime);
 
   if (active) {
-    return <ActiveSentence>{cue.text} </ActiveSentence>;
+    return (
+      <ActiveSentence onClick={() => setTime(cue.startTime)}>
+        {cue.text}{' '}
+      </ActiveSentence>
+    );
   } else {
-    return <Text>{cue.text} </Text>;
+    return (
+      <Sentence onClick={() => setTime(cue.startTime)}>{cue.text} </Sentence>
+    );
   }
 };

--- a/src/frontend/data/stores/useTranscriptTimeSelector/index.tsx
+++ b/src/frontend/data/stores/useTranscriptTimeSelector/index.tsx
@@ -1,0 +1,13 @@
+import create from 'zustand';
+
+interface State {
+  time: number;
+  setTime: (time: number) => void;
+}
+
+export const [useTranscriptTimeSelector, useTranscriptTimeSelectorApi] = create<
+  State
+>(set => ({
+  setTime: time => set({ time }),
+  time: 0,
+}));


### PR DESCRIPTION
## Purpose

A user can click on a word when the transcript is shown and then the
video will seek to the start time of the selected cue.

## Proposal

Using a zustand will help us to be in sync between the `TranscriptSentence` component and the plyr player. When the store is updated, the player can be updated once it has subscribed to the same store.

- [x] create a zustand store containing the time to seek on
- [x] Use the store in the `TranscriptSentence` component, the time will be updated when a user click on a sentence.
- [x] subscribe to the store in the `createPlyrPlayer` module, here we have access the plyr instance and we can set the `currentTime` we want.

closes #406
