### PR TITLE
🐛(back) fix sentry configuration to have env and release info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Fix admin video search
+- Rework sentry configuration to have environment and version info
 
 ## [3.10.2] - 2020-09-29
 

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -291,11 +291,16 @@ class Base(Configuration):
         """
         return get_release()
 
+    @classmethod
+    def _get_environment(cls):
+        """Environment in which the application is launched."""
+        return cls.__name__.lower()
+
     # pylint: disable=invalid-name
     @property
     def ENVIRONMENT(self):
         """Environment in which the application is launched."""
-        return self.__class__.__name__.lower()
+        return self._get_environment()
 
     @classmethod
     def post_setup(cls):
@@ -311,8 +316,8 @@ class Base(Configuration):
         if cls.SENTRY_DSN is not None:
             sentry_sdk.init(
                 dsn=cls.SENTRY_DSN,
-                environment=cls.ENVIRONMENT,
-                release=cls.RELEASE,
+                environment=cls._get_environment(),
+                release=get_release(),
                 integrations=[DjangoIntegration()],
             )
             with sentry_sdk.configure_scope() as scope:


### PR DESCRIPTION
## Purpose

When an error is reported to sentry fron the backend application, the
environment and release info are not set correctly. The bug is explained
in issue #723. To fix it, we don't call anymore method in the post_setup
method because this method is a classmethod and can't access to object's method.

Fixes #723 

## Proposal

- [x] fix sentry configuration to have env and release info

