### PR TITLE
🔖(minor) bump release to 3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.3.0] - 2019-12-17
+
 ### Added
 
 - New setting MAINTENANCE_MODE to disable the dashboard when Marsha is 
@@ -460,7 +462,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Minor fixes and improvements on features and tests
 
-[unreleased]: https://github.com/openfun/marsha/compare/v3.2.1...master
+[unreleased]: https://github.com/openfun/marsha/compare/v3.3.0...master
+[3.3.0]: https://github.com/openfun/marsha/compare/v3.2.1...v3.3.0
 [3.2.1]: https://github.com/openfun/marsha/compare/v3.2.0...v3.2.1
 [3.2.0]: https://github.com/openfun/marsha/compare/v3.1.7...v3.2.0
 [3.1.7]: https://github.com/openfun/marsha/compare/v3.1.6...v3.1.7

--- a/src/aws/lambda-complete/package.json
+++ b/src/aws/lambda-complete/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-complete",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "engines": {
     "node": "10"
   },

--- a/src/aws/lambda-configure/package.json
+++ b/src/aws/lambda-configure/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-configure",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "engines": {
     "node": "10"
   },

--- a/src/aws/lambda-encode/package.json
+++ b/src/aws/lambda-encode/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-convert",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "engines": {
     "node": "10"
   },

--- a/src/aws/lambda-migrate/package.json
+++ b/src/aws/lambda-migrate/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-migrate",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "engines": {
     "node": "10"
   },

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = marsha
 description = A FUN video provider for Open edX
-version = 3.2.1
+version = 3.3.0
 author = Open FUN (France Universite Numerique)
 author_email = fun.dev@fun-mooc.fr
 license = MIT

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marsha",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "description": "🐠 a FUN LTI video provider",
   "main": "front/index.tsx",
   "scripts": {


### PR DESCRIPTION
### Added

- New setting MAINTENANCE_MODE to disable the dashboard when Marsha is
  in maintenance

### Changed

- Upgrade django-storages to 1.8 and remove the workaround introduced in
  marsha 2.8.1 to ensure compatibility with ManifestStaticFilesStorage.

### Security

- Regenerate frontend yarn lockfile to get new version of vulnerable package
  `serialize-javascript`.
