### PR TITLE
Fix lambda-migrate issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix errors in lambda-migrate function. The timed text tracks migrations can
+  lead to an infinite loop.
+
 ## [3.1.0] - 2019-10-07
 
 ### Added

--- a/src/aws/lambda-migrate/index.js
+++ b/src/aws/lambda-migrate/index.js
@@ -17,18 +17,19 @@ exports.handler = async (event, context, callback) => {
       return acc;
     }, [])
     .map(migration => `./${basePath}/migrations/${migration}.js`)
-    .map(migration => {
+    .map(async (migration) => {
       let toMigrate;
       try {
         toMigrate = require(migration);
       } catch (e) {
         console.error(`migration ${migration} does not exists`);
+        callback(e);
         return;
       }
 
       try {
         console.log(`executing migration ${migration}`);
-        toMigrate();
+        await toMigrate();
         console.log(`end migration ${migration}`)
       } catch (e){
         errors.push(e);

--- a/src/aws/lambda-migrate/index.spec.js
+++ b/src/aws/lambda-migrate/index.spec.js
@@ -13,15 +13,15 @@ describe('lambda', () => {
     spyError.mockRestore();
   });
 
-  it('should execute nothing if MIGRATIONS env is missing', () => {
+  it('should execute nothing if MIGRATIONS env is missing', async () => {
     const lambda = require('./index.js').handler;
-    lambda(null, null, jest.fn());
+    await lambda(null, null, jest.fn());
   });
 
-  it('should execute only existing migrations', () => {
+  it('should execute only existing migrations', async () => {
     process.env.MIGRATIONS = ' 0001_migration,foo';
     const lambda = require('./index.js').handler;
-    lambda(null, null, jest.fn());
+    await lambda(null, null, jest.fn());
     expect(spyError).toHaveBeenCalledWith('migration ./stubs/migrations/foo.js does not exists');
     expect(spyLog).toHaveBeenNthCalledWith(1, 'executing migration ./stubs/migrations/0001_migration.js');
     expect(spyLog).toHaveBeenNthCalledWith(2, 'foo');

--- a/src/aws/lambda-migrate/src/migrations/0001_encode_timed_text_tracks.js
+++ b/src/aws/lambda-migrate/src/migrations/0001_encode_timed_text_tracks.js
@@ -5,17 +5,17 @@ const lambda = new AWS.Lambda({ apiVersion: '2015-03-31' });
 
 const regex = /^.*\/timedtexttrack\/.*$/
 
-const processTimedTextTracks = async (marker = null) => {
+const processTimedTextTracks = async (continuationToken = null) => {
 
   const params = {
     Bucket: process.env.S3_SOURCE_BUCKET,
   };
 
-  if (marker) {
-    params['Marker'] = marker;
+  if (continuationToken) {
+    params['ContinuationToken'] = continuationToken;
   }
 
-  const data = await s3.listObjects(params).promise();
+  const data = await s3.listObjectsV2(params).promise();
 
   data.Contents.map(async (object) => {
     if (regex.test(object.Key)) {
@@ -25,7 +25,7 @@ const processTimedTextTracks = async (marker = null) => {
   });
 
   if (data.IsTruncated) {
-    await processTimedTextTracks(data.NextMarker);
+    await processTimedTextTracks(data.NextContinuationToken);
   }
 }
 

--- a/src/aws/lambda-migrate/src/migrations/0001_encode_timed_text_tracks.spec.js
+++ b/src/aws/lambda-migrate/src/migrations/0001_encode_timed_text_tracks.spec.js
@@ -9,7 +9,7 @@ const mockListObjects = jest.fn();
 const mockInvokeAsync = jest.fn();
 jest.mock('aws-sdk', () => ({
   S3: function() {
-    this.listObjects = mockListObjects;
+    this.listObjectsV2 = mockListObjects;
   },
   Lambda: function() {
     this.invokeAsync = mockInvokeAsync
@@ -84,7 +84,7 @@ describe('0001_encode_timed_text_tracks', () => {
         { Key: '80c43d43-4ed0-4695-ac64-8318f59d04ec/timedtexttrack/2_st_en'},
       ],
       IsTruncated: true,
-      NextMarker: '80c43d43-4ed0-4695-ac64-8318f59d04ec/videos/2'
+      NextContinuationToken: '80c43d43-4ed0-4695-ac64-8318f59d04ec/videos/2'
     }
 
     const secondListObjectsResponse = {
@@ -113,7 +113,7 @@ describe('0001_encode_timed_text_tracks', () => {
     expect(mockListObjects).toHaveBeenCalledWith({ Bucket: 'test-marsha-source' });
     expect(mockListObjects).toHaveBeenCalledWith({
       Bucket: 'test-marsha-source',
-      Marker: '80c43d43-4ed0-4695-ac64-8318f59d04ec/videos/2'
+      ContinuationToken: '80c43d43-4ed0-4695-ac64-8318f59d04ec/videos/2'
     });
     expect(mockInvokeAsync).toHaveBeenCalledTimes(3);
     expect(mockInvokeAsync).toHaveBeenCalledWith({

--- a/src/aws/lambda.tf
+++ b/src/aws/lambda.tf
@@ -126,7 +126,7 @@ resource "aws_lambda_function" "marsha_migrate_lambda" {
   source_code_hash = "${base64sha256(file("dist/marsha_migrate.zip"))}"
   role             = "${aws_iam_role.lambda_migrate_invocation_role.arn}"
 
-  timeout = 600
+  timeout = 900
 
   environment {
     variables = {
@@ -145,7 +145,5 @@ data "aws_lambda_invocation" "invoke_migration" {
     "aws_lambda_function.marsha_encode_lambda"
   ]
   function_name     = "${aws_lambda_function.marsha_migrate_lambda.function_name}"
-  input = <<JSON
-{}
-JSON
+  input = "{}"
 }

--- a/src/aws/roles.tf
+++ b/src/aws/roles.tf
@@ -293,7 +293,10 @@ resource "aws_iam_policy" "lambda_migrate_lambda_invoke_policy" {
   "Version": "2012-10-17",
   "Statement": [
     {
-      "Action": ["lambda:invokeAsync"],
+      "Action": [
+        "lambda:invokeAsync",
+        "lambda:invokeFunction"
+      ],
       "Effect": "Allow",
       "Resource": "arn:aws:lambda:*:*:function:${aws_lambda_function.marsha_encode_lambda.function_name}"
     }


### PR DESCRIPTION
## Purpose

There are some issues on the timed text tracks migration script executed in the lambda-migrate function. Not using async-handler lead to hide important errors. The first one is calling the `lambda.InvokeAsync` does not provide error messages when the lambda is executed... and in fact our permissions does not allow to invoke a lambda...
The second is how pagination is made on the `S3.listObject` method. I didn't understand how the `NextMarker` in the response is set and in our case it leads to an infinite loop. To avoid this I switched to the `S3.listObjectV2` method where they totally changed how pagination is made and it is no longer confusing at all.

## Proposal

- [x] change handler to an asynchronous function
- [x] use `S3.listObjectV2` instead of `S3.listObject`
- [x] upgrade permissions to invoke lambda functions

