### PR TITLE
🐛(statics) ignore only js statics in .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -32,7 +32,7 @@ lib/gitlint
 
 # Assets
 data
-src/backend/marsha/static
+src/backend/marsha/static/js
 src/frontend/i18n
 
 # Front-end


### PR DESCRIPTION
## Purpose

We ignored all statics in marsha backend. This is a mistake, only js
folder should be ignored.

## Proposal

- [x] ignore path `src/backend/marsha/static/js` and not all statics in `.dockerignore` file

