### PR TITLE
⬆️(back) upgrade django-storages to version 1.9.1

### DIFF
--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
     djangorestframework==3.11.0
     djangorestframework_simplejwt==4.4.0
     django-safedelete==0.5.4
-    django-storages==1.9
+    django-storages==1.9.1
     dockerflow==2019.10.0
     gunicorn==20.0.4
     psycopg2-binary==2.8.4


### PR DESCRIPTION
## Purpose

It is impossible to deploy statics on AWS with django-storages 1.9.0 we
must upgrade it to version 1.9.1 which contains a fix for AWS.

## Proposal

Description...

- [x] Upgrade django-storages to version 1.9.1

