### PR TITLE
🏁(frontent) polyfill CustomEvents for IE11

### DIFF
--- a/src/frontend/index.tsx
+++ b/src/frontend/index.tsx
@@ -49,6 +49,15 @@ document.addEventListener('DOMContentLoaded', async event => {
       await import(`intl/locale-data/jsonp/${localeCode}.js`);
     }
 
+    // Plyr uses CustomEvents which we consume in our xapi event infrastructure
+    try {
+      // We need to specifically attempt to use the constructor as `CustomEvent` exists in some browsers
+      // (eg. IE11) but does not support the constructor.
+      const test = new CustomEvent('CustomEventConstructorIsSupported');
+    } catch (e) {
+      await import('custom-event-polyfill');
+    }
+
     if (!Intl.PluralRules) {
       await import('intl-pluralrules');
     }

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -65,6 +65,7 @@
     "@sentry/browser": "5.6.3",
     "@types/intl": "1.2.0",
     "core-js": "3",
+    "custom-event-polyfill": "1.0.7",
     "dashjs": "3.0.0",
     "grommet": "2.7.9",
     "iframe-resizer": "4.2.1",

--- a/src/frontend/types/libs/custom-event-polyfill/index.d.ts
+++ b/src/frontend/types/libs/custom-event-polyfill/index.d.ts
@@ -1,0 +1,1 @@
+declare module 'custom-event-polyfill';

--- a/src/frontend/yarn.lock
+++ b/src/frontend/yarn.lock
@@ -2754,7 +2754,7 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
-custom-event-polyfill@^1.0.7:
+custom-event-polyfill@1.0.7, custom-event-polyfill@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/custom-event-polyfill/-/custom-event-polyfill-1.0.7.tgz#9bc993ddda937c1a30ccd335614c6c58c4f87aee"
   integrity sha512-TDDkd5DkaZxZFM8p+1I3yAlvM3rSr1wbrOliG4yJiwinMZN8z/iGL7BTlDkrJcYTmgUSb4ywVCc3ZaUtOtC76w==


### PR DESCRIPTION
## Purpose

Plyr uses CustomEvents as specified in the browser API spec. This is not available in IE11, which we intend to support; to have any tracking available for IE11 users, and avoid piles of error reports.

## Proposal

Add a polyfill and lazy-load it only when necessary