### PR TITLE
default cloudfront rule must accept signed urls

### DIFF
--- a/src/aws/cloudfront.tf
+++ b/src/aws/cloudfront.tf
@@ -39,6 +39,7 @@ resource "aws_cloudfront_distribution" "marsha_cloudfront_distribution" {
     allowed_methods  = ["GET", "HEAD", "OPTIONS"]
     cached_methods   = ["GET", "HEAD", "OPTIONS"]
     target_origin_id = "${local.s3_destination_origin_id}"
+    trusted_signers  = ["${var.cloudfront_trusted_signer_id}"]
 
     forwarded_values {
       query_string = false
@@ -87,6 +88,72 @@ resource "aws_cloudfront_distribution" "marsha_cloudfront_distribution" {
     cached_methods   = ["GET", "HEAD", "OPTIONS"]
     target_origin_id = "${local.s3_destination_origin_id}"
     trusted_signers  = ["${var.cloudfront_trusted_signer_id}"]
+
+    forwarded_values {
+      query_string = false
+      headers = ["Access-Control-Request-Headers", "Access-Control-Request-Method", "Origin"]
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+    compress               = true
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  ordered_cache_behavior {
+    path_pattern     = "*/thumbnails/*"
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = "${local.s3_destination_origin_id}"
+
+    forwarded_values {
+      query_string = false
+      headers = ["Access-Control-Request-Headers", "Access-Control-Request-Method", "Origin"]
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+    compress               = true
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  ordered_cache_behavior {
+    path_pattern     = "*/cmaf/*"
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = "${local.s3_destination_origin_id}"
+
+    forwarded_values {
+      query_string = false
+      headers = ["Access-Control-Request-Headers", "Access-Control-Request-Method", "Origin"]
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+    compress               = true
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  ordered_cache_behavior {
+    path_pattern     = "*/previews/*"
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = "${local.s3_destination_origin_id}"
 
     forwarded_values {
       query_string = false

--- a/src/frontend/components/DashboardThumbnail/index.tsx
+++ b/src/frontend/components/DashboardThumbnail/index.tsx
@@ -66,7 +66,7 @@ export const DashboardThumbnail = ({ video }: DashboardThumbnailProps) => {
   const pollThumbnail = async () => {
     try {
       const response = await fetch(
-        `${API_ENDPOINT}/thumbnail/${thumbnail!.id}/`,
+        `${API_ENDPOINT}/${modelName.THUMBNAILS}/${thumbnail!.id}/`,
         {
           headers: {
             Authorization: `Bearer ${appData.jwt}`,


### PR DESCRIPTION
## Purpose

Our default cloudfront rule is "not" secure as it does not force to use
signed url. If a rule need to disable signed url we will explicitly
create one like we did for thumbnails

## Proposal

- [x] change the default rule to force using signed url
- [x] create missing rules removing signed url requirement
- [x] We also found a little bug, it;s out of the scope of this PR, the thumbnail url used to fetch the API was wrong.

