### PR TITLE
🐛(front) fix bad usage of permissions.can_access_dashboard from JWT

### DIFF
--- a/src/frontend/components/InstructorView/index.spec.tsx
+++ b/src/frontend/components/InstructorView/index.spec.tsx
@@ -19,7 +19,7 @@ describe('<InstructorView />', () => {
   it('renders the instructor controls', () => {
     mockDecodedJwt = {
       permissions: {
-        can_access_dasboard: false,
+        can_access_dashboard: true,
       },
     };
 
@@ -37,11 +37,11 @@ describe('<InstructorView />', () => {
     getByText('Go to Dashboard');
   });
 
-  it('removes the button when read_only is true', () => {
+  it('removes the button when permissions.can_access_dashboard is set to false', () => {
     mockDecodedJwt = {
       context_id: 'foo+context_id',
       permissions: {
-        can_access_dashboard: true,
+        can_access_dashboard: false,
       },
     };
 

--- a/src/frontend/components/InstructorView/index.tsx
+++ b/src/frontend/components/InstructorView/index.tsx
@@ -55,11 +55,11 @@ interface InstructorViewProps {
 export const InstructorView = ({ children }: InstructorViewProps) => {
   const canAccessDashboard = getDecodedJwt().permissions.can_access_dashboard;
   const message = canAccessDashboard
-    ? messages.disabledDashboard
-    : messages.title;
+    ? messages.title
+    : messages.disabledDashboard;
   const messagePlaceholder = canAccessDashboard
-    ? { context_id: getDecodedJwt().context_id }
-    : {};
+    ? {}
+    : { context_id: getDecodedJwt().context_id };
   return (
     <React.Fragment>
       <PreviewWrapper>
@@ -67,7 +67,7 @@ export const InstructorView = ({ children }: InstructorViewProps) => {
       </PreviewWrapper>
       <InstructorControls>
         <FormattedMessage {...message} values={messagePlaceholder} />
-        {!canAccessDashboard && (
+        {canAccessDashboard && (
           <BtnWithLink
             color={'brand'}
             label={<FormattedMessage {...messages.btnDashboard} />}


### PR DESCRIPTION
## Purpose

We change how permissions are handle. We migrate everything in the JWT
token creating a persmissions object. We made a mistake using the
can_access_dashboard property. We simply rename the old permission name
without changing it's behaviour and we invert the wanted behaviour.

## Proposal

- [x] change permissions behaviour in `<InstructorView />`

