### PR TITLE
♻️(front) create a dedicated component to manage document title form

### DIFF
--- a/src/frontend/components/DashboardDocument/index.spec.tsx
+++ b/src/frontend/components/DashboardDocument/index.spec.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, wait } from '@testing-library/react';
+import { render, wait } from '@testing-library/react';
 import fetchMock from 'fetch-mock';
 import { Grommet } from 'grommet';
 import React from 'react';
@@ -177,106 +177,6 @@ describe('<DashboardDocument />', () => {
     // show the player
     getByText('foo');
     expect(container.getElementsByClassName('icon-file-text2')).toHaveLength(1);
-  });
-
-  it('successfully update document title', async () => {
-    const document = {
-      description: '',
-      extension: 'pdf',
-      filename: 'bar_foo.pdf',
-      id: '46',
-      is_ready_to_show: true,
-      show_download: true,
-      title: 'foo.pdf',
-      upload_state: uploadState.READY,
-      url: 'https://example.com/document/45',
-    };
-
-    fetchMock.mock(
-      '/api/documents/46/',
-      JSON.stringify({
-        ...document,
-        title: 'Bar.pdf',
-      }),
-      { method: 'PUT' },
-    );
-
-    // wrap the component in a grommet provider to have a valid theme.
-    // Without it, the FormField component fail to render because it is a composed
-    // component using property in the theme.
-    const { getByText, container } = render(
-      wrapInIntlProvider(
-        wrapInRouter(
-          <Grommet>
-            <DashboardDocument document={document} />
-          </Grommet>,
-        ),
-      ),
-    );
-
-    getByText('Change document title');
-
-    // actual document title
-    getByText('foo.pdf');
-
-    const inputTitle = container.querySelector('#title');
-    fireEvent.change(inputTitle!, { target: { value: 'Bar.pdf' } });
-    fireEvent.click(getByText('Submit'));
-    await wait();
-
-    expect(fetchMock.called('/api/documents/46/', { method: 'PUT' })).toBe(
-      true,
-    );
-
-    // updated document title
-    getByText('Bar.pdf');
-    getByText('Title successfully updated');
-  });
-
-  it('fails to update document title', async () => {
-    const document = {
-      description: '',
-      extension: 'pdf',
-      filename: 'bar_foo.pdf',
-      id: '47',
-      is_ready_to_show: true,
-      show_download: true,
-      title: 'foo.pdf',
-      upload_state: uploadState.READY,
-      url: 'https://example.com/document/47',
-    };
-
-    fetchMock.mock('/api/documents/47/', 400, { method: 'PUT' });
-
-    // wrap the component in a grommet provider to have a valid theme.
-    // Without it, the FormField component fail to render because it is a composed
-    // component using property in the theme.
-    const { getByText, container } = render(
-      wrapInIntlProvider(
-        wrapInRouter(
-          <Grommet>
-            <DashboardDocument document={document} />
-          </Grommet>,
-        ),
-      ),
-    );
-    getByText('Change document title');
-
-    // actual document title
-    getByText('foo.pdf');
-
-    const inputTitle = container.querySelector('#title');
-    fireEvent.change(inputTitle!, { target: { value: 'Bar.pdf' } });
-    fireEvent.click(getByText('Submit'));
-    await wait();
-
-    expect(fetchMock.called('/api/documents/47/', { method: 'PUT' })).toBe(
-      true,
-    );
-
-    // document title is still the same
-    getByText('foo.pdf');
-    getByText('Impossible to update the title. Try again later.');
   });
 
   it('shows the progress bar when the document is uploading', () => {

--- a/src/frontend/components/DashboardDocument/index.tsx
+++ b/src/frontend/components/DashboardDocument/index.tsx
@@ -1,16 +1,15 @@
-import { Box, Button, Form, FormField, Text, TextInput } from 'grommet';
-import React, { useEffect, useState } from 'react';
+import { Box } from 'grommet';
+import React, { useEffect } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import styled from 'styled-components';
 
 import { pollForTrack } from '../../data/sideEffects/pollForTrack';
-import { updateResource } from '../../data/sideEffects/updateResource';
 import { useDocument } from '../../data/stores/useDocument';
 import { Document } from '../../types/file';
 import { modelName } from '../../types/models';
 import { uploadState } from '../../types/tracks';
-import { Maybe } from '../../utils/types';
 import { DashboardInternalHeading } from '../Dashboard/DashboardInternalHeading';
+import { DashboardDocumentTitleForm } from '../DashboardDocumentTitleForm';
 import { DashboardObjectProgress } from '../DashboardObjectProgress';
 import { DashboardPaneButtons } from '../DashboardPaneButtons';
 import { DashboardPaneHelptext } from '../DashboardPaneHelptext';
@@ -29,22 +28,6 @@ const messages = defineMessages({
     defaultMessage: 'Document status',
     description: 'Document upload status.',
     id: 'components.DashboardDocument.title',
-  },
-  updateError: {
-    defaultMessage: 'Impossible to update the title. Try again later.',
-    description:
-      'Error message to warn the user that a title update failed and ask them to try again later.',
-    id: 'components.DashboardDocument.form.label.error',
-  },
-  updateSuccessful: {
-    defaultMessage: 'Title successfully updated',
-    description: 'message display when the title is successfully updated',
-    id: 'components.DashboardDocument.form.success',
-  },
-  updateTitle: {
-    defaultMessage: 'Change document title',
-    description: 'Label informing the user they can change the document title.',
-    id: 'components.DashboardDocument.form.label.title',
   },
 });
 
@@ -65,13 +48,9 @@ interface DashboardDocumentProps {
 }
 
 const DashboardDocument = (props: DashboardDocumentProps) => {
-  const { document, updateDocument } = useDocument(state => ({
+  const { document } = useDocument(state => ({
     document: state.getDocument(props.document),
-    updateDocument: state.addResource,
   }));
-  const [title, setTitle] = useState(document.title);
-  const [error, setError] = useState<Maybe<string>>(undefined);
-  const [udpated, setUpdated] = useState(false);
   const intl = useIntl();
 
   useEffect(() => {
@@ -81,25 +60,6 @@ const DashboardDocument = (props: DashboardDocumentProps) => {
       }, 1000 * 10);
     }
   }, []);
-
-  const updateTitle = async () => {
-    try {
-      setUpdated(false);
-      const newDocument = await updateResource(
-        {
-          ...document,
-          title,
-        },
-        modelName.DOCUMENTS,
-      );
-      setError(undefined);
-      setUpdated(true);
-      updateDocument(newDocument);
-    } catch (error) {
-      setError(intl.formatMessage(messages.updateError));
-      setUpdated(false);
-    }
-  };
 
   const commonStatusLine = (
     <Box align={'center'} direction={'row'}>
@@ -169,28 +129,7 @@ const DashboardDocument = (props: DashboardDocumentProps) => {
             </Box>
           </Box>
           <Box margin={'small'}>
-            <Form onSubmit={updateTitle}>
-              <FormField
-                label={intl.formatMessage(messages.updateTitle)}
-                htmlFor={'title'}
-                error={error}
-                component={TextInput}
-              >
-                <TextInput
-                  placeholder="Title"
-                  value={title}
-                  onChange={event => setTitle(event.target.value)}
-                  size={'medium'}
-                  id={'title'}
-                />
-              </FormField>
-              <Button type="submit" primary label="Submit" />
-              {udpated && (
-                <Text margin={'small'} color={'status-ok'}>
-                  {intl.formatMessage(messages.updateSuccessful)}
-                </Text>
-              )}
-            </Form>
+            <DashboardDocumentTitleForm document={document} />
           </Box>
           <DashboardPaneButtons
             object={document}

--- a/src/frontend/components/DashboardDocumentTitleForm/index.spec.tsx
+++ b/src/frontend/components/DashboardDocumentTitleForm/index.spec.tsx
@@ -1,0 +1,126 @@
+import { fireEvent, render, wait } from '@testing-library/react';
+import fetchMock from 'fetch-mock';
+import { Grommet } from 'grommet';
+import React from 'react';
+
+import { DashboardDocumentTitleForm } from '.';
+import { uploadState } from '../../types/tracks';
+import { wrapInIntlProvider } from '../../utils/tests/intl';
+
+jest.mock('jwt-decode', () => jest.fn());
+jest.mock('../../data/appData', () => ({
+  appData: {
+    document: null,
+    jwt: 'cool_token_m8',
+  },
+}));
+
+describe('DashboardDocumentTitleForm', () => {
+  afterEach(fetchMock.restore);
+
+  it('shows the title form', () => {
+    const document = {
+      description: '',
+      extension: 'pdf',
+      filename: 'bar_foo.pdf',
+      id: '46',
+      is_ready_to_show: true,
+      show_download: true,
+      title: 'document title',
+      upload_state: uploadState.READY,
+      url: 'https://example.com/document/45',
+    };
+
+    const { container } = render(
+      wrapInIntlProvider(
+        <Grommet>
+          <DashboardDocumentTitleForm document={document} />
+        </Grommet>,
+      ),
+    );
+
+    const inputTitle = container.querySelector('#title') as HTMLInputElement;
+
+    expect(inputTitle.value).toEqual('document title');
+  });
+
+  it('successfully update document title', async () => {
+    const document = {
+      description: '',
+      extension: 'pdf',
+      filename: 'bar_foo.pdf',
+      id: '46',
+      is_ready_to_show: true,
+      show_download: true,
+      title: 'foo.pdf',
+      upload_state: uploadState.READY,
+      url: 'https://example.com/document/45',
+    };
+
+    fetchMock.mock(
+      '/api/documents/46/',
+      JSON.stringify({
+        ...document,
+        title: 'updated document title',
+      }),
+      { method: 'PUT' },
+    );
+
+    const { container, getByText } = render(
+      wrapInIntlProvider(
+        <Grommet>
+          <DashboardDocumentTitleForm document={document} />
+        </Grommet>,
+      ),
+    );
+
+    const inputTitle = container.querySelector('#title') as HTMLInputElement;
+
+    fireEvent.change(inputTitle!, {
+      target: { value: 'updated document title' },
+    });
+    fireEvent.click(getByText('Submit'));
+    await wait();
+
+    expect(fetchMock.called('/api/documents/46/', { method: 'PUT' })).toBe(
+      true,
+    );
+    expect(inputTitle.value).toEqual('updated document title');
+    getByText('Title successfully updated');
+  });
+
+  it('fails to update document title', async () => {
+    const document = {
+      description: '',
+      extension: 'pdf',
+      filename: 'bar_foo.pdf',
+      id: '47',
+      is_ready_to_show: true,
+      show_download: true,
+      title: 'document title',
+      upload_state: uploadState.READY,
+      url: 'https://example.com/document/47',
+    };
+
+    fetchMock.mock('/api/documents/47/', 400, { method: 'PUT' });
+
+    const { container, getByText } = render(
+      wrapInIntlProvider(
+        <Grommet>
+          <DashboardDocumentTitleForm document={document} />
+        </Grommet>,
+      ),
+    );
+
+    const inputTitle = container.querySelector('#title');
+    fireEvent.change(inputTitle!, { target: { value: 'Bar.pdf' } });
+    fireEvent.click(getByText('Submit'));
+    await wait();
+
+    expect(fetchMock.called('/api/documents/47/', { method: 'PUT' })).toBe(
+      true,
+    );
+
+    getByText('Impossible to update the title. Try again later.');
+  });
+});

--- a/src/frontend/components/DashboardDocumentTitleForm/index.tsx
+++ b/src/frontend/components/DashboardDocumentTitleForm/index.tsx
@@ -1,0 +1,92 @@
+import { Button, Form, FormField, Text, TextInput } from 'grommet';
+import React, { Fragment, useState } from 'react';
+import { defineMessages, useIntl } from 'react-intl';
+
+import { updateResource } from '../../data/sideEffects/updateResource';
+import { useDocument } from '../../data/stores/useDocument';
+import { Document } from '../../types/file';
+import { modelName } from '../../types/models';
+import { Maybe } from '../../utils/types';
+
+const messages = defineMessages({
+  updateError: {
+    defaultMessage: 'Impossible to update the title. Try again later.',
+    description:
+      'Error message to warn the user that a title update failed and ask them to try again later.',
+    id: 'components.DashboardDocumentTitleForm.form.label.error',
+  },
+  updateSuccessful: {
+    defaultMessage: 'Title successfully updated',
+    description: 'message display when the title is successfully updated',
+    id: 'components.DashboardDocumentTitleForm.form.success',
+  },
+  updateTitle: {
+    defaultMessage: 'Change document title',
+    description: 'Label informing the user they can change the document title.',
+    id: 'components.DashboardDocumentTitleForm.form.label.title',
+  },
+});
+
+interface DashboardDocumentTitleFormProps {
+  document: Document;
+}
+
+export const DashboardDocumentTitleForm = ({
+  document,
+}: DashboardDocumentTitleFormProps) => {
+  const { updateDocument } = useDocument(state => ({
+    updateDocument: state.addResource,
+  }));
+  const [title, setTitle] = useState(document.title);
+  const [error, setError] = useState<Maybe<string>>(undefined);
+  const [udpated, setUpdated] = useState(false);
+  const intl = useIntl();
+
+  const updateTitle = async () => {
+    try {
+      setUpdated(false);
+      const newDocument = await updateResource(
+        {
+          ...document,
+          title,
+        },
+        modelName.DOCUMENTS,
+      );
+      setError(undefined);
+      setUpdated(true);
+      updateDocument(newDocument);
+    } catch (error) {
+      setError(intl.formatMessage(messages.updateError));
+      setUpdated(false);
+    }
+  };
+
+  return (
+    <Fragment>
+      <Form onSubmit={updateTitle}>
+        <FormField
+          label={intl.formatMessage(messages.updateTitle)}
+          htmlFor={'title'}
+          error={error}
+          component={TextInput}
+        >
+          <TextInput
+            id={'title'}
+            maxLength={255}
+            onChange={event => setTitle(event.target.value)}
+            placeholder="Title"
+            required={true}
+            size={'medium'}
+            value={title}
+          />
+        </FormField>
+        <Button type="submit" primary label="Submit" />
+        {udpated && (
+          <Text margin={'small'} color={'status-ok'}>
+            {intl.formatMessage(messages.updateSuccessful)}
+          </Text>
+        )}
+      </Form>
+    </Fragment>
+  );
+};


### PR DESCRIPTION
## Purpose

Maintaining the title state in the DashboardDocument was not easy and
has unwanted behaviour like updating the form input once already render.
We choose to create a dedicated component, rendered only when the
document is in ready state. The document's title should not be updated
anymore at this step and we should not have unwanted behaviour anymore.

## Proposal

- [x] create a dedicated component to manage document title form

