### PR TITLE
🐛(front) test if Intl exists using global object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Correctly load Intl polyfill
+
 ## [3.1.2] - 2019-10-09
 
 ### Added

--- a/src/frontend/index.tsx
+++ b/src/frontend/index.tsx
@@ -44,7 +44,7 @@ export let intl: IntlShape;
 // Wait for the DOM to load before we scour it for an element that requires React to render
 document.addEventListener('DOMContentLoaded', async event => {
   try {
-    if (!Intl) {
+    if (!window.Intl) {
       await import('intl');
       await import(`intl/locale-data/jsonp/${localeCode}.js`);
     }


### PR DESCRIPTION
## Purpose

To know if Intl is present, simply testing Intl variable is not a good
solution, we still have the same error saying can't find variable Intl.
To test it, we should test if global.Intl is not undefined, if it is we
must import the Intl polyfill.

## Proposal

- [x] test if `global.Intl` is defined.

