### PR TITLE
⬆️ (backend) upgrade to Django 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade to Django 3.
+
 ## [3.3.0] - 2019-12-17
 
 ### Added

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -66,7 +66,7 @@ class Base(Configuration):
     DATABASES = {
         "default": {
             "ENGINE": values.Value(
-                "django.db.backends.postgresql_psycopg2",
+                "django.db.backends.postgresql",
                 environ_name="DATABASE_ENGINE",
                 environ_prefix=None,
             ),

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -30,13 +30,13 @@ install_requires =
     chardet==3.0.4 # pyup: >=3.0.2,<3.1.0
     coreapi==2.3.3
     cryptography==2.8
-    django==2.2.9 # pyup: <3.0.0
+    django==3.0.2
     dj-database-url==0.5.0
     django-configurations==2.2
     django-extensions==2.2.6
     djangorestframework==3.11.0
     djangorestframework_simplejwt==4.4.0
-    django-safedelete==0.5.2
+    django-safedelete==0.5.4
     django-storages==1.8
     dockerflow==2019.10.0
     gunicorn==20.0.4


### PR DESCRIPTION
## Purpose

Our code base is compatible with Django 3. We only need to upgrade
`django-safedelete` to a recent version to be compatible with Django 3.

## Proposal

- [x] upgrade `django` package to version `3.0.2`
- [x] upgrade `django-safedelete` package to version 0.5.4`

