### PR TITLE
♻️(recycle) remove dockerize in dev image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,7 +218,7 @@ jobs:
       # Nota bene: to run the django test suite, we need to ensure that the
       # PostgreSQL service is up and ready. To achieve this,
       # we wrap the command execution with dockerize, a tiny tool
-      # installed in the development image. In our case, dockerize will wait
+      # installed in circleci/python image. In our case, dockerize will wait
       # up to one minute until the database container is answering on port 5432.
       - run:
           name: Run tests

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,8 @@ logs: ## display app logs (follow mode)
 
 run: ## start the development server using Docker
 	@$(COMPOSE) up -d
+	@echo "Wait for postgresql to be up..."
+	@$(COMPOSE_RUN) dockerize -wait tcp://db:5432 -timeout 60s
 .PHONY: run
 
 stop: ## stop the development server using Docker
@@ -139,7 +141,8 @@ lint-pylint:  ## Run the pylint tool
 .PHONY: migrate
 migrate:  ## Run django migration for the marsha project.
 	@echo "$(BOLD)Running migrations$(RESET)"
-	@$(COMPOSE_RUN_APP) dockerize -wait tcp://db:5432 -timeout 60s python manage.py migrate
+	@$(COMPOSE_RUN) dockerize -wait tcp://db:5432 -timeout 60s
+	@$(COMPOSE_RUN_APP) python manage.py migrate
 
 superuser: ## create a Django superuser
 	@echo "$(BOLD)Creating a Django superuser$(RESET)"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,10 +25,9 @@ services:
     env_file:
       - env.d/${ENV_FILE:-development}
     # Override production container command that runs gunicorn in favor of the
-    # django development server (wrapped by dockerize to ensure the db is ready
-    # to accept connections before running the development server)
+    # django development server
     command: >
-      dockerize -wait tcp://db:5432 -timeout 60s python manage.py runserver 0.0.0.0:8000
+      python manage.py runserver 0.0.0.0:8000
     ports:
       - "8060:8000"
     volumes:
@@ -52,3 +51,6 @@ services:
     volumes:
       - ".:/app"
     working_dir: /app/src/frontend
+
+  dockerize:
+    image: jwilder/dockerize

--- a/docker/images/dev/Dockerfile
+++ b/docker/images/dev/Dockerfile
@@ -18,12 +18,3 @@ RUN apt-get update && \
 
 # Install development dependencies
 RUN pip install .[dev]
-
-# Install dockerize. It is used to ensure that the database service is accepting
-# connections before trying to access it from the main application.
-ENV DOCKERIZE_VERSION v0.6.1
-RUN curl -L \
-    --output dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-    https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
-    tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
-    rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz


### PR DESCRIPTION
## Purpose

A dockerize image exists and we choose to use it as a service in
our docker-compose configuration. Not having dockerize installed in the
development image will lighten it a little bit and speed its build.

## Proposal

- [x] remove dockerize in development image
- [x] use dockerize image in docker-compose configuration

Closes #546 