### PR TITLE
🐛(AWS) fallback on default audio bitrate when absent in mediainfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fallback on default audio bitrate when absent in mediainfo
+
 ## [3.9.0] - 2020-06-08
 
 ### Added

--- a/src/aws/lambda-encode/src/encodeVideo.js
+++ b/src/aws/lambda-encode/src/encodeVideo.js
@@ -36,7 +36,7 @@ module.exports = async (objectKey, sourceBucket) => {
     FramerateNumerator: 30000
   }
   let videoSizes = [144, 240, 480, 720, 1080];
-  let audioBirates = [64000, 960000, 128000, 160000, 192000];
+  let audioBirates = [64000, 96000, 128000, 160000, 192000];
 
   if (stdout) {
     const mediainfos = JSON.parse(stdout);

--- a/src/aws/lambda-encode/src/encodeVideo.js
+++ b/src/aws/lambda-encode/src/encodeVideo.js
@@ -44,8 +44,13 @@ module.exports = async (objectKey, sourceBucket) => {
     const videoInfo = mediainfos.media.track.find(track => track["@type"] === "Video");
     const audioInfo = mediainfos.media.track.find(track => track["@type"] === "Audio");
 
-    videoSizes = videoSizes.filter(size => size <= videoInfo.Height);
-    audioBirates = audioBirates.filter(bitrate => bitrate <= audioInfo.BitRate);
+    if (videoInfo.hasOwnProperty('Height')) {
+      videoSizes = videoSizes.filter(size => size <= videoInfo.Height);
+    }
+
+    if (audioInfo.hasOwnProperty('BitRate')) {
+      audioBirates = audioBirates.filter(bitrate => bitrate <= audioInfo.BitRate);
+    }
 
     const convertedFramerate = framerateConverter(videoInfo.FrameRate);
     framerateSettings.FramerateDenominator = convertedFramerate.denominator;


### PR DESCRIPTION
## Purpose

For some videos, mediainfo doesn't have bitrate info which result in
missing audio in the encoded video. To fix this issue, we test if the
BitRate property is present and fallback on default bitrate if absent.

## Proposal

- [x] Fallback on default audio bitrate when absent in mediainfo


