### PR TITLE
🐛(back) compute base static url from an existing file

### DIFF
--- a/src/backend/marsha/core/views.py
+++ b/src/backend/marsha/core/views.py
@@ -67,11 +67,11 @@ class BaseLTIView(ABC, TemplateResponseMixin, View):
                 "resource": None,
             }
 
-        static_base_url = staticfiles_storage.url("js").rstrip("/")
+        static_base_url = staticfiles_storage.url("js/index.js").rstrip("index.js")
 
         return {
             "app_data": json.dumps(app_data),
-            "static_base_url": f"{static_base_url}/",
+            "static_base_url": f"{static_base_url}",
         }
 
     def _get_app_data(self):


### PR DESCRIPTION
## Purpose

In commit b22477c we tried to fix how we compute the static base url.
In our tests it was working but we didn't test it in Production
environment. In the environment we tested it, the DEBUG mode was
activated and in this mode the S3Boto3Storage class storage always
return a result even if the requested file does not exist. To fix our
issue we choose to request an existing file: js/index.js
This file is the frontend entrypoint. It will always exist
until the frontend application choose to change it...


## Proposal

- [x] request an existing file to compute static base url.

