### PR TITLE
🔖(patch) bump release to 3.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.1.5] - 2019-10-22
+
 ### Fixed
 
 - Firefox does not interpret html entities in subtitles. Only transcripts
@@ -415,7 +417,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Minor fixes and improvements on features and tests
 
-[unreleased]: https://github.com/openfun/marsha/compare/v3.1.4...master
+[unreleased]: https://github.com/openfun/marsha/compare/v3.1.5...master
+[3.1.5]: https://github.com/openfun/marsha/compare/v3.1.4...v3.1.5
 [3.1.4]: https://github.com/openfun/marsha/compare/v3.1.3...v3.1.4
 [3.1.3]: https://github.com/openfun/marsha/compare/v3.1.2...v3.1.3
 [3.1.2]: https://github.com/openfun/marsha/compare/v3.1.1...v3.1.2

--- a/src/aws/lambda-complete/package.json
+++ b/src/aws/lambda-complete/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-complete",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "engines": {
     "node": "10"
   },

--- a/src/aws/lambda-configure/package.json
+++ b/src/aws/lambda-configure/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-configure",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "engines": {
     "node": "10"
   },

--- a/src/aws/lambda-encode/package.json
+++ b/src/aws/lambda-encode/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-convert",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "engines": {
     "node": "10"
   },

--- a/src/aws/lambda-migrate/package.json
+++ b/src/aws/lambda-migrate/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-migrate",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "engines": {
     "node": "10"
   },

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = marsha
 description = A FUN video provider for Open edX
-version = 3.1.4
+version = 3.1.5
 author = Open FUN (France Universite Numerique)
 author_email = fun.dev@fun-mooc.fr
 license = MIT

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marsha",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "description": "🐠 a FUN LTI video provider",
   "main": "front/index.tsx",
   "scripts": {


### PR DESCRIPTION
## Fixed

- Firefox does not interpret html entities in subtitles. Only transcripts
  are encoded.

