### PR TITLE
🐛(front) force to display thumbnail while the video is not played

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Upgrade to python 3.8
 - Set SECURE_REFERRER_POLICY setting to same-origin
 
+### Fixed
+
+- Force thumbnail to be displayed while the video is not played
+
 ## [3.3.0] - 2019-12-17
 
 ### Added

--- a/src/frontend/Player/createPlyrPlayer.ts
+++ b/src/frontend/Player/createPlyrPlayer.ts
@@ -172,9 +172,18 @@ export const createPlyrPlayer = (
     }
   };
 
-  const initialize = () => {
+  const initialize = (event: Plyr.PlyrEvent) => {
     // if the module is already initalized abort the operation.
     if (true === isInitialized) {
+      // this is a workaround to force the player to stay on the first frame (time code 0)
+      // while the video is not played. Without this, the state seeks a little bit
+      // when loaded and the poster is not displayed.
+      // see: https://github.com/sampotts/plyr/issues/1397
+      // the event "canplay" must be ignored because it can be used by plyr when
+      // it has seeked.
+      if (player.currentTime > 0 && event.type !== 'canplay') {
+        player.currentTime = 0;
+      }
       return;
     }
 
@@ -248,6 +257,7 @@ export const createPlyrPlayer = (
       player.currentTime = 0;
       return;
     }
+
     if (false === hasSeeked) {
       return;
     }


### PR DESCRIPTION
## Purpose

We have a regression on the thumbnail display feature. Before we forced
the frame code to 0 on the first seeked event because it happened before
the initialize event. We changed how the initialize event is caught and it
can happen now before the first seeked event. To fix this we have to
check in the initialized event itself if we have to reset the
`currentTime` property.

## Proposal

- [x] Check in the `initialize` event if `currentTime` property must be reset

