### PR TITLE
📄(project) add missing license copyright holder

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 
+Copyright (c) 2018-present GIP FUN-MOOC.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Purpose

Without copyright holder, the project license is broken.

## Proposal

- [x] add MIT license copyright holder