### PR TITLE
🐛(backend) referer can match ALLOWED_HOSTS as a valid passport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Referer can match ALLOWED_HOSTS as a valid passport domain name
+
 ## [3.7.0] - 2020-05-05
 
 ### Added


### PR DESCRIPTION
## Purpose

Some browsers, like Brave, [replace referer header value by the referred-to and not the referred-from value][1]. In this case the referred-to value will match value added in the ALLOWED_HOSTS setting and in this case we choose to trust this domain as a valid passport domain name.

[1]: https://bit.ly/35CvPXa

## Proposal

- [x] Referer can match ALLOWED_HOSTS as a valid passport domain name

