### PR TITLE
Maintenance mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- New setting MAINTENANCE_MODE to disable the dashboard when Marsha is 
+  in maintenance
+
 ### Changed
 
 - Upgrade django-storages to 1.8 and remove the workaround introduced in

--- a/src/backend/marsha/core/views.py
+++ b/src/backend/marsha/core/views.py
@@ -147,6 +147,7 @@ class BaseLTIView(ABC, TemplateResponseMixin, View):
                     "course": lti.get_course_info(),
                     "locale": locale,
                     "permissions": permissions,
+                    "maintenance": settings.MAINTENANCE_MODE,
                 }
             )
             try:

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -225,6 +225,8 @@ class Base(Configuration):
 
     EXTERNAL_JAVASCRIPT_SCRIPTS = values.ListValue([])
 
+    MAINTENANCE_MODE = values.BooleanValue(False)
+
     # pylint: disable=invalid-name
     @property
     def AWS_SOURCE_BUCKET_NAME(self):

--- a/src/frontend/components/InstructorView/index.spec.tsx
+++ b/src/frontend/components/InstructorView/index.spec.tsx
@@ -18,6 +18,7 @@ jest.mock('../../data/appData', () => ({
 describe('<InstructorView />', () => {
   it('renders the instructor controls', () => {
     mockDecodedJwt = {
+      maintenance: false,
       permissions: {
         can_access_dashboard: true,
       },
@@ -40,6 +41,7 @@ describe('<InstructorView />', () => {
   it('removes the button when permissions.can_access_dashboard is set to false', () => {
     mockDecodedJwt = {
       context_id: 'foo+context_id',
+      maintenance: false,
       permissions: {
         can_access_dashboard: false,
       },
@@ -55,6 +57,29 @@ describe('<InstructorView />', () => {
 
     getByText(
       'This video is read-only because it belongs to another course: foo+context_id',
+    );
+    expect(queryByText('Go to Dashboard')).toBeNull();
+  });
+
+  it('removes the button when permissions.maintenance is set to true', () => {
+    mockDecodedJwt = {
+      context_id: 'foo+context_id',
+      maintenance: true,
+      permissions: {
+        can_access_dashboard: true,
+      },
+    };
+
+    const { getByText, queryByText } = render(
+      wrapInIntlProvider(
+        <InstructorView>
+          <div className="some-child" />
+        </InstructorView>,
+      ),
+    );
+
+    getByText(
+      "The dashboard is undergoing maintenance work, it can't be accessed right now.",
     );
     expect(queryByText('Go to Dashboard')).toBeNull();
   });

--- a/src/frontend/components/InstructorView/index.tsx
+++ b/src/frontend/components/InstructorView/index.tsx
@@ -22,6 +22,13 @@ const messages = defineMessages({
       'Text explaining that the ivdeo is in read_only mode and the dashboard is not available',
     id: 'components.InstructorView.disabledDashboard',
   },
+  maintenance: {
+    defaultMessage:
+      "The dashboard is undergoing maintenance work, it can't be accessed right now.",
+    description:
+      'Text explaining that the dashboard is not accessible because marsha is in maintenance',
+    id: 'componenets.InstructorView.maintenance',
+  },
   title: {
     defaultMessage: 'Instructor Preview 👆',
     description: `Title for the Instructor View. Describes the area appearing right above, which is a preview
@@ -53,9 +60,13 @@ interface InstructorViewProps {
 }
 
 export const InstructorView = ({ children }: InstructorViewProps) => {
-  const canAccessDashboard = getDecodedJwt().permissions.can_access_dashboard;
+  const canAccessDashboard =
+    getDecodedJwt().permissions.can_access_dashboard &&
+    false === getDecodedJwt().maintenance;
   const message = canAccessDashboard
     ? messages.title
+    : getDecodedJwt().maintenance
+    ? messages.maintenance
     : messages.disabledDashboard;
   const messagePlaceholder = canAccessDashboard
     ? {}

--- a/src/frontend/types/jwt.ts
+++ b/src/frontend/types/jwt.ts
@@ -10,4 +10,5 @@ export interface DecodedJwt {
     can_access_dashboard: boolean;
     can_update: boolean;
   };
+  maintenance: boolean;
 }


### PR DESCRIPTION
## Purpose

Create a setting in the back application to put Marsha in maintenance mode. Once in maintenance mode, the dashboard is not accessible

## Proposal

- [x] create a setting `MAINTENANCE_MODE` and expose it in the JWT token
- [x] disable access to the dashboard when the maintenance mode is activated.

