### PR TITLE
🐛(AWS) encode only transcripts and simply convert others

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Firefox does not interpret html entities in subtitles. Only transcripts
+  are encoded.
+
 ## [3.1.4] - 2019-10-16
 
 ### Fixed

--- a/src/aws/lambda-encode/index.js
+++ b/src/aws/lambda-encode/index.js
@@ -80,7 +80,7 @@ exports.handler = async (event, context, callback) => {
 
     case 'timedtexttrack':
       try {
-        await encodeTimedTextTrack(objectKey, sourceBucket);
+        await encodeTimedTextTrack(objectKey, sourceBucket, extendedStamp);
         await updateState(objectKey, READY);
       } catch (error) {
         return callback(error);

--- a/src/aws/lambda-encode/index.spec.js
+++ b/src/aws/lambda-encode/index.spec.js
@@ -158,7 +158,7 @@ describe('lambda', () => {
             },
             object: {
               key:
-                '630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/timedtexttrack/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1542967735_fr',
+                '630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/timedtexttrack/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1542967735_fr_st',
             },
           },
         },
@@ -169,11 +169,12 @@ describe('lambda', () => {
       await lambda(event, null, callback);
 
       expect(mockEncodeTimedTextTrack).toHaveBeenCalledWith(
-        '630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/timedtexttrack/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1542967735_fr',
+        '630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/timedtexttrack/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1542967735_fr_st',
         'source bucket',
+        '1542967735_fr_st'
       );
       expect(mockUpdateState).toHaveBeenCalledWith(
-        '630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/timedtexttrack/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1542967735_fr',
+        '630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/timedtexttrack/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1542967735_fr_st',
         'ready',
       );
     });
@@ -186,8 +187,9 @@ describe('lambda', () => {
       await lambda(event, null, callback);
 
       expect(mockEncodeTimedTextTrack).toHaveBeenCalledWith(
-        '630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/timedtexttrack/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1542967735_fr',
+        '630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/timedtexttrack/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1542967735_fr_st',
         'source bucket',
+        '1542967735_fr_st'
       );
       expect(mockUpdateState).not.toHaveBeenCalled();
       expect(callback).toHaveBeenCalledWith('Failed!');


### PR DESCRIPTION
## Purpose

Firefox does not interpret html entities present in captions or
subtitles. We choose to only encode them in transcript and do nothing
for subtitles and captions, plyr handle them correctly.
The existing migration can be run again to fix the issue.

## Proposal

Description...

- [x] encode only transcript
