### PR TITLE
✨(front) allow to change video quality while using ABR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Allow to change video quality while using ABR
+
 ## [3.4.0] - 2020-02-06
 
 ### Changed

--- a/src/frontend/Player/createDashPlayer.spec.ts
+++ b/src/frontend/Player/createDashPlayer.spec.ts
@@ -38,6 +38,9 @@ describe('createDash{layer', () => {
           initialBitrate: {
             video: 1600,
           },
+          maxBitrate: {
+            video: 2400,
+          },
         },
         fastSwitchEnabled: true,
       },

--- a/src/frontend/Player/createDashPlayer.ts
+++ b/src/frontend/Player/createDashPlayer.ts
@@ -12,7 +12,10 @@ export const createDashPlayer = (
     streaming: {
       abr: {
         initialBitrate: {
-          video: 1600,
+          video: 1600, // 480p
+        },
+        maxBitrate: {
+          video: 2400, // 720p
         },
       },
       fastSwitchEnabled: true,

--- a/src/frontend/Player/createPlyrPlayer.spec.ts
+++ b/src/frontend/Player/createPlyrPlayer.spec.ts
@@ -11,8 +11,11 @@ jest.mock('../utils/isAbrSupported', () => ({
 const mockIsMSESupported = isMSESupported as jestMockOf<typeof isMSESupported>;
 const mockIsHlsSupported = isHlsSupported as jestMockOf<typeof isHlsSupported>;
 
+const mockDashOnListener = jest.fn();
 jest.mock('./createDashPlayer', () => ({
-  createDashPlayer: jest.fn(),
+  createDashPlayer: jest.fn(() => ({
+    on: mockDashOnListener,
+  })),
 }));
 
 const mockCreateDashPlayer = createDashPlayer as jestMockOf<
@@ -229,6 +232,7 @@ describe('createPlyrPlayer', () => {
     createPlyrPlayer(ref, jest.fn(), video as Video);
 
     expect(mockCreateDashPlayer).toHaveBeenCalledWith(video, ref);
+    expect(mockDashOnListener).toHaveBeenCalled();
   });
   it('overrides sources when ABR and HLS is not available', () => {
     mockIsMSESupported.mockReturnValue(false);

--- a/src/frontend/Player/createPlyrPlayer.spec.ts
+++ b/src/frontend/Player/createPlyrPlayer.spec.ts
@@ -239,9 +239,9 @@ describe('createPlyrPlayer', () => {
 
     expect(player.source).toEqual({
       sources: [
-        { size: '144', src: 'https://example.com/144p.mp4', type: 'video/mp4' },
+        { size: 144, src: 'https://example.com/144p.mp4', type: 'video/mp4' },
         {
-          size: '1080',
+          size: 1080,
           src: 'https://example.com/1080p.mp4',
           type: 'video/mp4',
         },

--- a/src/frontend/Player/createPlyrPlayer.ts
+++ b/src/frontend/Player/createPlyrPlayer.ts
@@ -30,13 +30,17 @@ export const createPlyrPlayer = (
   let dash: Maybe<MediaPlayerClass>;
   let sources;
   const settings = ['captions', 'speed', 'loop', 'quality'];
+  const videoSizes = Object.keys(video.urls.mp4).map(
+    size => Number(size) as videoSize,
+  );
+
   if (!isMSESupported() && !isHlsSupported(videoNode)) {
     const timedTextTracks = useTimedTextTrackApi
       .getState()
       .getTimedTextTracks();
 
     sources = {
-      sources: (Object.keys(video.urls.mp4) as videoSize[]).map(size => ({
+      sources: videoSizes.map(size => ({
         size,
         src: video.urls.mp4[size],
         type: 'video/mp4',
@@ -57,8 +61,6 @@ export const createPlyrPlayer = (
       type: 'video',
     } as SourceInfo;
   }
-
-  const videoSizes: string[] = Object.keys(video.urls.mp4);
 
   const sizeToBitrateMapping: { [key in videoSize]: number } = {
     144: 300,
@@ -119,7 +121,7 @@ export const createPlyrPlayer = (
     },
     iconUrl: appData.static.svg.plyr,
     quality: {
-      default: '480',
+      default: 480,
       forced: true,
       onChange: (quality: videoSize) => {
         if (!dash) {

--- a/src/frontend/components/DashboardThumbnailDisplay/index.tsx
+++ b/src/frontend/components/DashboardThumbnailDisplay/index.tsx
@@ -32,17 +32,16 @@ export const DashboardThumbnailDisplay = ({
       alt={messages.thumbnailAlt}
       fit={'cover'}
       src={urls[144]}
-      srcSet={(Object.keys(urls) as videoSize[]).reduce(
-        (acc: string, size: videoSize) => {
+      srcSet={Object.keys(urls)
+        .map(size => Number(size) as videoSize)
+        .reduce((acc: string, size: videoSize) => {
           const url = `${urls[size]} ${videoSizeMapping[size]}w`;
           if (acc.length === 0) {
             return url;
           } else {
             return `${acc}, ${url}`;
           }
-        },
-        '',
-      )}
+        }, '')}
     />
   );
 };

--- a/src/frontend/components/VideoPlayer/index.tsx
+++ b/src/frontend/components/VideoPlayer/index.tsx
@@ -126,14 +126,16 @@ const VideoPlayer = ({ video: baseVideo }: BaseVideoPlayerProps) => {
         )}
         {!!videoNodeRef.current &&
           !isHlsSupported(videoNodeRef.current) &&
-          (Object.keys(video.urls.mp4) as videoSize[]).map(size => (
-            <source
-              key={video.urls.mp4[size]}
-              size={size}
-              src={video.urls.mp4[size]}
-              type="video/mp4"
-            />
-          ))}
+          Object.keys(video.urls.mp4)
+            .map(size => Number(size) as videoSize)
+            .map(size => (
+              <source
+                key={video.urls.mp4[size]}
+                size={`${size}`}
+                src={video.urls.mp4[size]}
+                type="video/mp4"
+              />
+            ))}
 
         {/* This is a workaround to force plyr to load its tracks list once
           instantiated. Without this, captions are not loaded correctly, at least, on firefox.

--- a/src/frontend/types/XAPI.ts
+++ b/src/frontend/types/XAPI.ts
@@ -113,7 +113,7 @@ export interface InteractedContextExtensions {
   ccSubtitleLanguage?: string;
   frameRate?: number;
   fullScreen?: boolean;
-  quality?: string;
+  quality?: string | number;
   videoPlaybackSize?: string;
   speed?: string;
   track?: string;

--- a/src/frontend/types/libs/plyr/index.d.ts
+++ b/src/frontend/types/libs/plyr/index.d.ts
@@ -510,10 +510,10 @@ declare namespace Plyr {
   }
 
   export interface QualityOptions {
-    default: string;
+    default: number;
     forced: boolean;
     onChange: (quality: videoSize) => void;
-    options: string[];
+    options: videoSize[];
   }
 
   export interface LoopOptions {

--- a/src/frontend/types/libs/plyr/index.d.ts
+++ b/src/frontend/types/libs/plyr/index.d.ts
@@ -105,7 +105,7 @@ declare class Plyr {
    * Gets or sets the quality for the player. The setter accepts a value from the options specified in your config.
    * Remarks: YouTube only. HTML5 will follow.
    */
-  quality: string;
+  quality: string | number;
 
   /**
    * Gets or sets the current loop state of the player.

--- a/src/frontend/types/libs/plyr/index.d.ts
+++ b/src/frontend/types/libs/plyr/index.d.ts
@@ -511,6 +511,8 @@ declare namespace Plyr {
 
   export interface QualityOptions {
     default: string;
+    forced: boolean;
+    onChange: (quality: videoSize) => void;
     options: string[];
   }
 

--- a/src/frontend/types/tracks.ts
+++ b/src/frontend/types/tracks.ts
@@ -57,7 +57,7 @@ export interface TimedTextTranscript extends TimedText {
 }
 
 /** Possible sizes for an image, a video or stream. Used as keys in lists of files. */
-export type videoSize = '144' | '240' | '480' | '720' | '1080';
+export type videoSize = 144 | 240 | 480 | 720 | 1080;
 
 /** An URLs property that includes URLs for each possible visual size */
 export type urls = { [key in videoSize]: string };


### PR DESCRIPTION
## Purpose

Our user would like to choose the video quality and not let ABR decide
for them which one to use. But the main issue we had was the incompatibility
between plyr quality selector and dashjs. We found that plyr allow to
completely override the selector behaviour. The way we override it let
us change dashjs settings by setting the max bitrate the player can
choose, we don't rely anymore on plyr behaviour.
ABR is still working, if bandwith go down the player will choose a lower quality but it will not be able to upscale it as he want, it will be stop by the value we set in the settings.

## Proposal

- [x] Rely on dashjs to change video quality
- [x] Change quality selector when dash changes the video quality

Closes #589
