### PR TITLE
🐛(front) ensure useThumbnail return null when there is no thumbnail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix first thumbnail creation.
+
 ## [2.10.0] - 2019-08-12
 
 ### Added

--- a/src/frontend/data/stores/useThumbnail/index.spec.tsx
+++ b/src/frontend/data/stores/useThumbnail/index.spec.tsx
@@ -71,6 +71,15 @@ describe('stores/useThumbnail', () => {
       video: 'd9583272-dcb5-44f3-998f-59797e613754',
     });
   });
+
+  it('returns null when there is no thumbnail', () => {
+    useThumbnailApi.setState({
+      [modelName.THUMBNAIL]: {},
+    });
+
+    expect(useThumbnailApi.getState().getThumbnail()).toBeNull();
+  });
+
   it('adds a resource to the store', () => {
     useThumbnailApi.getState().addResource({ id: 'newResource' } as any);
 
@@ -78,6 +87,7 @@ describe('stores/useThumbnail', () => {
       { id: 'newResource' },
     );
   });
+
   it('removes an existing resource', () => {
     useThumbnailApi.getState().addResource({ id: 'toDelete' } as any);
 
@@ -91,6 +101,7 @@ describe('stores/useThumbnail', () => {
       useThumbnailApi.getState()[modelName.THUMBNAIL].toDelete,
     ).toBeUndefined();
   });
+
   it('adds multiple resources to the store', () => {
     useThumbnailApi
       .getState()

--- a/src/frontend/data/stores/useThumbnail/index.tsx
+++ b/src/frontend/data/stores/useThumbnail/index.tsx
@@ -17,7 +17,6 @@ interface ThumbnailState extends StoreState<Thumbnail> {
 export const [useThumbnail, useThumbnailApi] = create<ThumbnailState>(
   (set, get) => {
     let thumbnails = {};
-
     if (appData.video && appData.video.thumbnail !== null) {
       thumbnails = {
         [appData.video.thumbnail.id]: appData.video.thumbnail,
@@ -30,7 +29,7 @@ export const [useThumbnail, useThumbnailApi] = create<ThumbnailState>(
       addResource: (thumbnail: Thumbnail) =>
         set(addResource<Thumbnail>(get(), modelName.THUMBNAIL, thumbnail)),
       getThumbnail: () => {
-        if (get()[modelName.THUMBNAIL]) {
+        if (Object.keys(get()[modelName.THUMBNAIL]).length > 0) {
           const thumbnailId = Object.keys(get()[modelName.THUMBNAIL]).shift();
           return get()[modelName.THUMBNAIL][thumbnailId!];
         }


### PR DESCRIPTION
## Purpose

The method useThumbnail.getThumbnail() was not returning null when there
was no thumbnail but undefined and this is not what we want. We want to
return null. A test is added to be sure that null is really return.

## Proposal

- [x] test that useThumbnail.getThumbnail really return null

