### PR TITLE
♻️(statics) change how static base url is computed

### DIFF
--- a/src/backend/marsha/core/views.py
+++ b/src/backend/marsha/core/views.py
@@ -67,7 +67,7 @@ class BaseLTIView(ABC, TemplateResponseMixin, View):
                 "resource": None,
             }
 
-        static_base_url = staticfiles_storage.url("").rstrip("/")
+        static_base_url = staticfiles_storage.url("js").rstrip("/")
 
         return {
             "app_data": json.dumps(app_data),

--- a/src/frontend/public-path.js
+++ b/src/frontend/public-path.js
@@ -4,5 +4,5 @@ document.addEventListener('DOMContentLoaded', () => {
   // urls. By convention this static base url always has a trailing slash.
   const metaPublicPath = document.querySelector('meta[name="public-path"]');
 
-  __webpack_public_path__ = `${metaPublicPath.getAttribute('value')}js/`;
+  __webpack_public_path__ = `${metaPublicPath.getAttribute('value')}`;
 });


### PR DESCRIPTION
## Purpose

In commit #d9c3fd5 we decided to rely on the CLOUDFRONT_DOMAIN setting to
determine which staticfiles_storage is used and then use the `url`
method to compute a base url. In local this work fine but we use the s3
storage class it doesn't work anymore because the hack used to have the
url without filename does not work. To fix this, we want the js folder
path, we know it always exists and it is exactly the path we want in
front application. So we compute the url for the js folder and we don't
have to append /js at the end of the base url in the front application.
We can use the value in meta name public-path directly.

## Proposal

- [x] compute the public url of js folder in views.py.
- [x] use directly the value of the public-path meta tag.

