### PR TITLE
🐛(front) set plyr sources also if hls is not available

### DIFF
--- a/src/frontend/Player/createPlyrPlayer.ts
+++ b/src/frontend/Player/createPlyrPlayer.ts
@@ -10,7 +10,7 @@ import {
   InteractedContextExtensions,
 } from '../types/XAPI';
 import { report } from '../utils/errors/report';
-import { isMSESupported } from '../utils/isAbrSupported';
+import { isHlsSupported, isMSESupported } from '../utils/isAbrSupported';
 import { XAPIStatement } from '../XAPI/XAPIStatement';
 import { createDashPlayer } from './createDashPlayer';
 import { i18nMessages } from './i18n/plyrTranslation';
@@ -28,7 +28,7 @@ export const createPlyrPlayer = (
   let dash;
   let sources;
   const settings = ['captions', 'speed', 'loop'];
-  if (!isMSESupported()) {
+  if (!isMSESupported() && !isHlsSupported(videoNode)) {
     const timedTextTracks = useTimedTextTrackApi
       .getState()
       .getTimedTextTracks();


### PR DESCRIPTION
## Purpose

In commit fe357 we set plyr sources if ABR is not available but not when
hls is also not available. The consequence is that hls is no more used
when available in favor of mp4 sources. A fix is to set the sources when
ABR and HLS are not available.

## Proposal

- [x] set plyr source also if hls is not available

