### PR TITLE
♻️ (model) rename is_ready_* properties in is_ready_to_show

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Video model is a special File model
 - pluralize thumbnail url
 - Simplify template to frontend communication by using JSON instead of multiple data-attributes
+- Rename all is_ready_to_* model properties to is_ready_to_show
 
 ### Removed
 

--- a/src/backend/marsha/core/models/base.py
+++ b/src/backend/marsha/core/models/base.py
@@ -255,8 +255,8 @@ class AbstractImage(BaseModel):
         abstract = True
 
     @property
-    def is_ready_to_display(self):
-        """Whether the image is ready to display (ie) has been sucessfully uploaded.
+    def is_ready_to_show(self):
+        """Whether the file is ready to display (ie) has been sucessfully uploaded.
 
         The value of this field seems to be trivially derived from the value of the
         `uploaded_on` field but it is necessary for conveniency and clarity in the client.

--- a/src/backend/marsha/core/models/file.py
+++ b/src/backend/marsha/core/models/file.py
@@ -87,7 +87,7 @@ class BaseFile(BaseModel):
         return result
 
     @property
-    def is_ready_to_display(self):
+    def is_ready_to_show(self):
         """Whether the file is ready to display (ie) has been sucessfully uploaded.
 
         The value of this field seems to be trivially derived from the value of the

--- a/src/backend/marsha/core/models/video.py
+++ b/src/backend/marsha/core/models/video.py
@@ -30,15 +30,6 @@ class Video(BaseFile):
             )
         ]
 
-    @property
-    def is_ready_to_play(self):
-        """Whether the video is ready to play (ie) has been sucessfully uploaded.
-
-        The value of this field seems to be trivially derived from the value of the
-        `uploaded_on` field but it is necessary for conveniency and clarity in the client.
-        """
-        return self.uploaded_on is not None
-
     def get_source_s3_key(self, stamp=None):
         """Compute the S3 key in the source bucket (ID of the video + version stamp).
 
@@ -99,8 +90,8 @@ class BaseTrack(BaseModel):
         abstract = True
 
     @property
-    def is_ready_to_play(self):
-        """Whether the track is ready to play (ie) has been sucessfully uploaded.
+    def is_ready_to_show(self):
+        """Whether the file is ready to display (ie) has been sucessfully uploaded.
 
         The value of this field seems to be trivially derived from the value of the
         `uploaded_on` field but it is necessary for conveniency and clarity in the client.

--- a/src/backend/marsha/core/serializers.py
+++ b/src/backend/marsha/core/serializers.py
@@ -82,7 +82,7 @@ class TimedTextTrackSerializer(serializers.ModelSerializer):
         fields = (
             "active_stamp",
             "id",
-            "is_ready_to_play",
+            "is_ready_to_show",
             "mode",
             "language",
             "upload_state",
@@ -92,7 +92,7 @@ class TimedTextTrackSerializer(serializers.ModelSerializer):
         read_only_fields = (
             "id",
             "active_stamp",
-            "is_ready_to_play",
+            "is_ready_to_show",
             "upload_state",
             "url",
             "video",
@@ -106,7 +106,7 @@ class TimedTextTrackSerializer(serializers.ModelSerializer):
     video = serializers.PrimaryKeyRelatedField(
         read_only=True, pk_field=serializers.CharField()
     )
-    is_ready_to_play = serializers.BooleanField(read_only=True)
+    is_ready_to_show = serializers.BooleanField(read_only=True)
 
     def create(self, validated_data):
         """Force the video field to the video of the JWT Token if any.
@@ -181,7 +181,7 @@ class ThumbnailSerializer(serializers.ModelSerializer):
         fields = (
             "active_stamp",
             "id",
-            "is_ready_to_display",
+            "is_ready_to_show",
             "upload_state",
             "urls",
             "video",
@@ -189,7 +189,7 @@ class ThumbnailSerializer(serializers.ModelSerializer):
         read_only_fields = (
             "active_stamp",
             "id",
-            "is_ready_to_display",
+            "is_ready_to_show",
             "upload_state",
             "urls",
             "video",
@@ -201,7 +201,7 @@ class ThumbnailSerializer(serializers.ModelSerializer):
     video = serializers.PrimaryKeyRelatedField(
         read_only=True, pk_field=serializers.CharField()
     )
-    is_ready_to_display = serializers.BooleanField(read_only=True)
+    is_ready_to_show = serializers.BooleanField(read_only=True)
     urls = serializers.SerializerMethodField()
 
     def create(self, validated_data):
@@ -268,7 +268,7 @@ class VideoSerializer(serializers.ModelSerializer):
             "active_stamp",
             "description",
             "id",
-            "is_ready_to_play",
+            "is_ready_to_show",
             "timed_text_tracks",
             "thumbnail",
             "title",
@@ -279,7 +279,7 @@ class VideoSerializer(serializers.ModelSerializer):
         read_only_fields = (
             "id",
             "active_stamp",
-            "is_ready_to_play",
+            "is_ready_to_show",
             "upload_state",
             "urls",
         )
@@ -292,7 +292,7 @@ class VideoSerializer(serializers.ModelSerializer):
     )
     thumbnail = ThumbnailSerializer(read_only=True, allow_null=True)
     urls = serializers.SerializerMethodField()
-    is_ready_to_play = serializers.BooleanField(read_only=True)
+    is_ready_to_show = serializers.BooleanField(read_only=True)
 
     def get_urls(self, obj):
         """Urls of the video for each type of encoding.
@@ -439,7 +439,7 @@ class DocumentSerializer(serializers.ModelSerializer):
         fields = (
             "active_stamp",
             "id",
-            "is_ready_to_display",
+            "is_ready_to_show",
             "title",
             "upload_state",
             "url",
@@ -448,7 +448,7 @@ class DocumentSerializer(serializers.ModelSerializer):
         read_only_fields = (
             "id",
             "active_stamp",
-            "is_ready_to_display",
+            "is_ready_to_show",
             "upload_state",
             "url",
         )
@@ -457,7 +457,7 @@ class DocumentSerializer(serializers.ModelSerializer):
         source="uploaded_on", required=False, allow_null=True, read_only=True
     )
     url = serializers.SerializerMethodField()
-    is_ready_to_display = serializers.BooleanField(read_only=True)
+    is_ready_to_show = serializers.BooleanField(read_only=True)
 
     def get_url(self, obj):
         """Url of the Document.

--- a/src/backend/marsha/core/tests/test_api_document.py
+++ b/src/backend/marsha/core/tests/test_api_document.py
@@ -76,7 +76,7 @@ class DocumentAPITest(TestCase):
             {
                 "active_stamp": "1533686400",
                 "id": str(document.id),
-                "is_ready_to_display": True,
+                "is_ready_to_show": True,
                 "title": document.title,
                 "upload_state": "ready",
                 "url": "https://abc.cloudfront.net/4c51f469-f91e-4998-b438-e31ee3bd3ea6/"

--- a/src/backend/marsha/core/tests/test_api_thumbnail.py
+++ b/src/backend/marsha/core/tests/test_api_thumbnail.py
@@ -91,7 +91,7 @@ class ThumbnailApiTest(TestCase):
             {
                 "id": str(thumbnail.id),
                 "active_stamp": None,
-                "is_ready_to_display": False,
+                "is_ready_to_show": False,
                 "upload_state": "pending",
                 "urls": None,
                 "video": str(video.id),
@@ -140,7 +140,7 @@ class ThumbnailApiTest(TestCase):
             {
                 "id": str(thumbnail.id),
                 "active_stamp": None,
-                "is_ready_to_display": False,
+                "is_ready_to_show": False,
                 "upload_state": "pending",
                 "urls": None,
                 "video": str(video.id),
@@ -178,7 +178,7 @@ class ThumbnailApiTest(TestCase):
             {
                 "id": str(thumbnail.id),
                 "active_stamp": "1533686400",
-                "is_ready_to_display": True,
+                "is_ready_to_show": True,
                 "upload_state": "ready",
                 "urls": {
                     "144": "https://abc.cloudfront.net/78338c1c-356e-4156-bd95-5bed71ffb655/"
@@ -237,7 +237,7 @@ class ThumbnailApiTest(TestCase):
             {
                 "id": str(created_thumbnail.id),
                 "active_stamp": None,
-                "is_ready_to_display": False,
+                "is_ready_to_show": False,
                 "upload_state": "pending",
                 "urls": None,
                 "video": str(video.id),

--- a/src/backend/marsha/core/tests/test_api_timed_text_track.py
+++ b/src/backend/marsha/core/tests/test_api_timed_text_track.py
@@ -169,7 +169,7 @@ class TimedTextTrackAPITest(TestCase):
             content,
             {
                 "active_stamp": "1533686400",
-                "is_ready_to_play": True,
+                "is_ready_to_show": True,
                 "id": str(timed_text_track.id),
                 "mode": "cc",
                 "language": "fr",
@@ -220,7 +220,7 @@ class TimedTextTrackAPITest(TestCase):
             content,
             {
                 "active_stamp": "1533686400",
-                "is_ready_to_play": True,
+                "is_ready_to_show": True,
                 "id": str(timed_text_track.id),
                 "mode": "cc",
                 "language": "fr",
@@ -430,7 +430,7 @@ class TimedTextTrackAPITest(TestCase):
             {
                 "id": str(TimedTextTrack.objects.first().id),
                 "active_stamp": None,
-                "is_ready_to_play": False,
+                "is_ready_to_show": False,
                 "mode": "st",
                 "language": "fr",
                 "upload_state": "pending",

--- a/src/backend/marsha/core/tests/test_api_video.py
+++ b/src/backend/marsha/core/tests/test_api_video.py
@@ -152,14 +152,14 @@ class VideoAPITest(TestCase):
                 "id": str(video.id),
                 "title": video.title,
                 "active_stamp": "1533686400",
-                "is_ready_to_play": True,
+                "is_ready_to_show": True,
                 "show_download": True,
                 "upload_state": "ready",
                 "thumbnail": None,
                 "timed_text_tracks": [
                     {
                         "active_stamp": "1533686400",
-                        "is_ready_to_play": True,
+                        "is_ready_to_show": True,
                         "mode": "cc",
                         "id": str(timed_text_track.id),
                         "language": "fr",
@@ -245,7 +245,7 @@ class VideoAPITest(TestCase):
                 "id": str(video.id),
                 "title": video.title,
                 "active_stamp": None,
-                "is_ready_to_play": False,
+                "is_ready_to_show": False,
                 "show_download": True,
                 "upload_state": "pending",
                 "timed_text_tracks": [],
@@ -279,7 +279,7 @@ class VideoAPITest(TestCase):
                 "id": str(video.id),
                 "title": video.title,
                 "active_stamp": None,
-                "is_ready_to_play": False,
+                "is_ready_to_show": False,
                 "show_download": True,
                 "upload_state": state,
                 "timed_text_tracks": [],
@@ -398,7 +398,7 @@ class VideoAPITest(TestCase):
             {
                 "active_stamp": "1533686400",
                 "id": str(thumbnail.id),
-                "is_ready_to_display": True,
+                "is_ready_to_show": True,
                 "upload_state": "ready",
                 "urls": {
                     "144": "https://abc.cloudfront.net/38a91911-9aee-41e2-94dd-573abda6f48f/"

--- a/src/backend/marsha/core/tests/test_views_lti_video.py
+++ b/src/backend/marsha/core/tests/test_views_lti_video.py
@@ -75,7 +75,7 @@ class VideoViewTestCase(TestCase):
             context.get("resource"),
             {
                 "active_stamp": None,
-                "is_ready_to_play": False,
+                "is_ready_to_show": False,
                 "show_download": True,
                 "description": video.description,
                 "id": str(video.id),
@@ -140,7 +140,7 @@ class VideoViewTestCase(TestCase):
             context.get("resource"),
             {
                 "active_stamp": None,
-                "is_ready_to_play": False,
+                "is_ready_to_show": False,
                 "show_download": True,
                 "description": video.description,
                 "id": str(video.id),
@@ -194,7 +194,7 @@ class VideoViewTestCase(TestCase):
             context.get("resource"),
             {
                 "active_stamp": None,
-                "is_ready_to_play": False,
+                "is_ready_to_show": False,
                 "show_download": True,
                 "description": video.description,
                 "id": str(video.id),
@@ -257,7 +257,7 @@ class VideoViewTestCase(TestCase):
             context.get("resource"),
             {
                 "active_stamp": None,
-                "is_ready_to_play": False,
+                "is_ready_to_show": False,
                 "show_download": True,
                 "description": video.description,
                 "id": str(video.id),
@@ -526,7 +526,7 @@ class DevelopmentViewsTestCase(TestCase):
             context.get("resource"),
             {
                 "active_stamp": None,
-                "is_ready_to_play": False,
+                "is_ready_to_show": False,
                 "show_download": True,
                 "description": video.description,
                 "id": str(video.id),
@@ -580,7 +580,7 @@ class DevelopmentViewsTestCase(TestCase):
             context.get("resource"),
             {
                 "active_stamp": None,
-                "is_ready_to_play": False,
+                "is_ready_to_show": False,
                 "show_download": True,
                 "description": video.description,
                 "id": str(video.id),
@@ -631,7 +631,7 @@ class DevelopmentViewsTestCase(TestCase):
             context.get("resource"),
             {
                 "active_stamp": None,
-                "is_ready_to_play": False,
+                "is_ready_to_show": False,
                 "show_download": True,
                 "description": video.description,
                 "id": str(video.id),

--- a/src/frontend/components/DashboardDocument/index.spec.tsx
+++ b/src/frontend/components/DashboardDocument/index.spec.tsx
@@ -26,7 +26,7 @@ describe('<DashboardDocument />', () => {
     const document = {
       description: '',
       id: '44',
-      is_ready_to_display: true,
+      is_ready_to_show: true,
       show_download: true,
       title: 'foo.pdf',
       upload_state: uploadState.PROCESSING,
@@ -37,7 +37,7 @@ describe('<DashboardDocument />', () => {
       '/api/documents/44/',
       JSON.stringify({
         ...document,
-        is_ready_to_display: false,
+        is_ready_to_show: false,
         upload_state: uploadState.PROCESSING,
       }),
     );
@@ -73,7 +73,7 @@ describe('<DashboardDocument />', () => {
       '/api/documents/44/',
       JSON.stringify({
         ...document,
-        is_ready_to_display: true,
+        is_ready_to_show: true,
         upload_state: uploadState.READY,
       }),
     );
@@ -94,7 +94,7 @@ describe('<DashboardDocument />', () => {
     const document = {
       description: '',
       id: '45',
-      is_ready_to_display: true,
+      is_ready_to_show: true,
       show_download: true,
       title: 'foo.pdf',
       upload_state: uploadState.PENDING,
@@ -114,7 +114,7 @@ describe('<DashboardDocument />', () => {
     const document = {
       description: '',
       id: '45',
-      is_ready_to_display: true,
+      is_ready_to_show: true,
       show_download: true,
       title: 'foo.pdf',
       upload_state: uploadState.ERROR,
@@ -135,7 +135,7 @@ describe('<DashboardDocument />', () => {
     const document = {
       description: '',
       id: '45',
-      is_ready_to_display: true,
+      is_ready_to_show: true,
       show_download: true,
       title: 'foo.pdf',
       upload_state: uploadState.READY,
@@ -171,7 +171,7 @@ describe('<DashboardDocument />', () => {
     const document = {
       description: '',
       id: '46',
-      is_ready_to_display: true,
+      is_ready_to_show: true,
       show_download: true,
       title: 'foo.pdf',
       upload_state: uploadState.READY,
@@ -223,7 +223,7 @@ describe('<DashboardDocument />', () => {
     const document = {
       description: '',
       id: '47',
-      is_ready_to_display: true,
+      is_ready_to_show: true,
       show_download: true,
       title: 'foo.pdf',
       upload_state: uploadState.READY,
@@ -267,7 +267,7 @@ describe('<DashboardDocument />', () => {
     const document = {
       description: '',
       id: '45',
-      is_ready_to_display: true,
+      is_ready_to_show: true,
       show_download: true,
       title: 'foo.pdf',
       upload_state: uploadState.UPLOADING,

--- a/src/frontend/components/DashboardThumbnail/index.spec.tsx
+++ b/src/frontend/components/DashboardThumbnail/index.spec.tsx
@@ -31,12 +31,12 @@ describe('<DashboardThumbnail />', () => {
   const video = {
     description: '',
     id: '43',
-    is_ready_to_play: true,
+    is_ready_to_show: true,
     show_download: true,
     thumbnail: {
       active_stamp: 128748302847,
       id: '42',
-      is_ready_to_display: true,
+      is_ready_to_show: true,
       upload_state: uploadState.READY,
       urls: {
         144: 'https://example.com/thumbnail/144',

--- a/src/frontend/components/DashboardThumbnail/index.tsx
+++ b/src/frontend/components/DashboardThumbnail/index.tsx
@@ -76,7 +76,7 @@ export const DashboardThumbnail = ({ video }: DashboardThumbnailProps) => {
 
       const incomingThumbnail: Thumbnail = await response.json();
       if (
-        incomingThumbnail.is_ready_to_display &&
+        incomingThumbnail.is_ready_to_show &&
         incomingThumbnail.upload_state === uploadState.READY
       ) {
         addThumbnail(incomingThumbnail);

--- a/src/frontend/components/DashboardThumbnailDisplay/index.spec.tsx
+++ b/src/frontend/components/DashboardThumbnailDisplay/index.spec.tsx
@@ -8,7 +8,7 @@ describe('<DashboardThumbnailDisplay />', () => {
   it('display images from thumbnail resource when ready', () => {
     const thumbnail = {
       id: 42,
-      is_ready_to_display: true,
+      is_ready_to_show: true,
       urls: {
         144: 'https://example.com/thumbnail/144.jpg',
         240: 'https://example.com/thumbnail/240.jpg',
@@ -52,7 +52,7 @@ describe('<DashboardThumbnailDisplay />', () => {
   it('display images from video resource when thumbnail resource is not ready', () => {
     const thumbnail = {
       id: 42,
-      is_ready_to_display: false,
+      is_ready_to_show: false,
       urls: {
         144: 'https://example.com/thumbnail/144.jpg',
         240: 'https://example.com/thumbnail/240.jpg',

--- a/src/frontend/components/DashboardThumbnailDisplay/index.tsx
+++ b/src/frontend/components/DashboardThumbnailDisplay/index.tsx
@@ -24,7 +24,7 @@ export const DashboardThumbnailDisplay = ({
   thumbnail,
 }: DashboardThumbnailDisplayProps) => {
   const urls =
-    thumbnail && thumbnail.is_ready_to_display
+    thumbnail && thumbnail.is_ready_to_show
       ? thumbnail.urls
       : video.urls.thumbnails;
   return (

--- a/src/frontend/components/DashboardTimedTextPane/index.spec.tsx
+++ b/src/frontend/components/DashboardTimedTextPane/index.spec.tsx
@@ -49,7 +49,7 @@ describe('<DashboardTimedTextPane />', () => {
   const video = {
     description: '',
     id: '43',
-    is_ready_to_play: true,
+    is_ready_to_show: true,
     show_download: true,
     thumbnail: null,
     timed_text_tracks: [
@@ -57,7 +57,7 @@ describe('<DashboardTimedTextPane />', () => {
       {
         active_stamp: 2094219242,
         id: '142',
-        is_ready_to_play: true,
+        is_ready_to_show: true,
         language: 'en',
         mode: timedTextMode.SUBTITLE,
         upload_state: uploadState.READY,
@@ -94,7 +94,7 @@ describe('<DashboardTimedTextPane />', () => {
       {
         active_stamp: 2094219242,
         id: '142',
-        is_ready_to_play: true,
+        is_ready_to_show: true,
         language: 'en',
         mode: timedTextMode.SUBTITLE,
         upload_state: uploadState.READY,
@@ -104,7 +104,7 @@ describe('<DashboardTimedTextPane />', () => {
       {
         active_stamp: 2094219242,
         id: '144',
-        is_ready_to_play: true,
+        is_ready_to_show: true,
         language: 'fr',
         mode: timedTextMode.CLOSED_CAPTIONING,
         upload_state: uploadState.READY,

--- a/src/frontend/components/DashboardVideoPane/index.spec.tsx
+++ b/src/frontend/components/DashboardVideoPane/index.spec.tsx
@@ -26,7 +26,7 @@ describe('<DashboardVideoPane />', () => {
   const video = {
     description: '',
     id: '43',
-    is_ready_to_play: true,
+    is_ready_to_show: true,
     show_download: true,
     thumbnail: null,
     timed_text_tracks: [],
@@ -149,12 +149,12 @@ describe('<DashboardVideoPane />', () => {
     getByText('Your video is ready to play.');
   });
 
-  it('redirects to error when the video is in the error state and not `is_ready_to_play`', () => {
+  it('redirects to error when the video is in the error state and not `is_ready_to_show`', () => {
     const { getByText } = render(
       wrapInIntlProvider(
         wrapInRouter(
           <DashboardVideoPane
-            video={{ ...video, is_ready_to_play: false, upload_state: ERROR }}
+            video={{ ...video, is_ready_to_show: false, upload_state: ERROR }}
           />,
           [
             {
@@ -171,11 +171,11 @@ describe('<DashboardVideoPane />', () => {
     getByText('Error Component: upload');
   });
 
-  it('shows the dashboard when the video is in the error state but `is_ready_to_play`', () => {
+  it('shows the dashboard when the video is in the error state but `is_ready_to_show`', async () => {
     const { getByText } = render(
       wrapInIntlProvider(
         <DashboardVideoPane
-          video={{ ...video, is_ready_to_play: true, upload_state: ERROR }}
+          video={{ ...video, is_ready_to_show: true, upload_state: ERROR }}
         />,
       ),
     );
@@ -194,7 +194,7 @@ describe('<DashboardVideoPane />', () => {
             <DashboardVideoPane
               video={{
                 ...video,
-                is_ready_to_play: false,
+                is_ready_to_show: false,
                 upload_state: state,
               }}
             />,
@@ -229,7 +229,7 @@ describe('<DashboardVideoPane />', () => {
             <DashboardVideoPane
               video={{
                 ...video,
-                is_ready_to_play: false,
+                is_ready_to_show: false,
                 upload_state: state,
               }}
             />,
@@ -253,7 +253,7 @@ describe('<DashboardVideoPane />', () => {
             <DashboardVideoPane
               video={{
                 ...video,
-                is_ready_to_play: false,
+                is_ready_to_show: false,
                 upload_state: state,
               }}
             />,

--- a/src/frontend/components/DashboardVideoPane/index.tsx
+++ b/src/frontend/components/DashboardVideoPane/index.tsx
@@ -96,7 +96,7 @@ export const DashboardVideoPane = ({ video }: DashboardVideoPaneProps) => {
     return <Redirect push to={ERROR_COMPONENT_ROUTE('notFound')} />;
   }
 
-  if (!video.is_ready_to_play && video.upload_state === ERROR) {
+  if (!video.is_ready_to_show && video.upload_state === ERROR) {
     return <Redirect push to={ERROR_COMPONENT_ROUTE('upload')} />;
   }
 

--- a/src/frontend/components/DashboardVideoPaneDownloadOption/index.spec.tsx
+++ b/src/frontend/components/DashboardVideoPaneDownloadOption/index.spec.tsx
@@ -17,7 +17,7 @@ describe('<DashboardVideoPaneDownloadOption />', () => {
   const video = {
     description: 'Some description',
     id: '442',
-    is_ready_to_play: true,
+    is_ready_to_show: true,
     show_download: false,
     thumbnail: null,
     timed_text_tracks: [],

--- a/src/frontend/components/DocumentPlayer/index.spec.tsx
+++ b/src/frontend/components/DocumentPlayer/index.spec.tsx
@@ -9,7 +9,7 @@ jest.mock('../../data/appData', () => ({
     document: {
       description: '',
       id: '42',
-      is_ready_to_display: true,
+      is_ready_to_show: true,
       show_download: true,
       title: 'foo.pdf',
       upload_state: 'ready',
@@ -23,7 +23,7 @@ describe('<DocumentPlayer />', () => {
     const document = {
       description: '',
       id: '42',
-      is_ready_to_display: true,
+      is_ready_to_show: true,
       show_download: true,
       title: 'foo.pdf',
       upload_state: uploadState.READY,
@@ -41,7 +41,7 @@ describe('<DocumentPlayer />', () => {
     const document = {
       description: '',
       id: '43',
-      is_ready_to_display: true,
+      is_ready_to_show: true,
       show_download: true,
       title: 'bar.pdf',
       upload_state: uploadState.READY,

--- a/src/frontend/components/DownloadVideo/index.spec.tsx
+++ b/src/frontend/components/DownloadVideo/index.spec.tsx
@@ -9,7 +9,7 @@ describe('<DownloadVideo />', () => {
   const video = {
     description: 'Some description',
     id: 'video-id',
-    is_ready_to_play: true,
+    is_ready_to_show: true,
     title: 'Some title',
     upload_state: 'ready',
     urls: {

--- a/src/frontend/components/RedirectOnLoad/index.spec.tsx
+++ b/src/frontend/components/RedirectOnLoad/index.spec.tsx
@@ -67,7 +67,7 @@ describe('<RedirectOnLoad />', () => {
     mockIsEditable = true;
 
     for (const state of Object.values(uploadState)) {
-      mockVideo = { is_ready_to_play: true, upload_state: state };
+      mockVideo = { is_ready_to_show: true, upload_state: state };
       const { getByText } = render(
         wrapInRouter(<RedirectOnLoad />, [
           {
@@ -89,7 +89,7 @@ describe('<RedirectOnLoad />', () => {
     mockIsEditable = true;
 
     for (const state of Object.values(uploadState)) {
-      mockDocument = { is_ready_to_display: true, upload_state: state };
+      mockDocument = { is_ready_to_show: true, upload_state: state };
       const { getByText } = render(
         wrapInRouter(<RedirectOnLoad />, [
           {
@@ -111,7 +111,7 @@ describe('<RedirectOnLoad />', () => {
     mockIsEditable = false;
 
     for (const state of Object.values(uploadState)) {
-      mockVideo = { is_ready_to_play: true, upload_state: state };
+      mockVideo = { is_ready_to_show: true, upload_state: state };
       const { getByText } = render(
         wrapInRouter(<RedirectOnLoad />, [
           {
@@ -133,7 +133,7 @@ describe('<RedirectOnLoad />', () => {
     mockIsEditable = false;
 
     for (const state of Object.values(uploadState)) {
-      mockDocument = { is_ready_to_display: true, upload_state: state };
+      mockDocument = { is_ready_to_show: true, upload_state: state };
       const { getByText } = render(
         wrapInRouter(<RedirectOnLoad />, [
           {
@@ -152,7 +152,7 @@ describe('<RedirectOnLoad />', () => {
     mockState = appState.SUCCESS;
     mockVideo = {
       id: '42',
-      is_ready_to_play: false,
+      is_ready_to_show: false,
       upload_state: uploadState.PENDING,
     };
     mockModelName = modelName.VIDEOS;
@@ -179,7 +179,7 @@ describe('<RedirectOnLoad />', () => {
     mockModelName = modelName.DOCUMENTS;
     mockDocument = {
       id: '42',
-      is_ready_to_display: false,
+      is_ready_to_show: false,
       upload_state: uploadState.PENDING,
     };
     mockIsEditable = true;
@@ -201,7 +201,7 @@ describe('<RedirectOnLoad />', () => {
   it('redirects instructors to /dashboard when there is a video undergoing processing', () => {
     mockState = appState.SUCCESS;
     mockVideo = {
-      is_ready_to_play: false,
+      is_ready_to_show: false,
       upload_state: uploadState.PROCESSING,
     };
     mockModelName = modelName.VIDEOS;
@@ -227,7 +227,7 @@ describe('<RedirectOnLoad />', () => {
     mockVideo = null;
     mockModelName = modelName.DOCUMENTS;
     mockDocument = {
-      is_ready_to_display: false,
+      is_ready_to_show: false,
       upload_state: uploadState.PROCESSING,
     };
     mockIsEditable = true;
@@ -249,7 +249,7 @@ describe('<RedirectOnLoad />', () => {
   it('redirects students to the error view when the video is not ready', () => {
     mockState = appState.SUCCESS;
     mockVideo = {
-      is_ready_to_play: false,
+      is_ready_to_show: false,
       upload_state: uploadState.PROCESSING,
     };
     mockModelName = modelName.VIDEOS;
@@ -273,7 +273,7 @@ describe('<RedirectOnLoad />', () => {
   it('redirects students to the error view when the document is not ready', () => {
     mockState = appState.SUCCESS;
     mockDocument = {
-      is_ready_to_display: false,
+      is_ready_to_show: false,
       upload_state: uploadState.PROCESSING,
     };
     mockModelName = modelName.DOCUMENTS;

--- a/src/frontend/components/RedirectOnLoad/index.tsx
+++ b/src/frontend/components/RedirectOnLoad/index.tsx
@@ -3,9 +3,8 @@ import { Redirect } from 'react-router-dom';
 
 import { appData } from '../../data/appData';
 import { appState } from '../../types/AppData';
-import { Document } from '../../types/file';
 import { modelName } from '../../types/models';
-import { uploadState, Video } from '../../types/tracks';
+import { uploadState } from '../../types/tracks';
 import { DASHBOARD_ROUTE } from '../Dashboard/route';
 import { DOCUMENT_PLAYER_ROUTE } from '../DocumentPlayer/route';
 import { ERROR_COMPONENT_ROUTE } from '../ErrorComponent/route';
@@ -25,7 +24,7 @@ export const RedirectOnLoad = () => {
   if (
     appData.modelName === modelName.VIDEOS &&
     resource &&
-    (resource as Video).is_ready_to_play
+    resource.is_ready_to_show
   ) {
     return <Redirect push to={VIDEO_PLAYER_ROUTE()} />;
   }
@@ -33,7 +32,7 @@ export const RedirectOnLoad = () => {
   if (
     appData.modelName === modelName.DOCUMENTS &&
     resource &&
-    (resource as Document).is_ready_to_display
+    resource.is_ready_to_show
   ) {
     return <Redirect push to={DOCUMENT_PLAYER_ROUTE()} />;
   }

--- a/src/frontend/components/TimedTextCreationForm/index.spec.tsx
+++ b/src/frontend/components/TimedTextCreationForm/index.spec.tsx
@@ -62,7 +62,7 @@ describe('<TimedTextCreationForm />', () => {
       {
         active_stamp: null,
         id: '42',
-        is_ready_to_play: false,
+        is_ready_to_show: false,
         language: 'en',
         mode: timedTextMode.SUBTITLE,
         upload_state: uploadState.PENDING,

--- a/src/frontend/components/TimedTextListItem/index.spec.tsx
+++ b/src/frontend/components/TimedTextListItem/index.spec.tsx
@@ -41,12 +41,12 @@ describe('<TimedTextListItem />', () => {
   const video = {
     description: '',
     id: '43',
-    is_ready_to_play: true,
+    is_ready_to_show: true,
     show_download: true,
     thumbnail: {
       active_stamp: 128748302847,
       id: '42',
-      is_ready_to_display: true,
+      is_ready_to_show: true,
       upload_state: uploadState.READY,
       urls: {
         144: 'https://example.com/thumbnail/144',
@@ -90,7 +90,7 @@ describe('<TimedTextListItem />', () => {
             track={{
               active_stamp: 28271937429,
               id: '42',
-              is_ready_to_play: true,
+              is_ready_to_show: true,
               language: 'fr',
               mode: timedTextMode.SUBTITLE,
               title: 'foo',
@@ -116,7 +116,7 @@ describe('<TimedTextListItem />', () => {
     const track = {
       active_stamp: 28271937429,
       id: '1',
-      is_ready_to_play: false,
+      is_ready_to_show: false,
       language: 'fr',
       mode: timedTextMode.SUBTITLE,
       title: 'foo',
@@ -175,7 +175,7 @@ describe('<TimedTextListItem />', () => {
     const track = {
       active_stamp: 28271937429,
       id: '1',
-      is_ready_to_play: false,
+      is_ready_to_show: false,
       language: 'fr',
       mode: timedTextMode.SUBTITLE,
       title: 'foo',
@@ -205,7 +205,7 @@ describe('<TimedTextListItem />', () => {
 
     const updatedTrack = {
       ...track,
-      is_ready_to_play: true,
+      is_ready_to_show: true,
       upload_state: uploadState.READY,
     };
     fetchMock.restore();
@@ -237,7 +237,7 @@ describe('<TimedTextListItem />', () => {
               track={{
                 active_stamp: 28271937429,
                 id: '42',
-                is_ready_to_play: true,
+                is_ready_to_show: true,
                 language: 'fr',
                 mode: timedTextMode.SUBTITLE,
                 title: 'foo',

--- a/src/frontend/components/TimedTextListItem/index.tsx
+++ b/src/frontend/components/TimedTextListItem/index.tsx
@@ -77,7 +77,7 @@ export const TimedTextListItem = ({ track }: TimedTextListItemProps) => {
   useEffect(() => {
     getChoices();
 
-    if (track.is_ready_to_play === false) {
+    if (track.is_ready_to_show === false) {
       window.setTimeout(async () => {
         const result = await pollForTrack(modelName.TIMEDTEXTTRACKS, track.id);
         if (result === requestStatus.FAILURE) {

--- a/src/frontend/components/TranscriptReader/index.spec.tsx
+++ b/src/frontend/components/TranscriptReader/index.spec.tsx
@@ -46,7 +46,7 @@ jest.mock('../TranscriptSentence', () => ({
 const transcript = {
   active_stamp: 234243242353,
   id: '1',
-  is_ready_to_play: true,
+  is_ready_to_show: true,
   language: 'fr',
   mode: timedTextMode.TRANSCRIPT as timedTextMode.TRANSCRIPT,
   title: 'foo',

--- a/src/frontend/components/Transcripts/index.spec.tsx
+++ b/src/frontend/components/Transcripts/index.spec.tsx
@@ -29,7 +29,7 @@ const transcripts = [
   {
     active_stamp: 234243242353,
     id: '1',
-    is_ready_to_play: true,
+    is_ready_to_show: true,
     language: 'fr',
     mode: timedTextMode.TRANSCRIPT as timedTextMode.TRANSCRIPT,
     title: 'foo',
@@ -40,7 +40,7 @@ const transcripts = [
   {
     active_stamp: 1243401243953,
     id: '2',
-    is_ready_to_play: true,
+    is_ready_to_show: true,
     language: 'en',
     mode: timedTextMode.TRANSCRIPT as timedTextMode.TRANSCRIPT,
     title: 'foo',

--- a/src/frontend/components/UploadForm/index.spec.tsx
+++ b/src/frontend/components/UploadForm/index.spec.tsx
@@ -37,14 +37,14 @@ describe('UploadForm', () => {
   const object = {
     description: 'Some description',
     id: 'video-id',
-    is_ready_to_play: true,
+    is_ready_to_show: true,
     show_download: false,
     thumbnail: null,
     timed_text_tracks: [
       {
         active_stamp: 1549385921,
         id: 'ttt-1',
-        is_ready_to_play: true,
+        is_ready_to_show: true,
         language: 'fr',
         mode: timedTextMode.SUBTITLE,
         upload_state: uploadState.READY,
@@ -53,7 +53,7 @@ describe('UploadForm', () => {
       {
         active_stamp: 1549385922,
         id: 'ttt-2',
-        is_ready_to_play: false,
+        is_ready_to_show: false,
         language: 'fr',
         mode: timedTextMode.SUBTITLE,
         upload_state: uploadState.READY,
@@ -62,7 +62,7 @@ describe('UploadForm', () => {
       {
         active_stamp: 1549385923,
         id: 'ttt-3',
-        is_ready_to_play: true,
+        is_ready_to_show: true,
         language: 'en',
         mode: timedTextMode.CLOSED_CAPTIONING,
         upload_state: uploadState.READY,
@@ -71,7 +71,7 @@ describe('UploadForm', () => {
       {
         active_stamp: 1549385924,
         id: 'ttt-4',
-        is_ready_to_play: true,
+        is_ready_to_show: true,
         language: 'fr',
         mode: timedTextMode.TRANSCRIPT,
         upload_state: uploadState.READY,

--- a/src/frontend/components/VideoPlayer/index.spec.tsx
+++ b/src/frontend/components/VideoPlayer/index.spec.tsx
@@ -35,14 +35,14 @@ jest.mock('../../data/appData', () => ({
     video: {
       description: 'Some description',
       id: 'video-id',
-      is_ready_to_play: true,
+      is_ready_to_show: true,
       show_download: false,
       thumbnail: null,
       timed_text_tracks: [
         {
           active_stamp: 1549385921,
           id: 'ttt-1',
-          is_ready_to_play: true,
+          is_ready_to_show: true,
           language: 'fr',
           mode: 'st',
           upload_state: 'ready',
@@ -51,7 +51,7 @@ jest.mock('../../data/appData', () => ({
         {
           active_stamp: 1549385922,
           id: 'ttt-2',
-          is_ready_to_play: false,
+          is_ready_to_show: false,
           language: 'fr',
           mode: 'st',
           upload_state: 'ready',
@@ -60,7 +60,7 @@ jest.mock('../../data/appData', () => ({
         {
           active_stamp: 1549385923,
           id: 'ttt-3',
-          is_ready_to_play: true,
+          is_ready_to_show: true,
           language: 'en',
           mode: 'cc',
           upload_state: 'ready',
@@ -69,7 +69,7 @@ jest.mock('../../data/appData', () => ({
         {
           active_stamp: 1549385924,
           id: 'ttt-4',
-          is_ready_to_play: true,
+          is_ready_to_show: true,
           language: 'fr',
           mode: 'ts',
           upload_state: 'ready',

--- a/src/frontend/components/VideoPlayer/index.tsx
+++ b/src/frontend/components/VideoPlayer/index.tsx
@@ -113,11 +113,11 @@ const VideoPlayer = ({
   }
 
   const transcripts = timedTextTracks
-    .filter(track => track.is_ready_to_play)
+    .filter(track => track.is_ready_to_show)
     .filter(track => timedTextMode.TRANSCRIPT === track.mode);
 
   const thumbnailUrls =
-    (thumbnail && thumbnail.is_ready_to_display && thumbnail.urls) ||
+    (thumbnail && thumbnail.is_ready_to_show && thumbnail.urls) ||
     video.urls.thumbnails;
 
   return (
@@ -153,7 +153,7 @@ const VideoPlayer = ({
           */}
         {player &&
           timedTextTracks
-            .filter(track => track.is_ready_to_play)
+            .filter(track => track.is_ready_to_show)
             .filter(track =>
               [
                 timedTextMode.CLOSED_CAPTIONING,

--- a/src/frontend/components/VideoPlayer/indexWithDashjs.spec.tsx
+++ b/src/frontend/components/VideoPlayer/indexWithDashjs.spec.tsx
@@ -19,14 +19,14 @@ jest.mock('../../data/appData', () => ({
     video: {
       description: 'Some description',
       id: 'video-id',
-      is_ready_to_play: true,
+      is_ready_to_show: true,
       show_download: false,
       thumbnail: null,
       timed_text_tracks: [
         {
           active_stamp: 1549385921,
           id: 'ttt-1',
-          is_ready_to_play: true,
+          is_ready_to_show: true,
           language: 'fr',
           mode: 'st',
           upload_state: 'ready',
@@ -35,7 +35,7 @@ jest.mock('../../data/appData', () => ({
         {
           active_stamp: 1549385922,
           id: 'ttt-2',
-          is_ready_to_play: false,
+          is_ready_to_show: false,
           language: 'fr',
           mode: 'st',
           upload_state: 'ready',
@@ -44,7 +44,7 @@ jest.mock('../../data/appData', () => ({
         {
           active_stamp: 1549385923,
           id: 'ttt-3',
-          is_ready_to_play: true,
+          is_ready_to_show: true,
           language: 'en',
           mode: 'cc',
           upload_state: 'ready',
@@ -53,7 +53,7 @@ jest.mock('../../data/appData', () => ({
         {
           active_stamp: 1549385924,
           id: 'ttt-4',
-          is_ready_to_play: true,
+          is_ready_to_show: true,
           language: 'fr',
           mode: 'ts',
           upload_state: 'ready',

--- a/src/frontend/data/sideEffects/getResourceList/index.spec.tsx
+++ b/src/frontend/data/sideEffects/getResourceList/index.spec.tsx
@@ -29,13 +29,13 @@ const mockAddMultipleResources = addMultipleResources as jestMockOf<
 describe('sideEffects/getResourceList', () => {
   const video42 = {
     id: '42',
-    is_ready_to_play: false,
+    is_ready_to_show: false,
     upload_state: uploadState.PENDING,
   } as Video;
 
   const video43 = {
     id: '43',
-    is_ready_to_play: true,
+    is_ready_to_show: true,
     upload_state: uploadState.READY,
   } as Video;
 
@@ -57,12 +57,12 @@ describe('sideEffects/getResourceList', () => {
     expect(mockAddMultipleResources).toHaveBeenCalledWith(modelName.VIDEOS, [
       {
         id: '42',
-        is_ready_to_play: false,
+        is_ready_to_show: false,
         upload_state: uploadState.PENDING,
       },
       {
         id: '43',
-        is_ready_to_play: true,
+        is_ready_to_show: true,
         upload_state: uploadState.READY,
       },
     ]);

--- a/src/frontend/data/sideEffects/pollForTrack/index.spec.tsx
+++ b/src/frontend/data/sideEffects/pollForTrack/index.spec.tsx
@@ -21,7 +21,7 @@ describe('sideEffects/pollForTrack', () => {
   it('polls the track, backing off until it is ready and resolves with a success', async () => {
     fetchMock.mock(
       '/api/videos/42/',
-      JSON.stringify({ is_ready_to_play: false }),
+      JSON.stringify({ is_ready_to_show: false }),
       { method: 'GET' },
     );
     const promise = pollForTrack(modelName.VIDEOS, '42', 15);
@@ -48,7 +48,7 @@ describe('sideEffects/pollForTrack', () => {
 
     fetchMock.mock(
       '/api/videos/42/',
-      JSON.stringify({ is_ready_to_play: true }),
+      JSON.stringify({ is_ready_to_show: true }),
       { method: 'GET', overwriteRoutes: true },
     );
 
@@ -74,7 +74,7 @@ describe('sideEffects/pollForTrack', () => {
   it('polls a document, backing off until it is ready and resolves with a success', async () => {
     fetchMock.mock(
       '/api/documents/42/',
-      JSON.stringify({ is_ready_to_display: false }),
+      JSON.stringify({ is_ready_to_show: false }),
       { method: 'GET' },
     );
     const promise = pollForTrack(modelName.DOCUMENTS, '42', 15);
@@ -101,7 +101,7 @@ describe('sideEffects/pollForTrack', () => {
 
     fetchMock.mock(
       '/api/documents/42/',
-      JSON.stringify({ is_ready_to_display: true }),
+      JSON.stringify({ is_ready_to_show: true }),
       { method: 'GET', overwriteRoutes: true },
     );
 
@@ -127,7 +127,7 @@ describe('sideEffects/pollForTrack', () => {
   it('resolves with a failure and reports it when it fails to poll the track', async () => {
     fetchMock.mock(
       '/api/videos/42/',
-      JSON.stringify({ is_ready_to_play: false }),
+      JSON.stringify({ is_ready_to_show: false }),
       { method: 'GET' },
     );
     const promise = pollForTrack(modelName.VIDEOS, '42', 15);

--- a/src/frontend/data/sideEffects/pollForTrack/index.tsx
+++ b/src/frontend/data/sideEffects/pollForTrack/index.tsx
@@ -51,9 +51,9 @@ export async function pollForTrack<
 }
 
 const isReadyToPlay = (object: Document | Video | TimedText): boolean => {
-  if ((object as Document).is_ready_to_display !== undefined) {
-    return (object as Document).is_ready_to_display;
+  if ((object as Document).is_ready_to_show !== undefined) {
+    return (object as Document).is_ready_to_show;
   }
 
-  return (object as Video | TimedText).is_ready_to_play;
+  return (object as Video | TimedText).is_ready_to_show;
 };

--- a/src/frontend/data/sideEffects/updateResource/index.spec.ts
+++ b/src/frontend/data/sideEffects/updateResource/index.spec.ts
@@ -12,7 +12,7 @@ describe('sideEffects/updateResource', () => {
   const video = {
     description: 'Some description',
     id: 'video-id',
-    is_ready_to_play: true,
+    is_ready_to_show: true,
     show_download: false,
     title: 'Some title',
     upload_state: 'ready',

--- a/src/frontend/data/sideEffects/upload/index.spec.ts
+++ b/src/frontend/data/sideEffects/upload/index.spec.ts
@@ -23,14 +23,14 @@ describe('upload', () => {
   const object = {
     description: 'Some description',
     id: 'video-id',
-    is_ready_to_play: true,
+    is_ready_to_show: true,
     show_download: false,
     thumbnail: null,
     timed_text_tracks: [
       {
         active_stamp: 1549385921,
         id: 'ttt-1',
-        is_ready_to_play: true,
+        is_ready_to_show: true,
         language: 'fr',
         mode: timedTextMode.SUBTITLE,
         upload_state: uploadState.READY,
@@ -39,7 +39,7 @@ describe('upload', () => {
       {
         active_stamp: 1549385922,
         id: 'ttt-2',
-        is_ready_to_play: false,
+        is_ready_to_show: false,
         language: 'fr',
         mode: timedTextMode.SUBTITLE,
         upload_state: uploadState.READY,
@@ -48,7 +48,7 @@ describe('upload', () => {
       {
         active_stamp: 1549385923,
         id: 'ttt-3',
-        is_ready_to_play: true,
+        is_ready_to_show: true,
         language: 'en',
         mode: timedTextMode.CLOSED_CAPTIONING,
         upload_state: uploadState.READY,
@@ -57,7 +57,7 @@ describe('upload', () => {
       {
         active_stamp: 1549385924,
         id: 'ttt-4',
-        is_ready_to_play: true,
+        is_ready_to_show: true,
         language: 'fr',
         mode: timedTextMode.TRANSCRIPT,
         upload_state: uploadState.READY,
@@ -143,7 +143,7 @@ describe('upload', () => {
     const thumbnail: Thumbnail = {
       active_stamp: null,
       id: 'thumb1',
-      is_ready_to_display: false,
+      is_ready_to_show: false,
       upload_state: uploadState.PENDING,
       urls: {
         144: 'https://example.com/144p.jpg',

--- a/src/frontend/data/stores/useThumbnail/index.spec.tsx
+++ b/src/frontend/data/stores/useThumbnail/index.spec.tsx
@@ -10,7 +10,7 @@ jest.mock('../../appData', () => ({
       thumbnail: {
         active_stamp: '1564494507',
         id: 'c0ea0fbc-5ce1-4340-a589-3db01d804045',
-        is_ready_to_display: true,
+        is_ready_to_show: true,
         upload_state: 'ready',
         urls: {
           144: 'https://example.com/144.jpg',
@@ -44,7 +44,7 @@ describe('stores/useThumbnail', () => {
       'c0ea0fbc-5ce1-4340-a589-3db01d804045': {
         active_stamp: '1564494507',
         id: 'c0ea0fbc-5ce1-4340-a589-3db01d804045',
-        is_ready_to_display: true,
+        is_ready_to_show: true,
         upload_state: 'ready',
         urls: {
           144: 'https://example.com/144.jpg',
@@ -59,7 +59,7 @@ describe('stores/useThumbnail', () => {
     expect(state.getThumbnail()).toEqual({
       active_stamp: '1564494507',
       id: 'c0ea0fbc-5ce1-4340-a589-3db01d804045',
-      is_ready_to_display: true,
+      is_ready_to_show: true,
       upload_state: 'ready',
       urls: {
         144: 'https://example.com/144.jpg',

--- a/src/frontend/data/stores/useTimedTextTrack/index.spec.tsx
+++ b/src/frontend/data/stores/useTimedTextTrack/index.spec.tsx
@@ -11,7 +11,7 @@ jest.mock('../../appData', () => ({
         {
           active_stamp: 1549385921,
           id: 'ttt-1',
-          is_ready_to_play: true,
+          is_ready_to_show: true,
           language: 'fr',
           mode: 'st',
           upload_state: 'ready',
@@ -20,7 +20,7 @@ jest.mock('../../appData', () => ({
         {
           active_stamp: 1549385922,
           id: 'ttt-2',
-          is_ready_to_play: false,
+          is_ready_to_show: false,
           language: 'fr',
           mode: 'st',
           upload_state: 'ready',
@@ -29,7 +29,7 @@ jest.mock('../../appData', () => ({
         {
           active_stamp: 1549385923,
           id: 'ttt-3',
-          is_ready_to_play: true,
+          is_ready_to_show: true,
           language: 'en',
           mode: 'cc',
           upload_state: 'ready',
@@ -38,7 +38,7 @@ jest.mock('../../appData', () => ({
         {
           active_stamp: 1549385924,
           id: 'ttt-4',
-          is_ready_to_play: true,
+          is_ready_to_show: true,
           language: 'fr',
           mode: 'ts',
           upload_state: 'ready',
@@ -68,7 +68,7 @@ describe('stores/useTimedTextTrack', () => {
       'ttt-1': {
         active_stamp: 1549385921,
         id: 'ttt-1',
-        is_ready_to_play: true,
+        is_ready_to_show: true,
         language: 'fr',
         mode: 'st',
         upload_state: 'ready',
@@ -77,7 +77,7 @@ describe('stores/useTimedTextTrack', () => {
       'ttt-2': {
         active_stamp: 1549385922,
         id: 'ttt-2',
-        is_ready_to_play: false,
+        is_ready_to_show: false,
         language: 'fr',
         mode: 'st',
         upload_state: 'ready',
@@ -86,7 +86,7 @@ describe('stores/useTimedTextTrack', () => {
       'ttt-3': {
         active_stamp: 1549385923,
         id: 'ttt-3',
-        is_ready_to_play: true,
+        is_ready_to_show: true,
         language: 'en',
         mode: 'cc',
         upload_state: 'ready',
@@ -95,7 +95,7 @@ describe('stores/useTimedTextTrack', () => {
       'ttt-4': {
         active_stamp: 1549385924,
         id: 'ttt-4',
-        is_ready_to_play: true,
+        is_ready_to_show: true,
         language: 'fr',
         mode: 'ts',
         upload_state: 'ready',
@@ -106,7 +106,7 @@ describe('stores/useTimedTextTrack', () => {
       {
         active_stamp: 1549385921,
         id: 'ttt-1',
-        is_ready_to_play: true,
+        is_ready_to_show: true,
         language: 'fr',
         mode: 'st',
         upload_state: 'ready',
@@ -115,7 +115,7 @@ describe('stores/useTimedTextTrack', () => {
       {
         active_stamp: 1549385922,
         id: 'ttt-2',
-        is_ready_to_play: false,
+        is_ready_to_show: false,
         language: 'fr',
         mode: 'st',
         upload_state: 'ready',
@@ -124,7 +124,7 @@ describe('stores/useTimedTextTrack', () => {
       {
         active_stamp: 1549385923,
         id: 'ttt-3',
-        is_ready_to_play: true,
+        is_ready_to_show: true,
         language: 'en',
         mode: 'cc',
         upload_state: 'ready',
@@ -133,7 +133,7 @@ describe('stores/useTimedTextTrack', () => {
       {
         active_stamp: 1549385924,
         id: 'ttt-4',
-        is_ready_to_play: true,
+        is_ready_to_show: true,
         language: 'fr',
         mode: 'ts',
         upload_state: 'ready',

--- a/src/frontend/data/stores/useVideo/index.spec.tsx
+++ b/src/frontend/data/stores/useVideo/index.spec.tsx
@@ -11,14 +11,14 @@ jest.mock('../../appData', () => ({
     video: {
       description: 'Some description',
       id: 'video-id',
-      is_ready_to_play: true,
+      is_ready_to_show: true,
       show_download: false,
       thumbnail: null,
       timed_text_tracks: [
         {
           active_stamp: 1549385921,
           id: 'ttt-1',
-          is_ready_to_play: true,
+          is_ready_to_show: true,
           language: 'fr',
           mode: 'st',
           upload_state: 'ready',
@@ -27,7 +27,7 @@ jest.mock('../../appData', () => ({
         {
           active_stamp: 1549385922,
           id: 'ttt-2',
-          is_ready_to_play: false,
+          is_ready_to_show: false,
           language: 'fr',
           mode: 'st',
           upload_state: 'ready',
@@ -36,7 +36,7 @@ jest.mock('../../appData', () => ({
         {
           active_stamp: 1549385923,
           id: 'ttt-3',
-          is_ready_to_play: true,
+          is_ready_to_show: true,
           language: 'en',
           mode: 'cc',
           upload_state: 'ready',
@@ -45,7 +45,7 @@ jest.mock('../../appData', () => ({
         {
           active_stamp: 1549385924,
           id: 'ttt-4',
-          is_ready_to_play: true,
+          is_ready_to_show: true,
           language: 'fr',
           mode: 'ts',
           upload_state: 'ready',

--- a/src/frontend/types/file.ts
+++ b/src/frontend/types/file.ts
@@ -2,7 +2,7 @@ import { Resource, uploadState } from './tracks';
 
 export interface Document extends Resource {
   description: string;
-  is_ready_to_display: boolean;
+  is_ready_to_show: boolean;
   title: string;
   upload_state: uploadState;
   url: string;

--- a/src/frontend/types/tracks.ts
+++ b/src/frontend/types/tracks.ts
@@ -43,7 +43,7 @@ export enum timedTextMode {
 /** A timed text track record as it exists on the backend. */
 export interface TimedText extends Resource {
   active_stamp: Nullable<number>;
-  is_ready_to_play: boolean;
+  is_ready_to_show: boolean;
   language: string;
   mode: timedTextMode;
   upload_state: uploadState;
@@ -64,7 +64,7 @@ export type urls = { [key in videoSize]: string };
 
 /** A Thumbnail record as it exists on the backend. */
 export interface Thumbnail extends Resource {
-  is_ready_to_display: boolean;
+  is_ready_to_show: boolean;
   upload_state: uploadState;
   urls: urls;
   active_stamp: Nullable<number>;
@@ -74,7 +74,7 @@ export interface Thumbnail extends Resource {
 /** A Video record as it exists on the backend. */
 export interface Video extends Resource {
   description: string;
-  is_ready_to_play: boolean;
+  is_ready_to_show: boolean;
   show_download: boolean;
   thumbnail: Nullable<Thumbnail>;
   timed_text_tracks: TimedText[];


### PR DESCRIPTION
## Purpose

every resources have a property to know if they are ready to be shown
but they not have the same name. We decided to rename them in
is_ready_to_show.

## Proposal

- [x] rename `is_ready_to_*` properties in `is_ready_to_show`

closes #489
