### PR TITLE
🐛(front) remove usage of scrollIntoView to synchronize active transcript sentence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Remove usage of scrollIntoView to synchronize active transcript sentence
+
 ## [3.10.1] - 2020-08-27
 
 ### Changed

--- a/src/frontend/components/TranscriptReader/index.tsx
+++ b/src/frontend/components/TranscriptReader/index.tsx
@@ -36,12 +36,20 @@ export const TranscriptReader = ({ transcript }: TranscriptReaderProps) => {
   useEffect(() => {
     if (!transcriptWrapperRef.current) return;
 
-    transcriptWrapperRef.current
-      .querySelector(`.sentence-active`)
-      ?.scrollIntoView({
+    const target = transcriptWrapperRef.current.querySelector(
+      `.sentence-active`,
+    ) as HTMLSpanElement;
+
+    if (target) {
+      // Follow active sentence to be always visible.
+      transcriptWrapperRef.current.scrollTo({
+        top:
+          target.offsetTop -
+          (transcriptWrapperRef.current.offsetTop +
+            transcriptWrapperRef.current.offsetHeight / 2),
         behavior: 'smooth',
-        block: 'center',
       });
+    }
   }, [playerCurrentTime]);
 
   return (


### PR DESCRIPTION
## Purpose

To synchronize active sentence of a transcript we were using
scrollIntoView function. It works but it also move the entire page to
have the sentence of the middle of the entire view port (all the
browser) and this a bug because the video can be not visible.
To solve this issue, we remove the usage of this function and instead we
compute where the scroll position should be and never focus on it.

## Proposal
- [x] compute scroll bar position according to active sentence position.

