### PR TITLE
👷(linters) lint backend source code with bandit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,6 +181,9 @@ jobs:
       - run:
           name: Lint code with pylint
           command: ~/.local/bin/pylint --rcfile=pylintrc marsha
+      - run:
+          name: Lint code with bandit
+          command: ~/.local/bin/bandit -c .bandit -qr marsha
 
 
   test-back:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Replace `random` with `secrets` to generate random strings
+
+### Fixed
+
+- Remove `assert` statements and prepare codebase for activation of `bandit`
+  linter
+
 ## [3.7.1] - 2020-05-11
 
 ### Fixed

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -8,6 +8,7 @@
 - [Richard Moch](https://github.com/rmoch) <richard.moch@gmail.com>
 - [Samuel Paccoud](https://github.com/sampaccoud) <samuel.paccoud@fun-mooc.fr>
 - [Manuel Raynaud](https://github.com/lunika) <manu@raynaud.io>
+- [Matthieu Huguet](https://github.com/madmatah) <matthieu.huguet@fun-mooc.fr>
 
 - [Renovate Bot](https://renovatebot.com) <bot@renovateapp.com>
 - [Pyup Bot](https://pyup.io) <github-bot@pyup.io>

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,8 @@ lint: \
 	lint-isort \
 	lint-black \
 	lint-flake8 \
-	lint-pylint
+	lint-pylint \
+	lint-bandit
 .PHONY: lint
 
 lint-black:  ## Run the black tool and update files that need to
@@ -137,6 +138,11 @@ lint-pylint:  ## Run the pylint tool
 	@echo "$(BOLD)Running pylint$(RESET)"
 	@$(COMPOSE_RUN_APP) pylint --rcfile=pylintrc marsha
 .PHONY: lint-pylint
+
+lint-bandit: ## lint back-end python sources with bandit
+	@echo "$(BOLD)Running bandit$(RESET)"
+	@$(COMPOSE_RUN_APP) bandit -c .bandit -qr marsha
+.PHONY: lint-bandit
 
 .PHONY: migrate
 migrate:  ## Run django migration for the marsha project.

--- a/src/backend/.bandit
+++ b/src/backend/.bandit
@@ -1,0 +1,1 @@
+exclude_dirs: ["*/tests/*"]

--- a/src/backend/marsha/core/lti/__init__.py
+++ b/src/backend/marsha/core/lti/__init__.py
@@ -175,9 +175,7 @@ class LTI:
         """Find and return the passport targeted by the LTI request or raise an LTIException."""
         consumer_key = self.request.POST.get("oauth_consumer_key", None)
 
-        try:
-            assert consumer_key
-        except AssertionError:
+        if not consumer_key:
             raise LTIException("An oauth consumer key is required.")
 
         # find a passport related to the oauth consumer key

--- a/src/backend/marsha/core/models/account.py
+++ b/src/backend/marsha/core/models/account.py
@@ -1,5 +1,5 @@
 """This module holds the models for the marsha project."""
-import random
+import secrets
 import string
 
 from django.contrib.auth.models import AbstractUser
@@ -167,12 +167,12 @@ class LTIPassport(BaseModel):
         self.full_clean()
         if not self.oauth_consumer_key:
             self.oauth_consumer_key = "".join(
-                random.choice(OAUTH_CONSUMER_KEY_CHARS)
+                secrets.choice(OAUTH_CONSUMER_KEY_CHARS)
                 for _ in range(OAUTH_CONSUMER_KEY_SIZE)
             )
         if not self.shared_secret:
             self.shared_secret = "".join(
-                random.choice(SHARED_SECRET_CHARS) for _ in range(SHARED_SECRET_SIZE)
+                secrets.choice(SHARED_SECRET_CHARS) for _ in range(SHARED_SECRET_SIZE)
             )
         super().save(*args, **kwargs)
 

--- a/src/backend/marsha/core/utils/cloudfront_utils.py
+++ b/src/backend/marsha/core/utils/cloudfront_utils.py
@@ -39,4 +39,6 @@ def rsa_signer(message):
     except FileNotFoundError:
         raise MissingRSAKey()
 
-    return private_key.sign(message, padding.PKCS1v15(), hashes.SHA1())
+    # The following line is excluded from bandit security check because cloudfront supports
+    # only sha1 hash for signed URLs.
+    return private_key.sign(message, padding.PKCS1v15(), hashes.SHA1())  # nosec

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -63,6 +63,7 @@ console_scripts =
 
 [options.extras_require]
 dev =
+    bandit==1.6.2
     black==19.10b0
     factory_boy==2.12.0
     flake8==3.7.9


### PR DESCRIPTION
## Purpose

We would like to check for security issues in marsha's backend source code.

## Proposal

- [x] Add bandit linter
- [x] Treat all warnings

FYI, the following errors were reported by `bandit` : 

```
Test results:
>> Issue: [B101:assert_used] Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.
   Severity: Low   Confidence: High
   Location: marsha/core/lti/__init__.py:174
   More Info: https://bandit.readthedocs.io/en/latest/plugins/b101_assert_used.html
173	        try:
174	            assert consumer_key
175	        except AssertionError:

--------------------------------------------------
>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
   Severity: Low   Confidence: High
   Location: marsha/core/models/account.py:170
   More Info: https://bandit.readthedocs.io/en/latest/blacklists/blacklist_calls.html#b311-random
169	            self.oauth_consumer_key = "".join(
170	                random.choice(OAUTH_CONSUMER_KEY_CHARS)
171	                for _ in range(OAUTH_CONSUMER_KEY_SIZE)

--------------------------------------------------
>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
   Severity: Low   Confidence: High
   Location: marsha/core/models/account.py:175
   More Info: https://bandit.readthedocs.io/en/latest/blacklists/blacklist_calls.html#b311-random
174	            self.shared_secret = "".join(
175	                random.choice(SHARED_SECRET_CHARS) for _ in range(SHARED_SECRET_SIZE)
176	            )

--------------------------------------------------
>> Issue: [B303:blacklist] Use of insecure MD2, MD4, MD5, or SHA1 hash function.
   Severity: Medium   Confidence: High
   Location: marsha/core/utils/cloudfront_utils.py:42
   More Info: https://bandit.readthedocs.io/en/latest/blacklists/blacklist_calls.html#b303-md5
41	
42	    return private_key.sign(message, padding.PKCS1v15(), hashes.SHA1())

--------------------------------------------------
```


I silenced the last one because cloudfront documentation only refers to SHA1 hashing algorithm for signed urls. And the only [question I found](https://forums.aws.amazon.com/thread.jspa?threadID=263915) about this issue is still unanswered.

