### PR TITLE
⬆️(back) upgrade urllib3 to version 1.25.10

### DIFF
--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -45,7 +45,7 @@ install_requires =
     PyLTI==0.7.0
     sentry-sdk==0.17.8
     requests==2.24.0
-    urllib3==1.24.3 # pyup: >=1.21.1,<1.25
+    urllib3==1.25.10
 packages = find:
 package_dir =
     =.


### PR DESCRIPTION
## Purpose

urllib3 before 1.25.9 allows CRLF injection if the attacker controls
the HTTP request method, as demonstrated by inserting CR and LF
control characters in the first argument of putrequest().
See: CVE-2020-26137. (NOTE: this is similar to CVE-2020-26116.)

## Proposal

- [x] upgrade urllib3 to version 1.25.10