### PR TITLE
✨(back) register xapi statement in a logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Use subtitles as transcript when no transcript has been uploaded
+- Register xapi statements in a logger
 
 ## [3.6.0] - 2020-04-15
 

--- a/src/backend/marsha/core/lti/__init__.py
+++ b/src/backend/marsha/core/lti/__init__.py
@@ -351,5 +351,5 @@ class LTIUser:
         """
         try:
             return self.token.payload[name]
-        except MultiValueDictKeyError:
+        except KeyError:
             raise AttributeError(name)

--- a/src/backend/marsha/core/tests/test_api_xapi_statement.py
+++ b/src/backend/marsha/core/tests/test_api_xapi_statement.py
@@ -7,7 +7,6 @@ from django.test import TestCase
 import requests
 from rest_framework_simplejwt.tokens import AccessToken
 
-from ..exceptions import MissingUserIdError
 from ..factories import VideoFactory
 from ..models import Video
 
@@ -34,8 +33,22 @@ class XAPIStatementApiTest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(video.id)
         jwt_token.payload["roles"] = ["student"]
+        jwt_token.payload["user_id"] = "John Doe"
+        jwt_token.payload["course"] = {
+            "school_name": None,
+            "course_name": None,
+            "course_run": None,
+        }
 
-        data = {"foo": "bar"}
+        data = {
+            "verb": {
+                "id": "http://adlnet.gov/expapi/verbs/initialized",
+                "display": {"en-US": "initialized"},
+            },
+            "context": {
+                "extensions": {"https://w3id.org/xapi/video/extensions/volume": 1}
+            },
+        }
 
         response = self.client.post(
             "/xapi/",
@@ -118,6 +131,12 @@ class XAPIStatementApiTest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(video.id)
         jwt_token.payload["roles"] = ["student"]
+        jwt_token.payload["user_id"] = "John Doe"
+        jwt_token.payload["course"] = {
+            "school_name": None,
+            "course_name": None,
+            "course_run": None,
+        }
 
         data = {
             "verb": {
@@ -163,6 +182,12 @@ class XAPIStatementApiTest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(video.id)
         jwt_token.payload["roles"] = ["student"]
+        jwt_token.payload["user_id"] = "John Doe"
+        jwt_token.payload["course"] = {
+            "school_name": None,
+            "course_name": None,
+            "course_run": None,
+        }
 
         data = {
             "verb": {
@@ -188,8 +213,7 @@ class XAPIStatementApiTest(TestCase):
         self.assertEqual(response.status_code, 204)
 
     @mock.patch("marsha.core.api.Video.objects.get")
-    @mock.patch("marsha.core.api.XAPI")
-    def test_xapi_statement_with_missing_user_id(self, xapi_mock, video_model_mock):
+    def test_xapi_statement_with_missing_user_id(self, video_model_mock):
         """Missing user_id parameter in JWT will fail request to LRS."""
         video = VideoFactory(
             playlist__consumer_site__lrs_url="http://lrs.com/data/xAPI",
@@ -210,8 +234,6 @@ class XAPIStatementApiTest(TestCase):
         }
 
         video_model_mock.return_value = video
-        xapi_instance = xapi_mock.return_value
-        xapi_instance.send.side_effect = MissingUserIdError()
 
         response = self.client.post(
             "/xapi/",

--- a/src/backend/marsha/core/tests/test_xapi.py
+++ b/src/backend/marsha/core/tests/test_xapi.py
@@ -6,36 +6,24 @@ from django.test import TestCase
 from ..exceptions import MissingUserIdError
 from ..factories import VideoFactory
 from ..lti import LTIUser
-from ..xapi import XAPI, requests
+from ..xapi import XAPI, XAPIStatement, requests
 
 
 class MockLtiUser:
     """Mock LTIUser class."""
 
-    @property
-    def user_id(self):
-        """Force to raise a wanted exception."""
-        raise AttributeError("user_id")
 
+class XAPIStatmentTest(TestCase):
+    """Test the XAPIStatement class."""
 
-class XAPITest(TestCase):
-    """Test the xapi module."""
-
-    def test_xapi_missing_user_id(self):
+    def test_xapi_statement_missing_user_id(self):
         """Missing lti user_id should raise an exception."""
-        xapi = XAPI("https://lrs.example.com", "auth_token")
         video = VideoFactory()
-
         with self.assertRaises(MissingUserIdError):
-            xapi.send(video, {}, MockLtiUser())
+            XAPIStatement(video, {}, MockLtiUser())
 
-    @mock.patch.object(requests, "post")
-    def test_xapi_enrich_and_send_statement(self, mock_requests_post):
-        """XAPI statement sent by the front application should be enriched.
-
-        Before sending a statement, the xapi module is responsible for enriching it.
-        """
-        xapi = XAPI("https://lrs.example.com", "auth_token")
+    def test_xapi_statement_enrich_statement(self):
+        """XAPI statement sent by the front application should be enriched."""
         video = VideoFactory(
             id="68333c45-4b8c-4018-a195-5d5e1706b838",
             playlist__consumer_site__domain="example.com",
@@ -57,9 +45,6 @@ class XAPITest(TestCase):
 
         lti_user = LTIUser(mock_token_user)
 
-        mock_response = mock.MagicMock()
-        mock_response.raise_for_status.return_value = 200
-        mock_requests_post.return_value = mock_response
         base_statement = {
             "context": {
                 "extensions": {
@@ -83,30 +68,19 @@ class XAPITest(TestCase):
             "id": "17dfcd44-b3e0-403d-ab96-e3ef7da616d4",
         }
 
-        xapi.send(video, base_statement, lti_user)
+        xapi_statement = XAPIStatement(video, base_statement, lti_user)
+        statement = xapi_statement.get_statement()
 
-        args, kwargs = mock_requests_post.call_args_list[0]
-        self.assertEqual(args[0], "https://lrs.example.com")
+        self.assertIsNotNone(statement["timestamp"])
         self.assertEqual(
-            kwargs["headers"],
-            {
-                "Authorization": "auth_token",
-                "Content-Type": "application/json",
-                "X-Experience-API-Version": "1.0.3",
-            },
-        )
-        enriched_statement = kwargs["json"]
-
-        self.assertIsNotNone(enriched_statement["timestamp"])
-        self.assertEqual(
-            enriched_statement["actor"],
+            statement["actor"],
             {
                 "objectType": "Agent",
                 "account": {"name": "foo", "homePage": "http://example.com"},
             },
         )
         self.assertEqual(
-            enriched_statement["object"],
+            statement["object"],
             {
                 "definition": {
                     "type": "https://w3id.org/xapi/video/activity-type/video",
@@ -120,6 +94,40 @@ class XAPITest(TestCase):
                 "objectType": "Activity",
             },
         )
-        self.assertEqual(enriched_statement["verb"], base_statement["verb"])
-        self.assertEqual(enriched_statement["id"], base_statement["id"])
-        self.assertEqual(enriched_statement["result"], base_statement["result"])
+        self.assertEqual(statement["verb"], base_statement["verb"])
+        self.assertEqual(statement["id"], base_statement["id"])
+        self.assertEqual(statement["result"], base_statement["result"])
+
+
+class XAPITest(TestCase):
+    """Test the xapi module."""
+
+    @mock.patch.object(requests, "post")
+    def test_xapi_enrich_and_send_statement(self, mock_requests_post):
+        """XAPI statement sent by the front application should be enriched.
+
+        Before sending a statement, the xapi module is responsible for enriching it.
+        """
+        xapi = XAPI("https://lrs.example.com", "auth_token")
+
+        mock_response = mock.MagicMock()
+        mock_response.raise_for_status.return_value = 200
+        mock_requests_post.return_value = mock_response
+
+        statement = {"foo": "bar"}
+        mock_xapi_statement = mock.MagicMock()
+        mock_xapi_statement.get_statement.return_value = statement
+
+        xapi.send(mock_xapi_statement)
+
+        args, kwargs = mock_requests_post.call_args_list[0]
+        self.assertEqual(args[0], "https://lrs.example.com")
+        self.assertEqual(
+            kwargs["headers"],
+            {
+                "Authorization": "auth_token",
+                "Content-Type": "application/json",
+                "X-Experience-API-Version": "1.0.3",
+            },
+        )
+        self.assertEqual(kwargs["json"], statement)

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -204,10 +204,10 @@ class Base(Configuration):
                 "console": {
                     "class": "logging.StreamHandler",
                     "stream": "ext://sys.stdout",
-                }
+                },
             },
             "loggers": {
-                "marsha": {"handlers": ["console"], "level": "INFO", "propagate": True}
+                "marsha": {"handlers": ["console"], "level": "INFO", "propagate": True},
             },
         }
     )
@@ -332,18 +332,37 @@ class Development(Base):
     CLOUDFRONT_SIGNED_URLS_ACTIVE = values.BooleanValue(False)
     CACHES = {"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
 
+    # Logging
     LOGGING = values.DictValue(
         {
             "version": 1,
             "disable_existing_loggers": False,
+            "formatters": {
+                "gelf": {
+                    "()": "logging_gelf.formatters.GELFFormatter",
+                    "null_character": True,
+                },
+            },
             "handlers": {
                 "console": {
                     "class": "logging.StreamHandler",
                     "stream": "ext://sys.stdout",
-                }
+                },
+                "gelf": {
+                    "class": "logging.StreamHandler",
+                    "stream": "ext://sys.stdout",
+                    "formatter": "gelf",
+                },
             },
             "loggers": {
-                "marsha": {"handlers": ["console"], "level": "DEBUG", "propagate": True}
+                "marsha": {
+                    "handlers": ["console"],
+                    "level": "DEBUG",
+                    "propagate": True,
+                },
+                # This formatter is here as an example to what is possible to do
+                # with xapi loogers.
+                "xapi": {"handlers": ["gelf"], "level": "INFO", "propagate": True},
             },
         }
     )

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -40,6 +40,7 @@ install_requires =
     django-storages==1.9.1
     dockerflow==2019.10.0
     gunicorn==20.0.4
+    logging-ldp==0.0.6
     psycopg2-binary==2.8.5
     PyLTI==0.7.0
     sentry-sdk==0.14.3


### PR DESCRIPTION
## Purpose

We want to log xapi statement in a logger and also to configure a logger
by consumer site. We use for that a special logger name convention,
prefixing the domain name byt `xapi.`. For example for the consumer
site with domaine name foo.education you have to create a logger name
`xapi.foo.education` and configure as you want the associated handler
and formatter depending where you want to log the statements.

## Proposal

- [x] create a dedicated class to compute xapi statements
- [x] register xapi statement in a logger
