### PR TITLE
✨(auth/api) add drf token auth to retrieve video detail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Remove usage of react-intl-po
 - Rework front i18n workflow
+- Customize permission to also allow staff user for GET request
+
+### Added
+
+- Add drf api token backend
+- Add a new make target to generate user api token
 
 ### Fixed
 
@@ -45,7 +51,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Use `UploadableFileMixin` on `AbstractImage` model
-- Fix dashboard read versus update permissions in situations 
+- Fix dashboard read versus update permissions in situations
   of playlist portability
 
 ## [3.9.1] - 2020-06-24
@@ -59,7 +65,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Detect original video framerate and use it in lambda encode
-- Limit video encoding resolution to that of the source 
+- Limit video encoding resolution to that of the source
 
 ## [3.8.1] - 2020-05-18
 
@@ -129,7 +135,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- New setting MAINTENANCE_MODE to disable the dashboard when Marsha is 
+- New setting MAINTENANCE_MODE to disable the dashboard when Marsha is
   in maintenance
 
 ### Changed
@@ -579,7 +585,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Minor fixes and improvements on features and tests
 
-[unreleased]: https://github.com/openfun/marsha/compare/v3.10.2...master
+[Unreleased]: https://github.com/openfun/marsha/compare/v3.10.2...master
 [3.10.2]: https://github.com/openfun/marsha/compare/v3.10.1...v3.10.2
 [3.10.1]: https://github.com/openfun/marsha/compare/v3.10.0...v3.10.1
 [3.10.0]: https://github.com/openfun/marsha/compare/v3.9.1...v3.10.0

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -10,6 +10,7 @@
 - [Manuel Raynaud](https://github.com/lunika) <manu@raynaud.io>
 - [Matthieu Huguet](https://github.com/madmatah) <matthieu.huguet@fun-mooc.fr>
 - [Florian Pereira](https://github.com/flo-pereira) <pereira.florian@gmail.com>
+- [Simon Landrault](https://github.com/slandrault) <simon.landrault@fun-mooc.fr>
 
 - [Renovate Bot](https://renovatebot.com) <bot@renovateapp.com>
 - [Pyup Bot](https://pyup.io) <github-bot@pyup.io>

--- a/Makefile
+++ b/Makefile
@@ -163,6 +163,10 @@ test:  ## Run django tests for the marsha project.
 	@echo "$(BOLD)Running tests$(RESET)"
 	bin/pytest
 
+token-create:  ## create a token for user=<user> (ie: make token-create user=foo)
+	@$(COMPOSE_RUN_APP) python manage.py drf_create_token $(user)
+.PHONY: token-create
+
 ## -- Front-end
 
 build-front: ## Build front application

--- a/README.md
+++ b/README.md
@@ -134,6 +134,18 @@ Now that your `Docker` services are ready to be used, start the application by r
 
 You should be able to view the development view at [localhost:8060/development/](http://localhost:8060/development/).
 
+#### Getting video detail from API
+
+If you ever need to get detail from a video but don't want to forge extra jwt token, the backend API can be used.
+To do so:
+- Create a user in the Django Backend (lets call it `foo` for this example)
+- Make sure to tick the "staff" checkbox
+- Now, generate a API token and retrieve it for this user `make create-token user=foo`
+- You can now make api call to get your video detail: `curl http://127.0.0.1:8060/api/videos/<video-id>/ -H 'Authorization: Token <the-api-token>'`
+- Once you have finished to get your data, you can remove the user or simply untick the staff status*
+
+*For extra security those API calls only works with a GET method and for staff user.
+
 ### The `React` frontend
 
 All tasks related to the `React` frontend are run from the `./src/frontend` directory.

--- a/src/backend/marsha/core/api.py
+++ b/src/backend/marsha/core/api.py
@@ -106,7 +106,9 @@ class VideoViewSet(
     queryset = Video.objects.all()
     serializer_class = serializers.VideoSerializer
     permission_classes = [
-        permissions.IsResourceAdmin | permissions.IsResourceInstructor
+        permissions.IsResourceAdmin
+        | permissions.IsResourceInstructor
+        | permissions.StaffUserVideoPermission
     ]
 
     @action(methods=["post"], detail=True, url_path="initiate-upload")

--- a/src/backend/marsha/core/permissions.py
+++ b/src/backend/marsha/core/permissions.py
@@ -172,3 +172,61 @@ class IsVideoToken(permissions.IsAuthenticated):
             return True
 
         return super().has_permission(request, view)
+
+
+class StaffUserVideoPermission(permissions.BasePermission):
+    """A custom permission class for API Tokens related to objects linked to a video.
+
+    This permission allow GET request from a staff user and deny for other methods or
+    non-staff users.
+
+    """
+
+    def has_permission(self, request, view):
+        """Allow staff api GET requests and postpone further check to the object permission check.
+
+        Parameters
+        ----------
+        request : Type[rest_framework.request]
+            The request that holds the authenticated user
+        view : Type[restframework.viewsets or restframework.views]
+            The API view for which permissions are being checked
+
+        Returns
+        -------
+        boolean
+            True if the request is authorized, False otherwise
+
+        """
+        if request.user.is_staff and request.method == "GET":
+            return True
+
+        return False
+
+    def has_object_permission(self, request, view, obj):
+        """Add a check to allow GET request for staff users identified via an API token.
+
+        Parameters
+        ----------
+        request : Type[django.http.request.HttpRequest]
+            The request that holds the authenticated user
+        view : Type[restframework.viewsets or restframework.views]
+            The API view for which permissions are being checked
+        obj: Type[models.Model]
+            The object for which object permissions are being checked
+
+        Raises
+        ------
+        PermissionDenied
+            Raised if the request is not authorized
+
+        Returns
+        -------
+        boolean
+            True if authorized, False otherwise
+
+        """
+        if request.user.is_staff and request.method == "GET":
+            return True
+
+        return False

--- a/src/backend/marsha/core/tests/test_drf_api_video.py
+++ b/src/backend/marsha/core/tests/test_drf_api_video.py
@@ -1,0 +1,111 @@
+"""Tests for the Video API with DRF token of the Marsha project."""
+import json
+
+from django.test import TestCase
+
+from rest_framework.authtoken.models import Token
+
+from ..factories import UserFactory, VideoFactory
+
+
+class VideoDRFAPITest(TestCase):
+    """Test the DRF API of the video object."""
+
+    def test_api_video_get_detail_staff_with_drf_token(self):
+        """Staff users should be able to get video details with a drf token."""
+        staff_token = Token.objects.create(user=UserFactory(is_staff=True))
+        video = VideoFactory()
+
+        # Test staff user (200)
+        response = self.client.get(
+            "/api/videos/{!s}/".format(video.id),
+            HTTP_AUTHORIZATION="Token {!s}".format(staff_token.key),
+        )
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content["id"], str(video.id))
+        self.assertEqual(content["title"], video.title)
+
+    def test_api_video_get_detail_user_with_drf_token(self):
+        """Non-staff users should not be able to get video details with a drf token."""
+        user_token = Token.objects.create(user=UserFactory())
+        video = VideoFactory()
+
+        # Test regular user (403)
+        response = self.client.get(
+            "/api/videos/{!s}/".format(video.id),
+            HTTP_AUTHORIZATION="Token {!s}".format(user_token.key),
+        )
+        self.assertEqual(response.status_code, 403)
+        content = json.loads(response.content)
+        self.assertEqual(
+            content, {"detail": "You do not have permission to perform this action."}
+        )
+
+    def test_api_video_patch_detail_staff_with_drf_token(self):
+        """Staff users should not be able to patch videos with a drf token."""
+        staff_token = Token.objects.create(user=UserFactory(is_staff=True))
+        video = VideoFactory()
+        data = {"description": "my new description"}
+
+        # Test staff user (403)
+        response = self.client.patch(
+            "/api/videos/{!s}/".format(video.id),
+            json.dumps(data),
+            HTTP_AUTHORIZATION="Token {!s}".format(staff_token.key),
+        )
+        self.assertEqual(response.status_code, 403)
+        content = json.loads(response.content)
+        self.assertEqual(
+            content, {"detail": "You do not have permission to perform this action."}
+        )
+
+    def test_api_video_patch_detail_user_with_drf_token(self):
+        """Regular users should not be able to patch videos with a drf token."""
+        user_token = Token.objects.create(user=UserFactory())
+        video = VideoFactory()
+        data = {"description": "my new description"}
+
+        # Test regular user (403)
+        response = self.client.patch(
+            "/api/videos/{!s}/".format(video.id),
+            json.dumps(data),
+            HTTP_AUTHORIZATION="Token {!s}".format(user_token.key),
+        )
+        self.assertEqual(response.status_code, 403)
+        content = json.loads(response.content)
+        self.assertEqual(
+            content, {"detail": "You do not have permission to perform this action."}
+        )
+
+    def test_api_video_delete_staff_with_drf_token(self):
+        """Staff users should not be able to delete videos with a drf token."""
+        staff_token = Token.objects.create(user=UserFactory(is_staff=True))
+        video = VideoFactory()
+
+        # Test staff user (403)
+        response = self.client.delete(
+            "/api/videos/{!s}/".format(video.id),
+            HTTP_AUTHORIZATION="Token {!s}".format(staff_token.key),
+        )
+        self.assertEqual(response.status_code, 403)
+        content = json.loads(response.content)
+        self.assertEqual(
+            content, {"detail": "You do not have permission to perform this action."}
+        )
+
+    def test_api_video_delete_user_with_drf_token(self):
+        """Regular users should not be able to delete videos with a drf token."""
+        user_token = Token.objects.create(user=UserFactory())
+        video = VideoFactory()
+
+        # Test regular user (403)
+        response = self.client.delete(
+            "/api/videos/{!s}/".format(video.id),
+            HTTP_AUTHORIZATION="Token {!s}".format(user_token.key),
+        )
+        self.assertEqual(response.status_code, 403)
+        content = json.loads(response.content)
+        self.assertEqual(
+            content, {"detail": "You do not have permission to perform this action."}
+        )

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -111,6 +111,7 @@ class Base(Configuration):
         "django_extensions",
         "dockerflow.django",
         "rest_framework",
+        "rest_framework.authtoken",
         "marsha.core.apps.CoreConfig",
     ]
 
@@ -150,6 +151,7 @@ class Base(Configuration):
     REST_FRAMEWORK = {
         "DEFAULT_AUTHENTICATION_CLASSES": (
             "rest_framework_simplejwt.authentication.JWTTokenUserAuthentication",
+            "rest_framework.authentication.TokenAuthentication",
         )
     }
 


### PR DESCRIPTION
## Purpose

This commit aim to add the drf token auth system. In this way,
we can easily retrieve (GET) video informations from a staff
user.

This commit was done because we sometimes need to retrieve data
from videos to enhance the ElasticSearch index with new data.
Without it, we would have to manually forge LTI tokens to get
video data.

## Proposal

In order to achieve this, the following steps need to be done:

- [x] Activate token auth with DRF
- [x] Add a Makefile command to easily create user token
- [x] Restrict access to GET *and* user.staff to the view we need access with this API token
- [x] Document!