### PR TITLE
♻️(resources) share same resource name between front and back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,13 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Create a File model which will be the base model for all the resources
   we will manage
+- create a property `RESOURCE_NAME` on models having a url
 
 ## Changed
 
 - Refactor the LTI view to be generic for all the resources we want to manage
 - Video model is a special File model
+- pluralize thumbnail url
 
 ### Removed
 
@@ -28,7 +30,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Fix first thumbnail creation.
-- Remove undefined values in zustand store when removing a resource.
+- create a property `RESOURCE_NAME` on models having a url to make it DRY
 
 ## [2.10.0] - 2019-08-12
 

--- a/src/backend/marsha/core/models/file.py
+++ b/src/backend/marsha/core/models/file.py
@@ -104,6 +104,8 @@ class BaseFile(BaseModel):
 class Document(BaseFile):
     """Model representing a document."""
 
+    RESOURCE_NAME = "documents"
+
     class Meta:
         """Options for the ``Document`` model."""
 

--- a/src/backend/marsha/core/models/video.py
+++ b/src/backend/marsha/core/models/video.py
@@ -13,6 +13,8 @@ from .file import BaseFile
 class Video(BaseFile):
     """Model representing a video, created by an author."""
 
+    RESOURCE_NAME = "videos"
+
     class Meta:
         """Options for the ``Video`` model."""
 
@@ -130,6 +132,8 @@ class TimedTextTrack(BaseTrack):
     Can be subtitles, closed captioning or transcripts.
     """
 
+    RESOURCE_NAME = "timedtexttracks"
+
     SUBTITLE, TRANSCRIPT, CLOSED_CAPTIONING = "st", "ts", "cc"
     MODE_CHOICES = (
         (SUBTITLE, _("Subtitle")),
@@ -215,6 +219,8 @@ class SignTrack(BaseTrack):
 
 class Thumbnail(AbstractImage):
     """Thumbnail model illustrating a video."""
+
+    RESOURCE_NAME = "thumbnails"
 
     video = models.OneToOneField(
         to="Video",

--- a/src/backend/marsha/core/tests/test_api_thumbnail.py
+++ b/src/backend/marsha/core/tests/test_api_thumbnail.py
@@ -26,7 +26,7 @@ class ThumbnailApiTest(TestCase):
         """Anonymous users should not be allowed to retrieve a thumbnail."""
         video = VideoFactory()
         thumbnail = ThumbnailFactory(video=video)
-        response = self.client.get("/api/thumbnail/{!s}/".format(thumbnail.id))
+        response = self.client.get("/api/thumbnails/{!s}/".format(thumbnail.id))
         self.assertEqual(response.status_code, 401)
         content = json.loads(response.content)
         self.assertEqual(
@@ -43,7 +43,7 @@ class ThumbnailApiTest(TestCase):
         jwt_token.payload["roles"] = ["student"]
 
         response = self.client.get(
-            "/api/thumbnail/{!s}/".format(thumbnail.id),
+            "/api/thumbnails/{!s}/".format(thumbnail.id),
             HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token),
         )
 
@@ -59,7 +59,7 @@ class ThumbnailApiTest(TestCase):
         jwt_token.payload["read_only"] = True
 
         response = self.client.get(
-            "/api/thumbnail/{!s}/".format(thumbnail.id),
+            "/api/thumbnails/{!s}/".format(thumbnail.id),
             HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token),
         )
 
@@ -79,7 +79,7 @@ class ThumbnailApiTest(TestCase):
         jwt_token.payload["read_only"] = False
 
         response = self.client.get(
-            "/api/thumbnail/{!s}/".format(thumbnail.id),
+            "/api/thumbnails/{!s}/".format(thumbnail.id),
             HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token),
         )
 
@@ -108,7 +108,7 @@ class ThumbnailApiTest(TestCase):
         jwt_token.payload["read_only"] = True
 
         response = self.client.get(
-            "/api/thumbnail/{!s}/".format(thumbnail.id),
+            "/api/thumbnails/{!s}/".format(thumbnail.id),
             HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token),
         )
 
@@ -128,7 +128,7 @@ class ThumbnailApiTest(TestCase):
         jwt_token.payload["read_only"] = False
 
         response = self.client.get(
-            "/api/thumbnail/{!s}/".format(thumbnail.id),
+            "/api/thumbnails/{!s}/".format(thumbnail.id),
             HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token),
         )
 
@@ -166,7 +166,7 @@ class ThumbnailApiTest(TestCase):
         jwt_token.payload["read_only"] = False
 
         response = self.client.get(
-            "/api/thumbnail/{!s}/".format(thumbnail.id),
+            "/api/thumbnails/{!s}/".format(thumbnail.id),
             HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token),
         )
 
@@ -198,7 +198,7 @@ class ThumbnailApiTest(TestCase):
 
     def test_api_thumbnail_create_anonymous(self):
         """Anonymous users should not be able to create a thumbnail."""
-        response = self.client.post("/api/thumbnail/")
+        response = self.client.post("/api/thumbnails/")
         self.assertEqual(response.status_code, 401)
 
     def test_api_thumbnail_create_student(self):
@@ -210,7 +210,7 @@ class ThumbnailApiTest(TestCase):
         jwt_token.payload["roles"] = ["student"]
 
         response = self.client.post(
-            "/api/thumbnail/", HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token)
+            "/api/thumbnails/", HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token)
         )
 
         self.assertEqual(response.status_code, 403)
@@ -225,7 +225,7 @@ class ThumbnailApiTest(TestCase):
         jwt_token.payload["read_only"] = False
 
         response = self.client.post(
-            "/api/thumbnail/", HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token)
+            "/api/thumbnails/", HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token)
         )
 
         self.assertEqual(response.status_code, 201)
@@ -254,7 +254,7 @@ class ThumbnailApiTest(TestCase):
         jwt_token.payload["read_only"] = True
 
         response = self.client.post(
-            "/api/thumbnail/", HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token)
+            "/api/thumbnails/", HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token)
         )
 
         self.assertEqual(response.status_code, 403)
@@ -264,7 +264,7 @@ class ThumbnailApiTest(TestCase):
         video = VideoFactory()
         thumbnail = ThumbnailFactory(video=video)
 
-        response = self.client.delete("/api/thumbnail/{!s}/".format(thumbnail.id))
+        response = self.client.delete("/api/thumbnails/{!s}/".format(thumbnail.id))
         self.assertEqual(response.status_code, 401)
 
     def test_api_thumbnail_delete_student(self):
@@ -277,7 +277,7 @@ class ThumbnailApiTest(TestCase):
         jwt_token.payload["roles"] = ["student"]
 
         response = self.client.delete(
-            "/api/thumbnail/{!s}/".format(thumbnail.id),
+            "/api/thumbnails/{!s}/".format(thumbnail.id),
             HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token),
         )
         self.assertEqual(response.status_code, 403)
@@ -293,7 +293,7 @@ class ThumbnailApiTest(TestCase):
         jwt_token.payload["read_only"] = False
 
         response = self.client.delete(
-            "/api/thumbnail/{!s}/".format(thumbnail.id),
+            "/api/thumbnails/{!s}/".format(thumbnail.id),
             HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token),
         )
         self.assertEqual(response.status_code, 204)
@@ -309,7 +309,7 @@ class ThumbnailApiTest(TestCase):
         jwt_token.payload["read_only"] = True
 
         response = self.client.delete(
-            "/api/thumbnail/{!s}/".format(thumbnail.id),
+            "/api/thumbnails/{!s}/".format(thumbnail.id),
             HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token),
         )
 
@@ -327,7 +327,7 @@ class ThumbnailApiTest(TestCase):
         jwt_token.payload["read_only"] = False
 
         response = self.client.delete(
-            "/api/thumbnail/{!s}/".format(thumbnail.id),
+            "/api/thumbnails/{!s}/".format(thumbnail.id),
             HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token),
         )
         self.assertEqual(response.status_code, 404)
@@ -337,7 +337,7 @@ class ThumbnailApiTest(TestCase):
         thumbnail = ThumbnailFactory()
 
         response = self.client.post(
-            "/api/thumbnail/{!s}/initiate-upload/".format(thumbnail.id)
+            "/api/thumbnails/{!s}/initiate-upload/".format(thumbnail.id)
         )
         self.assertEqual(response.status_code, 401)
 
@@ -349,7 +349,7 @@ class ThumbnailApiTest(TestCase):
         jwt_token.payload["roles"] = ["student"]
 
         response = self.client.post(
-            "/api/thumbnail/{!s}/initiate-upload/".format(thumbnail.id),
+            "/api/thumbnails/{!s}/initiate-upload/".format(thumbnail.id),
             HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token),
         )
         self.assertEqual(response.status_code, 403)
@@ -372,7 +372,7 @@ class ThumbnailApiTest(TestCase):
         now = datetime(2018, 8, 8, tzinfo=pytz.utc)
         with mock.patch.object(timezone, "now", return_value=now):
             response = self.client.post(
-                "/api/thumbnail/{!s}/initiate-upload/".format(thumbnail.id),
+                "/api/thumbnails/{!s}/initiate-upload/".format(thumbnail.id),
                 HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token),
             )
         self.assertEqual(response.status_code, 200)
@@ -437,7 +437,7 @@ class ThumbnailApiTest(TestCase):
         jwt_token.payload["read_only"] = True
 
         response = self.client.post(
-            "/api/thumbnail/{!s}/initiate-upload/".format(thumbnail.id),
+            "/api/thumbnails/{!s}/initiate-upload/".format(thumbnail.id),
             HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token),
         )
 

--- a/src/backend/marsha/core/views.py
+++ b/src/backend/marsha/core/views.py
@@ -81,7 +81,7 @@ class BaseLTIView(ABC, TemplateResponseMixin, View):
             logger.warning("LTI Exception: %s", str(error))
             return {
                 "state": "error",
-                "resource": self.model._meta.verbose_name_plural.lower(),
+                "resource": self.model.RESOURCE_NAME,
                 "resource_data": "null",
             }
 
@@ -120,7 +120,7 @@ class BaseLTIView(ABC, TemplateResponseMixin, View):
         context["resource_data"] = json.dumps(
             self.serializer_class(resource).data if resource else None
         )
-        context["resource"] = self.model._meta.verbose_name_plural.lower()
+        context["resource"] = self.model.RESOURCE_NAME
 
         if getattr(settings, "STATICFILES_AWS_ENABLED", False):
             context["cloudfront_domain"] = settings.CLOUDFRONT_DOMAIN

--- a/src/backend/marsha/urls.py
+++ b/src/backend/marsha/urls.py
@@ -7,6 +7,7 @@ from rest_framework.renderers import CoreJSONRenderer
 from rest_framework.routers import DefaultRouter
 from rest_framework.schemas import get_schema_view
 
+from marsha.core import models
 from marsha.core.admin import admin_site
 from marsha.core.api import (
     DocumentViewSet,
@@ -20,10 +21,14 @@ from marsha.core.views import DocumentLTIView, LTIDevelopmentView, VideoLTIView
 
 
 router = DefaultRouter()
-router.register(r"videos", VideoViewSet, basename="videos")
-router.register(r"documents", DocumentViewSet, basename="documents")
-router.register(r"timedtexttracks", TimedTextTrackViewSet, basename="timed_text_tracks")
-router.register(r"thumbnail", ThumbnailViewSet, basename="thumbnail")
+router.register(models.Video.RESOURCE_NAME, VideoViewSet, basename="videos")
+router.register(models.Document.RESOURCE_NAME, DocumentViewSet, basename="documents")
+router.register(
+    models.TimedTextTrack.RESOURCE_NAME,
+    TimedTextTrackViewSet,
+    basename="timed_text_tracks",
+)
+router.register(models.Thumbnail.RESOURCE_NAME, ThumbnailViewSet, basename="thumbnails")
 
 urlpatterns = [
     # Admin

--- a/src/frontend/components/DashboardThumbnail/index.spec.tsx
+++ b/src/frontend/components/DashboardThumbnail/index.spec.tsx
@@ -235,7 +235,7 @@ describe('<DashboardThumbnail />', () => {
   });
 
   it('creates a new thumbnail and redirects the user to the upload form they click on the replace button', async () => {
-    fetchMock.mock('/api/thumbnail/', JSON.stringify(video.thumbnail), {
+    fetchMock.mock('/api/thumbnails/', JSON.stringify(video.thumbnail), {
       method: 'POST',
     });
     const videoWithoutThumbnail = {
@@ -271,12 +271,12 @@ describe('<DashboardThumbnail />', () => {
     fireEvent.click(getByText('Replace this thumbnail'));
     await wait();
     expect(fetchMock.calls()).toHaveLength(1);
-    expect(fetchMock.lastCall()![0]).toEqual('/api/thumbnail/');
+    expect(fetchMock.lastCall()![0]).toEqual('/api/thumbnails/');
     expect(fetchMock.lastCall()![1]!.headers).toEqual({
       Authorization: 'Bearer some token',
       'Content-Type': 'application/json',
     });
     expect(mockAddThumbnail).toHaveBeenCalled();
-    getByText('Redirect push to /form/thumbnail/42.');
+    getByText('Redirect push to /form/thumbnails/42.');
   });
 });

--- a/src/frontend/components/DashboardThumbnail/index.tsx
+++ b/src/frontend/components/DashboardThumbnail/index.tsx
@@ -103,7 +103,7 @@ export const DashboardThumbnail = ({ video }: DashboardThumbnailProps) => {
     return (
       <Redirect
         push
-        to={UPLOAD_FORM_ROUTE(modelName.THUMBNAIL, thumbnail!.id)}
+        to={UPLOAD_FORM_ROUTE(modelName.THUMBNAILS, thumbnail!.id)}
       />
     );
   }

--- a/src/frontend/components/UploadForm/index.tsx
+++ b/src/frontend/components/UploadForm/index.tsx
@@ -32,7 +32,7 @@ const titleMessages = defineMessages({
     description: 'Title for the video upload form',
     id: 'components.UploadForm.title-videos',
   },
-  [modelName.THUMBNAIL]: {
+  [modelName.THUMBNAILS]: {
     defaultMessage: 'Upload a new thumbnail',
     description: 'Title for the thumbnail upload form',
     id: 'components.UploadForm.title-thumbnail',

--- a/src/frontend/data/sideEffects/createThumbnail/index.spec.ts
+++ b/src/frontend/data/sideEffects/createThumbnail/index.spec.ts
@@ -12,7 +12,7 @@ describe('sideEffects/createThumbnail', () => {
   afterEach(fetchMock.restore);
 
   it('creates a new thumbnail and return it', async () => {
-    fetchMock.mock('/api/thumbnail/', {
+    fetchMock.mock('/api/thumbnails/', {
       id: '42',
       ready_to_display: false,
       urls: null,
@@ -36,7 +36,7 @@ describe('sideEffects/createThumbnail', () => {
 
   it('throws when it fails to create the thumbnail (request failure)', async () => {
     fetchMock.mock(
-      '/api/thumbnail/',
+      '/api/thumbnails/',
       Promise.reject(new Error('Failed to perform the request')),
     );
 
@@ -46,7 +46,7 @@ describe('sideEffects/createThumbnail', () => {
   });
 
   it('throws when it fails to create the thumbnail (API error)', async () => {
-    fetchMock.mock('/api/thumbnail/', 400);
+    fetchMock.mock('/api/thumbnails/', 400);
 
     await expect(createThumbnail()).rejects.toThrowError(
       'Failed to create a new thumbnail.',

--- a/src/frontend/data/sideEffects/createThumbnail/index.ts
+++ b/src/frontend/data/sideEffects/createThumbnail/index.ts
@@ -7,7 +7,7 @@ import { appData } from '../../appData';
  * Create a new thumbnail record for a language-mode combination.
  */
 export const createThumbnail = async () => {
-  const response = await fetch(`${API_ENDPOINT}/${modelName.THUMBNAIL}/`, {
+  const response = await fetch(`${API_ENDPOINT}/${modelName.THUMBNAILS}/`, {
     headers: {
       Authorization: `Bearer ${appData.jwt}`,
       'Content-Type': 'application/json',

--- a/src/frontend/data/sideEffects/upload/index.spec.ts
+++ b/src/frontend/data/sideEffects/upload/index.spec.ts
@@ -158,7 +158,7 @@ describe('upload', () => {
     const file = new File(['(⌐□_□)'], 'thumbnail.png', { type: 'image/png' });
 
     fetchMock.mock(
-      '/api/thumbnail/thumb1/initiate-upload/',
+      '/api/thumbnails/thumb1/initiate-upload/',
       {
         bucket: 'dev',
         s3_endpoint: 's3.aws.example.com',
@@ -166,7 +166,7 @@ describe('upload', () => {
       { method: 'POST' },
     );
 
-    fetchMock.mock('/api/thumbnail/thumb1/', 200, { method: 'PUT' });
+    fetchMock.mock('/api/thumbnails/thumb1/', 200, { method: 'PUT' });
 
     xhrMock.post('https://s3.aws.example.com/dev', {
       body: 'form data body',
@@ -176,25 +176,25 @@ describe('upload', () => {
     await upload(
       setStatus,
       notifyObjectUploadProgress,
-      modelName.THUMBNAIL,
+      modelName.THUMBNAILS,
       thumbnail,
     )(file);
 
     expect(
-      fetchMock.called('/api/thumbnail/thumb1/initiate-upload/', {
+      fetchMock.called('/api/thumbnails/thumb1/initiate-upload/', {
         method: 'POST',
       }),
     ).toBe(true);
     expect(setStatus).toHaveBeenCalledWith('uploading');
-    expect(mockAddResource).toHaveBeenCalledWith(modelName.THUMBNAIL, {
+    expect(mockAddResource).toHaveBeenCalledWith(modelName.THUMBNAILS, {
       ...thumbnail,
       upload_state: uploadState.UPLOADING,
     });
-    expect(mockAddResource).toHaveBeenCalledWith(modelName.THUMBNAIL, {
+    expect(mockAddResource).toHaveBeenCalledWith(modelName.THUMBNAILS, {
       ...thumbnail,
       upload_state: uploadState.PROCESSING,
     });
-    expect(fetchMock.called('/api/thumbnail/thumb1/', { method: 'PUT' })).toBe(
+    expect(fetchMock.called('/api/thumbnails/thumb1/', { method: 'PUT' })).toBe(
       false,
     );
   });

--- a/src/frontend/data/sideEffects/upload/index.ts
+++ b/src/frontend/data/sideEffects/upload/index.ts
@@ -36,7 +36,7 @@ export const upload = (
   const formData = makeFormData.apply(null, [
     ['key', policy.key],
     ['acl', policy.acl],
-    ...(([modelName.VIDEOS, modelName.THUMBNAIL].includes(objectType)
+    ...(([modelName.VIDEOS, modelName.THUMBNAILS].includes(objectType)
       ? [['Content-Type', file!.type]]
       : []) as any),
     ['X-Amz-Credential', policy.x_amz_credential],

--- a/src/frontend/data/stores/actions.spec.ts
+++ b/src/frontend/data/stores/actions.spec.ts
@@ -7,17 +7,21 @@ describe('stores/actions', () => {
     it('adds multiple resources to an empty state', () => {
       const state = {};
 
-      const newState = addMultipleResources(state as any, modelName.THUMBNAIL, [
-        {
-          id: 'foo',
-        },
-        {
-          id: 'bar',
-        },
-      ]);
+      const newState = addMultipleResources(
+        state as any,
+        modelName.THUMBNAILS,
+        [
+          {
+            id: 'foo',
+          },
+          {
+            id: 'bar',
+          },
+        ],
+      );
 
       expect(newState).toEqual({
-        [modelName.THUMBNAIL]: {
+        [modelName.THUMBNAILS]: {
           bar: {
             id: 'bar',
           },
@@ -30,25 +34,29 @@ describe('stores/actions', () => {
 
     it('adds multiple resources to an existing state', () => {
       const state = {
-        [modelName.THUMBNAIL]: {
+        [modelName.THUMBNAILS]: {
           foo: {
             id: 'foo',
           },
         },
       };
 
-      const newState = addMultipleResources(state as any, modelName.THUMBNAIL, [
-        {
-          id: 'foo',
-          upload_state: uploadState.PENDING,
-        },
-        {
-          id: 'bar',
-        },
-      ]);
+      const newState = addMultipleResources(
+        state as any,
+        modelName.THUMBNAILS,
+        [
+          {
+            id: 'foo',
+            upload_state: uploadState.PENDING,
+          },
+          {
+            id: 'bar',
+          },
+        ],
+      );
 
       expect(newState).toEqual({
-        [modelName.THUMBNAIL]: {
+        [modelName.THUMBNAILS]: {
           bar: {
             id: 'bar',
           },
@@ -65,12 +73,12 @@ describe('stores/actions', () => {
     it('adds a new resource to an empty state', () => {
       const state = {};
 
-      const newState = addResource(state as any, modelName.THUMBNAIL, {
+      const newState = addResource(state as any, modelName.THUMBNAILS, {
         id: 'foo',
       });
 
       expect(newState).toEqual({
-        [modelName.THUMBNAIL]: {
+        [modelName.THUMBNAILS]: {
           foo: {
             id: 'foo',
           },
@@ -80,19 +88,19 @@ describe('stores/actions', () => {
 
     it('adds a new resource to an existing state', () => {
       const state = {
-        [modelName.THUMBNAIL]: {
+        [modelName.THUMBNAILS]: {
           foo: {
             id: 'foo',
           },
         },
       };
 
-      const newState = addResource(state as any, modelName.THUMBNAIL, {
+      const newState = addResource(state as any, modelName.THUMBNAILS, {
         id: 'bar',
       });
 
       expect(newState).toEqual({
-        [modelName.THUMBNAIL]: {
+        [modelName.THUMBNAILS]: {
           bar: {
             id: 'bar',
           },
@@ -105,20 +113,20 @@ describe('stores/actions', () => {
 
     it('replaces an existing resource if same id already exists', () => {
       const state = {
-        [modelName.THUMBNAIL]: {
+        [modelName.THUMBNAILS]: {
           foo: {
             id: 'foo',
           },
         },
       };
 
-      const newState = addResource(state as any, modelName.THUMBNAIL, {
+      const newState = addResource(state as any, modelName.THUMBNAILS, {
         id: 'foo',
         upload_state: uploadState.PENDING,
       });
 
       expect(newState).toEqual({
-        [modelName.THUMBNAIL]: {
+        [modelName.THUMBNAILS]: {
           foo: {
             id: 'foo',
             upload_state: uploadState.PENDING,
@@ -131,37 +139,37 @@ describe('stores/actions', () => {
   describe('removeResource', () => {
     it('removes an existing resource', () => {
       const state = {
-        [modelName.THUMBNAIL]: {
+        [modelName.THUMBNAILS]: {
           foo: {
             id: 'foo',
           },
         },
       };
 
-      const newState = removeResource(state as any, modelName.THUMBNAIL, {
+      const newState = removeResource(state as any, modelName.THUMBNAILS, {
         id: 'foo',
       });
 
       expect(newState).toEqual({
-        [modelName.THUMBNAIL]: {},
+        [modelName.THUMBNAILS]: {},
       });
     });
 
     it('returns the same state when trying to remove a non existing resource', () => {
       const state = {
-        [modelName.THUMBNAIL]: {
+        [modelName.THUMBNAILS]: {
           foo: {
             id: 'foo',
           },
         },
       };
 
-      const newState = removeResource(state as any, modelName.THUMBNAIL, {
+      const newState = removeResource(state as any, modelName.THUMBNAILS, {
         id: 'bar',
       });
 
       expect(newState).toEqual({
-        [modelName.THUMBNAIL]: {
+        [modelName.THUMBNAILS]: {
           foo: {
             id: 'foo',
           },

--- a/src/frontend/data/stores/generics.spec.ts
+++ b/src/frontend/data/stores/generics.spec.ts
@@ -11,7 +11,7 @@ describe('stores/generics', () => {
       [modelName.VIDEOS]: {},
     });
     useThumbnailApi.setState({
-      [modelName.THUMBNAIL]: {},
+      [modelName.THUMBNAILS]: {},
     });
     useTimedTextTrackApi.setState({
       [modelName.TIMEDTEXTTRACKS]: {},
@@ -20,10 +20,12 @@ describe('stores/generics', () => {
 
   describe('addResource', () => {
     it('adds a thumbnail resource', async () => {
-      await addResource(modelName.THUMBNAIL, { id: 'thumbnail' } as any);
+      await addResource(modelName.THUMBNAILS, { id: 'thumbnail' } as any);
 
       const state = useThumbnailApi.getState();
-      expect(state[modelName.THUMBNAIL].thumbnail).toEqual({ id: 'thumbnail' });
+      expect(state[modelName.THUMBNAILS].thumbnail).toEqual({
+        id: 'thumbnail',
+      });
     });
     it('adds a timed text track resource', async () => {
       await addResource(modelName.TIMEDTEXTTRACKS, {
@@ -45,14 +47,14 @@ describe('stores/generics', () => {
 
   describe('getResource', () => {
     it('fetch an existing thumbnail resource and return it', async () => {
-      await addResource(modelName.THUMBNAIL, { id: 'thumbnail' } as any);
+      await addResource(modelName.THUMBNAILS, { id: 'thumbnail' } as any);
 
-      expect(await getResource(modelName.THUMBNAIL, 'thumbnail')).toEqual({
+      expect(await getResource(modelName.THUMBNAILS, 'thumbnail')).toEqual({
         id: 'thumbnail',
       });
     });
     it('fetch a non existing thumbnail and should return undefined', async () => {
-      expect(await getResource(modelName.THUMBNAIL, 'foo')).toBeUndefined();
+      expect(await getResource(modelName.THUMBNAILS, 'foo')).toBeUndefined();
     });
     it('fetch an existing timed text resource and return it', async () => {
       await addResource(modelName.TIMEDTEXTTRACKS, { id: 'timedtext' } as any);
@@ -82,7 +84,7 @@ describe('stores/generics', () => {
 
   describe('addMultipleResources', () => {
     it('adds multiple thumbnails', async () => {
-      await addMultipleResources(modelName.THUMBNAIL, [
+      await addMultipleResources(modelName.THUMBNAILS, [
         { id: 'multi1' } as any,
         { id: 'multi2' } as any,
         { id: 'multi3' } as any,
@@ -90,9 +92,9 @@ describe('stores/generics', () => {
 
       const state = useThumbnailApi.getState();
 
-      expect(state[modelName.THUMBNAIL].multi1).toEqual({ id: 'multi1' });
-      expect(state[modelName.THUMBNAIL].multi2).toEqual({ id: 'multi2' });
-      expect(state[modelName.THUMBNAIL].multi3).toEqual({ id: 'multi3' });
+      expect(state[modelName.THUMBNAILS].multi1).toEqual({ id: 'multi1' });
+      expect(state[modelName.THUMBNAILS].multi2).toEqual({ id: 'multi2' });
+      expect(state[modelName.THUMBNAILS].multi3).toEqual({ id: 'multi3' });
     });
     it('adds multiple timed text tracks', async () => {
       await addMultipleResources(modelName.TIMEDTEXTTRACKS, [

--- a/src/frontend/data/stores/generics.ts
+++ b/src/frontend/data/stores/generics.ts
@@ -3,7 +3,7 @@ import { UploadableObject } from '../../types/tracks';
 
 const getStore = async (objectType: modelName) => {
   switch (objectType) {
-    case modelName.THUMBNAIL:
+    case modelName.THUMBNAILS:
       const { useThumbnailApi } = await import('./useThumbnail');
       return useThumbnailApi;
     case modelName.TIMEDTEXTTRACKS:

--- a/src/frontend/data/stores/useThumbnail/index.spec.tsx
+++ b/src/frontend/data/stores/useThumbnail/index.spec.tsx
@@ -40,7 +40,7 @@ describe('stores/useThumbnail', () => {
 
     const state = getLatestHookValues();
 
-    expect(state[modelName.THUMBNAIL]).toEqual({
+    expect(state[modelName.THUMBNAILS]).toEqual({
       'c0ea0fbc-5ce1-4340-a589-3db01d804045': {
         active_stamp: '1564494507',
         id: 'c0ea0fbc-5ce1-4340-a589-3db01d804045',
@@ -74,7 +74,7 @@ describe('stores/useThumbnail', () => {
 
   it('returns null when there is no thumbnail', () => {
     useThumbnailApi.setState({
-      [modelName.THUMBNAIL]: {},
+      [modelName.THUMBNAILS]: {},
     });
 
     expect(useThumbnailApi.getState().getThumbnail()).toBeNull();
@@ -83,22 +83,22 @@ describe('stores/useThumbnail', () => {
   it('adds a resource to the store', () => {
     useThumbnailApi.getState().addResource({ id: 'newResource' } as any);
 
-    expect(useThumbnailApi.getState()[modelName.THUMBNAIL].newResource).toEqual(
-      { id: 'newResource' },
-    );
+    expect(
+      useThumbnailApi.getState()[modelName.THUMBNAILS].newResource,
+    ).toEqual({ id: 'newResource' });
   });
 
   it('removes an existing resource', () => {
     useThumbnailApi.getState().addResource({ id: 'toDelete' } as any);
 
-    expect(useThumbnailApi.getState()[modelName.THUMBNAIL].toDelete).toEqual({
+    expect(useThumbnailApi.getState()[modelName.THUMBNAILS].toDelete).toEqual({
       id: 'toDelete',
     });
 
     useThumbnailApi.getState().removeResource({ id: 'toDelete' } as any);
 
     expect(
-      useThumbnailApi.getState()[modelName.THUMBNAIL].toDelete,
+      useThumbnailApi.getState()[modelName.THUMBNAILS].toDelete,
     ).toBeUndefined();
   });
 
@@ -111,13 +111,13 @@ describe('stores/useThumbnail', () => {
         { id: 'multi3' } as any,
       ]);
 
-    expect(useThumbnailApi.getState()[modelName.THUMBNAIL].multi1).toEqual({
+    expect(useThumbnailApi.getState()[modelName.THUMBNAILS].multi1).toEqual({
       id: 'multi1',
     });
-    expect(useThumbnailApi.getState()[modelName.THUMBNAIL].multi2).toEqual({
+    expect(useThumbnailApi.getState()[modelName.THUMBNAILS].multi2).toEqual({
       id: 'multi2',
     });
-    expect(useThumbnailApi.getState()[modelName.THUMBNAIL].multi3).toEqual({
+    expect(useThumbnailApi.getState()[modelName.THUMBNAILS].multi3).toEqual({
       id: 'multi3',
     });
   });

--- a/src/frontend/data/stores/useThumbnail/index.tsx
+++ b/src/frontend/data/stores/useThumbnail/index.tsx
@@ -9,7 +9,7 @@ import { addMultipleResources, addResource, removeResource } from '../actions';
 
 interface ThumbnailState extends StoreState<Thumbnail> {
   getThumbnail: () => Nullable<Thumbnail>;
-  [modelName.THUMBNAIL]: {
+  [modelName.THUMBNAILS]: {
     [id: string]: Thumbnail;
   };
 }
@@ -25,20 +25,20 @@ export const [useThumbnail, useThumbnailApi] = create<ThumbnailState>(
 
     return {
       addMultipleResources: (thumbnailsToAdd: Thumbnail[]) =>
-        set(addMultipleResources(get(), modelName.THUMBNAIL, thumbnailsToAdd)),
+        set(addMultipleResources(get(), modelName.THUMBNAILS, thumbnailsToAdd)),
       addResource: (thumbnail: Thumbnail) =>
-        set(addResource<Thumbnail>(get(), modelName.THUMBNAIL, thumbnail)),
+        set(addResource<Thumbnail>(get(), modelName.THUMBNAILS, thumbnail)),
       getThumbnail: () => {
-        if (Object.keys(get()[modelName.THUMBNAIL]).length > 0) {
-          const thumbnailId = Object.keys(get()[modelName.THUMBNAIL]).shift();
-          return get()[modelName.THUMBNAIL][thumbnailId!];
+        if (Object.keys(get()[modelName.THUMBNAILS]).length > 0) {
+          const thumbnailId = Object.keys(get()[modelName.THUMBNAILS]).shift();
+          return get()[modelName.THUMBNAILS][thumbnailId!];
         }
 
         return null;
       },
       removeResource: (thumbnail: Thumbnail) =>
-        set(removeResource(get(), modelName.THUMBNAIL, thumbnail)),
-      [modelName.THUMBNAIL]: thumbnails,
+        set(removeResource(get(), modelName.THUMBNAILS, thumbnail)),
+      [modelName.THUMBNAILS]: thumbnails,
     };
   },
 );

--- a/src/frontend/types/models.ts
+++ b/src/frontend/types/models.ts
@@ -1,6 +1,6 @@
 export enum modelName {
   TIMEDTEXTTRACKS = 'timedtexttracks',
-  THUMBNAIL = 'thumbnail',
+  THUMBNAILS = 'thumbnails',
   VIDEOS = 'videos',
   DOCUMENTS = 'documents',
 }

--- a/src/frontend/types/stores.ts
+++ b/src/frontend/types/stores.ts
@@ -6,7 +6,7 @@ export interface StoreState<R extends Resource> {
   addResource: (Resource: R) => void;
   addMultipleResources: (Resources: R[]) => void;
   removeResource: (Resource: R) => void;
-  [modelName.THUMBNAIL]?: {
+  [modelName.THUMBNAILS]?: {
     [id: string]: Thumbnail;
   };
   [modelName.TIMEDTEXTTRACKS]?: {


### PR DESCRIPTION
## Purpose

The resource name put in the lti view does not come from a reliable
model property. We decided to create a dedicated one and use it also to
manage urls. The same resource name is used in the front application.

## Proposal

- [x] create the property `RESOURCE_NAME` on model having an url
- [x] use this property in urls and lti view
- [x] pluralize thumbnail resource name
- [x] share same resource name in front application

