### PR TITLE
Bump application data cache duration to 60 seconds

### DIFF
--- a/docs/env.md
+++ b/docs/env.md
@@ -145,6 +145,15 @@ User to connect to the Postgres database used by Marsha.
 - Required: No
 - Default: `"marsha_user"`
 
+#### APP_DATA_CACHE_DURATION
+
+Cache expiration (in seconds) for application data passed to the frontend by LTI views.
+
+- Type: number
+- Required: No
+- Default: 60
+
+
 ### Amazon Web Services-related settings
 
 #### DJANGO_AWS_ACCESS_KEY_ID, DJANGO_AWS_SECRET_ACCESS_KEY

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -214,7 +214,7 @@ class Base(Configuration):
     STATICFILES_AWS_ENABLED = False
 
     # Cache
-    APP_DATA_CACHE_DURATION = values.Value(10)  # 10 secondes
+    APP_DATA_CACHE_DURATION = values.Value(60)  # 60 secondes
 
     # pylint: disable=invalid-name
     @property


### PR DESCRIPTION
## Purpose

A lot of different unique resources are requested via the LTI views, so 10 seconds is not enough to efficiently cache requests. 

## Proposal

We think a 60 seconds delay before a student sees modifications made by an instructor does not impact user experience. So we propose to bump the application data cache duration to 60 seconds.

While doing this, I realized that we forgot to add the `APP_DATA_CACHE_DURATION` setting to our environment variables documentation.
