### PR TITLE
manage documents url in cloudfront configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Create a File model which will be the base model for all the resources
   we will manage
 - create a property `RESOURCE_NAME` on models having a url
+- Use document title as filename when the user download it
 
 ## Changed
 

--- a/src/aws/cloudfront.tf
+++ b/src/aws/cloudfront.tf
@@ -81,6 +81,29 @@ resource "aws_cloudfront_distribution" "marsha_cloudfront_distribution" {
     viewer_protocol_policy = "redirect-to-https"
   }
 
+  ordered_cache_behavior {
+    path_pattern     = "*/document/*"
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = "${local.s3_destination_origin_id}"
+    trusted_signers  = ["${var.cloudfront_trusted_signer_id}"]
+
+    forwarded_values {
+      query_string = true
+      headers = ["Access-Control-Request-Headers", "Access-Control-Request-Method", "Origin"]
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+    compress               = true
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
   # Destination bucket: access to timed text tracks is restricted to signed urls/cookies
   ordered_cache_behavior {
     path_pattern     = "*/timedtext/*"

--- a/src/aws/lambda-encode/src/copyDocument.js
+++ b/src/aws/lambda-encode/src/copyDocument.js
@@ -18,7 +18,6 @@ module.exports = async (objectKey, sourceBucket) => {
       Body: sourceDocument.Body,
       Bucket: destinationBucket,
       Key: `${parts[0]}/document/${parts[3]}`,
-      ContentType: 'binary/octet-stream',
     })
     .promise();
 };

--- a/src/aws/lambda-encode/src/copyDocument.spec.js
+++ b/src/aws/lambda-encode/src/copyDocument.spec.js
@@ -36,7 +36,6 @@ describe('lambda-encore/src/copyDocument', () => {
       Body: 'input timed text',
       Bucket: 'destination bucket',
       Key: 'foo/document/bar',
-      ContentType: 'binary/octet-stream',
     })
   });
 })

--- a/src/backend/marsha/core/serializers.py
+++ b/src/backend/marsha/core/serializers.py
@@ -1,6 +1,7 @@
 """Define the structure of our API responses with Django Rest Framework serializers."""
 from datetime import timedelta
 import re
+from urllib.parse import quote_plus
 import uuid
 
 from django.conf import settings
@@ -477,11 +478,15 @@ class DocumentSerializer(serializers.ModelSerializer):
         if obj.uploaded_on is None:
             return None
 
-        url = "{protocol:s}://{cloudfront:s}/{pk!s}/document/{stamp:s}".format(
+        url = (
+            "{protocol:s}://{cloudfront:s}/{pk!s}/document/{stamp:s}"
+            "?response-content-disposition={content_disposition:s}"
+        ).format(
             protocol=settings.AWS_S3_URL_PROTOCOL,
             cloudfront=settings.CLOUDFRONT_DOMAIN,
             pk=obj.pk,
             stamp=time_utils.to_timestamp(obj.uploaded_on),
+            content_disposition=quote_plus("attachment; filename=" + obj.title),
         )
 
         # Sign the document urls only if the functionality is activated

--- a/src/backend/marsha/core/tests/test_api_document.py
+++ b/src/backend/marsha/core/tests/test_api_document.py
@@ -58,6 +58,7 @@ class DocumentAPITest(TestCase):
             pk="4c51f469-f91e-4998-b438-e31ee3bd3ea6",
             uploaded_on=datetime(2018, 8, 8, tzinfo=pytz.utc),
             upload_state="ready",
+            title="foo.pdf",
         )
 
         jwt_token = AccessToken()
@@ -80,7 +81,8 @@ class DocumentAPITest(TestCase):
                 "title": document.title,
                 "upload_state": "ready",
                 "url": "https://abc.cloudfront.net/4c51f469-f91e-4998-b438-e31ee3bd3ea6/"
-                "document/1533686400",
+                "document/1533686400"
+                "?response-content-disposition=attachment%3B+filename%3Dfoo.pdf",
                 "show_download": True,
             },
         )


### PR DESCRIPTION
## Purpose

The url for documents was missing in the cloudfront documentation and we used the default behaviour. We must add one for document forcing to sign the url

## Proposal

- [x] add a new ordered cache behavior in cloudfront configuration
- [x] allow to forward querystring to S3 bucket
- [x] use `response-content-tdisposition` querystring to change the content-disposition on the fly.

