### PR TITLE
🔖(minor) bump release to 2.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.10.0] - 2019-08-12
+
 ### Added
 
 - Add the `show_download` flag to the video admin view.
@@ -308,7 +310,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Minor fixes and improvements on features and tests
 
-[unreleased]: https://github.com/openfun/marsha/compare/v2.9.0...master
+[unreleased]: https://github.com/openfun/marsha/compare/v2.10.0...master
+[2.10.0]: https://github.com/openfun/marsha/compare/v2.9.0...v2.10.0
 [2.9.0]: https://github.com/openfun/marsha/compare/v2.8.4...v2.9.0
 [2.8.4]: https://github.com/openfun/marsha/compare/v2.8.3...v2.8.4
 [2.8.3]: https://github.com/openfun/marsha/compare/v2.8.2...v2.8.3

--- a/src/aws/lambda-complete/package.json
+++ b/src/aws/lambda-complete/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-complete",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "engines": {
     "node": ">8.10"
   },

--- a/src/aws/lambda-configure/package.json
+++ b/src/aws/lambda-configure/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-configure",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "engines": {
     "node": ">8.10"
   },

--- a/src/aws/lambda-encode/package.json
+++ b/src/aws/lambda-encode/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-convert",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "engines": {
     "node": ">8.10"
   },

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = marsha
 description = A FUN video provider for Open edX
-version = 2.9.0
+version = 2.10.0
 author = Open FUN (France Universite Numerique)
 author_email = fun.dev@fun-mooc.fr
 license = MIT

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marsha",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "description": "🐠 a FUN LTI video provider",
   "main": "front/index.tsx",
   "scripts": {


### PR DESCRIPTION
### Added

- Add the `show_download` flag to the video admin view.
- Translate plyr interface.
- Seek the video to the time corresponding to a transcript sentence
  when a user click on it.

### Changed

- Hide dashboard button in instructor view when a video is in read only.
- Reactivate HLS support.
- Only one play button in the plyr is active for a screen reader.
- Remove usage of react-redux
- Change seek time to 5 seconds in plyr configuration.

### Fixed

- Fix an issue that prevented replacement videos from being shown as "ready"
  in the dashboard.
- Add time in interacted xapi payload.
- Pin Terraform to version 0.11.14.
- Change arial-label on play button when its state changes.

### Security

- Update `handlebars` and `lodash` packages to safe versions.

