### PR TITLE
✨(XAPI) add video title in xapi statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Video title in xapi statement
+
 ### Changed
 
 - Replace `random` with `secrets` to generate random strings

--- a/src/backend/marsha/core/tests/test_xapi.py
+++ b/src/backend/marsha/core/tests/test_xapi.py
@@ -1,7 +1,7 @@
 """Tests for the xapi module of the Marsha project."""
 from unittest import mock
 
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from ..exceptions import MissingUserIdError
 from ..factories import VideoFactory
@@ -22,11 +22,13 @@ class XAPIStatmentTest(TestCase):
         with self.assertRaises(MissingUserIdError):
             XAPIStatement(video, {}, MockLtiUser())
 
+    @override_settings(LANGUAGE_CODE="en-us")
     def test_xapi_statement_enrich_statement(self):
         """XAPI statement sent by the front application should be enriched."""
         video = VideoFactory(
             id="68333c45-4b8c-4018-a195-5d5e1706b838",
             playlist__consumer_site__domain="example.com",
+            title="test video xapi",
         )
 
         mock_token_user = mock.MagicMock()
@@ -91,6 +93,7 @@ class XAPIStatmentTest(TestCase):
                     },
                 },
                 "id": "uuid://68333c45-4b8c-4018-a195-5d5e1706b838",
+                "name": {"en-US": "test video xapi"},
                 "objectType": "Activity",
             },
         )

--- a/src/backend/marsha/core/xapi.py
+++ b/src/backend/marsha/core/xapi.py
@@ -2,7 +2,9 @@
 import re
 import uuid
 
+from django.conf import settings
 from django.utils import timezone
+from django.utils.translation import to_locale
 
 import requests
 
@@ -70,6 +72,7 @@ class XAPIStatement:
 
         statement["object"] = {
             "definition": {"type": "https://w3id.org/xapi/video/activity-type/video"},
+            "name": {to_locale(settings.LANGUAGE_CODE).replace("_", "-"): video.title},
             "id": "uuid://{id}".format(id=str(video.id)),
             "objectType": "Activity",
         }


### PR DESCRIPTION
## Purpose

We want to add the video title in all xapi statements. To do that, we
added it in the object property. We use the language map name in this
property to store it.

## Proposal

- [x] add video title in xapi statement

