### PR TITLE
🐛(back) use UploadableFileMixin on AbstractImage model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Synchronize scroll with active transcript sentence
 
+### Fixed
+
+- Use `UploadableFileMixin` on `AbstractImage` model
+
 ## [3.9.1] - 2020-06-24
 
 ### Fixed

--- a/src/backend/marsha/core/models/base.py
+++ b/src/backend/marsha/core/models/base.py
@@ -12,8 +12,6 @@ from django.utils.translation import gettext_lazy as _
 
 from safedelete.models import SOFT_DELETE_CASCADE, SafeDeleteModel
 
-from ..defaults import PENDING, STATE_CHOICES
-
 
 CHECKED_APPS = {"core"}
 
@@ -228,37 +226,3 @@ class BaseModel(SafeDeleteModel):
         errors.extend(cls._check_through_models())
 
         return errors
-
-
-class AbstractImage(BaseModel):
-    """Abstract model for images."""
-
-    uploaded_on = models.DateTimeField(
-        verbose_name=_("uploaded on"),
-        help_text=_(
-            "datetime at which the active version of the resource was uploaded."
-        ),
-        null=True,
-        blank=True,
-    )
-    upload_state = models.CharField(
-        max_length=20,
-        verbose_name=_("upload state"),
-        help_text=_("state of the upload in AWS."),
-        choices=STATE_CHOICES,
-        default=PENDING,
-    )
-
-    class Meta:
-        """Options for the ``AbstractImage`` model."""
-
-        abstract = True
-
-    @property
-    def is_ready_to_show(self):
-        """Whether the file is ready to display (ie) has been sucessfully uploaded.
-
-        The value of this field seems to be trivially derived from the value of the
-        `uploaded_on` field but it is necessary for conveniency and clarity in the client.
-        """
-        return self.uploaded_on is not None

--- a/src/backend/marsha/core/models/file.py
+++ b/src/backend/marsha/core/models/file.py
@@ -213,3 +213,21 @@ class Document(BaseFile):
         """
         self.extension = extra_parameters.get("extension")
         super().update_upload_state(upload_state, uploaded_on, **extra_parameters)
+
+
+class AbstractImage(UploadableFileMixin, BaseModel):
+    """Abstract model for images."""
+
+    class Meta:
+        """Options for the ``AbstractImage`` model."""
+
+        abstract = True
+
+    @property
+    def is_ready_to_show(self):
+        """Whether the file is ready to display (ie) has been sucessfully uploaded.
+
+        The value of this field seems to be trivially derived from the value of the
+        `uploaded_on` field but it is necessary for conveniency and clarity in the client.
+        """
+        return self.uploaded_on is not None

--- a/src/backend/marsha/core/models/file.py
+++ b/src/backend/marsha/core/models/file.py
@@ -52,6 +52,15 @@ class UploadableFileMixin(models.Model):
 
         self.save()
 
+    @property
+    def is_ready_to_show(self):
+        """Whether the file is ready to display (ie) has been sucessfully uploaded.
+
+        The value of this field seems to be trivially derived from the value of the
+        `uploaded_on` field but it is necessary for conveniency and clarity in the client.
+        """
+        return self.uploaded_on is not None
+
 
 class BaseFile(UploadableFileMixin, BaseModel):
     """Base file model used by all our File based models."""
@@ -116,15 +125,6 @@ class BaseFile(UploadableFileMixin, BaseModel):
         if self.deleted:
             result = _("{:s} [deleted]").format(result)
         return result
-
-    @property
-    def is_ready_to_show(self):
-        """Whether the file is ready to display (ie) has been sucessfully uploaded.
-
-        The value of this field seems to be trivially derived from the value of the
-        `uploaded_on` field but it is necessary for conveniency and clarity in the client.
-        """
-        return self.uploaded_on is not None
 
     @property
     def consumer_site(self):
@@ -222,12 +222,3 @@ class AbstractImage(UploadableFileMixin, BaseModel):
         """Options for the ``AbstractImage`` model."""
 
         abstract = True
-
-    @property
-    def is_ready_to_show(self):
-        """Whether the file is ready to display (ie) has been sucessfully uploaded.
-
-        The value of this field seems to be trivially derived from the value of the
-        `uploaded_on` field but it is necessary for conveniency and clarity in the client.
-        """
-        return self.uploaded_on is not None

--- a/src/backend/marsha/core/models/video.py
+++ b/src/backend/marsha/core/models/video.py
@@ -111,15 +111,6 @@ class BaseTrack(UploadableFileMixin, BaseModel):
 
         abstract = True
 
-    @property
-    def is_ready_to_show(self):
-        """Whether the file is ready to display (ie) has been sucessfully uploaded.
-
-        The value of this field seems to be trivially derived from the value of the
-        `uploaded_on` field but it is necessary for conveniency and clarity in the client.
-        """
-        return self.uploaded_on is not None
-
 
 class AudioTrack(BaseTrack):
     """Model representing an additional audio track for a video."""

--- a/src/backend/marsha/core/models/video.py
+++ b/src/backend/marsha/core/models/video.py
@@ -6,8 +6,8 @@ from django.utils.functional import lazy
 from django.utils.translation import gettext_lazy as _
 
 from ..utils.time_utils import to_timestamp
-from .base import AbstractImage, BaseModel
-from .file import BaseFile, UploadableFileMixin
+from .base import BaseModel
+from .file import AbstractImage, BaseFile, UploadableFileMixin
 
 
 class Video(BaseFile):


### PR DESCRIPTION
## Purpose

Thumbnail can not be updated from the update state endpoint because its
model doesn't have the update_upload_state method. To fix it, we choose
to add the UploadableFileMixin to the AbstractImage class which already
contains required fields to manage an upload state.

## Proposal

- [x] Use UploadableFileMixin on AbstractImage model

