### PR TITLE
🔥(permissions) remove outdated video_id parameter from JWT token

### DIFF
--- a/src/backend/marsha/core/tests/test_views_lti_video.py
+++ b/src/backend/marsha/core/tests/test_views_lti_video.py
@@ -59,7 +59,7 @@ class VideoViewTestCase(TestCase):
 
         context = json.loads(unescape(match.group(1)))
         jwt_token = AccessToken(context.get("jwt"))
-        self.assertEqual(jwt_token.payload["video_id"], str(video.id))
+        self.assertEqual(jwt_token.payload["resource_id"], str(video.id))
         self.assertEqual(jwt_token.payload["user_id"], data["user_id"])
         self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
         self.assertEqual(jwt_token.payload["roles"], [data["roles"]])
@@ -124,7 +124,7 @@ class VideoViewTestCase(TestCase):
 
         context = json.loads(unescape(match.group(1)))
         jwt_token = AccessToken(context.get("jwt"))
-        self.assertEqual(jwt_token.payload["video_id"], str(video.id))
+        self.assertEqual(jwt_token.payload["resource_id"], str(video.id))
         self.assertEqual(jwt_token.payload["user_id"], data["user_id"])
         self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
         self.assertEqual(jwt_token.payload["roles"], [data["roles"]])
@@ -241,7 +241,7 @@ class VideoViewTestCase(TestCase):
 
         context = json.loads(unescape(match.group(1)))
         jwt_token = AccessToken(context.get("jwt"))
-        self.assertEqual(jwt_token.payload["video_id"], str(video.id))
+        self.assertEqual(jwt_token.payload["resource_id"], str(video.id))
         self.assertEqual(jwt_token.payload["user_id"], data["user_id"])
         self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
         self.assertEqual(jwt_token.payload["roles"], [data["roles"]])
@@ -304,7 +304,7 @@ class VideoViewTestCase(TestCase):
 
         context = json.loads(unescape(match.group(1)))
         jwt_token = AccessToken(context.get("jwt"))
-        self.assertEqual(jwt_token.payload["video_id"], str(video.id))
+        self.assertEqual(jwt_token.payload["resource_id"], str(video.id))
         self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
         self.assertEqual(jwt_token.payload["roles"], [data["roles"]])
         self.assertEqual(jwt_token.payload["locale"], "en_US")
@@ -409,7 +409,7 @@ class VideoViewTestCase(TestCase):
 
         context = json.loads(unescape(match.group(1)))
         jwt_token = AccessToken(context.get("jwt"))
-        self.assertEqual(jwt_token.payload["video_id"], str(video.id))
+        self.assertEqual(jwt_token.payload["resource_id"], str(video.id))
         self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
         self.assertEqual(jwt_token.payload["roles"], [data["roles"]])
         self.assertEqual(jwt_token.payload["locale"], "en_US")
@@ -512,7 +512,7 @@ class DevelopmentViewsTestCase(TestCase):
 
         context = json.loads(unescape(match.group(1)))
         jwt_token = AccessToken(context.get("jwt"))
-        self.assertEqual(jwt_token.payload["video_id"], str(video.id))
+        self.assertEqual(jwt_token.payload["resource_id"], str(video.id))
         self.assertEqual(jwt_token.payload["user_id"], data["user_id"])
         self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
         self.assertEqual(jwt_token.payload["roles"], [data["roles"]])
@@ -566,7 +566,7 @@ class DevelopmentViewsTestCase(TestCase):
 
         context = json.loads(unescape(match.group(1)))
         jwt_token = AccessToken(context.get("jwt"))
-        self.assertEqual(jwt_token.payload["video_id"], str(video.id))
+        self.assertEqual(jwt_token.payload["resource_id"], str(video.id))
         self.assertEqual(jwt_token.payload["user_id"], data["user_id"])
         self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
         self.assertEqual(jwt_token.payload["roles"], [data["roles"]])
@@ -616,7 +616,7 @@ class DevelopmentViewsTestCase(TestCase):
         context = json.loads(unescape(match.group(1)))
         jwt_token = AccessToken(context.get("jwt"))
         video = Video.objects.get()
-        self.assertEqual(jwt_token.payload["video_id"], str(video.id))
+        self.assertEqual(jwt_token.payload["resource_id"], str(video.id))
         self.assertEqual(jwt_token.payload["user_id"], data["user_id"])
         self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
         self.assertEqual(jwt_token.payload["roles"], [data["roles"]])

--- a/src/backend/marsha/core/views.py
+++ b/src/backend/marsha/core/views.py
@@ -46,10 +46,6 @@ class BaseLTIView(ABC, TemplateResponseMixin, View):
     def serializer_class(self):
         """Return the serializer used by the view."""
 
-    @abstractmethod
-    def _enrich_jwt_token(self, token, resource):
-        """Enrich the base JWT Token with specific data from the targeted resource."""
-
     def get_context_data(self):
         """Build a context with data retrieved from the LTI launch request.
 
@@ -117,8 +113,6 @@ class BaseLTIView(ABC, TemplateResponseMixin, View):
             except AttributeError:
                 pass
 
-            self._enrich_jwt_token(jwt_token, resource)
-
             app_data["jwt"] = str(jwt_token)
 
         app_data["resource"] = (
@@ -164,19 +158,12 @@ class VideoLTIView(BaseLTIView):
     model = Video
     serializer_class = VideoSerializer
 
-    def _enrich_jwt_token(self, token, resource):
-        """Enrich the base JWT Token with specific data from the targeted resource."""
-        token.payload.update({"video_id": str(resource.id)})
-
 
 class DocumentLTIView(BaseLTIView):
     """Document view called by an LTI launch request."""
 
     model = Document
     serializer_class = DocumentSerializer
-
-    def _enrich_jwt_token(self, token, resource):
-        pass
 
 
 class LTIDevelopmentView(TemplateView):

--- a/src/frontend/types/jwt.ts
+++ b/src/frontend/types/jwt.ts
@@ -4,7 +4,7 @@ export interface DecodedJwt {
   roles: string[];
   session_id: string;
   user_id: string;
-  video_id: string;
+  resource_id: string;
   locale: string;
   read_only: boolean;
 }


### PR DESCRIPTION
## Purpose

The `video_id` parameter in the JWT token was replaced by `resource_id` when more resources were added. At the time, we forgot to remove it although it is not being used anymore.

## Proposal

- [x] Remove all mentions of `video_id` and replace them by `resource_id`.
