### PR TITLE
🐛(encoding) remove STRETCH_TO_OUTPUT option from MediaConvert presets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Videos uploaded in other formats than 16/9 were distorted to fit that
+  ratio. We now do our best to respect their format during encoding and
+  also in the player.
+
 ## [3.2.0] - 2019-11-22
 
 ### Added

--- a/src/aws/lambda-configure/presets/cmaf_video_h264_1080p_30fps_5400kbps.json
+++ b/src/aws/lambda-configure/presets/cmaf_video_h264_1080p_30fps_5400kbps.json
@@ -4,9 +4,7 @@
   "Name": "marsha_cmaf_video_1080",
   "Settings": {
     "VideoDescription": {
-      "Width": 1920,
       "Height": 1080,
-      "ScalingBehavior": "STRETCH_TO_OUTPUT",
       "TimecodeInsertion": "DISABLED",
       "AntiAlias": "ENABLED",
       "Sharpness": 50,

--- a/src/aws/lambda-configure/presets/cmaf_video_h264_144p_30fps_300kbps.json
+++ b/src/aws/lambda-configure/presets/cmaf_video_h264_144p_30fps_300kbps.json
@@ -4,9 +4,7 @@
   "Name": "marsha_cmaf_video_144",
   "Settings": {
     "VideoDescription": {
-      "Width": 256,
       "Height": 144,
-      "ScalingBehavior": "STRETCH_TO_OUTPUT",
       "TimecodeInsertion": "DISABLED",
       "AntiAlias": "ENABLED",
       "Sharpness": 50,

--- a/src/aws/lambda-configure/presets/cmaf_video_h264_240p_30fps_600kbps.json
+++ b/src/aws/lambda-configure/presets/cmaf_video_h264_240p_30fps_600kbps.json
@@ -4,9 +4,7 @@
   "Name": "marsha_cmaf_video_240",
   "Settings": {
     "VideoDescription": {
-      "Width": 426,
       "Height": 240,
-      "ScalingBehavior": "STRETCH_TO_OUTPUT",
       "TimecodeInsertion": "DISABLED",
       "AntiAlias": "ENABLED",
       "Sharpness": 50,

--- a/src/aws/lambda-configure/presets/cmaf_video_h264_480p_30fps_1200kbps.json
+++ b/src/aws/lambda-configure/presets/cmaf_video_h264_480p_30fps_1200kbps.json
@@ -4,9 +4,7 @@
   "Name": "marsha_cmaf_video_480",
   "Settings": {
     "VideoDescription": {
-      "Width": 854,
       "Height": 480,
-      "ScalingBehavior": "STRETCH_TO_OUTPUT",
       "TimecodeInsertion": "DISABLED",
       "AntiAlias": "ENABLED",
       "Sharpness": 50,

--- a/src/aws/lambda-configure/presets/cmaf_video_h264_720p_30fps_2400kbps.json
+++ b/src/aws/lambda-configure/presets/cmaf_video_h264_720p_30fps_2400kbps.json
@@ -4,9 +4,7 @@
   "Name": "marsha_cmaf_video_720",
   "Settings": {
     "VideoDescription": {
-      "Width": 1280,
       "Height": 720,
-      "ScalingBehavior": "STRETCH_TO_OUTPUT",
       "TimecodeInsertion": "DISABLED",
       "AntiAlias": "ENABLED",
       "Sharpness": 50,

--- a/src/aws/lambda-configure/presets/video_mp4_h264_1080p_30fps_5400kbps.json
+++ b/src/aws/lambda-configure/presets/video_mp4_h264_1080p_30fps_5400kbps.json
@@ -4,9 +4,7 @@
   "Name": "marsha_video_mp4_1080",
   "Settings": {
     "VideoDescription": {
-      "Width": 1920,
       "Height": 1080,
-      "ScalingBehavior": "STRETCH_TO_OUTPUT",
       "VideoPreprocessors": {
         "Deinterlacer": {
           "Algorithm": "INTERPOLATE",

--- a/src/aws/lambda-configure/presets/video_mp4_h264_144p_30fps_300kbps.json
+++ b/src/aws/lambda-configure/presets/video_mp4_h264_144p_30fps_300kbps.json
@@ -4,9 +4,7 @@
   "Name": "marsha_video_mp4_144",
   "Settings": {
     "VideoDescription": {
-      "Width": 256,
       "Height": 144,
-      "ScalingBehavior": "STRETCH_TO_OUTPUT",
       "VideoPreprocessors": {
         "Deinterlacer": {
           "Algorithm": "INTERPOLATE",

--- a/src/aws/lambda-configure/presets/video_mp4_h264_240p_30fps_600kbps.json
+++ b/src/aws/lambda-configure/presets/video_mp4_h264_240p_30fps_600kbps.json
@@ -4,9 +4,7 @@
   "Name": "marsha_video_mp4_240",
   "Settings": {
     "VideoDescription": {
-      "Width": 426,
       "Height": 240,
-      "ScalingBehavior": "STRETCH_TO_OUTPUT",
       "VideoPreprocessors": {
         "Deinterlacer": {
           "Algorithm": "INTERPOLATE",

--- a/src/aws/lambda-configure/presets/video_mp4_h264_480p_30fps_1200kbps.json
+++ b/src/aws/lambda-configure/presets/video_mp4_h264_480p_30fps_1200kbps.json
@@ -4,9 +4,7 @@
   "Name": "marsha_video_mp4_480",
   "Settings": {
     "VideoDescription": {
-      "Width": 854,
       "Height": 480,
-      "ScalingBehavior": "STRETCH_TO_OUTPUT",
       "VideoPreprocessors": {
         "Deinterlacer": {
           "Algorithm": "INTERPOLATE",

--- a/src/aws/lambda-configure/presets/video_mp4_h264_720p_30fps_2400kbps.json
+++ b/src/aws/lambda-configure/presets/video_mp4_h264_720p_30fps_2400kbps.json
@@ -4,9 +4,7 @@
   "Name": "marsha_video_mp4_720",
   "Settings": {
     "VideoDescription": {
-      "Width": 1280,
       "Height": 720,
-      "ScalingBehavior": "STRETCH_TO_OUTPUT",
       "VideoPreprocessors": {
         "Deinterlacer": {
           "Algorithm": "INTERPOLATE",

--- a/src/frontend/components/VideoPlayer/VideoPlayer.css
+++ b/src/frontend/components/VideoPlayer/VideoPlayer.css
@@ -11,7 +11,7 @@
    * We use this ratio as we base marsha's layout on video display
    */
   width: 100vw;
-  height: 56.25vw;
+  min-height: 56.25vw;
   overflow: hidden;
 }
 


### PR DESCRIPTION
## Purpose

All our video presets for AWS MediaConvert, which control the way in which videos are encoded to all the formats we need in Marsha, included the "STRETH_TO_OUTPUT" option.

This is not what we want (we'd rather have black bars than distorted output for eg. 4/3 videos) and was only there due to the files we used as boilerplates to bootstrap our MediaConvert presets.
## Proposal

We can just remove the `ScalingBehavior` param entirely as it's optional.
