### PR TITLE
🐛(back) ignore domain check if http referer is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Fix errors in lambda-migrate function. The timed text tracks migrations can
   lead to an infinite loop.
+- Authorize LTI requests that have an empty HTTP referer.
 
 ## [3.1.0] - 2019-10-07
 

--- a/src/backend/marsha/core/lti/__init__.py
+++ b/src/backend/marsha/core/lti/__init__.py
@@ -108,8 +108,10 @@ class LTI:
         # Make sure we only accept requests from domains in which the "top parts" match
         # the URL for the consumer_site associated with the passport.
         # eg. sub.example.com & example.com for an example.com consumer site.
-        if request_domain != consumer_site.domain and not request_domain.endswith(
-            ".{:s}".format(consumer_site.domain)
+        if (
+            request_domain
+            and request_domain != consumer_site.domain
+            and not request_domain.endswith(".{:s}".format(consumer_site.domain))
         ):
             raise LTIException(
                 "Host domain ({:s}) does not match registered passport ({:s}).".format(


### PR DESCRIPTION
## Purpose

In the LTI.verify method we check if the referer matches the
URL for the consumer_site associated with the passport. In some cases
users block the referer for privacy concern and we can not do the check
and an error is raised. To avoid this error we choose to not verify the
domain if the referer is absent.

## Proposal

- allow to make LTI request without HTTP referer

