### PR TITLE
🔧(circleci) migrate image to python 3.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
   # Check that the git history is clean and complies with our expectations
   lint-git:
     docker:
-      - image: circleci/python:3.6-stretch
+      - image: circleci/python:3.7-stretch
     working_directory: ~/marsha
     steps:
       - checkout
@@ -100,7 +100,7 @@ jobs:
   # Build backend development environment
   build-back:
     docker:
-      - image: circleci/python:3.6-stretch
+      - image: circleci/python:3.7-stretch
     working_directory: ~/marsha/src/backend
     steps:
       - checkout:
@@ -120,7 +120,7 @@ jobs:
   # Build backend translations
   build-back-i18n:
     docker:
-      - image: circleci/python:3.6-stretch
+      - image: circleci/python:3.7-stretch
         environment:
           DJANGO_SETTINGS_MODULE: marsha.settings
           PYTHONPATH: /home/circleci/marsha/src/backend
@@ -161,7 +161,7 @@ jobs:
 
   lint-back:
     docker:
-      - image: circleci/python:3.6-stretch
+      - image: circleci/python:3.7-stretch
     working_directory: ~/marsha/src/backend
     steps:
       - checkout:
@@ -185,7 +185,7 @@ jobs:
 
   test-back:
     docker:
-      - image: circleci/python:3.6-stretch
+      - image: circleci/python:3.7-stretch
         environment:
           DJANGO_SETTINGS_MODULE: marsha.settings
           PYTHONPATH: /home/circleci/marsha/src/backend


### PR DESCRIPTION
## Purpose

We use in our Dockerfile a base image based on python 3.7 but we missed
to change the python version used in our CI. In the circle-ci
configuration file we must change the images used to python 3.7

## Proposal

- [x] upgrade circle-ci configuration file to use python 3.7 in our steps
