### PR TITLE
✨(back) introduce a new setting ABSOLUTE_STATIC_URL

### DIFF
--- a/src/backend/marsha/core/views.py
+++ b/src/backend/marsha/core/views.py
@@ -5,7 +5,6 @@ from logging import getLogger
 import uuid
 
 from django.conf import settings
-from django.contrib.staticfiles.storage import staticfiles_storage
 from django.core.cache import cache
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.decorators import method_decorator
@@ -67,11 +66,9 @@ class BaseLTIView(ABC, TemplateResponseMixin, View):
                 "resource": None,
             }
 
-        static_base_url = staticfiles_storage.url("js").rstrip("/")
-
         return {
             "app_data": json.dumps(app_data),
-            "static_base_url": f"{static_base_url}/",
+            "static_base_url": f"{settings.ABSOLUTE_STATIC_URL}js/",
         }
 
     def _get_app_data(self):

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -33,6 +33,7 @@ class Base(Configuration):
     # Static files (CSS, JavaScript, Images)
     STATICFILES_DIRS = (os.path.join(BASE_DIR, "static"),)
     STATIC_URL = "/static/"
+    ABSOLUTE_STATIC_URL = STATIC_URL
     MEDIA_URL = "/media/"
     # Allow to configure location of static/media files for non-Docker installation
     MEDIA_ROOT = values.Value(os.path.join(str(DATA_DIR), "media"))
@@ -336,6 +337,12 @@ class Production(Base):
 
     SESSION_COOKIE_SECURE = True
     CSRF_COOKIE_SECURE = True
+
+    # pylint: disable=invalid-name
+    @property
+    def ABSOLUTE_STATIC_URL(self):
+        """Compute the absolute static url used in the lti template."""
+        return f"//{self.CLOUDFRONT_DOMAIN}{self.STATIC_URL}"
 
 
 class Staging(Production):


### PR DESCRIPTION
## Purpose

In order to compute the static base url we choose to create a new
setting ABSOLUTE_STATIC_URL instead of relying on the staticfiles_storage
class. This settings is computed and can not be overriden with an
environment variable. In production we compute it using the
CLOUDFRONT_DOMAIN.

## Proposal

- [x] create a setting ABSOLUTE_STATIC_URL computed in Base and Production environment.

