### PR TITLE
♻️(circleci) use crowdin/cli 3 in circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -374,7 +374,7 @@ jobs:
   # translation management tool
   i18n:
     docker:
-      - image: fundocker/crowdin:2.0.31
+      - image: crowdin/cli:3.2.1
     working_directory: ~/marsha
     steps:
       - checkout:
@@ -383,7 +383,7 @@ jobs:
           at: ~/marsha
       - run:
           name: upload files to crowdin
-          command: crowdin -c crowdin/config.yml upload sources
+          command: crowdin upload sources -c crowdin/config.yml
 
   # ---- DockerHub publication job ----
   hub:


### PR DESCRIPTION
## Purpose

We miss to use crowdin/cli 3 in circle ci. Without this upgrade, the
configuration file is not compatible anymore with CLI v2. We must
upgrade it.

## Proposal

- [x] use crowdin/cli v3 in circleci

