### PR TITLE
♻️(S3) use boto3 to generate upload form

### DIFF
--- a/src/frontend/components/UploadForm/index.spec.tsx
+++ b/src/frontend/components/UploadForm/index.spec.tsx
@@ -117,8 +117,10 @@ describe('UploadForm', () => {
     fetchMock.mock(
       '/api/videos/video-id/initiate-upload/',
       {
-        bucket: 'dev',
-        s3_endpoint: 's3.aws.example.com',
+        fields: {
+          key: 'foo',
+        },
+        url: 'https://s3.aws.example.com/',
       },
       { method: 'POST' },
     );

--- a/src/frontend/data/sideEffects/upload/index.spec.ts
+++ b/src/frontend/data/sideEffects/upload/index.spec.ts
@@ -97,15 +97,17 @@ describe('upload', () => {
     fetchMock.mock(
       '/api/videos/video-id/initiate-upload/',
       {
-        bucket: 'dev',
-        s3_endpoint: 's3.aws.example.com',
+        fields: {
+          key: 'foo',
+        },
+        url: 'https://s3.aws.example.com/',
       },
       { method: 'POST' },
     );
 
     fetchMock.mock('/api/videos/video-id/', 200, { method: 'PUT' });
 
-    xhrMock.post('https://s3.aws.example.com/dev', {
+    xhrMock.post('https://s3.aws.example.com/', {
       body: 'form data body',
       status: 204,
     });
@@ -163,15 +165,17 @@ describe('upload', () => {
     fetchMock.mock(
       '/api/thumbnails/thumb1/initiate-upload/',
       {
-        bucket: 'dev',
-        s3_endpoint: 's3.aws.example.com',
+        fields: {
+          key: 'foo',
+        },
+        url: 'https://s3.aws.example.com/',
       },
       { method: 'POST' },
     );
 
     fetchMock.mock('/api/thumbnails/thumb1/', 200, { method: 'PUT' });
 
-    xhrMock.post('https://s3.aws.example.com/dev', {
+    xhrMock.post('https://s3.aws.example.com/', {
       body: 'form data body',
       status: 204,
     });
@@ -209,7 +213,7 @@ describe('upload', () => {
       method: 'POST',
     });
 
-    xhrMock.post('https://s3.aws.example.com/dev', () => {
+    xhrMock.post('https://s3.aws.example.com/', () => {
       throw new Error('upload file should not be called');
     });
 
@@ -234,13 +238,15 @@ describe('upload', () => {
     fetchMock.mock(
       '/api/videos/video-id/initiate-upload/',
       {
-        bucket: 'dev',
-        s3_endpoint: 's3.aws.example.com',
+        fields: {
+          key: 'foo',
+        },
+        url: 'https://s3.aws.example.com/',
       },
       { method: 'POST' },
     );
 
-    xhrMock.post('https://s3.aws.example.com/dev', {
+    xhrMock.post('https://s3.aws.example.com/', {
       status: 400,
     });
 
@@ -274,8 +280,10 @@ describe('upload', () => {
     fetchMock.mock(
       '/api/videos/video-id/initiate-upload/',
       {
-        bucket: 'dev',
-        s3_endpoint: 's3.aws.example.com',
+        fields: {
+          key: 'foo',
+        },
+        url: 'https://s3.aws.example.com/',
       },
       { method: 'POST' },
     );
@@ -303,8 +311,10 @@ describe('upload', () => {
     fetchMock.mock(
       '/api/videos/video-id/initiate-upload/',
       {
-        bucket: 'dev',
-        s3_endpoint: 's3.aws.example.com',
+        fields: {
+          key: 'foo',
+        },
+        url: 'https://s3.aws.example.com/',
       },
       { method: 'POST' },
     );

--- a/src/frontend/types/AWSPresignedPost.ts
+++ b/src/frontend/types/AWSPresignedPost.ts
@@ -10,3 +10,10 @@ export interface AWSPolicy {
   x_amz_expires: string;
   x_amz_signature: string;
 }
+
+export interface AWSPresignedPost {
+  fields: {
+    [key: string]: string;
+  };
+  url: string;
+}


### PR DESCRIPTION
## Purpose

To upload a file on s3, a form is crafted with a policy, signature and
more fields defining upload conditions. Since now all of this was
computed by us but we found that boto3 is able to do this job, it is
less error prone and we have less code to maintain.

## Proposal

- [x] generate presigned post using boto3
- [x] refactor upload in front using new payload

