### PR TITLE
🐛(back) fix video search in the admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Remove usage of react-intl-po
 - Rework front i18n workflow
 
+### Fixed
+
+- Fix admin video search
+
 ## [3.10.2] - 2020-09-29
 
 ### Fixed

--- a/src/backend/marsha/core/admin.py
+++ b/src/backend/marsha/core/admin.py
@@ -377,7 +377,9 @@ class PlaylistAdmin(admin.ModelAdmin):
         "consumer_site__name",
         "organization__name",
         "lti_id",
-        "portable_to",
+        "portable_to__title",
+        "portable_to__lti_id",
+        "portable_to__id",
         "title",
     )
     verbose_name = _("Playlist")


### PR DESCRIPTION
## Purpose

The video seach feature was not working in the admin. One of the
searchable field is portable_to and portable_to is a primary key. To fix
this problem, we choose to explicitly search on some fields in the
portable_to table: title, lti_id and id.

Fixes #736 

## Proposal

- [x] fix video search in the admin

