### PR TITLE
♻️(permissions) group all permissions in the JWT token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Changed
 
+- Move all permission flags to a "permissions" object in the JWT token
 - Refactor the LTI view to be generic for all the resources we want to manage
 - Video model is a special File model
 - pluralize thumbnail url

--- a/src/backend/marsha/core/lti/__init__.py
+++ b/src/backend/marsha/core/lti/__init__.py
@@ -251,18 +251,6 @@ class LTI:
         return roles.lower().split(",") if roles else []
 
     @property
-    def is_editable(self):
-        """Check if the current role is one that allows the user to modify the resource.
-
-        Returns
-        -------
-        boolean
-            True if the user can edit a resource
-
-        """
-        return self.is_instructor or self.is_admin
-
-    @property
     def is_instructor(self):
         """Check if the user of the launch request is an instructor on the course.
 

--- a/src/backend/marsha/core/tests/test_api_document.py
+++ b/src/backend/marsha/core/tests/test_api_document.py
@@ -39,7 +39,7 @@ class DocumentAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(document.id)
         jwt_token.payload["roles"] = ["student"]
-        jwt_token.payload["read_only"] = False
+        jwt_token.payload["permissions"] = {"can_update": True}
 
         response = self.client.get(
             "/api/documents/{!s}/".format(document.id),
@@ -66,7 +66,7 @@ class DocumentAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(document.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = False
+        jwt_token.payload["permissions"] = {"can_update": True}
 
         response = self.client.get(
             "/api/documents/{!s}/".format(document.id),
@@ -98,7 +98,7 @@ class DocumentAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(document.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = True
+        jwt_token.payload["permissions"] = {"can_update": False}
 
         response = self.client.get(
             "/api/documents/{!s}/".format(document.id),
@@ -122,7 +122,7 @@ class DocumentAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(document.id)
         jwt_token.payload["roles"] = ["student"]
-        jwt_token.payload["read_only"] = False
+        jwt_token.payload["permissions"] = {"can_update": True}
 
         response = self.client.get(
             "/api/documents/", HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token)
@@ -136,7 +136,7 @@ class DocumentAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(document.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = False
+        jwt_token.payload["permissions"] = {"can_update": True}
 
         response = self.client.get(
             "/api/documents/", HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token)
@@ -155,7 +155,7 @@ class DocumentAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(document.id)
         jwt_token.payload["roles"] = ["student"]
-        jwt_token.payload["read_only"] = False
+        jwt_token.payload["permissions"] = {"can_update": True}
 
         response = self.client.post(
             "/api/documents/", HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token)
@@ -169,7 +169,7 @@ class DocumentAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(document.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = False
+        jwt_token.payload["permissions"] = {"can_update": True}
 
         response = self.client.get(
             "/api/documents/", HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token)
@@ -189,7 +189,7 @@ class DocumentAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(document.id)
         jwt_token.payload["roles"] = ["student"]
-        jwt_token.payload["read_only"] = False
+        jwt_token.payload["permissions"] = {"can_update": True}
 
         response = self.client.delete(
             "/api/documents/{!s}/".format(document.id),
@@ -204,7 +204,7 @@ class DocumentAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(document.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = False
+        jwt_token.payload["permissions"] = {"can_update": True}
 
         response = self.client.delete(
             "/api/documents/{!s}/".format(document.id),
@@ -225,7 +225,7 @@ class DocumentAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(document.id)
         jwt_token.payload["roles"] = ["student"]
-        jwt_token.payload["read_only"] = False
+        jwt_token.payload["permissions"] = {"can_update": True}
         data = {"title": "new title"}
 
         response = self.client.put(
@@ -243,7 +243,7 @@ class DocumentAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(document.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = True
+        jwt_token.payload["permissions"] = {"can_update": False}
         data = {"title": "new title"}
 
         response = self.client.put(
@@ -261,7 +261,7 @@ class DocumentAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(document.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = False
+        jwt_token.payload["permissions"] = {"can_update": True}
         data = {"title": "new title"}
 
         response = self.client.put(
@@ -282,7 +282,7 @@ class DocumentAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(document.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = False
+        jwt_token.payload["permissions"] = {"can_update": True}
         data = {"title": "new title.pdf"}
 
         response = self.client.put(
@@ -311,7 +311,7 @@ class DocumentAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(document.id)
         jwt_token.payload["roles"] = ["student"]
-        jwt_token.payload["read_only"] = False
+        jwt_token.payload["permissions"] = {"can_update": True}
 
         response = self.client.post(
             "/api/documents/{!s}/initiate-upload/".format(document.id),
@@ -326,7 +326,7 @@ class DocumentAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(document.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = True
+        jwt_token.payload["permissions"] = {"can_update": False}
 
         response = self.client.post(
             "/api/documents/{!s}/initiate-upload/".format(document.id),
@@ -344,7 +344,7 @@ class DocumentAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(document.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = False
+        jwt_token.payload["permissions"] = {"can_update": True}
 
         now = datetime(2018, 8, 8, tzinfo=pytz.utc)
         with mock.patch.object(timezone, "now", return_value=now):
@@ -409,7 +409,7 @@ class DocumentAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(document.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = False
+        jwt_token.payload["permissions"] = {"can_update": True}
 
         now = datetime(2018, 8, 8, tzinfo=pytz.utc)
         with mock.patch.object(timezone, "now", return_value=now):
@@ -474,7 +474,7 @@ class DocumentAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(document.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = False
+        jwt_token.payload["permissions"] = {"can_update": True}
 
         now = datetime(2018, 8, 8, tzinfo=pytz.utc)
         with mock.patch.object(timezone, "now", return_value=now):

--- a/src/backend/marsha/core/tests/test_api_thumbnail.py
+++ b/src/backend/marsha/core/tests/test_api_thumbnail.py
@@ -56,7 +56,7 @@ class ThumbnailApiTest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(thumbnail.video.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = True
+        jwt_token.payload["permissions"] = {"can_update": False}
 
         response = self.client.get(
             "/api/thumbnails/{!s}/".format(thumbnail.id),
@@ -76,7 +76,7 @@ class ThumbnailApiTest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(video.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = False
+        jwt_token.payload["permissions"] = {"can_update": True}
 
         response = self.client.get(
             "/api/thumbnails/{!s}/".format(thumbnail.id),
@@ -105,7 +105,7 @@ class ThumbnailApiTest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(thumbnail.video.id)
         jwt_token.payload["roles"] = ["administrator"]
-        jwt_token.payload["read_only"] = True
+        jwt_token.payload["permissions"] = {"can_update": False}
 
         response = self.client.get(
             "/api/thumbnails/{!s}/".format(thumbnail.id),
@@ -125,7 +125,7 @@ class ThumbnailApiTest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(video.id)
         jwt_token.payload["roles"] = ["administrator"]
-        jwt_token.payload["read_only"] = False
+        jwt_token.payload["permissions"] = {"can_update": True}
 
         response = self.client.get(
             "/api/thumbnails/{!s}/".format(thumbnail.id),
@@ -163,7 +163,7 @@ class ThumbnailApiTest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(video.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = False
+        jwt_token.payload["permissions"] = {"can_update": True}
 
         response = self.client.get(
             "/api/thumbnails/{!s}/".format(thumbnail.id),
@@ -222,7 +222,7 @@ class ThumbnailApiTest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(video.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = False
+        jwt_token.payload["permissions"] = {"can_update": True}
 
         response = self.client.post(
             "/api/thumbnails/", HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token)
@@ -251,7 +251,7 @@ class ThumbnailApiTest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(thumbnail.video.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = True
+        jwt_token.payload["permissions"] = {"can_update": False}
 
         response = self.client.post(
             "/api/thumbnails/", HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token)
@@ -290,7 +290,7 @@ class ThumbnailApiTest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(video.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = False
+        jwt_token.payload["permissions"] = {"can_update": True}
 
         response = self.client.delete(
             "/api/thumbnails/{!s}/".format(thumbnail.id),
@@ -306,7 +306,7 @@ class ThumbnailApiTest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(thumbnail.video.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = True
+        jwt_token.payload["permissions"] = {"can_update": False}
 
         response = self.client.delete(
             "/api/thumbnails/{!s}/".format(thumbnail.id),
@@ -324,7 +324,7 @@ class ThumbnailApiTest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(video_token.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = False
+        jwt_token.payload["permissions"] = {"can_update": True}
 
         response = self.client.delete(
             "/api/thumbnails/{!s}/".format(thumbnail.id),
@@ -365,7 +365,7 @@ class ThumbnailApiTest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(video.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = False
+        jwt_token.payload["permissions"] = {"can_update": True}
 
         # Get the upload policy for this thumbnail
         # It should generate a key file with the Unix timestamp of the present time
@@ -434,7 +434,7 @@ class ThumbnailApiTest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(thumbnail.video.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = True
+        jwt_token.payload["permissions"] = {"can_update": False}
 
         response = self.client.post(
             "/api/thumbnails/{!s}/initiate-upload/".format(thumbnail.id),

--- a/src/backend/marsha/core/tests/test_api_timed_text_track.py
+++ b/src/backend/marsha/core/tests/test_api_timed_text_track.py
@@ -155,7 +155,7 @@ class TimedTextTrackAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(timed_text_track.video.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = False
+        jwt_token.payload["permissions"] = {"can_update": True}
 
         # Get the timed text track using the JWT token
         response = self.client.get(
@@ -206,7 +206,7 @@ class TimedTextTrackAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(timed_text_track.video.id)
         jwt_token.payload["roles"] = ["administrator"]
-        jwt_token.payload["read_only"] = False
+        jwt_token.payload["permissions"] = {"can_update": True}
 
         # Get the timed text track using the JWT token
         response = self.client.get(
@@ -250,7 +250,7 @@ class TimedTextTrackAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(timed_text_track.video.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = True
+        jwt_token.payload["permissions"] = {"can_update": False}
 
         response = self.client.get(
             "/api/timedtexttracks/{!s}/".format(timed_text_track.id),
@@ -268,7 +268,7 @@ class TimedTextTrackAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(timed_text_track.video.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = False
+        jwt_token.payload["permissions"] = {"can_update": True}
 
         # Get the timed text track using the JWT token
         response = self.client.get(
@@ -289,7 +289,7 @@ class TimedTextTrackAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(timed_text_track.video.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = False
+        jwt_token.payload["permissions"] = {"can_update": True}
 
         # Get the timed_text_track linked to the JWT token
         response = self.client.get(
@@ -318,7 +318,7 @@ class TimedTextTrackAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(timed_text_track.video.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = False
+        jwt_token.payload["permissions"] = {"can_update": True}
 
         # Get the timed_text_track via the API using the JWT token
         # fix the time so that the url signature is deterministic and can be checked
@@ -378,7 +378,7 @@ class TimedTextTrackAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(timed_text_track_one.video.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = False
+        jwt_token.payload["permissions"] = {"can_update": True}
 
         response = self.client.get(
             "/api/timedtexttracks/", HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token)
@@ -413,7 +413,7 @@ class TimedTextTrackAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(video.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = False
+        jwt_token.payload["permissions"] = {"can_update": True}
 
         data = {"language": "fr"}
         response = self.client.post(
@@ -446,7 +446,7 @@ class TimedTextTrackAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(timed_text_track.video.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = True
+        jwt_token.payload["permissions"] = {"can_update": False}
 
         response = self.client.post(
             "/api/timedtexttracks/", HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token)
@@ -480,7 +480,7 @@ class TimedTextTrackAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(timed_text_track.video.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = False
+        jwt_token.payload["permissions"] = {"can_update": True}
 
         data = {"language": "en"}
         response = self.client.put(
@@ -499,7 +499,7 @@ class TimedTextTrackAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(timed_text_track.video.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = False
+        jwt_token.payload["permissions"] = {"can_update": True}
 
         response = self.client.get(
             "/api/timedtexttracks/{!s}/".format(timed_text_track.id),
@@ -524,7 +524,7 @@ class TimedTextTrackAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(timed_text_track.video.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = False
+        jwt_token.payload["permissions"] = {"can_update": True}
 
         response = self.client.get(
             "/api/timedtexttracks/{!s}/".format(timed_text_track.id),
@@ -550,7 +550,7 @@ class TimedTextTrackAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(timed_text_track.video.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = False
+        jwt_token.payload["permissions"] = {"can_update": True}
 
         response = self.client.get(
             "/api/timedtexttracks/{!s}/".format(timed_text_track.id),
@@ -577,7 +577,7 @@ class TimedTextTrackAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(timed_text_track.video.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = True
+        jwt_token.payload["permissions"] = {"can_update": False}
 
         response = self.client.put(
             "/api/timedtexttracks/{!s}/".format(timed_text_track.id),
@@ -594,7 +594,7 @@ class TimedTextTrackAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(timed_text_track.video.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = False
+        jwt_token.payload["permissions"] = {"can_update": True}
         self.assertEqual(timed_text_track.upload_state, "pending")
         self.assertIsNone(timed_text_track.uploaded_on)
 
@@ -619,7 +619,7 @@ class TimedTextTrackAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(timed_text_track.video.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = False
+        jwt_token.payload["permissions"] = {"can_update": True}
 
         response = self.client.get(
             "/api/timedtexttracks/{!s}/".format(timed_text_track.id),
@@ -645,7 +645,7 @@ class TimedTextTrackAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(timed_text_track.video.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = False
+        jwt_token.payload["permissions"] = {"can_update": True}
 
         response = self.client.get(
             "/api/timedtexttracks/{!s}/".format(timed_text_track.id),
@@ -671,7 +671,7 @@ class TimedTextTrackAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(other_video.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = False
+        jwt_token.payload["permissions"] = {"can_update": True}
 
         data = {"language": "fr"}
         response = self.client.put(
@@ -691,7 +691,7 @@ class TimedTextTrackAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(timed_text_track.video.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = True
+        jwt_token.payload["permissions"] = {"can_update": False}
 
         response = self.client.patch(
             "/api/timedtexttracks/{!s}/".format(timed_text_track.id),
@@ -725,7 +725,7 @@ class TimedTextTrackAPITest(TestCase):
             jwt_token.payload["roles"] = [
                 random.choice(["instructor", "administrator"])
             ]
-            jwt_token.payload["read_only"] = False
+            jwt_token.payload["permissions"] = {"can_update": True}
             response = self.client.delete(
                 "/api/timedtexttracks/{!s}/".format(timed_text_track.id),
                 HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token),
@@ -769,7 +769,7 @@ class TimedTextTrackAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(timed_text_track.video.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = False
+        jwt_token.payload["permissions"] = {"can_update": True}
 
         response = self.client.delete(
             "/api/timedtexttracks/", HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token)
@@ -799,7 +799,7 @@ class TimedTextTrackAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(timed_text_track.video.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = True
+        jwt_token.payload["permissions"] = {"can_update": False}
 
         response = self.client.delete(
             "/api/timedtexttracks/{!s}/".format(timed_text_track.id),
@@ -833,7 +833,7 @@ class TimedTextTrackAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(timed_text_track.video.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = False
+        jwt_token.payload["permissions"] = {"can_update": True}
 
         # Create other timed text tracks to check that their upload state are unaffected
         # Make sure we avoid unicty constraints by setting a different language
@@ -949,7 +949,7 @@ class TimedTextTrackAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(timed_text_track.video.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = True
+        jwt_token.payload["permissions"] = {"can_update": False}
 
         response = self.client.post(
             "/api/timedtexttracks/{!s}/initiate-upload/".format(timed_text_track.id),

--- a/src/backend/marsha/core/tests/test_api_video.py
+++ b/src/backend/marsha/core/tests/test_api_video.py
@@ -73,7 +73,7 @@ class VideoAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(video.id)
         jwt_token.payload["roles"] = ["student"]
-        jwt_token.payload["read_only"] = True
+        jwt_token.payload["permissions"] = {"can_update": False}
         # Get the video linked to the JWT token
         response = self.client.get(
             "/api/videos/{!s}/".format(video.id),
@@ -93,7 +93,7 @@ class VideoAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(video.id)
         jwt_token.payload["roles"] = ["administrator"]
-        jwt_token.payload["read_only"] = False
+        jwt_token.payload["permissions"] = {"can_update": True}
 
         # Get the video linked to the JWT token
         response = self.client.get(
@@ -122,7 +122,7 @@ class VideoAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(video.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = False
+        jwt_token.payload["permissions"] = {"can_update": True}
 
         # Get the video linked to the JWT token
         response = self.client.get(
@@ -215,7 +215,7 @@ class VideoAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(video.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = True
+        jwt_token.payload["permissions"] = {"can_update": False}
 
         # Get the video linked to the JWT token
         response = self.client.get(
@@ -231,7 +231,7 @@ class VideoAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(video.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = False
+        jwt_token.payload["permissions"] = {"can_update": True}
 
         # Get the video linked to the JWT token
         response = self.client.get(
@@ -266,7 +266,7 @@ class VideoAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(video.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = False
+        jwt_token.payload["permissions"] = {"can_update": True}
 
         # Get the video linked to the JWT token
         response = self.client.get(
@@ -308,7 +308,7 @@ class VideoAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(video.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = False
+        jwt_token.payload["permissions"] = {"can_update": True}
 
         # Get the video linked to the JWT token
         # fix the time so that the url signature is deterministic and can be checked
@@ -389,7 +389,7 @@ class VideoAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(video.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = False
+        jwt_token.payload["permissions"] = {"can_update": True}
 
         # Get the video linked to the JWT token
         response = self.client.get(
@@ -488,7 +488,7 @@ class VideoAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(video.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = False
+        jwt_token.payload["permissions"] = {"can_update": True}
         data = {"title": "my new title"}
         response = self.client.put(
             "/api/videos/{!s}/".format(video.id),
@@ -506,7 +506,7 @@ class VideoAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(video.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = False
+        jwt_token.payload["permissions"] = {"can_update": True}
 
         response = self.client.get(
             "/api/videos/{!s}/".format(video.id),
@@ -530,7 +530,7 @@ class VideoAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(video.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = False
+        jwt_token.payload["permissions"] = {"can_update": True}
 
         response = self.client.get(
             "/api/videos/{!s}/".format(video.id),
@@ -556,7 +556,7 @@ class VideoAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(video.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = False
+        jwt_token.payload["permissions"] = {"can_update": True}
 
         response = self.client.get(
             "/api/videos/{!s}/".format(video.id),
@@ -582,7 +582,7 @@ class VideoAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(video.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = True
+        jwt_token.payload["permissions"] = {"can_update": False}
 
         data = {"upload_state": "ready"}
 
@@ -600,7 +600,7 @@ class VideoAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(video.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = True
+        jwt_token.payload["permissions"] = {"can_update": False}
 
         data = {"upload_state": "ready"}
 
@@ -621,7 +621,7 @@ class VideoAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(video.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = False
+        jwt_token.payload["permissions"] = {"can_update": True}
         self.assertEqual(video.upload_state, "pending")
         self.assertIsNone(video.uploaded_on)
 
@@ -646,7 +646,7 @@ class VideoAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(video.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = False
+        jwt_token.payload["permissions"] = {"can_update": True}
 
         response = self.client.get(
             "/api/videos/{!s}/".format(video.id),
@@ -672,6 +672,7 @@ class VideoAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(video_token.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
+        jwt_token.payload["permissions"] = {"can_update": True}
 
         data = {"title": "my new title"}
         response = self.client.put(
@@ -691,7 +692,7 @@ class VideoAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(video.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = False
+        jwt_token.payload["permissions"] = {"can_update": True}
 
         data = {"description": "my new description"}
 
@@ -722,7 +723,7 @@ class VideoAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(videos[0].id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = False
+        jwt_token.payload["permissions"] = {"can_update": True}
 
         # Try deleting the video linked to the JWT token and the other one
         for video in videos:
@@ -756,7 +757,7 @@ class VideoAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(video.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = True
+        jwt_token.payload["permissions"] = {"can_update": False}
 
         response = self.client.delete(
             "/api/videos/{!s}/".format(video.id),
@@ -817,7 +818,7 @@ class VideoAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(video.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = True
+        jwt_token.payload["permissions"] = {"can_update": False}
 
         response = self.client.post(
             "/api/videos/{!s}/initiate-upload/".format(video.id),
@@ -834,7 +835,7 @@ class VideoAPITest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(video.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
-        jwt_token.payload["read_only"] = False
+        jwt_token.payload["permissions"] = {"can_update": True}
 
         # Create another video to check that its upload state is unaffected
         other_video = VideoFactory(upload_state=random.choice(["ready", "error"]))

--- a/src/backend/marsha/core/tests/test_views_lti_video.py
+++ b/src/backend/marsha/core/tests/test_views_lti_video.py
@@ -64,7 +64,10 @@ class VideoViewTestCase(TestCase):
         self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
         self.assertEqual(jwt_token.payload["roles"], [data["roles"]])
         self.assertEqual(jwt_token.payload["locale"], "fr_FR")
-        self.assertFalse(jwt_token.payload["read_only"])
+        self.assertEqual(
+            jwt_token.payload["permissions"],
+            {"can_access_dashboard": True, "can_update": True},
+        )
         self.assertDictEqual(
             jwt_token.payload["course"],
             {"school_name": "ufr", "course_name": "mathematics", "course_run": "00001"},
@@ -87,7 +90,6 @@ class VideoViewTestCase(TestCase):
             },
         )
         self.assertEqual(context.get("modelName"), "videos")
-        self.assertTrue(context.get("isEditable"))
         # Make sure we only go through LTI verification once as it is costly (getting passport +
         # signature)
         self.assertEqual(mock_verify.call_count, 1)
@@ -129,7 +131,10 @@ class VideoViewTestCase(TestCase):
         self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
         self.assertEqual(jwt_token.payload["roles"], [data["roles"]])
         self.assertEqual(jwt_token.payload["locale"], "fr_FR")
-        self.assertFalse(jwt_token.payload["read_only"])
+        self.assertEqual(
+            jwt_token.payload["permissions"],
+            {"can_access_dashboard": True, "can_update": True},
+        )
         self.assertDictEqual(
             jwt_token.payload["course"],
             {"school_name": "ufr", "course_name": "mathematics", "course_run": "00001"},
@@ -152,14 +157,15 @@ class VideoViewTestCase(TestCase):
             },
         )
         self.assertEqual(context.get("modelName"), "videos")
-        self.assertTrue(context.get("isEditable"))
         # Make sure we only go through LTI verification once as it is costly (getting passport +
         # signature)
         self.assertEqual(mock_verify.call_count, 1)
 
     @mock.patch.object(LTI, "verify")
     @mock.patch.object(LTI, "get_consumer_site")
-    def test_views_lti_video_read_only_video(self, mock_get_consumer_site, mock_verify):
+    def test_views_lti_video_read_other_playlist(
+        self, mock_get_consumer_site, mock_verify
+    ):
         """A video from another portable playlist should have read_only attribute set to True."""
         passport = ConsumerSiteLTIPassportFactory(consumer_site__domain="example.com")
         video = VideoFactory(
@@ -188,7 +194,10 @@ class VideoViewTestCase(TestCase):
 
         context = json.loads(unescape(match.group(1)))
         jwt_token = AccessToken(context.get("jwt"))
-        self.assertTrue(jwt_token.payload["read_only"])
+        self.assertEqual(
+            jwt_token.payload["permissions"],
+            {"can_access_dashboard": True, "can_update": False},
+        )
         self.assertEqual(context.get("state"), "success")
         self.assertEqual(
             context.get("resource"),
@@ -206,7 +215,6 @@ class VideoViewTestCase(TestCase):
             },
         )
         self.assertEqual(context.get("modelName"), "videos")
-        self.assertTrue(context.get("isEditable"))
         # Make sure we only go through LTI verification once as it is costly (getting passport +
         # signature)
         self.assertEqual(mock_verify.call_count, 1)
@@ -246,7 +254,10 @@ class VideoViewTestCase(TestCase):
         self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
         self.assertEqual(jwt_token.payload["roles"], [data["roles"]])
         self.assertEqual(jwt_token.payload["locale"], "en_US")
-        self.assertTrue(jwt_token.payload["read_only"])
+        self.assertEqual(
+            jwt_token.payload["permissions"],
+            {"can_access_dashboard": False, "can_update": False},
+        )
         self.assertDictEqual(
             jwt_token.payload["course"],
             {"school_name": "ufr", "course_name": "mathematics", "course_run": "00001"},
@@ -269,7 +280,6 @@ class VideoViewTestCase(TestCase):
             },
         )
         self.assertEqual(context.get("modelName"), "videos")
-        self.assertFalse(context.get("isEditable"))
         # Make sure we only go through LTI verification once as it is costly (getting passport +
         # signature)
         self.assertEqual(mock_verify.call_count, 1)
@@ -308,11 +318,14 @@ class VideoViewTestCase(TestCase):
         self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
         self.assertEqual(jwt_token.payload["roles"], [data["roles"]])
         self.assertEqual(jwt_token.payload["locale"], "en_US")
+        self.assertEqual(
+            jwt_token.payload["permissions"],
+            {"can_access_dashboard": False, "can_update": False},
+        )
         self.assertDictEqual(
             jwt_token.payload["course"],
             {"school_name": "ufr", "course_name": "mathematics", "course_run": None},
         )
-        self.assertFalse(context.get("isEditable"))
         self.assertEqual(context.get("modelName"), "videos")
 
         # Make sure we only go through LTI verification once as it is costly (getting passport +
@@ -347,7 +360,6 @@ class VideoViewTestCase(TestCase):
         context = json.loads(unescape(match.group(1)))
         self.assertEqual(context.get("state"), "success")
         self.assertIsNone(context.get("resource"))
-        self.assertFalse(context.get("isEditable"))
         self.assertEqual(context.get("modelName"), "videos")
 
         # Make sure we only go through LTI verification once as it is costly (getting passport +
@@ -413,8 +425,11 @@ class VideoViewTestCase(TestCase):
         self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
         self.assertEqual(jwt_token.payload["roles"], [data["roles"]])
         self.assertEqual(jwt_token.payload["locale"], "en_US")
+        self.assertEqual(
+            jwt_token.payload["permissions"],
+            {"can_access_dashboard": True, "can_update": True},
+        )
         self.assertEqual(context.get("modelName"), "videos")
-        self.assertTrue(context.get("isEditable"))
 
     @override_settings(STATICFILES_AWS_ENABLED=False)
     @override_settings(CLOUDFRONT_DOMAIN="abcd.cloudfront.net")
@@ -517,6 +532,10 @@ class DevelopmentViewsTestCase(TestCase):
         self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
         self.assertEqual(jwt_token.payload["roles"], [data["roles"]])
         self.assertEqual(jwt_token.payload["locale"], "fr_FR")
+        self.assertEqual(
+            jwt_token.payload["permissions"],
+            {"can_access_dashboard": False, "can_update": False},
+        )
         self.assertDictEqual(
             jwt_token.payload["course"],
             {"school_name": "ufr", "course_name": "mathematics", "course_run": None},
@@ -538,7 +557,6 @@ class DevelopmentViewsTestCase(TestCase):
             },
         )
         self.assertEqual(context.get("modelName"), "videos")
-        self.assertFalse(context.get("isEditable"))
 
     @override_settings(DEBUG=True)
     @override_settings(BYPASS_LTI_VERIFICATION=True)
@@ -556,7 +574,6 @@ class DevelopmentViewsTestCase(TestCase):
         }
         response = self.client.post("/lti/videos/{!s}".format(video.pk), data)
         self.assertEqual(response.status_code, 200)
-        print(response)
         self.assertContains(response, "<html>")
         content = response.content.decode("utf-8")
 
@@ -571,6 +588,10 @@ class DevelopmentViewsTestCase(TestCase):
         self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
         self.assertEqual(jwt_token.payload["roles"], [data["roles"]])
         self.assertEqual(jwt_token.payload["locale"], "en_US")
+        self.assertEqual(
+            jwt_token.payload["permissions"],
+            {"can_access_dashboard": True, "can_update": True},
+        )
         self.assertDictEqual(
             jwt_token.payload["course"],
             {"school_name": "ufr", "course_name": "mathematics", "course_run": None},
@@ -592,7 +613,6 @@ class DevelopmentViewsTestCase(TestCase):
             },
         )
         self.assertEqual(context.get("modelName"), "videos")
-        self.assertTrue(context.get("isEditable"))
 
     @override_settings(DEBUG=True)
     @override_settings(BYPASS_LTI_VERIFICATION=True)
@@ -643,7 +663,6 @@ class DevelopmentViewsTestCase(TestCase):
             },
         )
         self.assertEqual(context.get("modelName"), "videos")
-        self.assertTrue(context.get("isEditable"))
         # The consumer site was created with a name and a domain name
         ConsumerSite.objects.get(name="example.com", domain="example.com")
 


### PR DESCRIPTION
## Purpose

The "IsReadable" flag was passed in `app_data` and "read_only" flag was passed in the JWT token.

We propose to move all permission flags to the JWT token so they are available in the form to the frontend and to the API backend.

## Proposal

- [x] Add a `permissions` object in the JWT token
- [x] Remove the `IsReadonly` flag from `app_data`
- [x] Rename permission flags to `can_update` and `can_access_dashboard` to be more explicit
- [x] Change to a safer permission logic that is "forbidden by default" (can_update instead of is_read_only)
- [x] Update frontend to consume the new permission flags
