### PR TITLE
⬆️ (circle) upgrade crowdin image version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -371,7 +371,7 @@ jobs:
   # translation management tool
   i18n:
     docker:
-      - image: fundocker/crowdin:2.0.27
+      - image: fundocker/crowdin:2.0.31
     working_directory: ~/marsha
     steps:
       - checkout:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Change gunicorn configuration to increase number of threads, worker class and worker tmpdir
 - Upgrade @openfun/subsrt in lambda-encode. Patched version parses most of srt files
   (a critical feature for us)
+- Upgrade crowdin image used in circle-ci to version 2.0.31 including tar command
 
 ### Removed
 


### PR DESCRIPTION
## Purpose

The circle-ci job uploading translations on crowdin is failing since few
days because there is an issue with the tar version used in our crowdin
image. We think it's a circle-ci regression, they remove the fallback on
their tools to use the good tar commad. We decided to add tar in our
crowdin image and to use it in our i18n job.

## Proposal

- [x] Upgrade crowdin image used in circle-ci to version 2.0.31 including tar command

