### PR TITLE
Allow to load external js sources in LTI template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Load third party js script using EXTERNAL_JAVASCRIPT_SCRIPTS setting
+
 ## [3.1.7] - 2019-11-05
 
 ### Fixed

--- a/docs/env.md
+++ b/docs/env.md
@@ -103,6 +103,14 @@ Note: should include the value from `TF_VAR_update_state_secret` in `src/aws` fo
 - Required: Yes
 - Default: None
 
+#### DJANGO_EXTERNAL_JAVASCRIPT_SCRIPTS
+
+List of external javascript scripts to load in the LTI template. This list will be loaded after loading the main react script. This setting allows to load scripts hosted on another domain and specific to your project.
+
+- Type: comma-separated list of strings <br> ⚠️ *ITEMS MUST NOT INCLUDE ANY COMMAS* as commas are used to separated items.
+- Required: No
+- Default: Empty list
+
 ### Database-related settings
 
 #### POSTGRES_DB

--- a/src/backend/marsha/core/templates/core/lti.html
+++ b/src/backend/marsha/core/templates/core/lti.html
@@ -11,5 +11,8 @@
 
     <div id="marsha-frontend-root"></div>
     <script src='{% static "js/index.js" %}'></script>
+    {% for external_script in external_javascript_scripts %}
+      <script src="{{ external_script }}" ></script>
+    {% endfor %}
   </body>
 </html>

--- a/src/backend/marsha/core/views.py
+++ b/src/backend/marsha/core/views.py
@@ -70,6 +70,7 @@ class BaseLTIView(ABC, TemplateResponseMixin, View):
         return {
             "app_data": json.dumps(app_data),
             "static_base_url": f"{settings.ABSOLUTE_STATIC_URL}js/",
+            "external_javascript_scripts": settings.EXTERNAL_JAVASCRIPT_SCRIPTS,
         }
 
     def _get_app_data(self):

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -223,6 +223,8 @@ class Base(Configuration):
     SUBTITLE_SOURCE_MAX_SIZE = values.Value(2 ** 20)  # 1MB
     THUMBNAIL_SOURCE_MAX_SIZE = values.Value(10 * (2 ** 20))  # 10MB
 
+    EXTERNAL_JAVASCRIPT_SCRIPTS = values.ListValue([])
+
     # pylint: disable=invalid-name
     @property
     def AWS_SOURCE_BUCKET_NAME(self):

--- a/src/frontend/components/VideoPlayer/index.tsx
+++ b/src/frontend/components/VideoPlayer/index.tsx
@@ -81,6 +81,14 @@ const VideoPlayer = ({ video: baseVideo }: BaseVideoPlayerProps) => {
         ),
       );
 
+      document.dispatchEvent(
+        new CustomEvent('marsha_player_created', {
+          detail: {
+            videoNode: videoNodeRef.current!,
+          },
+        }),
+      );
+
       /** Make sure to destroy the player on unmount. */
       return () => player && player.destroy();
     }


### PR DESCRIPTION
## Purpose

We want to use third party js and not commit them in the project because they are only used by a particular marsha client and it makes no sense to add them in marsha. The idea here is add js script in the LTI template usinga django setting. This settin can accept a comma separated list of url

example:
```
DJANGO_EXTERNAL_JAVASCRIPT_SCRIPTS=https://unpkg.com/@ungap/url-search-params@0.1.2/min.js,https://example.com/demo.js"
```

With this example, two script tags will added to the lti template.

## Proposal

- [x] introduce `EXTERNAL_JAVASCRIPT_SCRIPTS` django setting.
- [x] dispatch an event when the video player is created.

