### PR TITLE
⬆️(dependencies) update @openfun/substr in lambda-encode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Change filename when a user downloads a resource. It now uses the playlist title
   and upload timestamp and ended with the appropriate extension.
 - Change gunicorn configuration to increase number of threads, worker class and worker tmpdir
+- Upgrade @openfun/subsrt in lambda-encode. Patched version parses most of srt files
+  (a critical feature for us)
 
 ### Removed
 

--- a/src/aws/lambda-encode/package.json
+++ b/src/aws/lambda-encode/package.json
@@ -7,7 +7,7 @@
   },
   "description": "Convert a source video to all the formats used in Marsha",
   "dependencies": {
-    "@openfun/subsrt": "1.0.1",
+    "@openfun/subsrt": "1.0.2",
     "aws-sdk": "2.524.0",
     "jimp": "0.8.0",
     "request": "2.88.0",

--- a/src/aws/lambda-encode/yarn.lock
+++ b/src/aws/lambda-encode/yarn.lock
@@ -539,10 +539,10 @@
   dependencies:
     core-js "^2.5.7"
 
-"@openfun/subsrt@1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@openfun/subsrt/-/subsrt-1.0.1.tgz#b735038ef887ffd185a19dd83766f0dc6c58a77b"
-  integrity sha512-zcfdY/q5QGJJkcsCuxIYX/z+8C0ySJfJK5yY2i3oMwylrTZhs80pgdlQnvt09urskb6B54vI6H5sJUitIAAlYA==
+"@openfun/subsrt@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@openfun/subsrt/-/subsrt-1.0.2.tgz#ef3bfc3db0ded11db8b0ecad5d370dfda9dce34a"
+  integrity sha512-sJKcj1KYC2MOR94vbGclas/C+Tut9GX9vkc80YavvJn2hcGnXSZbI+bW5wqA6P4bm3UsS4wgHF7u4dgTrA9sgQ==
 
 "@types/babel__core@^7.1.0":
   version "7.1.2"


### PR DESCRIPTION
## Purpose

A new release of @openfun/substr containing a patch we want is
available. We upgraded it in lambda-encode project.
Patched version parses most of srt files (a critical feature for us).

## Proposal

- [x] upgrade `@openfun/substr` in lambda-encode project

