### PR TITLE
✨(AWS) upgrade lambdas to use node 10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -297,7 +297,7 @@ jobs:
   # ---- Lambda related jobs ----
   test-lambda-configure:
     docker:
-      - image: circleci/node:8.10
+      - image: circleci/node:10.16.3
       # Run on the highest version of node available on AWS Lambda
       # https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Runtime
     working_directory: ~/marsha/src/aws/lambda-configure
@@ -310,7 +310,7 @@ jobs:
             - v3-lambdas-configure-dependencies-
       - run:
           name: Install configure lambda dependencies
-          command: yarn install --ignore-engines --frozen-lockfile
+          command: yarn install --frozen-lockfile
       - run:
           name: Run configure lambda tests
           command: yarn test
@@ -321,7 +321,7 @@ jobs:
 
   test-lambda-encode:
     docker:
-      - image: circleci/node:8.10
+      - image: circleci/node:10.16.3
       # Run on the highest version of node available on AWS Lambda
       # https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Runtime
     working_directory: ~/marsha/src/aws/lambda-encode
@@ -334,7 +334,7 @@ jobs:
             - v3-lambdas-encode-dependencies-
       - run:
           name: Install encode lambda dependencies
-          command: yarn install --ignore-engines --frozen-lockfile
+          command: yarn install --frozen-lockfile
       - run:
           name: Run encode lambda tests
           command: yarn test
@@ -345,7 +345,7 @@ jobs:
 
   test-lambda-complete:
     docker:
-      - image: circleci/node:8.10
+      - image: circleci/node:10.16.3
       # Run on the highest version of node available on AWS Lambda
       # https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Runtime
     working_directory: ~/marsha/src/aws/lambda-complete
@@ -358,7 +358,7 @@ jobs:
             - v3-lambdas-complete-dependencies-
       - run:
           name: Install complete lambda dependencies
-          command: yarn install --ignore-engines --frozen-lockfile
+          command: yarn install --frozen-lockfile
       - run:
           name: Run complete lambda tests
           command: yarn test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Using HTML entities in timed text tracks is allowed. Every tag used
   will be escaped and rendered in the web page without being executed.
+- Use node 10 engine to run AWS lambdas.
 
 ## [3.0.0] - 2019-09-24
 

--- a/src/aws/Makefile
+++ b/src/aws/Makefile
@@ -32,7 +32,7 @@ lambda:
 	@rm -rf dist && mkdir dist
 	@for lambda_name in configure encode complete ; do \
 		cd ./lambda-$$lambda_name ; \
-		docker run --rm -it -v "${PWD}:/app" -w "/app/lambda-$$lambda_name" node:8 bash -c "rm -rf node_modules; yarn install --frozen-lockfile --production=true" ; \
+		docker run --rm -it -v "${PWD}:/app" -w "/app/lambda-$$lambda_name" node:10 bash -c "rm -rf node_modules; yarn install --frozen-lockfile --production=true" ; \
 		zip -q -r9 ../dist/marsha_$$lambda_name.zip *; \
 		cd - ; \
 	done
@@ -43,7 +43,7 @@ test:
 	@echo "Test all lambda packages"
 	@for lambda_name in configure encode complete ; do \
 		cd ./lambda-$$lambda_name ; \
-		docker run --rm -it -v "${PWD}:/app" -w "/app/lambda-$$lambda_name" node:8 bash -c "rm -rf node_modules; yarn install --frozen-lockfile" ; \
+		docker run --rm -it -v "${PWD}:/app" -w "/app/lambda-$$lambda_name" node:10 bash -c "rm -rf node_modules; yarn install --frozen-lockfile" ; \
 		yarn test; \
 		cd - ; \
 	done

--- a/src/aws/lambda-complete/package.json
+++ b/src/aws/lambda-complete/package.json
@@ -3,7 +3,7 @@
   "name": "aws-marsha-complete",
   "version": "3.0.0",
   "engines": {
-    "node": ">8.10"
+    "node": "10"
   },
   "description": "Tasks to execute when encoding for a video is complete",
   "repository": {

--- a/src/aws/lambda-configure/package.json
+++ b/src/aws/lambda-configure/package.json
@@ -3,7 +3,7 @@
   "name": "aws-marsha-configure",
   "version": "3.0.0",
   "engines": {
-    "node": ">8.10"
+    "node": "10"
   },
   "description": "Configure AWS via a Lambda for what can not be configured via Terraform for the Marsha video workflow",
   "repository": {

--- a/src/aws/lambda-encode/package.json
+++ b/src/aws/lambda-encode/package.json
@@ -3,7 +3,7 @@
   "name": "aws-marsha-convert",
   "version": "3.0.0",
   "engines": {
-    "node": ">8.10"
+    "node": "10"
   },
   "description": "Convert a source video to all the formats used in Marsha",
   "dependencies": {

--- a/src/aws/lambda.tf
+++ b/src/aws/lambda.tf
@@ -6,7 +6,7 @@ resource "aws_lambda_function" "marsha_configure_lambda" {
   handler          = "index.handler"
   # Run on the highest version of node available on AWS lambda
   # https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Runtime
-  runtime          = "nodejs8.10"
+  runtime          = "nodejs10.x"
   filename         = "dist/marsha_configure.zip"
   source_code_hash = "${base64sha256(file("dist/marsha_configure.zip"))}"
   role             = "${aws_iam_role.lambda_invocation_role.arn}"
@@ -54,7 +54,7 @@ resource "aws_lambda_function" "marsha_encode_lambda" {
   handler          = "index.handler"
   # Run on the highest version of node available on AWS lambda
   # https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Runtime
-  runtime          = "nodejs8.10"
+  runtime          = "nodejs10.x"
   filename         = "dist/marsha_encode.zip"
   source_code_hash = "${base64sha256(file("dist/marsha_encode.zip"))}"
   role             = "${aws_iam_role.lambda_invocation_role.arn}"
@@ -91,7 +91,7 @@ resource "aws_lambda_function" "marsha_complete_lambda" {
   handler          = "index.handler"
   # Run on the highest version of node available on AWS lambda
   # https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Runtime
-  runtime          = "nodejs8.10"
+  runtime          = "nodejs10.x"
   filename         = "dist/marsha_complete.zip"
   source_code_hash = "${base64sha256(file("dist/marsha_complete.zip"))}"
   role             = "${aws_iam_role.lambda_invocation_role.arn}"

--- a/src/aws/state.tf
+++ b/src/aws/state.tf
@@ -1,4 +1,5 @@
 provider "aws" {
+  version = "~> 2.0"
   region = "${var.aws_region}"
 }
 


### PR DESCRIPTION
## Purpose

It is now possible to use node version 10 for lambda functions. We are
interested to upgrade the engine version used, this will allow us to use
new features introduce in node 10 and moreover node 10 is the current
LTS version.

## Proposal

- [x] change runtime in all lambda templates
- [x] upgrade node version used on circleci to version 10
- [x] upgrade makefile to use node 10
- [x] upgrade aws terraform provider to version 2

