### PR TITLE
✨(gunicorn) configure worker and threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Rename all is_ready_to_* model properties to is_ready_to_show
 - Change filename when a user downloads a resource. It now uses the playlist title
   and upload timestamp and ended with the appropriate extension.
+- Change gunicorn configuration to increase number of threads, worker class and worker tmpdir
 
 ### Removed
 

--- a/docker/files/usr/local/etc/gunicorn/marsha.py
+++ b/docker/files/usr/local/etc/gunicorn/marsha.py
@@ -9,6 +9,9 @@ python_path = "/app"
 graceful_timeout = 90
 timeout = 90
 workers = 3
+worker_class = "gthread"
+worker_tmp_dir = "/dev/shm"
+threads = 6
 
 # Logging
 # Using '-' for the access log file makes gunicorn log accesses to stdout


### PR DESCRIPTION
## Purpose

The Gunicorn configuration we have is an example of how to configure Gunicorn when running Marsha in a container. We discovered that the number of workers and threads must be increased when Gunicorn is used in a container and the `tmpdir` used by workers should use a filesystem mounted in memory instead of a filesystem [1].

[1] https://pythonspeed.com/articles/gunicorn-in-docker/

## Proposal

- [x] update Gunicorn configuration:
  - increase the number of threads
  - change the worker class to use `gthread`
  - change worker tmpdir

