### PR TITLE
✨(AWS) detect framerate from original video 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Detect original video framerate and use it in lambda encode
+
 ## [3.8.1] - 2020-05-18
 
 ### Fixed

--- a/src/aws/lambda-encode/src/utils/framerateConverter.js
+++ b/src/aws/lambda-encode/src/utils/framerateConverter.js
@@ -1,0 +1,11 @@
+
+module.exports = (framerate) => {
+  const roundedFramerate = Math.round(framerate);
+  const denominator = Math.round((1000 * roundedFramerate / Math.round(framerate*1000)) * 1000);
+  const numerator = 1000 * roundedFramerate;
+
+  return {
+    denominator,
+    numerator
+  };
+};

--- a/src/aws/lambda-encode/src/utils/framerateConverter.spec.js
+++ b/src/aws/lambda-encode/src/utils/framerateConverter.spec.js
@@ -1,0 +1,40 @@
+const framerateConverter = require('./framerateConverter');
+
+describe('src/utils/framerateConverter', () => {
+  it('converts fps to denominator and numerator', () => {
+    const fpsMapping = [
+      {
+        fps: '24',
+        expectedConverted: {
+          numerator: 24000,
+          denominator: 1000
+        }
+      },
+      {
+        fps: '25',
+        expectedConverted: {
+          numerator: 25000,
+          denominator: 1000,
+        }
+      },
+      {
+        fps: '23.976',
+        expectedConverted: {
+          numerator: 24000,
+          denominator: 1001,
+        }
+      },
+      {
+        fps: '29.970',
+        expectedConverted: {
+          numerator: 30000,
+          denominator: 1001,
+        }
+      }
+    ];
+
+    fpsMapping.forEach(({fps, expectedConverted}) => {
+      expect(framerateConverter(fps)).toEqual(expectedConverted);
+    });
+  });
+});

--- a/src/aws/lambda.tf
+++ b/src/aws/lambda.tf
@@ -1,3 +1,14 @@
+# Lambda Layers
+###############
+
+resource "aws_lambda_layer_version" "media_info_layer" {
+  filename    = "layers/MediaInfo_CLI_20.03.20200523_Lambda.zip"
+  source_code_hash = "${base64sha256(file("layers/MediaInfo_CLI_20.03.20200523_Lambda.zip"))}"
+  layer_name  = "media_info_layer"
+
+  description = "Layer containing mediainfo binary file compatible with AWS lambda servers."
+}
+
 # Configuration
 #################
 
@@ -60,6 +71,8 @@ resource "aws_lambda_function" "marsha_encode_lambda" {
   role             = "${aws_iam_role.lambda_invocation_role.arn}"
   memory_size      = "1536"
   timeout          = "90"
+  layers           = ["${aws_lambda_layer_version.media_info_layer.arn}"]
+  depends_on       = ["aws_lambda_layer_version.media_info_layer"]
 
 
   environment {

--- a/src/aws/lambda.tf
+++ b/src/aws/lambda.tf
@@ -6,7 +6,7 @@ resource "aws_lambda_layer_version" "media_info_layer" {
   source_code_hash = "${base64sha256(file("layers/MediaInfo_CLI_20.03.20200523_Lambda.zip"))}"
   layer_name  = "media_info_layer"
 
-  description = "Layer containing mediainfo binary file compatible with AWS lambda servers."
+  description = "Layer containing mediainfo binary file compatible with AWS lambda servers (from https://mediaarea.net/download/snapshots/binary/mediainfo/)"
 }
 
 # Configuration


### PR DESCRIPTION
## Purpose

All our mediaconvert presets are using a 29.970 fps but a user can
upload a video with a different framerate. Using mediainfo we detect the
original framerate and keep it in the job creation.

## Proposal

- [x] presign s3 url to fetch video uploaded
- [x] retrieve video info using [mediainfo](https://mediaarea.net/en/MediaInfo)
- [x] send wanted info to mediaconvert

