### PR TITLE
🐛(front) change how we poll timed text track when we replace them

### DIFF
--- a/src/frontend/components/TimedTextListItem/index.tsx
+++ b/src/frontend/components/TimedTextListItem/index.tsx
@@ -17,6 +17,8 @@ import { ERROR_COMPONENT_ROUTE } from '../ErrorComponent/route';
 import { UPLOAD_FORM_ROUTE } from '../UploadForm/route';
 import { UploadStatusPicker } from '../UploadStatusPicker';
 
+const { PENDING, PROCESSING, UPLOADING } = uploadState;
+
 const messages = defineMessages({
   delete: {
     defaultMessage: 'Delete',
@@ -77,7 +79,7 @@ export const TimedTextListItem = ({ track }: TimedTextListItemProps) => {
   useEffect(() => {
     getChoices();
 
-    if (track.is_ready_to_show === false) {
+    if ([PENDING, UPLOADING, PROCESSING].includes(track.upload_state)) {
       window.setTimeout(async () => {
         const result = await pollForTrack(modelName.TIMEDTEXTTRACKS, track.id);
         if (result === requestStatus.FAILURE) {

--- a/src/frontend/data/sideEffects/pollForTrack/index.tsx
+++ b/src/frontend/data/sideEffects/pollForTrack/index.tsx
@@ -35,7 +35,7 @@ export async function pollForTrack<
       ? Document
       : never = await response.json();
 
-    if (isReadyToPlay(incomingTrack)) {
+    if (incomingTrack.is_ready_to_show) {
       await addResource(resourceName, incomingTrack);
       return requestStatus.SUCCESS;
     } else {
@@ -49,11 +49,3 @@ export async function pollForTrack<
     return requestStatus.FAILURE;
   }
 }
-
-const isReadyToPlay = (object: Document | Video | TimedText): boolean => {
-  if ((object as Document).is_ready_to_show !== undefined) {
-    return (object as Document).is_ready_to_show;
-  }
-
-  return (object as Video | TimedText).is_ready_to_show;
-};


### PR DESCRIPTION
## Purpose

When a timed text track was already in READY state and is_ready_to_show
set to true, it was blocked in pending state if we use the replace
feature. The issue is in the useEffect of TimedTextListItem component,
we start polling only when the is_ready_to_show property was equal to
false. Doing like this is wrong, we have to check the updload state and
start polling when the state is pending, uploading and processing.

## Proposal

- [x] start polling when the timed text track upload state is pending, processing and uploading

