### PR TITLE
♻️(front) group all permissions in the JWT token

### DIFF
--- a/src/frontend/components/InstructorView/index.spec.tsx
+++ b/src/frontend/components/InstructorView/index.spec.tsx
@@ -1,7 +1,6 @@
 import { render } from '@testing-library/react';
 import React from 'react';
 
-import { modelName } from '../../types/models';
 import { wrapInIntlProvider } from '../../utils/tests/intl';
 import { wrapInRouter } from '../../utils/tests/router';
 import { InstructorView } from './';
@@ -19,7 +18,9 @@ jest.mock('../../data/appData', () => ({
 describe('<InstructorView />', () => {
   it('renders the instructor controls', () => {
     mockDecodedJwt = {
-      read_only: false,
+      permissions: {
+        can_access_dasboard: false,
+      },
     };
 
     const { getByText } = render(
@@ -39,7 +40,9 @@ describe('<InstructorView />', () => {
   it('removes the button when read_only is true', () => {
     mockDecodedJwt = {
       context_id: 'foo+context_id',
-      read_only: true,
+      permissions: {
+        can_access_dashboard: true,
+      },
     };
 
     const { getByText, queryByText } = render(

--- a/src/frontend/components/InstructorView/index.tsx
+++ b/src/frontend/components/InstructorView/index.tsx
@@ -53,9 +53,11 @@ interface InstructorViewProps {
 }
 
 export const InstructorView = ({ children }: InstructorViewProps) => {
-  const readOnly = getDecodedJwt().read_only;
-  const message = readOnly ? messages.disabledDashboard : messages.title;
-  const messagePlaceholder = readOnly
+  const canAccessDashboard = getDecodedJwt().permissions.can_access_dashboard;
+  const message = canAccessDashboard
+    ? messages.disabledDashboard
+    : messages.title;
+  const messagePlaceholder = canAccessDashboard
     ? { context_id: getDecodedJwt().context_id }
     : {};
   return (
@@ -65,7 +67,7 @@ export const InstructorView = ({ children }: InstructorViewProps) => {
       </PreviewWrapper>
       <InstructorControls>
         <FormattedMessage {...message} values={messagePlaceholder} />
-        {!readOnly && (
+        {!canAccessDashboard && (
           <BtnWithLink
             color={'brand'}
             label={<FormattedMessage {...messages.btnDashboard} />}

--- a/src/frontend/components/InstructorWrapper/index.spec.tsx
+++ b/src/frontend/components/InstructorWrapper/index.spec.tsx
@@ -14,18 +14,18 @@ jest.mock('../InstructorView/index', () => {
   };
 });
 
-let mockIsEditable: boolean;
+let mockCanUpdate: boolean;
 jest.mock('../../data/appData', () => ({
-  appData: {
-    get isEditable() {
-      return mockIsEditable;
+  getDecodedJwt: () => ({
+    permissions: {
+      can_update: mockCanUpdate,
     },
-  },
+  }),
 }));
 
 describe('<InstructorWrapper />', () => {
   it('wraps its children in an instructor view if the current user is an instructor', () => {
-    mockIsEditable = true;
+    mockCanUpdate = true;
     const { getByText, getByTitle } = render(
       <InstructorWrapper>
         <div title="some-child" />
@@ -37,7 +37,7 @@ describe('<InstructorWrapper />', () => {
   });
 
   it('just renders the children if the current user is not an instructor', () => {
-    mockIsEditable = false;
+    mockCanUpdate = false;
     const { getByTitle, queryByText } = render(
       <InstructorWrapper>
         <div title="some-child" />

--- a/src/frontend/components/InstructorWrapper/index.tsx
+++ b/src/frontend/components/InstructorWrapper/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { appData } from '../../data/appData';
+import { getDecodedJwt } from '../../data/appData';
 import { InstructorView } from '../InstructorView';
 
 interface InstructorWrapperProps {
@@ -8,7 +8,7 @@ interface InstructorWrapperProps {
 }
 
 export const InstructorWrapper = ({ children }: InstructorWrapperProps) => {
-  if (appData.isEditable) {
+  if (getDecodedJwt().permissions.can_update) {
     return <InstructorView>{children}</InstructorView>;
   } else {
     return <React.Fragment>{children}</React.Fragment>;

--- a/src/frontend/components/RedirectOnLoad/index.spec.tsx
+++ b/src/frontend/components/RedirectOnLoad/index.spec.tsx
@@ -15,11 +15,11 @@ let mockState: any;
 let mockVideo: any;
 let mockDocument: any;
 let mockModelName: any;
-let mockIsEditable: boolean;
+let mockCanUpdate: boolean;
 jest.mock('../../data/appData', () => ({
   appData: {
     get isEditable() {
-      return mockIsEditable;
+      return mockCanUpdate;
     },
     get state() {
       return mockState;
@@ -34,6 +34,11 @@ jest.mock('../../data/appData', () => ({
       return mockModelName;
     },
   },
+  getDecodedJwt: () => ({
+    permissions: {
+      can_update: mockCanUpdate,
+    },
+  }),
 }));
 
 describe('<RedirectOnLoad />', () => {
@@ -63,7 +68,7 @@ describe('<RedirectOnLoad />', () => {
     mockState = appState.SUCCESS;
     mockModelName = modelName.VIDEOS;
     mockDocument = null;
-    mockIsEditable = true;
+    mockCanUpdate = true;
 
     for (const state of Object.values(uploadState)) {
       mockVideo = { is_ready_to_show: true, upload_state: state };
@@ -85,7 +90,7 @@ describe('<RedirectOnLoad />', () => {
     mockState = appState.SUCCESS;
     mockModelName = modelName.DOCUMENTS;
     mockVideo = null;
-    mockIsEditable = true;
+    mockCanUpdate = true;
 
     for (const state of Object.values(uploadState)) {
       mockDocument = { is_ready_to_show: true, upload_state: state };
@@ -107,7 +112,7 @@ describe('<RedirectOnLoad />', () => {
     mockState = appState.SUCCESS;
     mockModelName = modelName.VIDEOS;
     mockDocument = null;
-    mockIsEditable = false;
+    mockCanUpdate = false;
 
     for (const state of Object.values(uploadState)) {
       mockVideo = { is_ready_to_show: true, upload_state: state };
@@ -129,7 +134,7 @@ describe('<RedirectOnLoad />', () => {
     mockState = appState.SUCCESS;
     mockModelName = modelName.DOCUMENTS;
     mockVideo = null;
-    mockIsEditable = false;
+    mockCanUpdate = false;
 
     for (const state of Object.values(uploadState)) {
       mockDocument = { is_ready_to_show: true, upload_state: state };
@@ -156,7 +161,7 @@ describe('<RedirectOnLoad />', () => {
     };
     mockModelName = modelName.VIDEOS;
     mockDocument = null;
-    mockIsEditable = true;
+    mockCanUpdate = true;
 
     const { getByText } = render(
       wrapInRouter(<RedirectOnLoad />, [
@@ -181,7 +186,7 @@ describe('<RedirectOnLoad />', () => {
       is_ready_to_show: false,
       upload_state: uploadState.PENDING,
     };
-    mockIsEditable = true;
+    mockCanUpdate = true;
 
     const { getByText } = render(
       wrapInRouter(<RedirectOnLoad />, [
@@ -205,7 +210,7 @@ describe('<RedirectOnLoad />', () => {
     };
     mockModelName = modelName.VIDEOS;
     mockDocument = null;
-    mockIsEditable = true;
+    mockCanUpdate = true;
 
     const { getByText } = render(
       wrapInRouter(<RedirectOnLoad />, [
@@ -229,7 +234,7 @@ describe('<RedirectOnLoad />', () => {
       is_ready_to_show: false,
       upload_state: uploadState.PROCESSING,
     };
-    mockIsEditable = true;
+    mockCanUpdate = true;
 
     const { getByText } = render(
       wrapInRouter(<RedirectOnLoad />, [
@@ -253,7 +258,7 @@ describe('<RedirectOnLoad />', () => {
     };
     mockModelName = modelName.VIDEOS;
     mockDocument = null;
-    mockIsEditable = false;
+    mockCanUpdate = false;
 
     const { getByText } = render(
       wrapInRouter(<RedirectOnLoad />, [
@@ -277,7 +282,7 @@ describe('<RedirectOnLoad />', () => {
     };
     mockModelName = modelName.DOCUMENTS;
     mockVideo = null;
-    mockIsEditable = false;
+    mockCanUpdate = false;
 
     const { getByText } = render(
       wrapInRouter(<RedirectOnLoad />, [
@@ -297,7 +302,7 @@ describe('<RedirectOnLoad />', () => {
     mockState = appState.SUCCESS;
     mockVideo = null;
     mockDocument = null;
-    mockIsEditable = false;
+    mockCanUpdate = false;
 
     for (const model of [modelName.VIDEOS, modelName.DOCUMENTS]) {
       mockModelName = model;

--- a/src/frontend/components/RedirectOnLoad/index.tsx
+++ b/src/frontend/components/RedirectOnLoad/index.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
 import { Redirect } from 'react-router-dom';
 
-import { appData } from '../../data/appData';
+import { appData, getDecodedJwt } from '../../data/appData';
 import { appState } from '../../types/AppData';
-import { modelName } from '../../types/models';
 import { uploadState } from '../../types/tracks';
 import { DASHBOARD_ROUTE } from '../Dashboard/route';
 import { ERROR_COMPONENT_ROUTE } from '../ErrorComponent/route';
@@ -24,7 +23,7 @@ export const RedirectOnLoad = () => {
     return <Redirect push to={PLAYER_ROUTE(appData.modelName)} />;
   }
 
-  if (appData.isEditable) {
+  if (getDecodedJwt().permissions.can_update) {
     if (resource!.upload_state === uploadState.PENDING) {
       return (
         <Redirect

--- a/src/frontend/types/AppData.ts
+++ b/src/frontend/types/AppData.ts
@@ -11,7 +11,6 @@ export enum appState {
 export interface AppData {
   jwt?: string;
   state: appState;
-  isEditable: boolean;
   video?: Nullable<Video>;
   document?: Nullable<Document>;
   modelName: modelName.VIDEOS | modelName.DOCUMENTS;

--- a/src/frontend/types/jwt.ts
+++ b/src/frontend/types/jwt.ts
@@ -6,5 +6,8 @@ export interface DecodedJwt {
   user_id: string;
   resource_id: string;
   locale: string;
-  read_only: boolean;
+  permissions: {
+    can_access_dashboard: boolean;
+    can_update: boolean;
+  };
 }


### PR DESCRIPTION
## Purpose

A new object permissions is in the JWT token, it replaces the property
read_only from the JWT token and isEditable from AppData. read_only is
replaced by can_access_dashboard and isEditable by can_update.

## Proposal

- [x] use new permission object present in JWT token.

