### PR TITLE
fix how permissions are used to display dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Use `UploadableFileMixin` on `AbstractImage` model
-- Fix how permissions are used to display dashboard
+- Fix dashboard read versus update permissions in situations 
+  of playlist portability
 
 ## [3.9.1] - 2020-06-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Use `UploadableFileMixin` on `AbstractImage` model
+- Fix how permissions are used to display dashboard
 
 ## [3.9.1] - 2020-06-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Synchronize scroll with active transcript sentence
+- Sideload Playlist in Video and Document resources
 
 ### Fixed
 

--- a/src/backend/marsha/core/serializers.py
+++ b/src/backend/marsha/core/serializers.py
@@ -14,7 +14,7 @@ from rest_framework import serializers
 from rest_framework_simplejwt.models import TokenUser
 
 from .defaults import ERROR, PROCESSING, READY, STATE_CHOICES
-from .models import Document, Thumbnail, TimedTextTrack, Video
+from .models import Document, Playlist, Thumbnail, TimedTextTrack, Video
 from .utils import cloudfront_utils, time_utils
 
 
@@ -265,6 +265,15 @@ class ThumbnailSerializer(serializers.ModelSerializer):
         return None
 
 
+class PlaylistSerializer(serializers.ModelSerializer):
+    """A serializer to display a Playlist resource."""
+
+    class Meta:  # noqa
+        model = Playlist
+        fields = ("title", "lti_id")
+        read_only_fields = ("title", "lti_id")
+
+
 class VideoSerializer(serializers.ModelSerializer):
     """Serializer to display a video model with all its resolution options."""
 
@@ -283,6 +292,7 @@ class VideoSerializer(serializers.ModelSerializer):
             "show_download",
             "should_use_subtitle_as_transcript",
             "has_transcript",
+            "playlist",
         )
         read_only_fields = (
             "id",
@@ -300,6 +310,7 @@ class VideoSerializer(serializers.ModelSerializer):
         source="timedtexttracks", many=True, read_only=True
     )
     thumbnail = ThumbnailSerializer(read_only=True, allow_null=True)
+    playlist = PlaylistSerializer(read_only=True)
     urls = serializers.SerializerMethodField()
     is_ready_to_show = serializers.BooleanField(read_only=True)
     has_transcript = serializers.SerializerMethodField()
@@ -486,6 +497,7 @@ class DocumentSerializer(serializers.ModelSerializer):
             "upload_state",
             "url",
             "show_download",
+            "playlist",
         )
         read_only_fields = (
             "active_stamp",
@@ -503,6 +515,7 @@ class DocumentSerializer(serializers.ModelSerializer):
     filename = serializers.SerializerMethodField()
     url = serializers.SerializerMethodField()
     is_ready_to_show = serializers.BooleanField(read_only=True)
+    playlist = PlaylistSerializer(read_only=True)
 
     def _get_extension_string(self, obj):
         """Document extension with the leading dot.

--- a/src/backend/marsha/core/tests/test_api_document.py
+++ b/src/backend/marsha/core/tests/test_api_document.py
@@ -61,6 +61,7 @@ class DocumentAPITest(TestCase):
             upload_state="ready",
             extension="pdf",
             playlist__title="foo",
+            playlist__lti_id="course-v1:ufr+mathematics+00001",
             title="bar baz",
         )
 
@@ -89,6 +90,10 @@ class DocumentAPITest(TestCase):
                 "document/1533686400.pdf"
                 "?response-content-disposition=attachment%3B+filename%3Dfoo_bar-baz.pdf",
                 "show_download": True,
+                "playlist": {
+                    "title": "foo",
+                    "lti_id": "course-v1:ufr+mathematics+00001",
+                },
             },
         )
 

--- a/src/backend/marsha/core/tests/test_api_video.py
+++ b/src/backend/marsha/core/tests/test_api_video.py
@@ -113,6 +113,7 @@ class VideoAPITest(TestCase):
             upload_state="ready",
             resolutions=resolutions,
             playlist__title="foo bar",
+            playlist__lti_id="course-v1:ufr+mathematics+00001",
         )
         timed_text_track = TimedTextTrackFactory(
             video=video,
@@ -198,6 +199,10 @@ class VideoAPITest(TestCase):
                 },
                 "should_use_subtitle_as_transcript": False,
                 "has_transcript": False,
+                "playlist": {
+                    "title": "foo bar",
+                    "lti_id": "course-v1:ufr+mathematics+00001",
+                },
             },
         )
 
@@ -232,7 +237,11 @@ class VideoAPITest(TestCase):
     @override_settings(CLOUDFRONT_SIGNED_URLS_ACTIVE=False)
     def test_api_video_read_detail_token_user_no_active_stamp(self):
         """A video with no active stamp should not fail and its "urls" should be set to `None`."""
-        video = VideoFactory(uploaded_on=None)
+        video = VideoFactory(
+            uploaded_on=None,
+            playlist__title="foo bar",
+            playlist__lti_id="course-v1:ufr+mathematics+00001",
+        )
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(video.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
@@ -262,6 +271,10 @@ class VideoAPITest(TestCase):
                 "urls": None,
                 "should_use_subtitle_as_transcript": False,
                 "has_transcript": False,
+                "playlist": {
+                    "title": "foo bar",
+                    "lti_id": "course-v1:ufr+mathematics+00001",
+                },
             },
         )
 
@@ -269,7 +282,12 @@ class VideoAPITest(TestCase):
     def test_api_video_read_detail_token_user_not_sucessfully_uploaded(self):
         """A video that has never been uploaded successfully should have no url."""
         state = random.choice(["pending", "error", "ready"])
-        video = VideoFactory(uploaded_on=None, upload_state=state)
+        video = VideoFactory(
+            uploaded_on=None,
+            upload_state=state,
+            playlist__title="foo bar",
+            playlist__lti_id="course-v1:ufr+mathematics+00001",
+        )
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(video.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
@@ -298,6 +316,10 @@ class VideoAPITest(TestCase):
                 "urls": None,
                 "should_use_subtitle_as_transcript": False,
                 "has_transcript": False,
+                "playlist": {
+                    "title": "foo bar",
+                    "lti_id": "course-v1:ufr+mathematics+00001",
+                },
             },
         )
 

--- a/src/backend/marsha/core/tests/test_views_lti_development.py
+++ b/src/backend/marsha/core/tests/test_views_lti_development.py
@@ -88,7 +88,11 @@ class DevelopmentLTIViewTestCase(TestCase):
     @override_settings(BYPASS_LTI_VERIFICATION=True)
     def test_views_lti_development_post_bypass_lti_instructor(self):
         """In development, passport creation and LTI verif can be bypassed for a instructor."""
-        video = VideoFactory(playlist__consumer_site__domain="example.com")
+        video = VideoFactory(
+            playlist__consumer_site__domain="example.com",
+            playlist__title="foo bar",
+            playlist__lti_id="course-v1:ufr+mathematics+00001",
+        )
         data = {
             "resource_link_id": video.lti_id,
             "context_id": video.playlist.lti_id,
@@ -124,7 +128,7 @@ class DevelopmentLTIViewTestCase(TestCase):
         )
         self.assertDictEqual(
             jwt_token.payload["course"],
-            {"school_name": "ufr", "course_name": "mathematics", "course_run": None},
+            {"school_name": "ufr", "course_name": "mathematics", "course_run": "00001"},
         )
         self.assertEqual(context.get("state"), "success")
         self.assertEqual(
@@ -142,6 +146,10 @@ class DevelopmentLTIViewTestCase(TestCase):
                 "urls": None,
                 "should_use_subtitle_as_transcript": False,
                 "has_transcript": False,
+                "playlist": {
+                    "title": "foo bar",
+                    "lti_id": "course-v1:ufr+mathematics+00001",
+                },
             },
         )
         self.assertEqual(context.get("modelName"), "videos")
@@ -198,6 +206,10 @@ class DevelopmentLTIViewTestCase(TestCase):
                 "urls": None,
                 "should_use_subtitle_as_transcript": False,
                 "has_transcript": False,
+                "playlist": {
+                    "title": "course-v1:ufr+mathematics+00001",
+                    "lti_id": "course-v1:ufr+mathematics+00001",
+                },
             },
         )
         self.assertEqual(context.get("modelName"), "videos")

--- a/src/backend/marsha/core/tests/test_views_lti_video.py
+++ b/src/backend/marsha/core/tests/test_views_lti_video.py
@@ -39,6 +39,7 @@ class VideoLTIViewTestCase(TestCase):
         passport = ConsumerSiteLTIPassportFactory()
         video = VideoFactory(
             playlist__lti_id="course-v1:ufr+mathematics+00001",
+            playlist__title="foo bar",
             playlist__consumer_site=passport.consumer_site,
         )
         data = {
@@ -95,6 +96,10 @@ class VideoLTIViewTestCase(TestCase):
                 "urls": None,
                 "should_use_subtitle_as_transcript": False,
                 "has_transcript": False,
+                "playlist": {
+                    "title": "foo bar",
+                    "lti_id": "course-v1:ufr+mathematics+00001",
+                },
             },
         )
         self.assertEqual(context.get("modelName"), "videos")
@@ -141,6 +146,7 @@ class VideoLTIViewTestCase(TestCase):
         passport = ConsumerSiteLTIPassportFactory()
         video = VideoFactory(
             playlist__lti_id="course-v1:ufr+mathematics+00001",
+            playlist__title="foo bar",
             playlist__consumer_site=passport.consumer_site,
         )
         data = {
@@ -194,6 +200,10 @@ class VideoLTIViewTestCase(TestCase):
                 "urls": None,
                 "should_use_subtitle_as_transcript": False,
                 "has_transcript": False,
+                "playlist": {
+                    "title": "foo bar",
+                    "lti_id": "course-v1:ufr+mathematics+00001",
+                },
             },
         )
         self.assertEqual(context.get("modelName"), "videos")
@@ -214,6 +224,7 @@ class VideoLTIViewTestCase(TestCase):
             playlist__is_portable_to_playlist=True,
             playlist__is_portable_to_consumer_site=True,
             playlist__title="playlist-003",
+            playlist__lti_id="course-v1:ufr+mathematics+00001",
             upload_state=random.choice([s[0] for s in STATE_CHOICES]),
             uploaded_on="2019-09-24 07:24:40+00",
             resolutions=[144, 240, 480, 720, 1080],
@@ -297,6 +308,10 @@ class VideoLTIViewTestCase(TestCase):
                 },
                 "should_use_subtitle_as_transcript": False,
                 "has_transcript": False,
+                "playlist": {
+                    "title": "playlist-003",
+                    "lti_id": "course-v1:ufr+mathematics+00001",
+                },
             },
         )
         self.assertEqual(context.get("modelName"), "videos")
@@ -306,7 +321,7 @@ class VideoLTIViewTestCase(TestCase):
 
     @mock.patch.object(LTI, "verify")
     @mock.patch.object(LTI, "get_consumer_site")
-    def test_views_lti_video_restristed_resolutions_list(
+    def test_views_lti_video_restricted_resolutions_list(
         self, mock_get_consumer_site, mock_verify
     ):
         """Urls list should contains resolutions from resolutions field."""
@@ -399,6 +414,10 @@ class VideoLTIViewTestCase(TestCase):
                 },
                 "should_use_subtitle_as_transcript": False,
                 "has_transcript": False,
+                "playlist": {
+                    "title": "playlist-002",
+                    "lti_id": "course-v1:ufr+mathematics+00001",
+                },
             },
         )
         self.assertEqual(context.get("modelName"), "videos")
@@ -511,6 +530,10 @@ class VideoLTIViewTestCase(TestCase):
                 },
                 "should_use_subtitle_as_transcript": False,
                 "has_transcript": False,
+                "playlist": {
+                    "title": "playlist-002",
+                    "lti_id": "course-v1:ufr+mathematics+00001",
+                },
             },
         )
         self.assertEqual(context.get("modelName"), "videos")
@@ -695,7 +718,11 @@ class VideoLTIViewTestCase(TestCase):
     def test_views_lti_video_has_transcript(self, mock_get_consumer_site, mock_verify):
         """Compute has_transcript when a transcript is uploaded."""
         passport = ConsumerSiteLTIPassportFactory()
-        video = VideoFactory(playlist__consumer_site=passport.consumer_site)
+        video = VideoFactory(
+            playlist__consumer_site=passport.consumer_site,
+            playlist__title="foo bar",
+            playlist__lti_id="course-v1:ufr+mathematics+00001",
+        )
         # Create a TimedTextTrack associated with the video to trigger the error
         transcript = TimedTextTrackFactory(
             video=video,
@@ -752,6 +779,10 @@ class VideoLTIViewTestCase(TestCase):
                 "urls": None,
                 "should_use_subtitle_as_transcript": False,
                 "has_transcript": True,
+                "playlist": {
+                    "title": "foo bar",
+                    "lti_id": "course-v1:ufr+mathematics+00001",
+                },
             },
         )
 
@@ -762,7 +793,11 @@ class VideoLTIViewTestCase(TestCase):
     ):
         """Compute has_transcript when a transcript is uploaded and not ready to be shown."""
         passport = ConsumerSiteLTIPassportFactory()
-        video = VideoFactory(playlist__consumer_site=passport.consumer_site)
+        video = VideoFactory(
+            playlist__consumer_site=passport.consumer_site,
+            playlist__title="foo bar",
+            playlist__lti_id="course-v1:ufr+mathematics+00001",
+        )
         # Create a TimedTextTrack associated with the video to trigger the error
         transcript = TimedTextTrackFactory(
             video=video, mode="ts", upload_state=PENDING,
@@ -815,5 +850,9 @@ class VideoLTIViewTestCase(TestCase):
                 "urls": None,
                 "should_use_subtitle_as_transcript": False,
                 "has_transcript": False,
+                "playlist": {
+                    "title": "foo bar",
+                    "lti_id": "course-v1:ufr+mathematics+00001",
+                },
             },
         )

--- a/src/frontend/components/AppRoutes/index.tsx
+++ b/src/frontend/components/AppRoutes/index.tsx
@@ -28,7 +28,7 @@ export const AppRoutes = () => (
           render={({ match }) => {
             if (match.params.objectType === modelName.VIDEOS && appData.video) {
               return (
-                <InstructorWrapper>
+                <InstructorWrapper resource={appData.video}>
                   <VideoPlayer video={appData.video} />
                 </InstructorWrapper>
               );
@@ -39,7 +39,7 @@ export const AppRoutes = () => (
               appData.document
             ) {
               return (
-                <InstructorWrapper>
+                <InstructorWrapper resource={appData.document}>
                   <DocumentPlayer document={appData.document} />
                 </InstructorWrapper>
               );

--- a/src/frontend/components/DashboardDocument/index.spec.tsx
+++ b/src/frontend/components/DashboardDocument/index.spec.tsx
@@ -35,6 +35,10 @@ describe('<DashboardDocument />', () => {
       title: 'foo.pdf',
       upload_state: uploadState.PROCESSING,
       url: 'https://example.com/document/44',
+      playlist: {
+        title: 'foo',
+        lti_id: 'foo+context_id',
+      },
     };
 
     fetchMock.mock('/api/documents/44/', deferred.promise);
@@ -109,6 +113,10 @@ describe('<DashboardDocument />', () => {
       title: 'foo.pdf',
       upload_state: uploadState.PENDING,
       url: 'https://example.com/document/45',
+      playlist: {
+        title: 'foo',
+        lti_id: 'foo+context_id',
+      },
     };
 
     render(
@@ -131,6 +139,10 @@ describe('<DashboardDocument />', () => {
       title: 'foo.pdf',
       upload_state: uploadState.ERROR,
       url: 'https://example.com/document/45',
+      playlist: {
+        title: 'foo',
+        lti_id: 'foo+context_id',
+      },
     };
 
     render(
@@ -154,6 +166,10 @@ describe('<DashboardDocument />', () => {
       title: 'foo',
       upload_state: uploadState.READY,
       url: 'https://example.com/document/45',
+      playlist: {
+        title: 'foo',
+        lti_id: 'foo+context_id',
+      },
     };
 
     // wrap the component in a grommet provider to have a valid theme.
@@ -196,6 +212,10 @@ describe('<DashboardDocument />', () => {
       title: 'foo.pdf',
       upload_state: uploadState.UPLOADING,
       url: 'https://example.com/document/45',
+      playlist: {
+        title: 'foo',
+        lti_id: 'foo+context_id',
+      },
     };
 
     render(

--- a/src/frontend/components/DashboardDocumentTitleForm/index.spec.tsx
+++ b/src/frontend/components/DashboardDocumentTitleForm/index.spec.tsx
@@ -30,6 +30,10 @@ describe('DashboardDocumentTitleForm', () => {
       title: 'document title',
       upload_state: uploadState.READY,
       url: 'https://example.com/document/45',
+      playlist: {
+        title: 'foo',
+        lti_id: 'foo+context_id',
+      },
     };
 
     const { container } = render(
@@ -57,6 +61,10 @@ describe('DashboardDocumentTitleForm', () => {
       title: 'foo.pdf',
       upload_state: uploadState.READY,
       url: 'https://example.com/document/45',
+      playlist: {
+        title: 'foo',
+        lti_id: 'foo+context_id',
+      },
     };
 
     fetchMock.mock('/api/documents/46/', deferred.promise, { method: 'PUT' });
@@ -103,6 +111,10 @@ describe('DashboardDocumentTitleForm', () => {
       title: 'document title',
       upload_state: uploadState.READY,
       url: 'https://example.com/document/47',
+      playlist: {
+        title: 'foo',
+        lti_id: 'foo+context_id',
+      },
     };
 
     fetchMock.mock('/api/documents/47/', deferred.promise, { method: 'PUT' });

--- a/src/frontend/components/DashboardThumbnail/index.spec.tsx
+++ b/src/frontend/components/DashboardThumbnail/index.spec.tsx
@@ -76,6 +76,10 @@ describe('<DashboardThumbnail />', () => {
       },
     },
     should_use_subtitle_as_transcript: false,
+    playlist: {
+      title: 'foo',
+      lti_id: 'foo+context_id',
+    },
   };
 
   it('displays a thumbnail image when the related Thumbnail object is ready', () => {

--- a/src/frontend/components/DashboardVideoPane/index.spec.tsx
+++ b/src/frontend/components/DashboardVideoPane/index.spec.tsx
@@ -55,6 +55,10 @@ describe('<DashboardVideoPane />', () => {
       },
     },
     should_use_subtitle_as_transcript: false,
+    playlist: {
+      title: 'foo',
+      lti_id: 'foo+context_id',
+    },
   };
 
   it('redirects to error when it fails to fetch the video', async () => {

--- a/src/frontend/components/DashboardVideoPaneDownloadOption/index.spec.tsx
+++ b/src/frontend/components/DashboardVideoPaneDownloadOption/index.spec.tsx
@@ -46,6 +46,10 @@ describe('<DashboardVideoPaneDownloadOption />', () => {
       },
     },
     should_use_subtitle_as_transcript: false,
+    playlist: {
+      title: 'foo',
+      lti_id: 'foo+context_id',
+    },
   };
 
   it('renders with checkbox not checked', () => {

--- a/src/frontend/components/DashboardVideoPaneTranscriptOption/index.spec.tsx
+++ b/src/frontend/components/DashboardVideoPaneTranscriptOption/index.spec.tsx
@@ -54,6 +54,10 @@ describe('<DashboardVideoPaneTranscriptOption />', () => {
       },
     },
     should_use_subtitle_as_transcript: false,
+    playlist: {
+      title: 'foo',
+      lti_id: 'foo+context_id',
+    },
   };
 
   it('renders nothing if there is no timed text track', () => {

--- a/src/frontend/components/DocumentPlayer/index.spec.tsx
+++ b/src/frontend/components/DocumentPlayer/index.spec.tsx
@@ -16,6 +16,10 @@ jest.mock('../../data/appData', () => ({
       title: 'foo.pdf',
       upload_state: 'ready',
       url: 'https://example.com/document/42',
+      playlist: {
+        title: 'foo',
+        lti_id: 'foo+context_id',
+      },
     },
   },
 }));
@@ -32,6 +36,10 @@ describe('<DocumentPlayer />', () => {
       title: 'foo.pdf',
       upload_state: uploadState.READY,
       url: 'https://example.com/document/42',
+      playlist: {
+        title: 'foo',
+        lti_id: 'foo+context_id',
+      },
     };
     const { getByText, container } = render(
       <DocumentPlayer document={document} />,
@@ -52,6 +60,10 @@ describe('<DocumentPlayer />', () => {
       title: 'bar.pdf',
       upload_state: uploadState.READY,
       url: 'https://example.com/document/43',
+      playlist: {
+        title: 'foo',
+        lti_id: 'foo+context_id',
+      },
     };
     const { getByText, container } = render(
       <DocumentPlayer document={document} />,

--- a/src/frontend/components/InstructorView/index.spec.tsx
+++ b/src/frontend/components/InstructorView/index.spec.tsx
@@ -20,7 +20,7 @@ describe('<InstructorView />', () => {
     mockDecodedJwt = {
       maintenance: false,
       permissions: {
-        can_access_dashboard: true,
+        can_update: true,
       },
     };
 
@@ -38,12 +38,12 @@ describe('<InstructorView />', () => {
     getByText('Go to Dashboard');
   });
 
-  it('removes the button when permissions.can_access_dashboard is set to false', () => {
+  it('removes the button when permissions.can_update is set to false', () => {
     mockDecodedJwt = {
       context_id: 'foo+context_id',
       maintenance: false,
       permissions: {
-        can_access_dashboard: false,
+        can_update: false,
       },
     };
 
@@ -66,7 +66,7 @@ describe('<InstructorView />', () => {
       context_id: 'foo+context_id',
       maintenance: true,
       permissions: {
-        can_access_dashboard: true,
+        can_update: true,
       },
     };
 

--- a/src/frontend/components/InstructorView/index.spec.tsx
+++ b/src/frontend/components/InstructorView/index.spec.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { wrapInIntlProvider } from '../../utils/tests/intl';
 import { wrapInRouter } from '../../utils/tests/router';
 import { InstructorView } from './';
+import { Video } from '../../types/tracks';
 
 jest.mock('jwt-decode', () => jest.fn());
 
@@ -16,6 +17,13 @@ jest.mock('../../data/appData', () => ({
 }));
 
 describe('<InstructorView />', () => {
+  const video = {
+    id: 'bc5b2a9a-4963-4a55-bb79-b94489a8164f',
+    playlist: {
+      title: 'foo',
+      lti_id: 'foo+context_id',
+    },
+  } as Video;
   it('renders the instructor controls', () => {
     mockDecodedJwt = {
       maintenance: false,
@@ -27,7 +35,7 @@ describe('<InstructorView />', () => {
     const { getByText } = render(
       wrapInIntlProvider(
         wrapInRouter(
-          <InstructorView>
+          <InstructorView resource={video}>
             <div className="some-child" />
           </InstructorView>,
         ),
@@ -40,7 +48,6 @@ describe('<InstructorView />', () => {
 
   it('removes the button when permissions.can_update is set to false', () => {
     mockDecodedJwt = {
-      context_id: 'foo+context_id',
       maintenance: false,
       permissions: {
         can_update: false,
@@ -49,7 +56,7 @@ describe('<InstructorView />', () => {
 
     const { getByText, queryByText } = render(
       wrapInIntlProvider(
-        <InstructorView>
+        <InstructorView resource={video}>
           <div className="some-child" />
         </InstructorView>,
       ),
@@ -63,7 +70,6 @@ describe('<InstructorView />', () => {
 
   it('removes the button when permissions.maintenance is set to true', () => {
     mockDecodedJwt = {
-      context_id: 'foo+context_id',
       maintenance: true,
       permissions: {
         can_update: true,
@@ -72,7 +78,7 @@ describe('<InstructorView />', () => {
 
     const { getByText, queryByText } = render(
       wrapInIntlProvider(
-        <InstructorView>
+        <InstructorView resource={video}>
           <div className="some-child" />
         </InstructorView>,
       ),

--- a/src/frontend/components/InstructorView/index.tsx
+++ b/src/frontend/components/InstructorView/index.tsx
@@ -61,7 +61,7 @@ interface InstructorViewProps {
 
 export const InstructorView = ({ children }: InstructorViewProps) => {
   const canAccessDashboard =
-    getDecodedJwt().permissions.can_access_dashboard &&
+    getDecodedJwt().permissions.can_update &&
     false === getDecodedJwt().maintenance;
   const message = canAccessDashboard
     ? messages.title

--- a/src/frontend/components/InstructorView/index.tsx
+++ b/src/frontend/components/InstructorView/index.tsx
@@ -8,6 +8,8 @@ import { appData, getDecodedJwt } from '../../data/appData';
 import { theme } from '../../utils/theme/theme';
 import { DASHBOARD_ROUTE } from '../Dashboard/route';
 import { withLink } from '../withLink/withLink';
+import { Document } from '../../types/file';
+import { Video } from '../../types/tracks';
 
 const messages = defineMessages({
   btnDashboard: {
@@ -17,7 +19,7 @@ const messages = defineMessages({
   },
   disabledDashboard: {
     defaultMessage:
-      'This video is read-only because it belongs to another course: {context_id}',
+      'This video is read-only because it belongs to another course: {lti_id}',
     description:
       'Text explaining that the ivdeo is in read_only mode and the dashboard is not available',
     id: 'components.InstructorView.disabledDashboard',
@@ -57,9 +59,10 @@ const BtnWithLink = withLink(Button);
 
 interface InstructorViewProps {
   children: React.ReactNode;
+  resource: Video | Document;
 }
 
-export const InstructorView = ({ children }: InstructorViewProps) => {
+export const InstructorView = ({ children, resource }: InstructorViewProps) => {
   const canAccessDashboard =
     getDecodedJwt().permissions.can_update &&
     false === getDecodedJwt().maintenance;
@@ -70,7 +73,7 @@ export const InstructorView = ({ children }: InstructorViewProps) => {
     : messages.disabledDashboard;
   const messagePlaceholder = canAccessDashboard
     ? {}
-    : { context_id: getDecodedJwt().context_id };
+    : { lti_id: resource.playlist.lti_id };
   return (
     <React.Fragment>
       <PreviewWrapper>

--- a/src/frontend/components/InstructorWrapper/index.spec.tsx
+++ b/src/frontend/components/InstructorWrapper/index.spec.tsx
@@ -1,7 +1,8 @@
 import { render } from '@testing-library/react';
 import React from 'react';
 
-import { InstructorWrapper } from './index';
+import { InstructorWrapper } from './';
+import { Video } from '../../types/tracks';
 
 jest.mock('../InstructorView/index', () => {
   return {
@@ -24,10 +25,17 @@ jest.mock('../../data/appData', () => ({
 }));
 
 describe('<InstructorWrapper />', () => {
+  const video = {
+    id: 'bc5b2a9a-4963-4a55-bb79-b94489a8164f',
+    playlist: {
+      title: 'foo',
+      lti_id: 'foo+context_id',
+    },
+  } as Video;
   it('wraps its children in an instructor view if the current user is an instructor', () => {
     mockCanAccessDashboard = true;
     const { getByText, getByTitle } = render(
-      <InstructorWrapper>
+      <InstructorWrapper resource={video}>
         <div title="some-child" />
       </InstructorWrapper>,
     );
@@ -39,7 +47,7 @@ describe('<InstructorWrapper />', () => {
   it('just renders the children if the current user is not an instructor', () => {
     mockCanAccessDashboard = false;
     const { getByTitle, queryByText } = render(
-      <InstructorWrapper>
+      <InstructorWrapper resource={video}>
         <div title="some-child" />
       </InstructorWrapper>,
     );

--- a/src/frontend/components/InstructorWrapper/index.spec.tsx
+++ b/src/frontend/components/InstructorWrapper/index.spec.tsx
@@ -14,18 +14,18 @@ jest.mock('../InstructorView/index', () => {
   };
 });
 
-let mockCanUpdate: boolean;
+let mockCanAccessDashboard: boolean;
 jest.mock('../../data/appData', () => ({
   getDecodedJwt: () => ({
     permissions: {
-      can_update: mockCanUpdate,
+      can_access_dashboard: mockCanAccessDashboard,
     },
   }),
 }));
 
 describe('<InstructorWrapper />', () => {
   it('wraps its children in an instructor view if the current user is an instructor', () => {
-    mockCanUpdate = true;
+    mockCanAccessDashboard = true;
     const { getByText, getByTitle } = render(
       <InstructorWrapper>
         <div title="some-child" />
@@ -37,7 +37,7 @@ describe('<InstructorWrapper />', () => {
   });
 
   it('just renders the children if the current user is not an instructor', () => {
-    mockCanUpdate = false;
+    mockCanAccessDashboard = false;
     const { getByTitle, queryByText } = render(
       <InstructorWrapper>
         <div title="some-child" />

--- a/src/frontend/components/InstructorWrapper/index.tsx
+++ b/src/frontend/components/InstructorWrapper/index.tsx
@@ -2,14 +2,20 @@ import React from 'react';
 
 import { getDecodedJwt } from '../../data/appData';
 import { InstructorView } from '../InstructorView';
+import { Document } from '../../types/file';
+import { Video } from '../../types/tracks';
 
 interface InstructorWrapperProps {
   children: React.ReactNode;
+  resource: Video | Document;
 }
 
-export const InstructorWrapper = ({ children }: InstructorWrapperProps) => {
+export const InstructorWrapper = ({
+  children,
+  resource,
+}: InstructorWrapperProps) => {
   if (getDecodedJwt().permissions.can_access_dashboard) {
-    return <InstructorView>{children}</InstructorView>;
+    return <InstructorView resource={resource}>{children}</InstructorView>;
   } else {
     return <React.Fragment>{children}</React.Fragment>;
   }

--- a/src/frontend/components/InstructorWrapper/index.tsx
+++ b/src/frontend/components/InstructorWrapper/index.tsx
@@ -8,7 +8,7 @@ interface InstructorWrapperProps {
 }
 
 export const InstructorWrapper = ({ children }: InstructorWrapperProps) => {
-  if (getDecodedJwt().permissions.can_update) {
+  if (getDecodedJwt().permissions.can_access_dashboard) {
     return <InstructorView>{children}</InstructorView>;
   } else {
     return <React.Fragment>{children}</React.Fragment>;

--- a/src/frontend/types/file.ts
+++ b/src/frontend/types/file.ts
@@ -1,4 +1,4 @@
-import { Resource, uploadState } from './tracks';
+import { Playlist, Resource, uploadState } from './tracks';
 
 export interface Document extends Resource {
   description: string;
@@ -9,4 +9,5 @@ export interface Document extends Resource {
   upload_state: uploadState;
   url: string;
   show_download: boolean;
+  playlist: Playlist;
 }

--- a/src/frontend/types/tracks.ts
+++ b/src/frontend/types/tracks.ts
@@ -40,6 +40,11 @@ export enum timedTextMode {
   CLOSED_CAPTIONING = 'cc',
 }
 
+export interface Playlist {
+  title: string;
+  lti_id: string;
+}
+
 /** A timed text track record as it exists on the backend. */
 export interface TimedText extends Resource {
   active_stamp: Nullable<number>;
@@ -90,6 +95,7 @@ export interface Video extends Resource {
   };
   should_use_subtitle_as_transcript: boolean;
   has_transcript: boolean;
+  playlist: Playlist;
 }
 
 export type UploadableObject = TimedText | Video | Thumbnail | Document;


### PR DESCRIPTION
## Purpose

Permission object in JWT token was misused. To determine if a user can
see the instructor view it must have can_access_dashboard set to true
and to see the dashboard button in the instructor view it must have
can_update set to true. We did the opposite so when an instructor saw a
video from an other playlist it didn't see the message telling him that
the video is coming from an other playlist but it see the student view.

Also the info shown in the instructor view when a video is in read only is wrong. We are showing the current context_id and we want to display the original one. 

## Proposal

- [x] Fix how permissions are used to display dashboard
- [x] Expose origin playlist when resource come from a portable one
- [x] Use origin_context_id in `<InstructorView />`
