### PR TITLE
♻️(project) rename test methods and view class as per handbook guideline

### DIFF
--- a/src/backend/marsha/core/tests/test_views_lti_development.py
+++ b/src/backend/marsha/core/tests/test_views_lti_development.py
@@ -1,0 +1,256 @@
+"""Test the LTI video view."""
+from html import unescape
+import json
+import random
+import re
+import uuid
+
+from django.core.exceptions import ImproperlyConfigured
+from django.test import TestCase, override_settings
+
+from rest_framework_simplejwt.tokens import AccessToken
+
+from ..factories import VideoFactory
+from ..models import ConsumerSite, Video
+
+
+# We don't enforce arguments documentation in tests
+# pylint: disable=unused-argument
+
+
+class DevelopmentLTIViewTestCase(TestCase):
+    """Test the views in the ``core`` app of the Marsha project for development use cases.
+
+    When developing on marsha, we are using the DevelopmentLTIView to simulate a launch request
+    from an iframe in an LMS. However:
+    - This simple view does not compute the LTI signature,
+    - We don't want to have to create an LTI passport to make it work.
+
+    Setting the "BYPASS_LTI_VERIFICATION" setting to True, allows Marsha to work "normally" without
+    a passport and without the LTI verification. This is only allowed when DEBUG is True.
+    """
+
+    @override_settings(DEBUG=True)
+    @override_settings(BYPASS_LTI_VERIFICATION=True)
+    def test_views_lti_development_post_bypass_lti_student(self):
+        """In development, passport creation and LTI verification can be bypassed for a student."""
+        video = VideoFactory(
+            playlist__consumer_site__domain="example.com", upload_state="ready"
+        )
+        # There is no need to provide an "oauth_consumer_key"
+        data = {
+            "resource_link_id": video.lti_id,
+            "context_id": video.playlist.lti_id,
+            "roles": "student",
+            "context_title": "mathematics",
+            "tool_consumer_instance_name": "ufr",
+            "tool_consumer_instance_guid": "example.com",
+            "user_id": "56255f3807599c377bf0e5bf072359fd",
+            "launch_presentation_locale": "fr",
+        }
+        response = self.client.post(
+            "/lti/videos/{!s}".format(video.pk),
+            data,
+            HTTP_REFERER="https://example.com",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "<html>")
+        content = response.content.decode("utf-8")
+
+        match = re.search(
+            '<div id="marsha-frontend-data" data-context="(.*)">', content
+        )
+
+        context = json.loads(unescape(match.group(1)))
+        jwt_token = AccessToken(context.get("jwt"))
+        self.assertEqual(jwt_token.payload["resource_id"], str(video.id))
+        self.assertEqual(jwt_token.payload["user_id"], data["user_id"])
+        self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
+        self.assertEqual(jwt_token.payload["roles"], [data["roles"]])
+        self.assertEqual(jwt_token.payload["locale"], "fr_FR")
+        self.assertEqual(
+            jwt_token.payload["permissions"],
+            {"can_access_dashboard": False, "can_update": False},
+        )
+        self.assertDictEqual(
+            jwt_token.payload["course"],
+            {"school_name": "ufr", "course_name": "mathematics", "course_run": None},
+        )
+        self.assertEqual(context.get("state"), "success")
+        self.assertEqual(
+            context.get("resource"),
+            {
+                "active_stamp": None,
+                "is_ready_to_show": False,
+                "show_download": True,
+                "description": video.description,
+                "id": str(video.id),
+                "upload_state": "ready",
+                "timed_text_tracks": [],
+                "thumbnail": None,
+                "title": video.title,
+                "urls": None,
+            },
+        )
+        self.assertEqual(context.get("modelName"), "videos")
+
+    @override_settings(DEBUG=True)
+    @override_settings(BYPASS_LTI_VERIFICATION=True)
+    def test_views_lti_development_post_bypass_lti_instructor(self):
+        """In development, passport creation and LTI verif can be bypassed for a instructor."""
+        video = VideoFactory(playlist__consumer_site__domain="example.com")
+        data = {
+            "resource_link_id": video.lti_id,
+            "context_id": video.playlist.lti_id,
+            "roles": "instructor",
+            "tool_consumer_instance_guid": "example.com",
+            "context_title": "mathematics",
+            "tool_consumer_instance_name": "ufr",
+            "user_id": "56255f3807599c377bf0e5bf072359fd",
+        }
+        response = self.client.post(
+            "/lti/videos/{!s}".format(video.pk),
+            data,
+            HTTP_REFERER="https://example.com",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "<html>")
+        content = response.content.decode("utf-8")
+
+        match = re.search(
+            '<div id="marsha-frontend-data" data-context="(.*)">', content
+        )
+
+        context = json.loads(unescape(match.group(1)))
+        jwt_token = AccessToken(context.get("jwt"))
+        self.assertEqual(jwt_token.payload["resource_id"], str(video.id))
+        self.assertEqual(jwt_token.payload["user_id"], data["user_id"])
+        self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
+        self.assertEqual(jwt_token.payload["roles"], [data["roles"]])
+        self.assertEqual(jwt_token.payload["locale"], "en_US")
+        self.assertEqual(
+            jwt_token.payload["permissions"],
+            {"can_access_dashboard": True, "can_update": True},
+        )
+        self.assertDictEqual(
+            jwt_token.payload["course"],
+            {"school_name": "ufr", "course_name": "mathematics", "course_run": None},
+        )
+        self.assertEqual(context.get("state"), "success")
+        self.assertEqual(
+            context.get("resource"),
+            {
+                "active_stamp": None,
+                "is_ready_to_show": False,
+                "show_download": True,
+                "description": video.description,
+                "id": str(video.id),
+                "upload_state": "pending",
+                "timed_text_tracks": [],
+                "thumbnail": None,
+                "title": video.title,
+                "urls": None,
+            },
+        )
+        self.assertEqual(context.get("modelName"), "videos")
+
+    @override_settings(DEBUG=True)
+    @override_settings(BYPASS_LTI_VERIFICATION=True)
+    def test_views_lti_development_post_bypass_lti_instructor_no_video(self):
+        """When bypassing LTI, the "example.com" consumer site is automatically created."""
+        data = {
+            "resource_link_id": "example.com-123",
+            "context_id": "course-v1:ufr+mathematics+00001",
+            "roles": "instructor",
+            "tool_consumer_instance_guid": "example.com",
+            "user_id": "56255f3807599c377bf0e5bf072359fd",
+        }
+        response = self.client.post(
+            "/lti/videos/{!s}".format(uuid.uuid4()),
+            data,
+            HTTP_REFERER="https://example.com",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "<html>")
+        content = response.content.decode("utf-8")
+        match = re.search(
+            '<div id="marsha-frontend-data" data-context="(.*)">', content
+        )
+
+        context = json.loads(unescape(match.group(1)))
+        jwt_token = AccessToken(context.get("jwt"))
+        video = Video.objects.get()
+        self.assertEqual(jwt_token.payload["resource_id"], str(video.id))
+        self.assertEqual(jwt_token.payload["user_id"], data["user_id"])
+        self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
+        self.assertEqual(jwt_token.payload["roles"], [data["roles"]])
+        self.assertEqual(jwt_token.payload["locale"], "en_US")
+        self.assertDictEqual(
+            jwt_token.payload["course"],
+            {"school_name": "ufr", "course_name": "mathematics", "course_run": "00001"},
+        )
+        self.assertEqual(context.get("state"), "success")
+
+        self.assertEqual(
+            context.get("resource"),
+            {
+                "active_stamp": None,
+                "is_ready_to_show": False,
+                "show_download": True,
+                "description": video.description,
+                "id": str(video.id),
+                "upload_state": "pending",
+                "timed_text_tracks": [],
+                "thumbnail": None,
+                "title": video.title,
+                "urls": None,
+            },
+        )
+        self.assertEqual(context.get("modelName"), "videos")
+        # The consumer site was created with a name and a domain name
+        ConsumerSite.objects.get(name="example.com", domain="example.com")
+
+    @override_settings(BYPASS_LTI_VERIFICATION=True)
+    def test_views_lti_development_post_bypass_lti_no_debug_mode(self):
+        """Bypassing LTI verification is only allowed in debug mode."""
+        video = VideoFactory(playlist__consumer_site__domain="example.com")
+        role = random.choice(["instructor", "student"])
+        data = {
+            "resource_link_id": video.lti_id,
+            "roles": role,
+            "context_id": video.playlist.lti_id,
+            "user_id": "56255f3807599c377bf0e5bf072359fd",
+        }
+
+        with self.assertRaises(ImproperlyConfigured):
+            self.client.post("/lti/videos/{!s}".format(video.pk), data)
+
+    @override_settings(DEBUG=True)
+    @override_settings(BYPASS_LTI_VERIFICATION=True)
+    def test_views_lti_development_post_bypass_lti_no_referer(self):
+        """Trying to bypass LTI verification without a referer, should return an LTI error."""
+        video = VideoFactory(
+            playlist__consumer_site__domain="example.com", upload_state="ready"
+        )
+        # There is no need to provide an "oauth_consumer_key"
+        data = {
+            "resource_link_id": video.lti_id,
+            "context_id": video.playlist.lti_id,
+            "roles": random.choice(["instructor", "student"]),
+            "context_title": "mathematics",
+            "tool_consumer_instance_name": "ufr",
+            "tool_consumer_instance_guid": "example.com",
+            "user_id": "56255f3807599c377bf0e5bf072359fd",
+            "launch_presentation_locale": "fr",
+        }
+        response = self.client.post("/lti/videos/{!s}".format(video.pk), data)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "<html>")
+        content = response.content.decode("utf-8")
+
+        match = re.search(
+            '<div id="marsha-frontend-data" data-context="(.*)">', content
+        )
+
+        context = json.loads(unescape(match.group(1)))
+        self.assertEqual(context["state"], "error")

--- a/src/backend/marsha/core/tests/test_views_lti_document.py
+++ b/src/backend/marsha/core/tests/test_views_lti_document.py
@@ -25,7 +25,9 @@ class DocumentLTIViewTestCase(TestCase):
 
     @mock.patch.object(LTI, "verify")
     @mock.patch.object(LTI, "get_consumer_site")
-    def test_document_view_instructor(self, mock_get_consumer_site, mock_verify):
+    def test_views_lti_document_instructor_same_playlist(
+        self, mock_get_consumer_site, mock_verify
+    ):
         """Validate the format of the response returned by the view for an instructor request."""
         passport = ConsumerSiteLTIPassportFactory()
         document = DocumentFactory(
@@ -75,7 +77,7 @@ class DocumentLTIViewTestCase(TestCase):
 
     @mock.patch.object(LTI, "verify")
     @mock.patch.object(LTI, "get_consumer_site")
-    def test_document_view_instructor_other_playlist(
+    def test_views_lti_document_instructor_other_playlist(
         self, mock_get_consumer_site, mock_verify
     ):
         """Validate the response returned by the view for an instructor from another playlist."""
@@ -134,7 +136,9 @@ class DocumentLTIViewTestCase(TestCase):
 
     @mock.patch.object(LTI, "verify")
     @mock.patch.object(LTI, "get_consumer_site")
-    def test_document_view_student(self, mock_get_consumer_site, mock_verify):
+    def test_views_lti_document_student_with_video(
+        self, mock_get_consumer_site, mock_verify
+    ):
         """Validate the format of the response returned by the view for a student request."""
         passport = ConsumerSiteLTIPassportFactory()
         document = DocumentFactory(
@@ -186,7 +190,9 @@ class DocumentLTIViewTestCase(TestCase):
 
     @mock.patch.object(LTI, "verify")
     @mock.patch.object(LTI, "get_consumer_site")
-    def test_document_view_student_no_video(self, mock_get_consumer_site, mock_verify):
+    def test_views_lti_document_student_no_video(
+        self, mock_get_consumer_site, mock_verify
+    ):
         """Validate the response returned for a student request when there is no file."""
         passport = ConsumerSiteLTIPassportFactory()
         data = {
@@ -218,7 +224,7 @@ class DocumentLTIViewTestCase(TestCase):
 
     @mock.patch.object(LTI, "verify")
     @mock.patch.object(LTI, "get_consumer_site")
-    def test_document_view_instructor_no_video(
+    def test_views_lti_document_instructor_no_video(
         self, mock_get_consumer_site, mock_verify
     ):
         """Validate the response returned for an instructor request when there is no file."""
@@ -253,7 +259,7 @@ class DocumentLTIViewTestCase(TestCase):
 
     @mock.patch.object(Logger, "warning")
     @mock.patch.object(LTI, "verify", side_effect=LTIException("lti error"))
-    def test_document_view_lti_post_error(self, mock_verify, mock_logger):
+    def test_views_lti_document_post_error(self, mock_verify, mock_logger):
         """Validate the response returned in case of an LTI exception."""
         role = random.choice(["instructor", "student"])
         data = {"resource_link_id": "123", "roles": role, "context_id": "abc"}

--- a/src/backend/marsha/core/tests/test_views_lti_video.py
+++ b/src/backend/marsha/core/tests/test_views_lti_video.py
@@ -7,7 +7,6 @@ import re
 from unittest import mock
 import uuid
 
-from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase, override_settings
 
 from pylti.common import LTIException
@@ -19,7 +18,6 @@ from ..factories import (
     VideoFactory,
 )
 from ..lti import LTI
-from ..models import ConsumerSite, Video
 
 
 # We don't enforce arguments documentation in tests
@@ -31,7 +29,7 @@ class VideoLTIViewTestCase(TestCase):
 
     @mock.patch.object(LTI, "verify")
     @mock.patch.object(LTI, "get_consumer_site")
-    def test_views_video_lti_post_instructor(self, mock_get_consumer_site, mock_verify):
+    def test_views_lti_video_post_instructor(self, mock_get_consumer_site, mock_verify):
         """Validate the format of the response returned by the view for an instructor request."""
         passport = ConsumerSiteLTIPassportFactory()
         video = VideoFactory(
@@ -96,7 +94,7 @@ class VideoLTIViewTestCase(TestCase):
 
     @mock.patch.object(LTI, "verify")
     @mock.patch.object(LTI, "get_consumer_site")
-    def test_views_video_lti_post_administrator(
+    def test_views_lti_video_post_administrator(
         self, mock_get_consumer_site, mock_verify
     ):
         """Validate the format of the response returned by the view for an admin request."""
@@ -221,7 +219,9 @@ class VideoLTIViewTestCase(TestCase):
 
     @mock.patch.object(LTI, "verify")
     @mock.patch.object(LTI, "get_consumer_site")
-    def test_views_video_lti_post_student(self, mock_get_consumer_site, mock_verify):
+    def test_views_lti_video_post_student_with_video(
+        self, mock_get_consumer_site, mock_verify
+    ):
         """Validate the format of the response returned by the view for a student request."""
         passport = ConsumerSiteLTIPassportFactory()
         video = VideoFactory(
@@ -286,7 +286,7 @@ class VideoLTIViewTestCase(TestCase):
 
     @mock.patch.object(LTI, "verify")
     @mock.patch.object(LTI, "get_consumer_site")
-    def test_views_video_lti_without_user_id_parameter(
+    def test_views_lti_video_without_user_id_parameter(
         self, mock_get_consumer_site, mock_verify
     ):
         """Ensure JWT is created if user_id is missing in the LTI request."""
@@ -334,7 +334,7 @@ class VideoLTIViewTestCase(TestCase):
 
     @mock.patch.object(LTI, "verify")
     @mock.patch.object(LTI, "get_consumer_site")
-    def test_views_video_lti_post_student_no_video(
+    def test_views_lti_video_post_student_no_video(
         self, mock_get_consumer_site, mock_verify
     ):
         """Validate the response returned for a student request when there is no video."""
@@ -368,7 +368,7 @@ class VideoLTIViewTestCase(TestCase):
 
     @mock.patch.object(Logger, "warning")
     @mock.patch.object(LTI, "verify", side_effect=LTIException("lti error"))
-    def test_views_video_lti_post_error(self, mock_verify, mock_logger):
+    def test_views_lti_video_post_error(self, mock_verify, mock_logger):
         """Validate the response returned in case of an LTI exception."""
         role = random.choice(["instructor", "student"])
         data = {"resource_link_id": "123", "roles": role, "context_id": "abc"}
@@ -390,7 +390,7 @@ class VideoLTIViewTestCase(TestCase):
 
     @mock.patch.object(LTI, "verify")
     @mock.patch.object(LTI, "get_consumer_site")
-    def test_views_video_lti_with_timed_text(self, mock_get_consumer_site, mock_verify):
+    def test_views_lti_video_with_timed_text(self, mock_get_consumer_site, mock_verify):
         """Make sure the LTI Video view functions when the Video has associated TimedTextTracks.
 
         NB: This is a bug-reproducing test case.
@@ -435,7 +435,7 @@ class VideoLTIViewTestCase(TestCase):
     @override_settings(CLOUDFRONT_DOMAIN="abcd.cloudfront.net")
     @mock.patch.object(LTI, "verify")
     @mock.patch.object(LTI, "get_consumer_site")
-    def test_views_video_staticfiles_aws_disabled(
+    def test_views_lti_video_staticfiles_aws_disabled(
         self, mock_get_consumer_site, mock_verify
     ):
         """Meta tag public-path should'nt be in the response when staticfiles on AWS is diabled."""
@@ -462,7 +462,7 @@ class VideoLTIViewTestCase(TestCase):
     @override_settings(CLOUDFRONT_DOMAIN="abcd.cloudfront.net")
     @mock.patch.object(LTI, "verify")
     @mock.patch.object(LTI, "get_consumer_site")
-    def test_views_video_staticfiles_aws_enabled(
+    def test_views_lti_video_staticfiles_aws_enabled(
         self, mock_get_consumer_site, mock_verify
     ):
         """Meta tag public-path should be in the response when staticfiles on AWS is enabled."""
@@ -484,241 +484,3 @@ class VideoLTIViewTestCase(TestCase):
         self.assertContains(
             response, '<meta name="public-path" value="abcd.cloudfront.net" />'
         )
-
-
-class DevelopmentViewsTestCase(TestCase):
-    """Test the views in the ``core`` app of the Marsha project for development use cases.
-
-    When developing on marsha, we are using the LTIDevelopmentView to simulate a launch request
-    from an iframe in an LMS. However:
-    - This simple view does not compute the LTI signature,
-    - We don't want to have to create an LTI passport to make it work.
-
-    Setting the "BYPASS_LTI_VERIFICATION" setting to True, allows Marsha to work "normally" without
-    a passport and without the LTI verification. This is only allowed when DEBUG is True.
-    """
-
-    @override_settings(DEBUG=True)
-    @override_settings(BYPASS_LTI_VERIFICATION=True)
-    def test_views_video_lti_post_bypass_lti_student(self):
-        """In development, passport creation and LTI verification can be bypassed for a student."""
-        video = VideoFactory(
-            playlist__consumer_site__domain="example.com", upload_state="ready"
-        )
-        # There is no need to provide an "oauth_consumer_key"
-        data = {
-            "resource_link_id": video.lti_id,
-            "context_id": video.playlist.lti_id,
-            "roles": "student",
-            "context_title": "mathematics",
-            "tool_consumer_instance_name": "ufr",
-            "tool_consumer_instance_guid": "example.com",
-            "user_id": "56255f3807599c377bf0e5bf072359fd",
-            "launch_presentation_locale": "fr",
-        }
-        response = self.client.post(
-            "/lti/videos/{!s}".format(video.pk),
-            data,
-            HTTP_REFERER="https://example.com",
-        )
-        self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "<html>")
-        content = response.content.decode("utf-8")
-
-        match = re.search(
-            '<div id="marsha-frontend-data" data-context="(.*)">', content
-        )
-
-        context = json.loads(unescape(match.group(1)))
-        jwt_token = AccessToken(context.get("jwt"))
-        self.assertEqual(jwt_token.payload["resource_id"], str(video.id))
-        self.assertEqual(jwt_token.payload["user_id"], data["user_id"])
-        self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
-        self.assertEqual(jwt_token.payload["roles"], [data["roles"]])
-        self.assertEqual(jwt_token.payload["locale"], "fr_FR")
-        self.assertEqual(
-            jwt_token.payload["permissions"],
-            {"can_access_dashboard": False, "can_update": False},
-        )
-        self.assertDictEqual(
-            jwt_token.payload["course"],
-            {"school_name": "ufr", "course_name": "mathematics", "course_run": None},
-        )
-        self.assertEqual(context.get("state"), "success")
-        self.assertEqual(
-            context.get("resource"),
-            {
-                "active_stamp": None,
-                "is_ready_to_show": False,
-                "show_download": True,
-                "description": video.description,
-                "id": str(video.id),
-                "upload_state": "ready",
-                "timed_text_tracks": [],
-                "thumbnail": None,
-                "title": video.title,
-                "urls": None,
-            },
-        )
-        self.assertEqual(context.get("modelName"), "videos")
-
-    @override_settings(DEBUG=True)
-    @override_settings(BYPASS_LTI_VERIFICATION=True)
-    def test_views_video_lti_post_bypass_lti_instructor(self):
-        """In development, passport creation and LTI verif can be bypassed for a instructor."""
-        video = VideoFactory(playlist__consumer_site__domain="example.com")
-        data = {
-            "resource_link_id": video.lti_id,
-            "context_id": video.playlist.lti_id,
-            "roles": "instructor",
-            "tool_consumer_instance_guid": "example.com",
-            "context_title": "mathematics",
-            "tool_consumer_instance_name": "ufr",
-            "user_id": "56255f3807599c377bf0e5bf072359fd",
-        }
-        response = self.client.post(
-            "/lti/videos/{!s}".format(video.pk),
-            data,
-            HTTP_REFERER="https://example.com",
-        )
-        self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "<html>")
-        content = response.content.decode("utf-8")
-
-        match = re.search(
-            '<div id="marsha-frontend-data" data-context="(.*)">', content
-        )
-
-        context = json.loads(unescape(match.group(1)))
-        jwt_token = AccessToken(context.get("jwt"))
-        self.assertEqual(jwt_token.payload["resource_id"], str(video.id))
-        self.assertEqual(jwt_token.payload["user_id"], data["user_id"])
-        self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
-        self.assertEqual(jwt_token.payload["roles"], [data["roles"]])
-        self.assertEqual(jwt_token.payload["locale"], "en_US")
-        self.assertEqual(
-            jwt_token.payload["permissions"],
-            {"can_access_dashboard": True, "can_update": True},
-        )
-        self.assertDictEqual(
-            jwt_token.payload["course"],
-            {"school_name": "ufr", "course_name": "mathematics", "course_run": None},
-        )
-        self.assertEqual(context.get("state"), "success")
-        self.assertEqual(
-            context.get("resource"),
-            {
-                "active_stamp": None,
-                "is_ready_to_show": False,
-                "show_download": True,
-                "description": video.description,
-                "id": str(video.id),
-                "upload_state": "pending",
-                "timed_text_tracks": [],
-                "thumbnail": None,
-                "title": video.title,
-                "urls": None,
-            },
-        )
-        self.assertEqual(context.get("modelName"), "videos")
-
-    @override_settings(DEBUG=True)
-    @override_settings(BYPASS_LTI_VERIFICATION=True)
-    def test_views_video_lti_post_bypass_lti_instructor_no_video(self):
-        """When bypassing LTI, the "example.com" consumer site is automatically created."""
-        data = {
-            "resource_link_id": "example.com-123",
-            "context_id": "course-v1:ufr+mathematics+00001",
-            "roles": "instructor",
-            "tool_consumer_instance_guid": "example.com",
-            "user_id": "56255f3807599c377bf0e5bf072359fd",
-        }
-        response = self.client.post(
-            "/lti/videos/{!s}".format(uuid.uuid4()),
-            data,
-            HTTP_REFERER="https://example.com",
-        )
-        self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "<html>")
-        content = response.content.decode("utf-8")
-        match = re.search(
-            '<div id="marsha-frontend-data" data-context="(.*)">', content
-        )
-
-        context = json.loads(unescape(match.group(1)))
-        jwt_token = AccessToken(context.get("jwt"))
-        video = Video.objects.get()
-        self.assertEqual(jwt_token.payload["resource_id"], str(video.id))
-        self.assertEqual(jwt_token.payload["user_id"], data["user_id"])
-        self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
-        self.assertEqual(jwt_token.payload["roles"], [data["roles"]])
-        self.assertEqual(jwt_token.payload["locale"], "en_US")
-        self.assertDictEqual(
-            jwt_token.payload["course"],
-            {"school_name": "ufr", "course_name": "mathematics", "course_run": "00001"},
-        )
-        self.assertEqual(context.get("state"), "success")
-
-        self.assertEqual(
-            context.get("resource"),
-            {
-                "active_stamp": None,
-                "is_ready_to_show": False,
-                "show_download": True,
-                "description": video.description,
-                "id": str(video.id),
-                "upload_state": "pending",
-                "timed_text_tracks": [],
-                "thumbnail": None,
-                "title": video.title,
-                "urls": None,
-            },
-        )
-        self.assertEqual(context.get("modelName"), "videos")
-        # The consumer site was created with a name and a domain name
-        ConsumerSite.objects.get(name="example.com", domain="example.com")
-
-    @override_settings(BYPASS_LTI_VERIFICATION=True)
-    def test_views_video_lti_post_bypass_lti_no_debug_mode(self):
-        """Bypassing LTI verification is only allowed in debug mode."""
-        video = VideoFactory(playlist__consumer_site__domain="example.com")
-        role = random.choice(["instructor", "student"])
-        data = {
-            "resource_link_id": video.lti_id,
-            "roles": role,
-            "context_id": video.playlist.lti_id,
-            "user_id": "56255f3807599c377bf0e5bf072359fd",
-        }
-
-        with self.assertRaises(ImproperlyConfigured):
-            self.client.post("/lti/videos/{!s}".format(video.pk), data)
-
-    @override_settings(DEBUG=True)
-    @override_settings(BYPASS_LTI_VERIFICATION=True)
-    def test_views_video_lti_post_bypass_lti_no_referer(self):
-        """Trying to bypass LTI verification without a referer, should return an LTI error."""
-        video = VideoFactory(
-            playlist__consumer_site__domain="example.com", upload_state="ready"
-        )
-        # There is no need to provide an "oauth_consumer_key"
-        data = {
-            "resource_link_id": video.lti_id,
-            "context_id": video.playlist.lti_id,
-            "roles": random.choice(["instructor", "student"]),
-            "context_title": "mathematics",
-            "tool_consumer_instance_name": "ufr",
-            "tool_consumer_instance_guid": "example.com",
-            "user_id": "56255f3807599c377bf0e5bf072359fd",
-            "launch_presentation_locale": "fr",
-        }
-        response = self.client.post("/lti/videos/{!s}".format(video.pk), data)
-        self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "<html>")
-        content = response.content.decode("utf-8")
-
-        match = re.search(
-            '<div id="marsha-frontend-data" data-context="(.*)">', content
-        )
-
-        context = json.loads(unescape(match.group(1)))
-        self.assertEqual(context["state"], "error")

--- a/src/backend/marsha/core/views.py
+++ b/src/backend/marsha/core/views.py
@@ -192,7 +192,7 @@ class DocumentLTIView(BaseLTIView):
     serializer_class = DocumentSerializer
 
 
-class LTIDevelopmentView(TemplateView):
+class DevelopmentLTIView(TemplateView):
     """A development view with iframe POST / plain POST helpers.
 
     Not available outside of DEBUG = true environments.

--- a/src/backend/marsha/urls.py
+++ b/src/backend/marsha/urls.py
@@ -17,7 +17,7 @@ from marsha.core.api import (
     XAPIStatementView,
     update_state,
 )
-from marsha.core.views import DocumentLTIView, LTIDevelopmentView, VideoLTIView
+from marsha.core.views import DevelopmentLTIView, DocumentLTIView, VideoLTIView
 
 
 router = DefaultRouter()
@@ -51,5 +51,5 @@ urlpatterns = [
 
 if settings.DEBUG:
     urlpatterns += [
-        path("development/", LTIDevelopmentView.as_view(), name="lti-development-view")
+        path("development/", DevelopmentLTIView.as_view(), name="lti-development-view")
     ]


### PR DESCRIPTION
## Purpose

We usually name our test methods by the name of the module they are testing, from the most generic to the most specific. It allows to target tests with the desired granularity via pytest's `-k` flag.

This was materialized in FUN's handbook: https://openfun.gitbooks.io/handbook/content/python.html#test-files

While working on the lti views I noticed that some names were not following this practice.

## Proposal

- [x] Rename LTI views test methods to comply with guideline
- [x] Rename `LTIDevelopmentView` to `DevelopmentLTIView` for coherence with `VideoLTIView` and `DocumentLTIview`. Here again from the most generic inside to the most specific outside.
