### PR TITLE
do not expose the user role anymore but if he can edit the resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Refactor the LTI view to be generic for all the resources we want to manage
 - Video model is a special File model
 - pluralize thumbnail url
+- Simplify template to frontend communication by using JSON instead of multiple data-attributes
 
 ### Removed
 

--- a/src/backend/marsha/core/lti/__init__.py
+++ b/src/backend/marsha/core/lti/__init__.py
@@ -251,6 +251,18 @@ class LTI:
         return roles.lower().split(",") if roles else []
 
     @property
+    def is_editable(self):
+        """Check if the current role is one that allows the user to modify the resource.
+
+        Returns
+        -------
+        boolean
+            True if the user can edit a resource
+
+        """
+        return self.is_instructor or self.is_admin
+
+    @property
     def is_instructor(self):
         """Check if the user of the launch request is an instructor on the course.
 

--- a/src/backend/marsha/core/templates/core/lti.html
+++ b/src/backend/marsha/core/templates/core/lti.html
@@ -9,8 +9,7 @@
     {% endif %}
   </head>
   <body>
-    <div class="marsha-frontend-data"{% if jwt_token %} data-jwt="{{ jwt_token }}"{% endif %} data-state="{{ state }}"></div>
-    <div class="marsha-frontend-data" id="{{ resource }}" data-resource="{{ resource_data }}"></div>
+    <div id="marsha-frontend-data" data-context="{{ app_data }}"></div>
 
     <div id="marsha-frontend-root"></div>
     <script src='{% static "js/index.js" %}'></script>

--- a/src/backend/marsha/core/tests/test_views_lti_video.py
+++ b/src/backend/marsha/core/tests/test_views_lti_video.py
@@ -53,13 +53,12 @@ class VideoViewTestCase(TestCase):
         self.assertContains(response, "<html>")
         content = response.content.decode("utf-8")
 
-        # Extract the JWT Token and state
         match = re.search(
-            '<div class="marsha-frontend-data" data-jwt="(.*)" data-state="(.*)">',
-            content,
+            '<div id="marsha-frontend-data" data-context="(.*)">', content
         )
-        data_jwt = match.group(1)
-        jwt_token = AccessToken(data_jwt)
+
+        context = json.loads(unescape(match.group(1)))
+        jwt_token = AccessToken(context.get("jwt"))
         self.assertEqual(jwt_token.payload["video_id"], str(video.id))
         self.assertEqual(jwt_token.payload["user_id"], data["user_id"])
         self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
@@ -71,17 +70,9 @@ class VideoViewTestCase(TestCase):
             {"school_name": "ufr", "course_name": "mathematics", "course_run": "00001"},
         )
 
-        data_state = match.group(2)
-        self.assertEqual(data_state, "instructor")
-
-        # Extract the video data
-        data_video = re.search(
-            '<div class="marsha-frontend-data" id="videos" data-resource="(.*)">',
-            content,
-        ).group(1)
-
+        self.assertEqual(context.get("state"), "success")
         self.assertEqual(
-            json.loads(unescape(data_video)),
+            context.get("resource"),
             {
                 "active_stamp": None,
                 "is_ready_to_play": False,
@@ -95,6 +86,8 @@ class VideoViewTestCase(TestCase):
                 "urls": None,
             },
         )
+        self.assertEqual(context.get("modelName"), "videos")
+        self.assertTrue(context.get("isEditable"))
         # Make sure we only go through LTI verification once as it is costly (getting passport +
         # signature)
         self.assertEqual(mock_verify.call_count, 1)
@@ -125,13 +118,12 @@ class VideoViewTestCase(TestCase):
         self.assertContains(response, "<html>")
         content = response.content.decode("utf-8")
 
-        # Extract the JWT Token and state
         match = re.search(
-            '<div class="marsha-frontend-data" data-jwt="(.*)" data-state="(.*)">',
-            content,
+            '<div id="marsha-frontend-data" data-context="(.*)">', content
         )
-        data_jwt = match.group(1)
-        jwt_token = AccessToken(data_jwt)
+
+        context = json.loads(unescape(match.group(1)))
+        jwt_token = AccessToken(context.get("jwt"))
         self.assertEqual(jwt_token.payload["video_id"], str(video.id))
         self.assertEqual(jwt_token.payload["user_id"], data["user_id"])
         self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
@@ -143,18 +135,9 @@ class VideoViewTestCase(TestCase):
             {"school_name": "ufr", "course_name": "mathematics", "course_run": "00001"},
         )
 
-        data_state = match.group(2)
-        # front application will still use instructor role, nothing change here
-        self.assertEqual(data_state, "instructor")
-
-        # Extract the video data
-        data_video = re.search(
-            '<div class="marsha-frontend-data" id="videos" data-resource="(.*)">',
-            content,
-        ).group(1)
-
+        self.assertEqual(context.get("state"), "success")
         self.assertEqual(
-            json.loads(unescape(data_video)),
+            context.get("resource"),
             {
                 "active_stamp": None,
                 "is_ready_to_play": False,
@@ -168,6 +151,8 @@ class VideoViewTestCase(TestCase):
                 "urls": None,
             },
         )
+        self.assertEqual(context.get("modelName"), "videos")
+        self.assertTrue(context.get("isEditable"))
         # Make sure we only go through LTI verification once as it is costly (getting passport +
         # signature)
         self.assertEqual(mock_verify.call_count, 1)
@@ -197,26 +182,16 @@ class VideoViewTestCase(TestCase):
         self.assertContains(response, "<html>")
         content = response.content.decode("utf-8")
 
-        # Extract the JWT Token and state
         match = re.search(
-            '<div class="marsha-frontend-data" data-jwt="(.*)" data-state="(.*)">',
-            content,
+            '<div id="marsha-frontend-data" data-context="(.*)">', content
         )
-        data_jwt = match.group(1)
-        jwt_token = AccessToken(data_jwt)
+
+        context = json.loads(unescape(match.group(1)))
+        jwt_token = AccessToken(context.get("jwt"))
         self.assertTrue(jwt_token.payload["read_only"])
-
-        data_state = match.group(2)
-        self.assertEqual(data_state, "instructor")
-
-        # Extract the video data
-        data_video = re.search(
-            '<div class="marsha-frontend-data" id="videos" data-resource="(.*)">',
-            content,
-        ).group(1)
-
+        self.assertEqual(context.get("state"), "success")
         self.assertEqual(
-            json.loads(unescape(data_video)),
+            context.get("resource"),
             {
                 "active_stamp": None,
                 "is_ready_to_play": False,
@@ -230,6 +205,8 @@ class VideoViewTestCase(TestCase):
                 "urls": None,
             },
         )
+        self.assertEqual(context.get("modelName"), "videos")
+        self.assertTrue(context.get("isEditable"))
         # Make sure we only go through LTI verification once as it is costly (getting passport +
         # signature)
         self.assertEqual(mock_verify.call_count, 1)
@@ -259,12 +236,11 @@ class VideoViewTestCase(TestCase):
         content = response.content.decode("utf-8")
 
         match = re.search(
-            '<div class="marsha-frontend-data" data-jwt="(.*)" data-state="(.*)">',
-            content,
+            '<div id="marsha-frontend-data" data-context="(.*)">', content
         )
 
-        data_jwt = match.group(1)
-        jwt_token = AccessToken(data_jwt)
+        context = json.loads(unescape(match.group(1)))
+        jwt_token = AccessToken(context.get("jwt"))
         self.assertEqual(jwt_token.payload["video_id"], str(video.id))
         self.assertEqual(jwt_token.payload["user_id"], data["user_id"])
         self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
@@ -276,15 +252,9 @@ class VideoViewTestCase(TestCase):
             {"school_name": "ufr", "course_name": "mathematics", "course_run": "00001"},
         )
 
-        data_state = match.group(2)
-        self.assertEqual(data_state, "student")
-
-        data_video = re.search(
-            '<div class="marsha-frontend-data" id="videos" data-resource="(.*)">',
-            content,
-        ).group(1)
+        self.assertEqual(context.get("state"), "success")
         self.assertEqual(
-            json.loads(unescape(data_video)),
+            context.get("resource"),
             {
                 "active_stamp": None,
                 "is_ready_to_play": False,
@@ -298,6 +268,8 @@ class VideoViewTestCase(TestCase):
                 "urls": None,
             },
         )
+        self.assertEqual(context.get("modelName"), "videos")
+        self.assertFalse(context.get("isEditable"))
         # Make sure we only go through LTI verification once as it is costly (getting passport +
         # signature)
         self.assertEqual(mock_verify.call_count, 1)
@@ -327,12 +299,11 @@ class VideoViewTestCase(TestCase):
         self.assertContains(response, "<html>")
         content = response.content.decode("utf-8")
         match = re.search(
-            '<div class="marsha-frontend-data" data-jwt="(.*)" data-state="(.*)">',
-            content,
+            '<div id="marsha-frontend-data" data-context="(.*)">', content
         )
 
-        data_jwt = match.group(1)
-        jwt_token = AccessToken(data_jwt)
+        context = json.loads(unescape(match.group(1)))
+        jwt_token = AccessToken(context.get("jwt"))
         self.assertEqual(jwt_token.payload["video_id"], str(video.id))
         self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
         self.assertEqual(jwt_token.payload["roles"], [data["roles"]])
@@ -341,6 +312,8 @@ class VideoViewTestCase(TestCase):
             jwt_token.payload["course"],
             {"school_name": "ufr", "course_name": "mathematics", "course_run": None},
         )
+        self.assertFalse(context.get("isEditable"))
+        self.assertEqual(context.get("modelName"), "videos")
 
         # Make sure we only go through LTI verification once as it is costly (getting passport +
         # signature)
@@ -367,16 +340,15 @@ class VideoViewTestCase(TestCase):
         self.assertContains(response, "<html>")
         content = response.content.decode("utf-8")
 
-        data_state = re.search(
-            '<div class="marsha-frontend-data" data-state="(.*)">', content
-        ).group(1)
-        self.assertEqual(data_state, "student")
+        match = re.search(
+            '<div id="marsha-frontend-data" data-context="(.*)">', content
+        )
 
-        data_video = re.search(
-            '<div class="marsha-frontend-data" id="videos" data-resource="(.*)">',
-            content,
-        ).group(1)
-        self.assertEqual(data_video, "null")
+        context = json.loads(unescape(match.group(1)))
+        self.assertEqual(context.get("state"), "success")
+        self.assertIsNone(context.get("resource"))
+        self.assertFalse(context.get("isEditable"))
+        self.assertEqual(context.get("modelName"), "videos")
 
         # Make sure we only go through LTI verification once as it is costly (getting passport +
         # signature)
@@ -395,16 +367,14 @@ class VideoViewTestCase(TestCase):
 
         mock_logger.assert_called_once_with("LTI Exception: %s", "lti error")
 
-        data_state = re.search(
-            '<div class="marsha-frontend-data" data-state="(.*)">', content
-        ).group(1)
-        self.assertEqual(data_state, "error")
+        match = re.search(
+            '<div id="marsha-frontend-data" data-context="(.*)">', content
+        )
 
-        data_video = re.search(
-            '<div class="marsha-frontend-data" id="videos" data-resource="(.*)">',
-            content,
-        ).group(1)
-        self.assertEqual(data_video, "null")
+        context = json.loads(unescape(match.group(1)))
+        self.assertEqual(context.get("state"), "error")
+        self.assertIsNone(context.get("resource"))
+        self.assertEqual(context.get("modelName"), "videos")
 
     @mock.patch.object(LTI, "verify")
     @mock.patch.object(LTI, "get_consumer_site")
@@ -434,16 +404,17 @@ class VideoViewTestCase(TestCase):
         self.assertContains(response, "<html>")
         content = response.content.decode("utf-8")
         match = re.search(
-            '<div class="marsha-frontend-data" data-jwt="(.*)" data-state="(.*)">',
-            content,
+            '<div id="marsha-frontend-data" data-context="(.*)">', content
         )
 
-        data_jwt = match.group(1)
-        jwt_token = AccessToken(data_jwt)
+        context = json.loads(unescape(match.group(1)))
+        jwt_token = AccessToken(context.get("jwt"))
         self.assertEqual(jwt_token.payload["video_id"], str(video.id))
         self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
         self.assertEqual(jwt_token.payload["roles"], [data["roles"]])
         self.assertEqual(jwt_token.payload["locale"], "en_US")
+        self.assertEqual(context.get("modelName"), "videos")
+        self.assertTrue(context.get("isEditable"))
 
     @override_settings(STATICFILES_AWS_ENABLED=False)
     @override_settings(CLOUDFRONT_DOMAIN="abcd.cloudfront.net")
@@ -536,12 +507,11 @@ class DevelopmentViewsTestCase(TestCase):
         content = response.content.decode("utf-8")
 
         match = re.search(
-            '<div class="marsha-frontend-data" data-jwt="(.*)" data-state="(.*)">',
-            content,
+            '<div id="marsha-frontend-data" data-context="(.*)">', content
         )
 
-        data_jwt = match.group(1)
-        jwt_token = AccessToken(data_jwt)
+        context = json.loads(unescape(match.group(1)))
+        jwt_token = AccessToken(context.get("jwt"))
         self.assertEqual(jwt_token.payload["video_id"], str(video.id))
         self.assertEqual(jwt_token.payload["user_id"], data["user_id"])
         self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
@@ -551,17 +521,9 @@ class DevelopmentViewsTestCase(TestCase):
             jwt_token.payload["course"],
             {"school_name": "ufr", "course_name": "mathematics", "course_run": None},
         )
-
-        data_state = match.group(2)
-        self.assertEqual(data_state, "student")
-
-        data_video = re.search(
-            '<div class="marsha-frontend-data" id="videos" data-resource="(.*)">',
-            content,
-        ).group(1)
-
+        self.assertEqual(context.get("state"), "success")
         self.assertEqual(
-            json.loads(unescape(data_video)),
+            context.get("resource"),
             {
                 "active_stamp": None,
                 "is_ready_to_play": False,
@@ -575,6 +537,8 @@ class DevelopmentViewsTestCase(TestCase):
                 "urls": None,
             },
         )
+        self.assertEqual(context.get("modelName"), "videos")
+        self.assertFalse(context.get("isEditable"))
 
     @override_settings(DEBUG=True)
     @override_settings(BYPASS_LTI_VERIFICATION=True)
@@ -596,13 +560,12 @@ class DevelopmentViewsTestCase(TestCase):
         self.assertContains(response, "<html>")
         content = response.content.decode("utf-8")
 
-        # Extract the JWT Token and state
         match = re.search(
-            '<div class="marsha-frontend-data" data-jwt="(.*)" data-state="(.*)">',
-            content,
+            '<div id="marsha-frontend-data" data-context="(.*)">', content
         )
-        data_jwt = match.group(1)
-        jwt_token = AccessToken(data_jwt)
+
+        context = json.loads(unescape(match.group(1)))
+        jwt_token = AccessToken(context.get("jwt"))
         self.assertEqual(jwt_token.payload["video_id"], str(video.id))
         self.assertEqual(jwt_token.payload["user_id"], data["user_id"])
         self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
@@ -612,18 +575,9 @@ class DevelopmentViewsTestCase(TestCase):
             jwt_token.payload["course"],
             {"school_name": "ufr", "course_name": "mathematics", "course_run": None},
         )
-
-        data_state = match.group(2)
-        self.assertEqual(data_state, "instructor")
-
-        # Extract the video data
-        data_video = re.search(
-            '<div class="marsha-frontend-data" id="videos" data-resource="(.*)">',
-            content,
-        ).group(1)
-
+        self.assertEqual(context.get("state"), "success")
         self.assertEqual(
-            json.loads(unescape(data_video)),
+            context.get("resource"),
             {
                 "active_stamp": None,
                 "is_ready_to_play": False,
@@ -637,6 +591,8 @@ class DevelopmentViewsTestCase(TestCase):
                 "urls": None,
             },
         )
+        self.assertEqual(context.get("modelName"), "videos")
+        self.assertTrue(context.get("isEditable"))
 
     @override_settings(DEBUG=True)
     @override_settings(BYPASS_LTI_VERIFICATION=True)
@@ -653,13 +609,12 @@ class DevelopmentViewsTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "<html>")
         content = response.content.decode("utf-8")
-        # Extract the JWT Token and state
         match = re.search(
-            '<div class="marsha-frontend-data" data-jwt="(.*)" data-state="(.*)">',
-            content,
+            '<div id="marsha-frontend-data" data-context="(.*)">', content
         )
-        data_jwt = match.group(1)
-        jwt_token = AccessToken(data_jwt)
+
+        context = json.loads(unescape(match.group(1)))
+        jwt_token = AccessToken(context.get("jwt"))
         video = Video.objects.get()
         self.assertEqual(jwt_token.payload["video_id"], str(video.id))
         self.assertEqual(jwt_token.payload["user_id"], data["user_id"])
@@ -670,18 +625,10 @@ class DevelopmentViewsTestCase(TestCase):
             jwt_token.payload["course"],
             {"school_name": "ufr", "course_name": "mathematics", "course_run": "00001"},
         )
-
-        data_state = match.group(2)
-        self.assertEqual(data_state, "instructor")
-
-        # Extract the video data
-        data_video = re.search(
-            '<div class="marsha-frontend-data" id="videos" data-resource="(.*)">',
-            content,
-        ).group(1)
+        self.assertEqual(context.get("state"), "success")
 
         self.assertEqual(
-            json.loads(unescape(data_video)),
+            context.get("resource"),
             {
                 "active_stamp": None,
                 "is_ready_to_play": False,
@@ -695,6 +642,8 @@ class DevelopmentViewsTestCase(TestCase):
                 "urls": None,
             },
         )
+        self.assertEqual(context.get("modelName"), "videos")
+        self.assertTrue(context.get("isEditable"))
         # The consumer site was created with a name and a domain name
         ConsumerSite.objects.get(name="example.com", domain="example.com")
 

--- a/src/frontend/Player/createPlayer.spec.ts
+++ b/src/frontend/Player/createPlayer.spec.ts
@@ -8,6 +8,12 @@ jest.mock('jwt-decode', () => {
   }));
 });
 
+jest.mock('../data/appData', () => ({
+  appData: {
+    jwt: 'foo',
+  },
+}));
+
 jest.mock('./createPlyrPlayer');
 
 describe('createPlayer', () => {

--- a/src/frontend/Player/createPlyrPlayer.spec.ts
+++ b/src/frontend/Player/createPlyrPlayer.spec.ts
@@ -25,17 +25,18 @@ jest.mock('plyr', () => {
     on: jest.fn(),
   }));
 });
-jest.mock('jwt-decode', () => {
-  return jest.fn().mockImplementation(() => ({
-    locale: 'en',
-    session_id: 'abcd',
-  }));
-});
-
 jest.mock('../index', () => ({
   intl: {
     formatMessage: jest.fn(),
   },
+}));
+
+jest.mock('../data/appData', () => ({
+  appData: { jwt: 'foo' },
+  getDecodedJwt: jest.fn().mockImplementation(() => ({
+    locale: 'en',
+    session_id: 'abcd',
+  })),
 }));
 
 describe('createPlyrPlayer', () => {

--- a/src/frontend/Player/createPlyrPlayer.ts
+++ b/src/frontend/Player/createPlyrPlayer.ts
@@ -7,6 +7,7 @@ import {
   InitializedContextExtensions,
   InteractedContextExtensions,
 } from '../types/XAPI';
+import { report } from '../utils/errors/report';
 import { isMSESupported } from '../utils/isAbrSupported';
 import { XAPIStatement } from '../XAPI/XAPIStatement';
 import { i18nMessages } from './i18n/plyrTranslation';
@@ -100,10 +101,13 @@ export const createPlyrPlayer = async (
     },
   );
 
-  const xapiStatement = new XAPIStatement(
-    appData.jwt,
-    getDecodedJwt().session_id,
-  );
+  let xapiStatement: XAPIStatement;
+  try {
+    xapiStatement = new XAPIStatement(appData.jwt!, getDecodedJwt().session_id);
+  } catch (error) {
+    report(error);
+    throw error;
+  }
 
   let currentTime: number = 0;
   let seekingAt: number = 0;

--- a/src/frontend/components/DashboardTimedTextManager/index.spec.tsx
+++ b/src/frontend/components/DashboardTimedTextManager/index.spec.tsx
@@ -11,6 +11,12 @@ import { wrapInRouter } from '../../utils/tests/router';
 
 jest.mock('jwt-decode', () => jest.fn());
 
+jest.mock('../../data/appData', () => ({
+  appData: {
+    jwt: 'foo',
+  },
+}));
+
 describe('<DashboardTimedTextManager />', () => {
   it('renders the message & tracks it is passed', async () => {
     fetchMock.mock(
@@ -55,7 +61,6 @@ describe('<DashboardTimedTextManager />', () => {
 
     const state = {
       jwt: 'jwt-token',
-      state: appState.INSTRUCTOR,
       video: {
         id: 'dd44',
         thumbnail: null,

--- a/src/frontend/components/DashboardTimedTextManager/index.spec.tsx
+++ b/src/frontend/components/DashboardTimedTextManager/index.spec.tsx
@@ -4,7 +4,6 @@ import React from 'react';
 import { defineMessages } from 'react-intl';
 
 import { DashboardTimedTextManager } from '.';
-import { appState } from '../../types/AppData';
 import { TimedText, timedTextMode, uploadState } from '../../types/tracks';
 import { wrapInIntlProvider } from '../../utils/tests/intl';
 import { wrapInRouter } from '../../utils/tests/router';

--- a/src/frontend/components/DashboardTimedTextPane/index.spec.tsx
+++ b/src/frontend/components/DashboardTimedTextPane/index.spec.tsx
@@ -12,6 +12,12 @@ import { wrapInIntlProvider } from '../../utils/tests/intl';
 import { wrapInRouter } from '../../utils/tests/router';
 import { ERROR_COMPONENT_ROUTE } from '../ErrorComponent/route';
 
+jest.mock('../../data/appData', () => ({
+  appData: {
+    jwt: 'foo',
+  },
+}));
+
 describe('<DashboardTimedTextPane />', () => {
   beforeEach(() =>
     fetchMock.mock(

--- a/src/frontend/components/DashboardVideoPaneDownloadOption/index.spec.tsx
+++ b/src/frontend/components/DashboardVideoPaneDownloadOption/index.spec.tsx
@@ -7,6 +7,10 @@ import { DashboardVideoPaneDownloadOption } from '.';
 import { uploadState } from '../../types/tracks';
 import { wrapInIntlProvider } from '../../utils/tests/intl';
 
+jest.mock('../../data/appData', () => ({
+  appData: {},
+}));
+
 describe('<DashboardVideoPaneDownloadOption />', () => {
   afterEach(fetchMock.restore);
 

--- a/src/frontend/components/InstructorWrapper/index.spec.tsx
+++ b/src/frontend/components/InstructorWrapper/index.spec.tsx
@@ -1,7 +1,6 @@
 import { render } from '@testing-library/react';
 import React from 'react';
 
-import { appState } from '../../types/AppData';
 import { InstructorWrapper } from './index';
 
 jest.mock('../InstructorView/index', () => {

--- a/src/frontend/components/InstructorWrapper/index.spec.tsx
+++ b/src/frontend/components/InstructorWrapper/index.spec.tsx
@@ -15,18 +15,18 @@ jest.mock('../InstructorView/index', () => {
   };
 });
 
-let mockState: appState;
+let mockIsEditable: boolean;
 jest.mock('../../data/appData', () => ({
   appData: {
-    get state() {
-      return mockState;
+    get isEditable() {
+      return mockIsEditable;
     },
   },
 }));
 
 describe('<InstructorWrapper />', () => {
   it('wraps its children in an instructor view if the current user is an instructor', () => {
-    mockState = appState.INSTRUCTOR;
+    mockIsEditable = true;
     const { getByText, getByTitle } = render(
       <InstructorWrapper>
         <div title="some-child" />
@@ -38,7 +38,7 @@ describe('<InstructorWrapper />', () => {
   });
 
   it('just renders the children if the current user is not an instructor', () => {
-    mockState = appState.STUDENT;
+    mockIsEditable = false;
     const { getByTitle, queryByText } = render(
       <InstructorWrapper>
         <div title="some-child" />

--- a/src/frontend/components/InstructorWrapper/index.tsx
+++ b/src/frontend/components/InstructorWrapper/index.tsx
@@ -9,7 +9,7 @@ interface InstructorWrapperProps {
 }
 
 export const InstructorWrapper = ({ children }: InstructorWrapperProps) => {
-  if (appData.state === appState.INSTRUCTOR) {
+  if (appData.isEditable) {
     return <InstructorView>{children}</InstructorView>;
   } else {
     return <React.Fragment>{children}</React.Fragment>;

--- a/src/frontend/components/InstructorWrapper/index.tsx
+++ b/src/frontend/components/InstructorWrapper/index.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import { appData } from '../../data/appData';
-import { appState } from '../../types/AppData';
 import { InstructorView } from '../InstructorView';
 
 interface InstructorWrapperProps {

--- a/src/frontend/components/RedirectOnLoad/index.spec.tsx
+++ b/src/frontend/components/RedirectOnLoad/index.spec.tsx
@@ -16,8 +16,12 @@ let mockState: any;
 let mockVideo: any;
 let mockDocument: any;
 let mockModelName: any;
+let mockIsEditable: boolean;
 jest.mock('../../data/appData', () => ({
   appData: {
+    get isEditable() {
+      return mockIsEditable;
+    },
     get state() {
       return mockState;
     },
@@ -57,9 +61,10 @@ describe('<RedirectOnLoad />', () => {
   });
 
   it('redirects instructors to the player when the video is ready', () => {
-    mockState = appState.INSTRUCTOR;
+    mockState = appState.SUCCESS;
     mockModelName = modelName.VIDEOS;
     mockDocument = null;
+    mockIsEditable = true;
 
     for (const state of Object.values(uploadState)) {
       mockVideo = { is_ready_to_play: true, upload_state: state };
@@ -78,9 +83,10 @@ describe('<RedirectOnLoad />', () => {
   });
 
   it('redirects instructors to the player when the document is ready', () => {
-    mockState = appState.INSTRUCTOR;
+    mockState = appState.SUCCESS;
     mockModelName = modelName.DOCUMENTS;
     mockVideo = null;
+    mockIsEditable = true;
 
     for (const state of Object.values(uploadState)) {
       mockDocument = { is_ready_to_display: true, upload_state: state };
@@ -99,9 +105,10 @@ describe('<RedirectOnLoad />', () => {
   });
 
   it('redirects students to /player when the video is ready', () => {
-    mockState = appState.STUDENT;
+    mockState = appState.SUCCESS;
     mockModelName = modelName.VIDEOS;
     mockDocument = null;
+    mockIsEditable = false;
 
     for (const state of Object.values(uploadState)) {
       mockVideo = { is_ready_to_play: true, upload_state: state };
@@ -120,9 +127,10 @@ describe('<RedirectOnLoad />', () => {
   });
 
   it('redirects students to /player when the document is ready', () => {
-    mockState = appState.STUDENT;
+    mockState = appState.SUCCESS;
     mockModelName = modelName.DOCUMENTS;
     mockVideo = null;
+    mockIsEditable = false;
 
     for (const state of Object.values(uploadState)) {
       mockDocument = { is_ready_to_display: true, upload_state: state };
@@ -141,7 +149,7 @@ describe('<RedirectOnLoad />', () => {
   });
 
   it('redirects instructors to /form when there is no video yet', () => {
-    mockState = appState.INSTRUCTOR;
+    mockState = appState.SUCCESS;
     mockVideo = {
       id: '42',
       is_ready_to_play: false,
@@ -149,6 +157,7 @@ describe('<RedirectOnLoad />', () => {
     };
     mockModelName = modelName.VIDEOS;
     mockDocument = null;
+    mockIsEditable = true;
 
     const { getByText } = render(
       wrapInRouter(<RedirectOnLoad />, [
@@ -165,7 +174,7 @@ describe('<RedirectOnLoad />', () => {
   });
 
   it('redirects instructors to /form when there is no document yet', () => {
-    mockState = appState.INSTRUCTOR;
+    mockState = appState.SUCCESS;
     mockVideo = null;
     mockModelName = modelName.DOCUMENTS;
     mockDocument = {
@@ -173,6 +182,7 @@ describe('<RedirectOnLoad />', () => {
       is_ready_to_display: false,
       upload_state: uploadState.PENDING,
     };
+    mockIsEditable = true;
 
     const { getByText } = render(
       wrapInRouter(<RedirectOnLoad />, [
@@ -189,13 +199,14 @@ describe('<RedirectOnLoad />', () => {
   });
 
   it('redirects instructors to /dashboard when there is a video undergoing processing', () => {
-    mockState = appState.INSTRUCTOR;
+    mockState = appState.SUCCESS;
     mockVideo = {
       is_ready_to_play: false,
       upload_state: uploadState.PROCESSING,
     };
     mockModelName = modelName.VIDEOS;
     mockDocument = null;
+    mockIsEditable = true;
 
     const { getByText } = render(
       wrapInRouter(<RedirectOnLoad />, [
@@ -212,13 +223,14 @@ describe('<RedirectOnLoad />', () => {
   });
 
   it('redirects instructors to /dashboard when there is a document undergoing processing', () => {
-    mockState = appState.INSTRUCTOR;
+    mockState = appState.SUCCESS;
     mockVideo = null;
     mockModelName = modelName.DOCUMENTS;
     mockDocument = {
       is_ready_to_display: false,
       upload_state: uploadState.PROCESSING,
     };
+    mockIsEditable = true;
 
     const { getByText } = render(
       wrapInRouter(<RedirectOnLoad />, [
@@ -235,13 +247,14 @@ describe('<RedirectOnLoad />', () => {
   });
 
   it('redirects students to the error view when the video is not ready', () => {
-    mockState = appState.STUDENT;
+    mockState = appState.SUCCESS;
     mockVideo = {
       is_ready_to_play: false,
       upload_state: uploadState.PROCESSING,
     };
     mockModelName = modelName.VIDEOS;
     mockDocument = null;
+    mockIsEditable = false;
 
     const { getByText } = render(
       wrapInRouter(<RedirectOnLoad />, [
@@ -258,13 +271,14 @@ describe('<RedirectOnLoad />', () => {
   });
 
   it('redirects students to the error view when the document is not ready', () => {
-    mockState = appState.STUDENT;
+    mockState = appState.SUCCESS;
     mockDocument = {
       is_ready_to_display: false,
       upload_state: uploadState.PROCESSING,
     };
     mockModelName = modelName.DOCUMENTS;
     mockVideo = null;
+    mockIsEditable = false;
 
     const { getByText } = render(
       wrapInRouter(<RedirectOnLoad />, [
@@ -281,9 +295,10 @@ describe('<RedirectOnLoad />', () => {
   });
 
   it('redirects students to the error view when the resource is null', () => {
-    mockState = appState.STUDENT;
+    mockState = appState.SUCCESS;
     mockVideo = null;
     mockDocument = null;
+    mockIsEditable = false;
 
     for (const model of [modelName.VIDEOS, modelName.DOCUMENTS]) {
       mockModelName = model;

--- a/src/frontend/components/RedirectOnLoad/index.tsx
+++ b/src/frontend/components/RedirectOnLoad/index.tsx
@@ -15,11 +15,10 @@ import { VIDEO_PLAYER_ROUTE } from '../VideoPlayer/route';
 // RedirectOnLoad assesses the initial state of the application using appData and determines the proper
 // route to load in the Router
 export const RedirectOnLoad = () => {
-  const ltiState = appData.state;
   const resource = appData.document || appData.video || null;
 
   // Get LTI errors out of the way
-  if (ltiState === appState.ERROR) {
+  if (appData.state === appState.ERROR) {
     return <Redirect push to={ERROR_COMPONENT_ROUTE('lti')} />;
   }
 
@@ -39,7 +38,7 @@ export const RedirectOnLoad = () => {
     return <Redirect push to={DOCUMENT_PLAYER_ROUTE()} />;
   }
 
-  if (ltiState === appState.INSTRUCTOR) {
+  if (appData.isEditable) {
     if (resource!.upload_state === uploadState.PENDING) {
       return (
         <Redirect
@@ -52,7 +51,7 @@ export const RedirectOnLoad = () => {
     }
   }
 
-  // For safety default to the 404 view: this is for students, and any other role we add later on and don't add
-  // a special clause for, when the video is not ready.
+  // For safety default to the 404 view: this is for users not able to edit the current resource
+  // when this one is not ready.
   return <Redirect push to={ERROR_COMPONENT_ROUTE('notFound')} />;
 };

--- a/src/frontend/components/TimedTextListItem/index.spec.tsx
+++ b/src/frontend/components/TimedTextListItem/index.spec.tsx
@@ -8,6 +8,12 @@ import { timedTextMode, uploadState } from '../../types/tracks';
 import { wrapInIntlProvider } from '../../utils/tests/intl';
 import { wrapInRouter } from '../../utils/tests/router';
 
+jest.mock('../../data/appData', () => ({
+  appData: {
+    jwt: 'foo',
+  },
+}));
+
 describe('<TimedTextListItem />', () => {
   jest.useFakeTimers();
 

--- a/src/frontend/components/Transcripts/index.spec.tsx
+++ b/src/frontend/components/Transcripts/index.spec.tsx
@@ -6,6 +6,12 @@ import { Transcripts } from '.';
 import { timedTextMode, uploadState } from '../../types/tracks';
 import { wrapInIntlProvider } from '../../utils/tests/intl';
 
+jest.mock('../../data/appData', () => ({
+  appData: {
+    jwt: 'foo',
+  },
+}));
+
 const transcriptContent = `
 WEBVTT
 

--- a/src/frontend/data/appData.ts
+++ b/src/frontend/data/appData.ts
@@ -3,12 +3,9 @@ import jwt_decode from 'jwt-decode';
 import { DecodedJwt } from '../types/jwt';
 import { parseDataElements } from '../utils/parseDataElements/parseDataElements';
 
-export const appData = {
-  ...parseDataElements(
-    // Spread to pass an array instead of a NodeList
-    [...document.querySelectorAll('.marsha-frontend-data')],
-  ),
-};
+export const appData = parseDataElements(
+  document.getElementById('marsha-frontend-data')!,
+);
 
 // Jwt is lazily decoded only when needed
 let cacheDecodedJwt: DecodedJwt;

--- a/src/frontend/data/appData.ts
+++ b/src/frontend/data/appData.ts
@@ -7,7 +7,14 @@ export const appData = parseDataElements(
   document.getElementById('marsha-frontend-data')!,
 );
 
-// Jwt is lazily decoded only when needed
+// Jwt is lazily decoded only when needed and available
 let cacheDecodedJwt: DecodedJwt;
-export const getDecodedJwt = () =>
-  cacheDecodedJwt || (cacheDecodedJwt = jwt_decode(appData.jwt));
+export const getDecodedJwt = () => {
+  if (appData.jwt) {
+    return cacheDecodedJwt || (cacheDecodedJwt = jwt_decode(appData.jwt));
+  }
+
+  throw new Error(
+    'Impossible to decode JWT token, none present in the app state',
+  );
+};

--- a/src/frontend/data/stores/generics.spec.ts
+++ b/src/frontend/data/stores/generics.spec.ts
@@ -4,6 +4,10 @@ import { useThumbnailApi } from './useThumbnail';
 import { useTimedTextTrackApi } from './useTimedTextTrack';
 import { useVideoApi } from './useVideo';
 
+jest.mock('../../data/appData', () => ({
+  appData: {},
+}));
+
 describe('stores/generics', () => {
   afterEach(() => {
     // restore the state of each store.

--- a/src/frontend/index.tsx
+++ b/src/frontend/index.tsx
@@ -1,7 +1,6 @@
 import 'iframe-resizer/js/iframeResizer.contentWindow';
 
 import { Grommet } from 'grommet';
-import jwtDecode from 'jwt-decode';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {
@@ -12,18 +11,22 @@ import {
 } from 'react-intl';
 
 import { AppRoutes } from './components/AppRoutes';
-import { appData } from './data/appData';
-import { DecodedJwt } from './types/jwt';
+import { getDecodedJwt } from './data/appData';
 import { report } from './utils/errors/report';
 // Load our style reboot into the DOM
 import { GlobalStyles } from './utils/theme/baseStyles';
 import { theme } from './utils/theme/theme';
 
-const decodedToken: DecodedJwt = jwtDecode(appData.jwt);
-
-let localeCode = decodedToken.locale;
-if (localeCode.match(/^.*_.*$/)) {
-  localeCode = localeCode.split('_')[0];
+let localeCode: string;
+let locale: string;
+try {
+  locale = localeCode = getDecodedJwt().locale;
+  if (localeCode.match(/^.*_.*$/)) {
+    localeCode = localeCode.split('_')[0];
+  }
+} catch (e) {
+  localeCode = 'en';
+  locale = 'en_US';
 }
 
 export let intl: IntlShape;
@@ -48,9 +51,7 @@ document.addEventListener('DOMContentLoaded', async event => {
 
   let translatedMessages = null;
   try {
-    translatedMessages = await import(
-      `./translations/${decodedToken.locale}.json`
-    );
+    translatedMessages = await import(`./translations/${locale}.json`);
   } catch (e) {}
 
   const cache = createIntlCache();

--- a/src/frontend/types/AppData.ts
+++ b/src/frontend/types/AppData.ts
@@ -5,13 +5,13 @@ import { Video } from './tracks';
 
 export enum appState {
   ERROR = 'error',
-  INSTRUCTOR = 'instructor',
-  STUDENT = 'student',
+  SUCCESS = 'success',
 }
 
 export interface AppData {
   jwt: string;
   state: appState;
+  isEditable: boolean;
   video?: Nullable<Video>;
   document?: Nullable<Document>;
   modelName: modelName;

--- a/src/frontend/types/AppData.ts
+++ b/src/frontend/types/AppData.ts
@@ -9,7 +9,7 @@ export enum appState {
 }
 
 export interface AppData {
-  jwt: string;
+  jwt?: string;
   state: appState;
   isEditable: boolean;
   video?: Nullable<Video>;

--- a/src/frontend/utils/parseDataElements/parseDataElements.ts
+++ b/src/frontend/utils/parseDataElements/parseDataElements.ts
@@ -1,68 +1,23 @@
 import { AppData } from '../../types/AppData';
 import { modelName } from '../../types/models';
 
-// Transform a data-attribute into a proper key: drop 'data-' & camel-case it
-// Exported for testing purposes
-export const keyFromAttr = (attribute: string) => {
-  return (
-    attribute
-      // Drop 'data-'
-      .substr(5)
-      .split('-')
-      .map((part, index) =>
-        // Capitalize all but the first part to get a camelCased name
-        index === 0 ? part : part[0].toUpperCase() + part.substr(1),
-      )
-      .join('')
-  );
-};
+export const parseDataElements = (element: Element): AppData => {
+  const context = JSON.parse(element.getAttribute('data-context')!);
 
-// Extract all the necessary data the backend passed us through data-attributes on some elements
-export const parseDataElements: (
-  dataElements: Element[],
-) => AppData = dataElements => {
-  // Iterate over the data elements to add their data onto the root accumulator (starting with {})
-  return dataElements.reduce(
-    (rootAcc, element) =>
-      Object.keys(element.attributes)
-        // Get the actual attribute names from the NamedNodeMap object
-        .map(index => {
-          return element.attributes[Number(index)].nodeName;
-        })
-        // Filter out non-data attributes
-        .filter(key => key.indexOf('data-') === 0)
-        // Build the policy object using the element as data-{key}="value"
-        .reduce((acc: any, key) => {
-          if (element.id) {
-            // Use of ID denotes a nested object
-            // Nested objects use straight JSON instead of a series of data-attributes
-            const obj = {
-              ...acc,
-              modelName: element.id,
-            };
+  if (context.modelName) {
+    switch (context.modelName) {
+      case modelName.VIDEOS:
+        context.video = context.resource;
+        break;
+      case modelName.DOCUMENTS:
+        context.document = context.resource;
+        break;
+      default:
+        throw new Error(`Model ${context.modelName} not supported`);
+    }
 
-            switch (obj.modelName) {
-              case modelName.VIDEOS:
-                obj.video = JSON.parse(element.getAttribute(`data-resource`)!);
-                break;
-              case modelName.DOCUMENTS:
-                obj.document = JSON.parse(
-                  element.getAttribute(`data-resource`)!,
-                );
-                break;
-              default:
-                throw new Error(`model ${obj.modelName} not supported`);
-            }
+    delete context.resource;
+  }
 
-            return obj;
-          } else {
-            // If there's no ID, just merge on the main accumulator
-            return {
-              ...acc,
-              [key.substr(5)]: element.getAttribute(key),
-            };
-          }
-        }, rootAcc),
-    {},
-  ) as AppData;
+  return context;
 };


### PR DESCRIPTION
## Purpose

Since we have several roles having the same permissions rules it is not relevant anymore in the front application to rely on them. To have less complexity, we want to know if the user can edit the resource.

## Proposal

Do not expose the role in the state, add a new boolean property to know if the user can edit the resource.

- [x] add new attribute data-editable in lti view
- [x] remove role in data-state
- [x] use the new `editable` property in the front application

