### PR TITLE
Synchronize scroll with active transcript sentence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Synchronize scroll with active transcript sentence
+
 ## [3.9.1] - 2020-06-24
 
 ### Fixed

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -9,6 +9,7 @@
 - [Samuel Paccoud](https://github.com/sampaccoud) <samuel.paccoud@fun-mooc.fr>
 - [Manuel Raynaud](https://github.com/lunika) <manu@raynaud.io>
 - [Matthieu Huguet](https://github.com/madmatah) <matthieu.huguet@fun-mooc.fr>
+- [Florian Pereira](https://github.com/flo-pereira) <pereira.florian@gmail.com>
 
 - [Renovate Bot](https://renovatebot.com) <bot@renovateapp.com>
 - [Pyup Bot](https://pyup.io) <github-bot@pyup.io>

--- a/src/frontend/components/TranscriptReader/index.tsx
+++ b/src/frontend/components/TranscriptReader/index.tsx
@@ -1,5 +1,5 @@
 import { Box, Paragraph } from 'grommet';
-import React, { useState } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { VTTCue, WebVTT } from 'vtt.js';
 
 import { useVideoProgress } from '../../data/stores/useVideoProgress';
@@ -31,8 +31,22 @@ export const TranscriptReader = ({ transcript }: TranscriptReaderProps) => {
     parser.flush();
   }, []);
 
+  const transcriptWrapperRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!transcriptWrapperRef.current) return;
+
+    transcriptWrapperRef.current
+      .querySelector(`.sentence-active`)
+      ?.scrollIntoView({
+        behavior: 'smooth',
+        block: 'center',
+      });
+  }, [playerCurrentTime]);
+
   return (
     <Box
+      ref={transcriptWrapperRef}
       align="start"
       direction="row"
       pad="medium"

--- a/src/frontend/components/TranscriptSentence/index.spec.tsx
+++ b/src/frontend/components/TranscriptSentence/index.spec.tsx
@@ -41,14 +41,25 @@ describe('<TranscriptSentence />', () => {
       text: 'Lorem ipsum dolor sit amet.',
     };
 
-    const { getByText } = render(
+    const { getByText, asFragment } = render(
       <TranscriptSentence cue={cue} active={true} />,
     );
 
     const sentence = getByText('Lorem ipsum dolor sit amet.');
+    const child = asFragment().firstElementChild;
 
-    expect(sentence).toHaveStyleRule('background-color', /rgba(.*)/);
-    expect(sentence).toHaveStyleRule('outline', /1px solid rgba(.*)/);
+    if (!child) {
+      fail('Component does not render as expected');
+    }
+
+    const computedStyle = window.getComputedStyle(child);
+
+    expect(computedStyle.getPropertyValue('background-color')).toMatch(
+      /rgba(.*)/,
+    );
+    expect(computedStyle.getPropertyValue('outline')).toMatch(
+      /1px solid rgba(.*)/,
+    );
 
     fireEvent.click(sentence);
     expect(mockSetTime).toHaveBeenCalledWith(20);

--- a/src/frontend/components/TranscriptSentence/index.tsx
+++ b/src/frontend/components/TranscriptSentence/index.tsx
@@ -10,11 +10,11 @@ const Sentence = styled(Text)`
   :hover {
     text-decoration: underline;
   }
-`;
 
-const ActiveSentence = styled(Sentence)`
-  background-color: rgba(242, 94, 35, 0.25);
-  outline: 1px solid rgba(242, 94, 35, 0.5);
+  &.sentence-active {
+    background-color: rgba(242, 94, 35, 0.25);
+    outline: 1px solid rgba(242, 94, 35, 0.5);
+  }
 `;
 
 interface TranscriptSentenceProps {
@@ -30,19 +30,11 @@ export const TranscriptSentence = ({
 
   const textSentence = () => ({ __html: `${cue.text} ` });
 
-  if (active) {
-    return (
-      <ActiveSentence
-        onClick={() => setTime(cue.startTime)}
-        dangerouslySetInnerHTML={textSentence()}
-      />
-    );
-  } else {
-    return (
-      <Sentence
-        onClick={() => setTime(cue.startTime)}
-        dangerouslySetInnerHTML={textSentence()}
-      />
-    );
-  }
+  return (
+    <Sentence
+      className={active ? 'sentence-active' : ''}
+      onClick={() => setTime(cue.startTime)}
+      dangerouslySetInnerHTML={textSentence()}
+    />
+  );
 };


### PR DESCRIPTION
## Purpose

Is your feature request related to a problem or unsupported use case? Please describe.

When a video is played and a transcript shown, both are synchronized. We know which sentence is active by highlighting it. But in most of case we have a scroll bar and this scroll bar is not synchronized with the active transcript sentence.

## Proposal

The active sentence should always be visible in the screen. To do that the scroll position should change to always display it.



![sync-scroll](https://user-images.githubusercontent.com/1889274/85472960-e2acc100-b5b2-11ea-804f-009501122383.gif)


