### PR TITLE
🐛(xapi) move video title in definition property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Move video title in object.definition property in xapi statement
+
 ## [3.8.0] - 2020-05-18
 
 ### Added

--- a/src/backend/marsha/core/tests/test_xapi.py
+++ b/src/backend/marsha/core/tests/test_xapi.py
@@ -86,6 +86,7 @@ class XAPIStatmentTest(TestCase):
             {
                 "definition": {
                     "type": "https://w3id.org/xapi/video/activity-type/video",
+                    "name": {"en-US": "test video xapi"},
                     "extensions": {
                         "https://w3id.org/xapi/acrossx/extensions/school": "ufr",
                         "http://adlnet.gov/expapi/activities/course": "mathematics",
@@ -93,7 +94,6 @@ class XAPIStatmentTest(TestCase):
                     },
                 },
                 "id": "uuid://68333c45-4b8c-4018-a195-5d5e1706b838",
-                "name": {"en-US": "test video xapi"},
                 "objectType": "Activity",
             },
         )

--- a/src/backend/marsha/core/xapi.py
+++ b/src/backend/marsha/core/xapi.py
@@ -71,8 +71,12 @@ class XAPIStatement:
         }
 
         statement["object"] = {
-            "definition": {"type": "https://w3id.org/xapi/video/activity-type/video"},
-            "name": {to_locale(settings.LANGUAGE_CODE).replace("_", "-"): video.title},
+            "definition": {
+                "type": "https://w3id.org/xapi/video/activity-type/video",
+                "name": {
+                    to_locale(settings.LANGUAGE_CODE).replace("_", "-"): video.title
+                },
+            },
             "id": "uuid://{id}".format(id=str(video.id)),
             "objectType": "Activity",
         }


### PR DESCRIPTION
## Purpose

The name property is not set at the good level. We added it in the
option property but it should be in the object.definition property

## Proposal

- [x] Move video title in object.definition property in xapi statement

