### PR TITLE
🐛(front) remove undefined values in stores when removing resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Fix first thumbnail creation.
+- Remove undefined values in zustand store when removing a resource.
 
 ## [2.10.0] - 2019-08-12
 

--- a/src/frontend/data/stores/actions.ts
+++ b/src/frontend/data/stores/actions.ts
@@ -33,10 +33,16 @@ export function removeResource<R extends Resource>(
   objectType: modelName,
   object: R,
 ) {
+  const objects = Object.values(state[objectType]!).filter(
+    (objectToFilter: R) => objectToFilter.id !== object.id,
+  );
+
   return {
     [objectType]: {
-      ...state[objectType],
-      [object.id]: undefined,
+      ...objects.reduce(
+        (acc, resource) => ({ ...acc, [resource.id]: resource }),
+        {},
+      ),
     },
   };
 }

--- a/src/frontend/data/stores/useTimedTextTrack/index.spec.tsx
+++ b/src/frontend/data/stores/useTimedTextTrack/index.spec.tsx
@@ -160,6 +160,13 @@ describe('stores/useTimedTextTrack', () => {
     expect(
       useTimedTextTrackApi.getState()[modelName.TIMEDTEXTTRACKS].toDelete,
     ).toBeUndefined();
+
+    useTimedTextTrackApi
+      .getState()
+      .getTimedTextTracks()
+      .forEach(timedtext => {
+        expect(timedtext).toBeDefined();
+      });
   });
   it('adds multiple resources to the store', () => {
     useTimedTextTrackApi


### PR DESCRIPTION
## Purpose

When we remove a resource in a zustand store using the removeResource,
the undefind value is kept and return when doing a Object.values in
useTimedTextTrack store for example and leed on to unwanted behaviour.

## Proposal

- [x] remove undefined values in stores when removing resource

