### PR TITLE
🐛(back) set SECURE_REFERRER_POLICY setting to same-origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Upgrade to Django 3
 - Upgrade to python 3.8
+- Set SECURE_REFERRER_POLICY setting to same-origin
 
 ## [3.3.0] - 2019-12-17
 

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -95,6 +95,7 @@ class Base(Configuration):
     SECURE_BROWSER_XSS_FILTER = True
     SECURE_CONTENT_TYPE_NOSNIFF = True
     X_FRAME_OPTIONS = "DENY"
+    SECURE_REFERRER_POLICY = "same-origin"
     SILENCED_SYSTEM_CHECKS = values.ListValue([])
 
     # Application definition


### PR DESCRIPTION
## Purpose

Django 3.0 introduces a new setting `SECURE_REFERRER_POLICY` in its
`SecurityMiddleware`. There is no value by default but heartbeat requires
to set one in production. We only need the referer for the admin module
so we choose to use `same-origin`, this is the the value recommended by
the documentation to prevent CSRF issues:
https://docs.djangoproject.com/en/3.0/ref/middleware/#referrer-policy

## Proposal

- [x] set SECURE_REFERRER_POLICY setting to same-origin

