### PR TITLE
Manage case where info are missing in mediainfo result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Use formatjs/cli to manage message extraction and don't
   rely anymore on babel react-intl plugin.
 
+### Fixed
+
+- Manage case where info are missing in mediainfo result
+
 ## [3.10.0] - 2020-08-18
 
 ### Added

--- a/src/frontend/Player/i18n/plyrTranslation.ts
+++ b/src/frontend/Player/i18n/plyrTranslation.ts
@@ -106,12 +106,12 @@ export const i18nMessages = defineMessages({
     id: 'plyr.controls.exitFullscreen',
   },
   fastForward: {
-    defaultMessage: 'Forward {seektime}s',
+    defaultMessage: "Forward '{seektime}'s",
     description: 'Video control forward button',
     id: 'plyr.controls.forward',
   },
   frameTitle: {
-    defaultMessage: 'Player for {title}',
+    defaultMessage: "Player for '{title}'",
     description:
       'Title set to an iframe when the video is loaded in an iframe as parent element',
     id: 'plyr.ui.frameTitle',
@@ -170,7 +170,7 @@ export const i18nMessages = defineMessages({
     id: 'plyr.controls.restart',
   },
   rewind: {
-    defaultMessage: 'Rewind {seektime}s',
+    defaultMessage: "Rewind '{seektime}'s",
     description: 'Video control rewind button',
     id: 'plyr.controls.rewind',
   },
@@ -180,7 +180,7 @@ export const i18nMessages = defineMessages({
     id: 'plyr.controls.seek',
   },
   seekLabel: {
-    defaultMessage: '{currentTime} of {duration}',
+    defaultMessage: "'{currentTime}' of '{duration}'",
     description: 'Video seek progress bar used as polyfill for webkit',
     id: 'plyr.controls.rangeFill.seek',
   },


### PR DESCRIPTION
## Purpose

Some videos don't have Audio playlist, so the Audio part of mediainfo
result is missing. Also, we have to manage videos having height smaller
than 144px. If this happen we force sizes array with 144 value.

Also with new react-intl version we must escape string interpolation for plyr translation.

## Proposal

- [x] Manage case where info are missing in mediainfo result
- [x] Escape translation interpolation for plyr player


