### PR TITLE
🔖(patch) bump release to 3.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.10.1] - 2020-08-27
+
 ### Changed
 
 - Use formatjs/cli to manage message extraction and don't
@@ -561,7 +563,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Minor fixes and improvements on features and tests
 
-[unreleased]: https://github.com/openfun/marsha/compare/v3.10.0...master
+[unreleased]: https://github.com/openfun/marsha/compare/v3.10.1...master
+[3.10.1]: https://github.com/openfun/marsha/compare/v3.10.0...v3.10.1
 [3.10.0]: https://github.com/openfun/marsha/compare/v3.9.1...v3.10.0
 [3.9.1]: https://github.com/openfun/marsha/compare/v3.9.0...v3.9.1
 [3.9.0]: https://github.com/openfun/marsha/compare/v3.8.1...v3.9.0

--- a/src/aws/lambda-complete/package.json
+++ b/src/aws/lambda-complete/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-complete",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "engines": {
     "node": "10"
   },

--- a/src/aws/lambda-configure/package.json
+++ b/src/aws/lambda-configure/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-configure",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "engines": {
     "node": "10"
   },

--- a/src/aws/lambda-encode/package.json
+++ b/src/aws/lambda-encode/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-convert",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "engines": {
     "node": "10"
   },

--- a/src/aws/lambda-migrate/package.json
+++ b/src/aws/lambda-migrate/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-migrate",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "engines": {
     "node": "10"
   },

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = marsha
 description = A FUN video provider for Open edX
-version = 3.10.0
+version = 3.10.1
 author = Open FUN (France Universite Numerique)
 author_email = fun.dev@fun-mooc.fr
 license = MIT

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marsha",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "description": "🐠 a FUN LTI video provider",
   "main": "front/index.tsx",
   "scripts": {


### PR DESCRIPTION
### Changed

- Use formatjs/cli to manage message extraction and don't
  rely anymore on babel react-intl plugin.

### Fixed

- Manage case where info are missing in mediainfo result


