### PR TITLE
🔖(minor) bump release to 3.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,15 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.11.0] - 2020-10-08
+
 ### Changed
 
-- Remove usage of react-intl-po
 - Rework front i18n workflow
+
+### Removed
+
+- Remove usage of react-intl-po
 
 ### Fixed
 
@@ -579,7 +584,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Minor fixes and improvements on features and tests
 
-[unreleased]: https://github.com/openfun/marsha/compare/v3.10.2...master
+[unreleased]: https://github.com/openfun/marsha/compare/v3.11.0...master
+[3.11.0]: https://github.com/openfun/marsha/compare/v3.10.2...v3.11.0
 [3.10.2]: https://github.com/openfun/marsha/compare/v3.10.1...v3.10.2
 [3.10.1]: https://github.com/openfun/marsha/compare/v3.10.0...v3.10.1
 [3.10.0]: https://github.com/openfun/marsha/compare/v3.9.1...v3.10.0

--- a/src/aws/lambda-complete/package.json
+++ b/src/aws/lambda-complete/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-complete",
-  "version": "3.10.2",
+  "version": "3.11.0",
   "engines": {
     "node": "10"
   },

--- a/src/aws/lambda-configure/package.json
+++ b/src/aws/lambda-configure/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-configure",
-  "version": "3.10.2",
+  "version": "3.11.0",
   "engines": {
     "node": "10"
   },

--- a/src/aws/lambda-encode/package.json
+++ b/src/aws/lambda-encode/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-convert",
-  "version": "3.10.2",
+  "version": "3.11.0",
   "engines": {
     "node": "10"
   },

--- a/src/aws/lambda-migrate/package.json
+++ b/src/aws/lambda-migrate/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-migrate",
-  "version": "3.10.2",
+  "version": "3.11.0",
   "engines": {
     "node": "10"
   },

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = marsha
 description = A FUN video provider for Open edX
-version = 3.10.2
+version = 3.11.0
 author = Open FUN (France Universite Numerique)
 author_email = fun.dev@fun-mooc.fr
 license = MIT

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marsha",
-  "version": "3.10.2",
+  "version": "3.11.0",
   "description": "🐠 a FUN LTI video provider",
   "main": "front/index.tsx",
   "scripts": {


### PR DESCRIPTION
### Changed

- Rework front i18n workflow

### Removed

- Remove usage of react-intl-po

### Fixed

- Fix admin video search
- Rework sentry configuration to have environment and version info

