### PR TITLE
upgrade to python 3.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
   # Check that the git history is clean and complies with our expectations
   lint-git:
     docker:
-      - image: circleci/python:3.7-stretch
+      - image: circleci/python:3.8-buster
     working_directory: ~/marsha
     steps:
       - checkout
@@ -100,7 +100,7 @@ jobs:
   # Build backend development environment
   build-back:
     docker:
-      - image: circleci/python:3.7-stretch
+      - image: circleci/python:3.8-buster
     working_directory: ~/marsha/src/backend
     steps:
       - checkout:
@@ -120,7 +120,7 @@ jobs:
   # Build backend translations
   build-back-i18n:
     docker:
-      - image: circleci/python:3.7-stretch
+      - image: circleci/python:3.8-buster
         environment:
           DJANGO_SETTINGS_MODULE: marsha.settings
           PYTHONPATH: /home/circleci/marsha/src/backend
@@ -161,7 +161,7 @@ jobs:
 
   lint-back:
     docker:
-      - image: circleci/python:3.7-stretch
+      - image: circleci/python:3.8-buster
     working_directory: ~/marsha/src/backend
     steps:
       - checkout:
@@ -185,7 +185,7 @@ jobs:
 
   test-back:
     docker:
-      - image: circleci/python:3.7-stretch
+      - image: circleci/python:3.8-buster
         environment:
           DJANGO_SETTINGS_MODULE: marsha.settings
           PYTHONPATH: /home/circleci/marsha/src/backend

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- Upgrade to Django 3.
+- Upgrade to Django 3
+- Upgrade to python 3.8
 
 ## [3.3.0] - 2019-12-17
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 #
 
 # ---- base image to inherit from ----
-FROM python:3.7-stretch as base
+FROM python:3.8-buster as base
 
 # ---- back-end builder image ----
 FROM base as back-builder

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -40,8 +40,7 @@ install_requires =
     django-storages==1.8
     dockerflow==2019.10.0
     gunicorn==20.0.4
-    # Warning from psycopg2 "The psycopg2 wheel package will be renamed from release 2.8" => psyopg2-binary
-    psycopg2-binary==2.7.5 # pyup: <=2.7.5
+    psycopg2-binary==2.8.4
     PyLTI==0.7.0
     sentry-sdk==0.14.1
     requests==2.22.0


### PR DESCRIPTION
## Purpose

Python 3.8 is available since several months, it's time for us to use it in Marsha. 

## Proposal

- [x] upgrade base image to python 3.8
- [x] upgrade `psycopg2-binary` package to version `2.8,4`
- [x] upgrade python images used in circle-ci to version 3.8

