### PR TITLE
Remove error message in tests output

### DIFF
--- a/src/frontend/components/DashboardTimedTextPane/index.spec.tsx
+++ b/src/frontend/components/DashboardTimedTextPane/index.spec.tsx
@@ -145,6 +145,6 @@ describe('<DashboardTimedTextPane />', () => {
 
     await wait();
     getByText('Error Component: notFound');
-    expect(report).toBeCalledWith(Error('Failed!'));
+    expect(report).toBeCalledWith(new Error('Failed!'));
   });
 });

--- a/src/frontend/components/DashboardTimedTextPane/index.spec.tsx
+++ b/src/frontend/components/DashboardTimedTextPane/index.spec.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 
 import { DashboardTimedTextPane } from '.';
 import { timedTextMode, uploadState } from '../../types/tracks';
+import { report } from '../../utils/errors/report';
 import { wrapInIntlProvider } from '../../utils/tests/intl';
 import { wrapInRouter } from '../../utils/tests/router';
 import { ERROR_COMPONENT_ROUTE } from '../ErrorComponent/route';
@@ -16,6 +17,10 @@ jest.mock('../../data/appData', () => ({
   appData: {
     jwt: 'foo',
   },
+}));
+
+jest.mock('../../utils/errors/report', () => ({
+  report: jest.fn(),
 }));
 
 describe('<DashboardTimedTextPane />', () => {
@@ -140,5 +145,6 @@ describe('<DashboardTimedTextPane />', () => {
 
     await wait();
     getByText('Error Component: notFound');
+    expect(report).toBeCalledWith(Error('Failed!'));
   });
 });

--- a/src/frontend/components/DashboardVideoPane/index.spec.tsx
+++ b/src/frontend/components/DashboardVideoPane/index.spec.tsx
@@ -54,6 +54,33 @@ describe('<DashboardVideoPane />', () => {
     },
   };
 
+  it('redirects to error when it fails to fetch the video', async () => {
+    fetchMock.mock('/api/videos/43/', () => {
+      throw new Error('Failed request');
+    });
+    const { getByText } = render(
+      wrapInIntlProvider(
+        wrapInRouter(
+          <DashboardVideoPane video={{ ...video, upload_state: PROCESSING }} />,
+          [
+            {
+              path: ERROR_COMPONENT_ROUTE(),
+              render: ({ match }) => (
+                <span>{`Error Component: ${match.params.code}`}</span>
+              ),
+            },
+          ],
+        ),
+      ),
+    );
+
+    jest.advanceTimersByTime(1000 * 60 + 200);
+    await wait();
+
+    expect(report).toHaveBeenCalledWith(new Error('Failed request'));
+    getByText('Error Component: notFound');
+  });
+
   it('renders & starts polling for the video', async () => {
     fetchMock.mock(
       '/api/videos/43/',
@@ -122,34 +149,7 @@ describe('<DashboardVideoPane />', () => {
     getByText('Your video is ready to play.');
   });
 
-  it('redirects to error when it fails to fetch the video', async () => {
-    fetchMock.mock('/api/videos/43/', {
-      throws: new Error('Failed request'),
-    });
-    const { getByText } = render(
-      wrapInIntlProvider(
-        wrapInRouter(
-          <DashboardVideoPane video={{ ...video, upload_state: PROCESSING }} />,
-          [
-            {
-              path: ERROR_COMPONENT_ROUTE(),
-              render: ({ match }) => (
-                <span>{`Error Component: ${match.params.code}`}</span>
-              ),
-            },
-          ],
-        ),
-      ),
-    );
-
-    jest.advanceTimersByTime(1000 * 60 + 200);
-    await wait();
-
-    expect(report).toHaveBeenCalledWith(new Error('Failed request'));
-    getByText('Error Component: notFound');
-  });
-
-  it('redirects to error when the video is in the error state and not `is_ready_to_play`', async () => {
+  it('redirects to error when the video is in the error state and not `is_ready_to_play`', () => {
     const { getByText } = render(
       wrapInIntlProvider(
         wrapInRouter(
@@ -171,7 +171,7 @@ describe('<DashboardVideoPane />', () => {
     getByText('Error Component: upload');
   });
 
-  it('shows the dashboard when the video is in the error state but `is_ready_to_play`', async () => {
+  it('shows the dashboard when the video is in the error state but `is_ready_to_play`', () => {
     const { getByText } = render(
       wrapInIntlProvider(
         <DashboardVideoPane

--- a/src/frontend/components/DashboardVideoPane/index.tsx
+++ b/src/frontend/components/DashboardVideoPane/index.tsx
@@ -50,7 +50,6 @@ interface DashboardVideoPaneProps {
 
 export const DashboardVideoPane = ({ video }: DashboardVideoPaneProps) => {
   const [error, setError] = useState(false);
-  const [pollInterval, setPollInterval] = useState();
   const { updateVideo } = useVideo(state => ({
     updateVideo: state.addResource,
   }));
@@ -84,11 +83,11 @@ export const DashboardVideoPane = ({ video }: DashboardVideoPaneProps) => {
 
   useEffect(() => {
     if ([PENDING, UPLOADING, PROCESSING].includes(video.upload_state)) {
-      setPollInterval(window.setInterval(() => pollForVideo(), 1000 * 60));
+      const interval = window.setInterval(() => pollForVideo(), 1000 * 60);
 
       return () => {
         // As a matter of hygiene, stop the polling as we unmount
-        window.clearInterval(pollInterval);
+        window.clearInterval(interval);
       };
     }
   }, []);

--- a/src/frontend/components/UploadForm/index.spec.tsx
+++ b/src/frontend/components/UploadForm/index.spec.tsx
@@ -122,6 +122,7 @@ describe('UploadForm', () => {
       },
       { method: 'POST' },
     );
+    fetchMock.mock('/api/videos/video-id/', 200, { method: 'PUT' });
     mockUploadFile.mockResolvedValue(true);
     mockGetResource.mockResolvedValue(object);
 
@@ -147,11 +148,14 @@ describe('UploadForm', () => {
     });
     await wait();
     expect(
-      fetchMock.calls('/api/videos/video-id/initiate-upload/', {
+      fetchMock.called('/api/videos/video-id/initiate-upload/', {
         method: 'POST',
       }),
-    ).toHaveLength(1);
+    ).toBe(true);
     await wait();
+    expect(fetchMock.called('/api/videos/video-id/', { method: 'PUT' })).toBe(
+      true,
+    );
     expect(mockUploadFile).toHaveBeenCalled();
     // redirected to the dashboard
     getByText('dashboard');


### PR DESCRIPTION
## Purpose

There were some error messages in tests output. Most of them are logged by the `report` function. Now the ouput does not looks like a Christmas tree anymore.

## Proposal

- [x] update tests to remove error messages.

