### PR TITLE
🐛(makefile) call run task in bootstrap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ bootstrap: ## Prepare Docker images for the project
 bootstrap: \
 	env.d/development \
 	build \
+	run \
 	migrate \
 	i18n-compile-back
 .PHONY: bootstrap
@@ -144,11 +145,13 @@ lint-bandit: ## lint back-end python sources with bandit
 	@$(COMPOSE_RUN_APP) bandit -c .bandit -qr marsha
 .PHONY: lint-bandit
 
-.PHONY: migrate
+
 migrate:  ## Run django migration for the marsha project.
 	@echo "$(BOLD)Running migrations$(RESET)"
+	@$(COMPOSE) up -d db
 	@$(COMPOSE_RUN) dockerize -wait tcp://db:5432 -timeout 60s
 	@$(COMPOSE_RUN_APP) python manage.py migrate
+.PHONY: migrate
 
 superuser: ## create a Django superuser
 	@echo "$(BOLD)Creating a Django superuser$(RESET)"


### PR DESCRIPTION
## Purpose

During bootstrap the migrate fails because the database is not running.
To fix this we call run task after build task. Moreover to avoid migrate
to fail if the database is not up and running we explicitely start it.

## Proposal

- [x] fix bootstrap task  in makefile

