### PR TITLE
⚡️(lti) cache database queries and serialization in LTI views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Added
 
+- Cache database queries and serialization in LTI views for students
 - Create a File model which will be the base model for all the resources
   we will manage
 - create a property `RESOURCE_NAME` on models having a url

--- a/src/backend/marsha/core/lti/__init__.py
+++ b/src/backend/marsha/core/lti/__init__.py
@@ -55,6 +55,9 @@ class LTI:
         if self._consumer_site:
             return True
 
+        if not self.context_id:
+            raise LTIException("A context ID is required.")
+
         request_domain = self.request_domain
 
         if settings.BYPASS_LTI_VERIFICATION:

--- a/src/backend/marsha/core/tests/test_lti.py
+++ b/src/backend/marsha/core/tests/test_lti.py
@@ -211,6 +211,7 @@ class LTITestCase(TestCase):
         }
         request = self.factory.post("/", data, HTTP_REFERER="https://example.com/route")
         lti = LTI(request, uuid.uuid4())
+        lti.verify()
         video = get_or_create_resource(Video, lti)
         self.assertFalse(video.show_download)
 
@@ -238,6 +239,7 @@ class LTITestCase(TestCase):
         }
         request = self.factory.post("/", data, HTTP_REFERER="https://example.com/route")
         lti = LTI(request, uuid.uuid4())
+        lti.verify()
         video = get_or_create_resource(Video, lti)
         self.assertTrue(video.show_download)
 

--- a/src/backend/marsha/core/tests/test_views_lti_cache.py
+++ b/src/backend/marsha/core/tests/test_views_lti_cache.py
@@ -1,0 +1,138 @@
+"""Test caching LTI views in the ``core`` app of the Marsha project."""
+from html import unescape
+import json
+import re
+import time
+from unittest import mock
+
+from django.test import TestCase
+
+from ..factories import ConsumerSiteFactory, VideoFactory
+from ..lti import LTI
+
+
+# We don't enforce arguments documentation in tests
+# pylint: disable=unused-argument
+
+
+class CacheLTIViewTestCase(TestCase):
+    """Test caching in LTI views."""
+
+    def _post_lti_request(self, url, data):
+        """Not a test but utility method to make an LTI request and test cache behavior."""
+        started_at = time.time()
+        response = self.client.post(url, data)
+        elapsed = time.time() - started_at
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode("utf-8")
+        match = re.search(
+            '<div id="marsha-frontend-data" data-context="(.*)">', content
+        )
+        context = json.loads(unescape(match.group(1)))
+        return elapsed, context.get("resource")
+
+    @mock.patch.object(LTI, "verify")
+    @mock.patch.object(LTI, "get_consumer_site")
+    def test_views_lti_cache_student(self, mock_get_consumer_site, mock_verify):
+        """Validate that responses are cached for students."""
+        video1, video2 = VideoFactory.create_batch(
+            2,
+            upload_state="ready",
+            playlist__is_portable_to_playlist=True,
+            playlist__is_portable_to_consumer_site=True,
+        )
+
+        mock_get_consumer_site.return_value = video1.playlist.consumer_site
+
+        url = "/lti/videos/{!s}".format(video1.pk)
+        data = {
+            "resource_link_id": video1.lti_id,
+            "context_id": video1.playlist.lti_id,
+            "roles": "student",
+            "user_id": "111",
+        }
+
+        with self.assertNumQueries(3):
+            elapsed, resource_origin = self._post_lti_request(url, data)
+        self.assertEqual(resource_origin["id"], str(video1.id))
+        self.assertTrue(elapsed < 0.1)
+
+        # Calling the same resource a second time with the same LTI parameters
+        # should hit the cache and be ultra fast
+        with self.assertNumQueries(0):
+            elapsed, resource = self._post_lti_request(url, data)
+        self.assertEqual(resource, resource_origin)
+        self.assertTrue(elapsed < 0.01)
+
+        # The cache should not be hit on first call if we change the playlist id
+        data["context_id"] = "other_playlist"
+        with self.assertNumQueries(3):
+            elapsed, resource = self._post_lti_request(url, data)
+        self.assertEqual(resource, resource_origin)
+        self.assertTrue(elapsed < 0.1)
+
+        with self.assertNumQueries(0):
+            elapsed, resource = self._post_lti_request(url, data)
+        self.assertEqual(resource, resource_origin)
+        self.assertTrue(elapsed < 0.01)
+
+        # The cache should not be hit on first call if we change the domain
+        mock_get_consumer_site.return_value = ConsumerSiteFactory()
+        with self.assertNumQueries(3):
+            elapsed, resource = self._post_lti_request(url, data)
+        self.assertEqual(resource, resource_origin)
+        self.assertTrue(elapsed < 0.1)
+
+        with self.assertNumQueries(0):
+            elapsed, resource = self._post_lti_request(
+                url, {**data, "context_id": "other_playlist"}
+            )
+        self.assertEqual(resource, resource_origin)
+        self.assertTrue(elapsed < 0.01)
+
+        # The cache should not be hit on first call if we change the resource id
+        url = "/lti/videos/{!s}".format(video2.pk)
+        with self.assertNumQueries(3):
+            elapsed, resource_video2 = self._post_lti_request(url, data)
+        self.assertEqual(resource_video2["id"], str(video2.id))
+        self.assertTrue(elapsed < 0.1)
+
+        with self.assertNumQueries(0):
+            elapsed, resource = self._post_lti_request(url, data)
+        self.assertEqual(resource, resource_video2)
+        self.assertTrue(elapsed < 0.01)
+
+        # The cache should STILL be hit if the user changes
+        data["user_id"] = "222"
+        with self.assertNumQueries(0):
+            elapsed, resource = self._post_lti_request(url, data)
+        self.assertEqual(resource, resource_video2)
+        self.assertTrue(elapsed < 0.01)
+
+    @mock.patch.object(LTI, "verify")
+    @mock.patch.object(LTI, "get_consumer_site")
+    def test_views_lti_cache_instructor(self, mock_get_consumer_site, mock_verify):
+        """Validate that responses are not cached for instructors."""
+        video = VideoFactory(upload_state="ready")
+
+        mock_get_consumer_site.return_value = video.playlist.consumer_site
+
+        url = "/lti/videos/{!s}".format(video.pk)
+        data = {
+            "resource_link_id": video.lti_id,
+            "context_id": video.playlist.lti_id,
+            "roles": "instructor",
+            "user_id": "111",
+        }
+
+        with self.assertNumQueries(3):
+            elapsed, resource_origin = self._post_lti_request(url, data)
+        self.assertEqual(resource_origin["id"], str(video.id))
+        self.assertTrue(elapsed < 0.1)
+
+        # Calling the same resource a second time with the same LTI parameters
+        # should not hit the cache
+        with self.assertNumQueries(3):
+            elapsed, resource = self._post_lti_request(url, data)
+        self.assertEqual(resource, resource_origin)
+        self.assertTrue(elapsed < 0.1)

--- a/src/backend/marsha/core/tests/test_views_lti_document.py
+++ b/src/backend/marsha/core/tests/test_views_lti_document.py
@@ -20,7 +20,7 @@ from ..lti import LTI
 # pylint: disable=unused-argument
 
 
-class DocumentViewTestCase(TestCase):
+class DocumentLTIViewTestCase(TestCase):
     """Test case for the file LTI view."""
 
     @mock.patch.object(LTI, "verify")
@@ -66,7 +66,6 @@ class DocumentViewTestCase(TestCase):
             jwt_token.payload["course"],
             {"school_name": "ufr", "course_name": "mathematics", "course_run": "00001"},
         )
-
         self.assertEqual(context.get("state"), "success")
         self.assertIsNotNone(context.get("resource"))
         self.assertEqual(context.get("modelName"), "documents")
@@ -263,7 +262,7 @@ class DocumentViewTestCase(TestCase):
         self.assertContains(response, "<html>")
         content = response.content.decode("utf-8")
 
-        mock_logger.assert_called_once_with("LTI Exception: %s", "lti error")
+        mock_logger.assert_called_once_with("lti error")
 
         match = re.search(
             '<div id="marsha-frontend-data" data-context="(.*)">', content

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -213,6 +213,9 @@ class Base(Configuration):
     # Helper to easily know if static files in AWS is activated
     STATICFILES_AWS_ENABLED = False
 
+    # Cache
+    APP_DATA_CACHE_DURATION = values.Value(10)  # 10 secondes
+
     # pylint: disable=invalid-name
     @property
     def SIMPLE_JWT(self):
@@ -268,6 +271,7 @@ class Development(Base):
     AWS_SOURCE_BUCKET_NAME = values.Value("development-marsha-source")
     DEBUG = values.BooleanValue(True)
     CLOUDFRONT_SIGNED_URLS_ACTIVE = values.BooleanValue(False)
+    CACHES = {"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
 
     LOGGING = values.DictValue(
         {


### PR DESCRIPTION
## Purpose

We need to make sure that Marsha can scale to very heavy loads. In particular, we have noticed that signing the CloudFront urls is compute intensive. 

## Proposal

I propose to focus on caching the result of LTI views for student because this is were all the load comes from.

The cache duration is set to 10 seconds. This ensures that we cut the load and at the same time:
- don't impact the freshness of data served to students,
- avoid building a complicated and bug prone cache invalidation machinery,
- don't impact the validity of CloudFront urls (10 seconds is negligible compared to the validity of our signed urls).
