### PR TITLE
🐛(xapi) initliaze xapi module only when all video data are available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Start ABR at a lower level corresponding to 480p
 - Let the user choose video quality when ABR is disabled
+- Initialize xapi module only when all video data are available
 
 ## [3.1.6] - 2019-10-24
 

--- a/src/frontend/Player/createPlyrPlayer.spec.ts
+++ b/src/frontend/Player/createPlyrPlayer.spec.ts
@@ -149,62 +149,72 @@ describe('createPlyrPlayer', () => {
     );
     expect(player.on).toHaveBeenNthCalledWith(
       2,
+      'loadedmetadata',
+      expect.any(Function),
+    );
+    expect(player.on).toHaveBeenNthCalledWith(
+      3,
+      'loadeddata',
+      expect.any(Function),
+    );
+    expect(player.on).toHaveBeenNthCalledWith(
+      4,
       'playing',
       expect.any(Function),
     );
-    expect(player.on).toHaveBeenNthCalledWith(3, 'pause', expect.any(Function));
+    expect(player.on).toHaveBeenNthCalledWith(5, 'pause', expect.any(Function));
     expect(player.on).toHaveBeenNthCalledWith(
-      4,
+      6,
       'timeupdate',
       expect.any(Function),
     );
     expect(player.on).toHaveBeenNthCalledWith(
-      5,
+      7,
       'seeking',
       expect.any(Function),
     );
     expect(player.on).toHaveBeenNthCalledWith(
-      6,
+      8,
       'seeked',
       expect.any(Function),
     );
     expect(player.on).toHaveBeenNthCalledWith(
-      7,
+      9,
       'captionsdisabled',
       expect.any(Function),
     );
     expect(player.on).toHaveBeenNthCalledWith(
-      8,
+      10,
       'captionsenabled',
       expect.any(Function),
     );
     expect(player.on).toHaveBeenNthCalledWith(
-      9,
+      11,
       'enterfullscreen',
       expect.any(Function),
     );
     expect(player.on).toHaveBeenNthCalledWith(
-      10,
+      12,
       'exitfullscreen',
       expect.any(Function),
     );
     expect(player.on).toHaveBeenNthCalledWith(
-      11,
+      13,
       'languagechange',
       expect.any(Function),
     );
     expect(player.on).toHaveBeenNthCalledWith(
-      12,
+      14,
       'qualitychange',
       expect.any(Function),
     );
     expect(player.on).toHaveBeenNthCalledWith(
-      13,
+      15,
       'ratechange',
       expect.any(Function),
     );
     expect(player.on).toHaveBeenNthCalledWith(
-      14,
+      16,
       'volumechange',
       expect.any(Function),
     );

--- a/src/frontend/Player/createPlyrPlayer.ts
+++ b/src/frontend/Player/createPlyrPlayer.ts
@@ -172,13 +172,16 @@ export const createPlyrPlayer = (
     }
   };
 
-  // canplay is the event when the video is really initialized and
-  // information can be found in plyr object. Don't use ready event
-  player.on('canplay', event => {
+  const initialize = () => {
+    // if the module is already initalized abort the operation.
     if (true === isInitialized) {
       return;
     }
-    isInitialized = true;
+
+    // if duration is still not available abort the operation.
+    if (player.duration === 0) {
+      return;
+    }
 
     const contextExtensions: InitializedContextExtensions = {
       ccSubtitleEnabled: player.currentTrack === -1 ? false : true,
@@ -196,7 +199,14 @@ export const createPlyrPlayer = (
       }
     }
     xapiStatement.initialized(contextExtensions);
-  });
+    isInitialized = true;
+  };
+
+  // canplay, loadedmetadata or loadeddata are the possible event when the video is really
+  // initialized and information can be found in plyr object. Don't use ready event
+  player.on('canplay', initialize);
+  player.on('loadedmetadata', initialize);
+  player.on('loadeddata', initialize);
 
   player.on('playing', event => {
     xapiStatement.played({

--- a/src/frontend/XAPI/XAPIStatement.spec.ts
+++ b/src/frontend/XAPI/XAPIStatement.spec.ts
@@ -126,6 +126,7 @@ describe('XAPIStatement', () => {
         overwriteRoutes: true,
       });
       const xapiStatement = new XAPIStatement('jwt', 'abcd');
+      xapiStatement.setDuration(1);
       xapiStatement.played({
         time: 42.321,
       });
@@ -426,6 +427,7 @@ describe('XAPIStatement', () => {
         overwriteRoutes: true,
       });
       const xapiStatement = new XAPIStatement('jwt', 'abcd');
+      xapiStatement.setDuration(1);
       xapiStatement.interacted(
         {
           time: 50,

--- a/src/frontend/XAPI/XAPIStatement.ts
+++ b/src/frontend/XAPI/XAPIStatement.ts
@@ -375,6 +375,12 @@ export class XAPIStatement {
   }
 
   private send(data: DataPayload) {
+    // duration is set when initialized is called.
+    // While initialized is not called, no statement should be sent to the xapi server.
+    if (!this.duration) {
+      return;
+    }
+
     fetch(`${XAPI_ENDPOINT}/`, {
       body: JSON.stringify({
         ...data,


### PR DESCRIPTION
## Purpose

In some cases fetching all video data can take more time than expected
and some data are missing in the canplay event. Do be sure to have all
needed data we have to use others events (loadedmetadata and loadeddata)
and initialize the module only when the data are avaialble in one of
this 3 events.

## Proposal

- [x] listen `loadedmetadata` and `loadeddata` and initialize xapi module when all needed data are available.

Fixes #573

