### PR TITLE
♻️(front) create only one route to manage all players

### DIFF
--- a/src/frontend/components/AppRoutes/index.tsx
+++ b/src/frontend/components/AppRoutes/index.tsx
@@ -5,16 +5,15 @@ import { appData } from '../../data/appData';
 import { createPlayer } from '../../Player/createPlayer';
 import { modelName } from '../../types/models';
 import { DASHBOARD_ROUTE } from '../Dashboard/route';
-import { DOCUMENT_PLAYER_ROUTE } from '../DocumentPlayer/route';
 import { ErrorComponent } from '../ErrorComponent';
 import { ERROR_COMPONENT_ROUTE } from '../ErrorComponent/route';
 import { InstructorWrapper } from '../InstructorWrapper';
 import { Loader } from '../Loader';
 import { RedirectOnLoad } from '../RedirectOnLoad';
 import { REDIRECT_ON_LOAD_ROUTE } from '../RedirectOnLoad/route';
+import { PLAYER_ROUTE } from '../routes';
 import { UploadForm } from '../UploadForm';
 import { UPLOAD_FORM_ROUTE } from '../UploadForm/route';
-import { VIDEO_PLAYER_ROUTE } from '../VideoPlayer/route';
 
 const Dashboard = lazy(() => import('../Dashboard'));
 const DocumentPlayer = lazy(() => import('../DocumentPlayer'));
@@ -26,32 +25,32 @@ export const AppRoutes = () => (
       <Switch>
         <Route
           exact
-          path={VIDEO_PLAYER_ROUTE()}
-          render={() =>
-            appData.video ? (
-              <InstructorWrapper>
-                <VideoPlayer
-                  video={appData.video}
-                  createPlayer={createPlayer}
-                />
-              </InstructorWrapper>
-            ) : (
-              <Redirect push to={ERROR_COMPONENT_ROUTE('notFound')} />
-            )
-          }
-        />
-        <Route
-          exact
-          path={DOCUMENT_PLAYER_ROUTE()}
-          render={() =>
-            appData.document ? (
-              <InstructorWrapper>
-                <DocumentPlayer document={appData.document} />
-              </InstructorWrapper>
-            ) : (
-              <Redirect push to={ERROR_COMPONENT_ROUTE('notFound')} />
-            )
-          }
+          path={PLAYER_ROUTE()}
+          render={({ match }) => {
+            if (match.params.objectType === modelName.VIDEOS && appData.video) {
+              return (
+                <InstructorWrapper>
+                  <VideoPlayer
+                    video={appData.video}
+                    createPlayer={createPlayer}
+                  />
+                </InstructorWrapper>
+              );
+            }
+
+            if (
+              match.params.objectType === modelName.DOCUMENTS &&
+              appData.document
+            ) {
+              return (
+                <InstructorWrapper>
+                  <DocumentPlayer document={appData.document} />
+                </InstructorWrapper>
+              );
+            }
+
+            return <Redirect push to={ERROR_COMPONENT_ROUTE('notFound')} />;
+          }}
         />
         <Route
           exact

--- a/src/frontend/components/DashboardDocument/index.tsx
+++ b/src/frontend/components/DashboardDocument/index.tsx
@@ -15,7 +15,6 @@ import { DashboardObjectProgress } from '../DashboardObjectProgress';
 import { DashboardPaneButtons } from '../DashboardPaneButtons';
 import { DashboardPaneHelptext } from '../DashboardPaneHelptext';
 import DocumentPlayer from '../DocumentPlayer';
-import { DOCUMENT_PLAYER_ROUTE } from '../DocumentPlayer/route';
 import { UploadStatusPicker } from '../UploadStatusPicker';
 
 const { ERROR, PENDING, PROCESSING, READY, UPLOADING } = uploadState;
@@ -118,7 +117,6 @@ const DashboardDocument = (props: DashboardDocumentProps) => {
           <DashboardPaneButtons
             object={document}
             objectType={modelName.DOCUMENTS}
-            routePlayer={DOCUMENT_PLAYER_ROUTE()}
           />
         </DashboardDocumentInnerContainer>
       );
@@ -130,7 +128,6 @@ const DashboardDocument = (props: DashboardDocumentProps) => {
           <DashboardPaneButtons
             object={document}
             objectType={modelName.DOCUMENTS}
-            routePlayer={DOCUMENT_PLAYER_ROUTE()}
           />
         </DashboardDocumentInnerContainer>
       );
@@ -142,7 +139,6 @@ const DashboardDocument = (props: DashboardDocumentProps) => {
           <DashboardPaneButtons
             object={document}
             objectType={modelName.DOCUMENTS}
-            routePlayer={DOCUMENT_PLAYER_ROUTE()}
           />
         </DashboardDocumentInnerContainer>
       );
@@ -188,7 +184,6 @@ const DashboardDocument = (props: DashboardDocumentProps) => {
           <DashboardPaneButtons
             object={document}
             objectType={modelName.DOCUMENTS}
-            routePlayer={DOCUMENT_PLAYER_ROUTE()}
           />
         </DashboardDocumentInnerContainer>
       );

--- a/src/frontend/components/DashboardPaneButtons/index.spec.tsx
+++ b/src/frontend/components/DashboardPaneButtons/index.spec.tsx
@@ -6,7 +6,6 @@ import { modelName } from '../../types/models';
 import { uploadState, Video } from '../../types/tracks';
 import { wrapInIntlProvider } from '../../utils/tests/intl';
 import { wrapInRouter } from '../../utils/tests/router';
-import { VIDEO_PLAYER_ROUTE } from '../VideoPlayer/route';
 
 const { ERROR, PENDING, PROCESSING, READY, UPLOADING } = uploadState;
 
@@ -18,7 +17,6 @@ describe('<DashboardPaneButtons />', () => {
           <DashboardPaneButtons
             object={{ id: 'vid1', upload_state: READY } as Video}
             objectType={modelName.VIDEOS}
-            routePlayer={VIDEO_PLAYER_ROUTE()}
           />,
         ),
       ),
@@ -34,7 +32,6 @@ describe('<DashboardPaneButtons />', () => {
             <DashboardPaneButtons
               object={{ id: 'vid1', upload_state: state } as Video}
               objectType={modelName.VIDEOS}
-              routePlayer={VIDEO_PLAYER_ROUTE()}
             />,
           ),
         ),
@@ -51,7 +48,6 @@ describe('<DashboardPaneButtons />', () => {
           <DashboardPaneButtons
             object={{ id: 'vid1', upload_state: PENDING } as Video}
             objectType={modelName.VIDEOS}
-            routePlayer={VIDEO_PLAYER_ROUTE()}
           />,
         ),
       ),
@@ -65,7 +61,6 @@ describe('<DashboardPaneButtons />', () => {
             <DashboardPaneButtons
               object={{ id: 'vid1', upload_state: state } as Video}
               objectType={modelName.VIDEOS}
-              routePlayer={VIDEO_PLAYER_ROUTE()}
             />,
           ),
         ),

--- a/src/frontend/components/DashboardPaneButtons/index.tsx
+++ b/src/frontend/components/DashboardPaneButtons/index.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 import { Document } from '../../types/file';
 import { modelName } from '../../types/models';
 import { uploadState, Video } from '../../types/tracks';
+import { PLAYER_ROUTE } from '../routes';
 import { UPLOAD_FORM_ROUTE } from '../UploadForm/route';
 import { withLink } from '../withLink/withLink';
 
@@ -71,7 +72,6 @@ const DashboardButtonStyled = styled(BtnWithLink)`
 export interface DashboardPaneButtonsProps {
   object: Video | Document;
   objectType: modelName.VIDEOS | modelName.DOCUMENTS;
-  routePlayer: string;
 }
 
 /** Component. Displays buttons with links to the Player & the Form, adapting their state and
@@ -83,7 +83,6 @@ export interface DashboardPaneButtonsProps {
 export const DashboardPaneButtons = ({
   object,
   objectType,
-  routePlayer,
 }: DashboardPaneButtonsProps) => {
   const displayWatchBtn = object.upload_state === uploadState.READY;
 
@@ -108,7 +107,7 @@ export const DashboardPaneButtons = ({
         <DashboardButtonStyled
           label={<FormattedMessage {...messages[objectType].btnPlay} />}
           primary={displayWatchBtn}
-          to={routePlayer}
+          to={PLAYER_ROUTE(objectType)}
         />
       ) : null}
     </Box>

--- a/src/frontend/components/DashboardVideoPane/index.tsx
+++ b/src/frontend/components/DashboardVideoPane/index.tsx
@@ -18,7 +18,6 @@ import { DashboardThumbnail } from '../DashboardThumbnail';
 import { DashboardVideoPaneDownloadOption } from '../DashboardVideoPaneDownloadOption';
 import { ERROR_COMPONENT_ROUTE } from '../ErrorComponent/route';
 import { UploadStatusPicker } from '../UploadStatusPicker';
-import { VIDEO_PLAYER_ROUTE } from '../VideoPlayer/route';
 
 const { ERROR, PENDING, PROCESSING, READY, UPLOADING } = uploadState;
 
@@ -118,11 +117,7 @@ export const DashboardVideoPane = ({ video }: DashboardVideoPaneProps) => {
             objectType={modelName.VIDEOS}
             state={video.upload_state}
           />
-          <DashboardPaneButtons
-            object={video}
-            objectType={modelName.VIDEOS}
-            routePlayer={VIDEO_PLAYER_ROUTE()}
-          />
+          <DashboardPaneButtons object={video} objectType={modelName.VIDEOS} />
         </DashboardVideoPaneInnerContainer>
       );
 
@@ -166,11 +161,7 @@ export const DashboardVideoPane = ({ video }: DashboardVideoPaneProps) => {
               <DashboardThumbnail video={video} />
             </Box>
           </Box>
-          <DashboardPaneButtons
-            object={video}
-            objectType={modelName.VIDEOS}
-            routePlayer={VIDEO_PLAYER_ROUTE()}
-          />
+          <DashboardPaneButtons object={video} objectType={modelName.VIDEOS} />
         </DashboardVideoPaneInnerContainer>
       );
   }

--- a/src/frontend/components/DocumentPlayer/route.ts
+++ b/src/frontend/components/DocumentPlayer/route.ts
@@ -1,4 +1,0 @@
-/**
- * Route for the `<DocumentPlayer />` component.
- */
-export const DOCUMENT_PLAYER_ROUTE = () => '/player/document';

--- a/src/frontend/components/RedirectOnLoad/index.spec.tsx
+++ b/src/frontend/components/RedirectOnLoad/index.spec.tsx
@@ -6,10 +6,9 @@ import { modelName } from '../../types/models';
 import { uploadState } from '../../types/tracks';
 import { wrapInRouter } from '../../utils/tests/router';
 import { DASHBOARD_ROUTE } from '../Dashboard/route';
-import { DOCUMENT_PLAYER_ROUTE } from '../DocumentPlayer/route';
 import { ERROR_COMPONENT_ROUTE } from '../ErrorComponent/route';
+import { PLAYER_ROUTE } from '../routes';
 import { UPLOAD_FORM_ROUTE } from '../UploadForm/route';
-import { VIDEO_PLAYER_ROUTE } from '../VideoPlayer/route';
 import { RedirectOnLoad } from './index';
 
 let mockState: any;
@@ -71,7 +70,7 @@ describe('<RedirectOnLoad />', () => {
       const { getByText } = render(
         wrapInRouter(<RedirectOnLoad />, [
           {
-            path: VIDEO_PLAYER_ROUTE(),
+            path: PLAYER_ROUTE(modelName.VIDEOS),
             render: () => <span>video player</span>,
           },
         ]),
@@ -93,7 +92,7 @@ describe('<RedirectOnLoad />', () => {
       const { getByText } = render(
         wrapInRouter(<RedirectOnLoad />, [
           {
-            path: DOCUMENT_PLAYER_ROUTE(),
+            path: PLAYER_ROUTE(modelName.DOCUMENTS),
             render: () => <span>document player</span>,
           },
         ]),
@@ -115,7 +114,7 @@ describe('<RedirectOnLoad />', () => {
       const { getByText } = render(
         wrapInRouter(<RedirectOnLoad />, [
           {
-            path: VIDEO_PLAYER_ROUTE(),
+            path: PLAYER_ROUTE(modelName.VIDEOS),
             render: () => <span>video player</span>,
           },
         ]),
@@ -137,7 +136,7 @@ describe('<RedirectOnLoad />', () => {
       const { getByText } = render(
         wrapInRouter(<RedirectOnLoad />, [
           {
-            path: DOCUMENT_PLAYER_ROUTE(),
+            path: PLAYER_ROUTE(modelName.DOCUMENTS),
             render: () => <span>document player</span>,
           },
         ]),

--- a/src/frontend/components/RedirectOnLoad/index.tsx
+++ b/src/frontend/components/RedirectOnLoad/index.tsx
@@ -6,10 +6,9 @@ import { appState } from '../../types/AppData';
 import { modelName } from '../../types/models';
 import { uploadState } from '../../types/tracks';
 import { DASHBOARD_ROUTE } from '../Dashboard/route';
-import { DOCUMENT_PLAYER_ROUTE } from '../DocumentPlayer/route';
 import { ERROR_COMPONENT_ROUTE } from '../ErrorComponent/route';
+import { PLAYER_ROUTE } from '../routes';
 import { UPLOAD_FORM_ROUTE } from '../UploadForm/route';
-import { VIDEO_PLAYER_ROUTE } from '../VideoPlayer/route';
 
 // RedirectOnLoad assesses the initial state of the application using appData and determines the proper
 // route to load in the Router
@@ -21,20 +20,8 @@ export const RedirectOnLoad = () => {
     return <Redirect push to={ERROR_COMPONENT_ROUTE('lti')} />;
   }
 
-  if (
-    appData.modelName === modelName.VIDEOS &&
-    resource &&
-    resource.is_ready_to_show
-  ) {
-    return <Redirect push to={VIDEO_PLAYER_ROUTE()} />;
-  }
-
-  if (
-    appData.modelName === modelName.DOCUMENTS &&
-    resource &&
-    resource.is_ready_to_show
-  ) {
-    return <Redirect push to={DOCUMENT_PLAYER_ROUTE()} />;
+  if (resource && resource.is_ready_to_show) {
+    return <Redirect push to={PLAYER_ROUTE(appData.modelName)} />;
   }
 
   if (appData.isEditable) {

--- a/src/frontend/components/VideoPlayer/route.ts
+++ b/src/frontend/components/VideoPlayer/route.ts
@@ -1,4 +1,0 @@
-/**
- * Route for the `<VideoPlayer />` component.
- */
-export const VIDEO_PLAYER_ROUTE = () => '/player/video';

--- a/src/frontend/components/routes.ts
+++ b/src/frontend/components/routes.ts
@@ -1,0 +1,15 @@
+import { modelName } from '../types/models';
+
+/**
+ * Route for the player component.
+ * @param objectType The model name for the object we want to show
+ */
+export const PLAYER_ROUTE = (
+  objectType?: modelName.VIDEOS | modelName.DOCUMENTS,
+) => {
+  if (objectType) {
+    return `/player/${objectType}`;
+  }
+
+  return `/player/:objectType(${modelName.VIDEOS}|${modelName.DOCUMENTS})`;
+};

--- a/src/frontend/types/AppData.ts
+++ b/src/frontend/types/AppData.ts
@@ -14,5 +14,5 @@ export interface AppData {
   isEditable: boolean;
   video?: Nullable<Video>;
   document?: Nullable<Document>;
-  modelName: modelName;
+  modelName: modelName.VIDEOS | modelName.DOCUMENTS;
 }


### PR DESCRIPTION
## Purpose

It is redundant to declare a route for each player. They can have only
one specifying the resource targeted.

## Proposal

- [x] create one function `PLAYER_ROUTE` handling all players routes
- [x] use this new route instead of old one
- [x] remove unused routes

