### PR TITLE
⬆️(storage) bump django-storages to v1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade django-storages to 1.8 and remove the workaround introduced in
+  marsha 2.8.1 to ensure compatibility with ManifestStaticFilesStorage.
+
 ### Security
 
 - Regenerate frontend yarn lockfile to get new version of vulnerable package

--- a/src/backend/marsha/core/storage.py
+++ b/src/backend/marsha/core/storage.py
@@ -1,12 +1,11 @@
 """Customizing Django storage backends to enable blue/green deployments."""
 from collections import OrderedDict
-import os
 import re
 
 from django.conf import settings
 from django.contrib.staticfiles.storage import ManifestFilesMixin, StaticFilesStorage
 
-from storages.backends.s3boto3 import S3Boto3Storage, SpooledTemporaryFile
+from storages.backends.s3boto3 import S3Boto3Storage
 
 
 STATIC_POSTPROCESS_IGNORE_REGEX = re.compile(
@@ -67,28 +66,3 @@ class ConfigurableManifestS3Boto3Storage(
 
     bucket_name = settings.AWS_STATIC_BUCKET_NAME
     custom_domain = settings.CLOUDFRONT_DOMAIN
-
-    def _save_content(self, obj, content, parameters):
-        """
-        Workaround to use django-storages > 1.6.3.
-
-        We create a clone of the content file as when this is passed to boto3 it wrongly closes
-        the file upon upload where as the storage backend expects it to still be open
-        """
-        # Seek our content back to the start
-        content.seek(0, os.SEEK_SET)
-
-        # Create a temporary file that will write to disk after a specified size
-        content_autoclose = SpooledTemporaryFile()
-
-        # Write our original content into our copy that will be closed by boto3
-        content_autoclose.write(content.read())
-
-        # Upload the object which will auto close the content_autoclose instance
-        super(ConfigurableManifestS3Boto3Storage, self)._save_content(
-            obj, content_autoclose, parameters
-        )
-
-        # Cleanup if this is fixed upstream our duplicate should always close
-        if not content_autoclose.closed:
-            content_autoclose.close()

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -37,8 +37,7 @@ install_requires =
     djangorestframework==3.10.3
     djangorestframework_simplejwt==4.3.0
     django-safedelete==0.5.2
-    # superior versions of django-storages are not compatible with ManifestStaticFilesStorage
-    django-storages==1.7.2
+    django-storages==1.8
     dockerflow==2019.10.0
     gunicorn==19.9.0
     # Warning from psycopg2 "The psycopg2 wheel package will be renamed from release 2.8" => psyopg2-binary


### PR DESCRIPTION
## Purpose

Django-storages 1.8 came out and fixes a bug that we solved with a workaround. See PR https://github.com/openfun/marsha/pull/387

The bug was fixed in `django-storages` 1.7.2 as detailed in their [CHANGELOG](https://github.com/jschneier/django-storages/blob/master/CHANGELOG.rst).

## Proposal

I bumped the version of `django-storages` to 1.8.

I then removed the workaround introduced in commit 6e7ee9b that was making `django-storages` 1.7.1 work with Django's `ManifestStaticFilesStorage` backend. 

