### PR TITLE
manage dash endpoint in live mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Manage live streaming using AWS Elemental
 - Download timed text track in video dashboard
 - Create shared resources between terraform workspaces
+- Add dash endpoint to mediapackage channel
 
 ### Changed
 

--- a/src/backend/marsha/core/serializers.py
+++ b/src/backend/marsha/core/serializers.py
@@ -475,7 +475,7 @@ class VideoSerializer(serializers.ModelSerializer):
             return {
                 "manifests": {
                     "hls": obj.live_info["mediapackage"]["endpoints"]["hls"]["url"],
-                    "dash": None,
+                    "dash": obj.live_info["mediapackage"]["endpoints"]["dash"]["url"],
                 },
                 "mp4": {},
                 "thumbnails": {},

--- a/src/backend/marsha/core/tests/test_api_video.py
+++ b/src/backend/marsha/core/tests/test_api_video.py
@@ -1052,7 +1052,11 @@ class VideoAPITest(TestCase):
                     "hls": {
                         "id": "endpoint1",
                         "url": "https://channel_endpoint1/live.m3u8",
-                    }
+                    },
+                    "dash": {
+                        "id": "endpoint2",
+                        "url": "https://channel_endpoint2/live.mpd",
+                    },
                 },
             },
         }
@@ -1081,7 +1085,7 @@ class VideoAPITest(TestCase):
                 "urls": {
                     "manifests": {
                         "hls": "https://channel_endpoint1/live.m3u8",
-                        "dash": None,
+                        "dash": "https://channel_endpoint2/live.mpd",
                     },
                     "mp4": {},
                     "thumbnails": {},
@@ -1189,6 +1193,10 @@ class VideoAPITest(TestCase):
                             "id": "endpoint1",
                             "url": "https://channel_endpoint1/live.m3u8",
                         },
+                        "dash": {
+                            "id": "endpoint2",
+                            "url": "https://channel_endpoint2/live.mpd",
+                        },
                     },
                 },
             },
@@ -1222,7 +1230,7 @@ class VideoAPITest(TestCase):
                 "urls": {
                     "manifests": {
                         "hls": "https://channel_endpoint1/live.m3u8",
-                        "dash": None,
+                        "dash": "https://channel_endpoint2/live.mpd",
                     },
                     "mp4": {},
                     "thumbnails": {},
@@ -1369,6 +1377,10 @@ class VideoAPITest(TestCase):
                             "id": "endpoint1",
                             "url": "https://channel_endpoint1/live.m3u8",
                         },
+                        "dash": {
+                            "id": "endpoint2",
+                            "url": "https://channel_endpoint2/live.mpd",
+                        },
                     },
                 },
             },
@@ -1402,7 +1414,7 @@ class VideoAPITest(TestCase):
                 "urls": {
                     "manifests": {
                         "hls": "https://channel_endpoint1/live.m3u8",
-                        "dash": None,
+                        "dash": "https://channel_endpoint2/live.mpd",
                     },
                     "mp4": {},
                     "thumbnails": {},

--- a/src/backend/marsha/core/tests/test_utils_medialive_utils.py
+++ b/src/backend/marsha/core/tests/test_utils_medialive_utils.py
@@ -155,6 +155,11 @@ class MediaLiveUtilsTestCase(TestCase):
             "Url": "https://endpoint1/channel.m3u8",
             "Id": "enpoint1",
         }
+        mediapackage_create_dash_origin_endpoint_response = {
+            "ChannelId": "channel1",
+            "Url": "https://endpoint1/channel.mpd",
+            "Id": "enpoint1",
+        }
         with Stubber(
             medialive_utils.mediapackage_client
         ) as mediapackage_stubber, Stubber(medialive_utils.ssm_client) as ssm_stubber:
@@ -205,14 +210,37 @@ class MediaLiveUtilsTestCase(TestCase):
                     "Tags": {"environment": "test"},
                 },
             )
+            mediapackage_stubber.add_response(
+                "create_origin_endpoint",
+                service_response=mediapackage_create_dash_origin_endpoint_response,
+                expected_params={
+                    "ChannelId": f"test_{key}",
+                    "Id": "test_video-key_dash",
+                    "ManifestName": "test_video-key_dash",
+                    "StartoverWindowSeconds": 86400,
+                    "TimeDelaySeconds": 0,
+                    "DashPackage": {
+                        "ManifestWindowSeconds": 2,
+                        "SegmentDurationSeconds": 1,
+                    },
+                    "Tags": {"environment": "test"},
+                },
+            )
 
-            [channel, hls_endpoint] = medialive_utils.create_mediapackage_channel(key)
+            [
+                channel,
+                hls_endpoint,
+                dash_endpoint,
+            ] = medialive_utils.create_mediapackage_channel(key)
 
             mediapackage_stubber.assert_no_pending_responses()
             ssm_stubber.assert_no_pending_responses()
 
         self.assertEqual(channel, mediapackage_create_channel_response)
         self.assertEqual(hls_endpoint, mediapackage_create_hls_origin_endpoint_response)
+        self.assertEqual(
+            dash_endpoint, mediapackage_create_dash_origin_endpoint_response
+        )
 
     @override_settings(AWS_BASE_NAME="test")
     def test_create_medialive_input(self):
@@ -362,7 +390,12 @@ class MediaLiveUtilsTestCase(TestCase):
                 {
                     "ChannelId": "channel1",
                     "Url": "https://endpoint1/channel.m3u8",
-                    "Id": "enpoint1",
+                    "Id": "endpoint1",
+                },
+                {
+                    "ChannelId": "channel1",
+                    "Url": "https://endpoint2/channel.mpd",
+                    "Id": "endpoint2",
                 },
             ]
             mock_medialive_input.return_value = {
@@ -403,8 +436,12 @@ class MediaLiveUtilsTestCase(TestCase):
                     "channel": {"id": "channel1"},
                     "endpoints": {
                         "hls": {
-                            "id": "enpoint1",
+                            "id": "endpoint1",
                             "url": "https://endpoint1/channel.m3u8",
+                        },
+                        "dash": {
+                            "id": "endpoint2",
+                            "url": "https://endpoint2/channel.mpd",
                         },
                     },
                 },
@@ -422,6 +459,7 @@ class MediaLiveUtilsTestCase(TestCase):
                 "mediapackage": {
                     "endpoints": {
                         "hls": {"id": "mediapackage_endpoint1"},
+                        "dash": {"id": "mediapackage_endpoint2"},
                     },
                     "channel": {"id": "mediapackage_channel1"},
                 },
@@ -434,6 +472,11 @@ class MediaLiveUtilsTestCase(TestCase):
             mediapackage_stubber.add_response(
                 "delete_origin_endpoint",
                 expected_params={"Id": "mediapackage_endpoint1"},
+                service_response={},
+            )
+            mediapackage_stubber.add_response(
+                "delete_origin_endpoint",
+                expected_params={"Id": "mediapackage_endpoint2"},
                 service_response={},
             )
             mediapackage_stubber.add_response(

--- a/src/backend/marsha/core/tests/test_views_lti_video.py
+++ b/src/backend/marsha/core/tests/test_views_lti_video.py
@@ -144,6 +144,10 @@ class VideoLTIViewTestCase(TestCase):
                             "id": "endpoint1",
                             "url": "https://channel_endpoint1/live.m3u8",
                         },
+                        "dash": {
+                            "id": "endpoint2",
+                            "url": "https://channel_endpoint2/live.mpd",
+                        },
                     },
                 },
             },
@@ -203,7 +207,7 @@ class VideoLTIViewTestCase(TestCase):
                 "urls": {
                     "manifests": {
                         "hls": "https://channel_endpoint1/live.m3u8",
-                        "dash": None,
+                        "dash": "https://channel_endpoint2/live.mpd",
                     },
                     "mp4": {},
                     "thumbnails": {},
@@ -267,6 +271,10 @@ class VideoLTIViewTestCase(TestCase):
                             "id": "endpoint1",
                             "url": "https://channel_endpoint1/live.m3u8",
                         },
+                        "dash": {
+                            "id": "endpoint2",
+                            "url": "https://channel_endpoint2/live.mpd",
+                        },
                     },
                 },
             },
@@ -326,7 +334,7 @@ class VideoLTIViewTestCase(TestCase):
                 "urls": {
                     "manifests": {
                         "hls": "https://channel_endpoint1/live.m3u8",
-                        "dash": None,
+                        "dash": "https://channel_endpoint2/live.mpd",
                     },
                     "mp4": {},
                     "thumbnails": {},

--- a/src/backend/marsha/core/utils/medialive_utils.py
+++ b/src/backend/marsha/core/utils/medialive_utils.py
@@ -297,7 +297,10 @@ def delete_aws_element_stack(video):
     # First delete mediapackage endpoints
     for endpoint in ["hls", "dash"]:
         mediapackage_client.delete_origin_endpoint(
-            Id=video.live_info.get("mediapackage").get("endpoints").get(endpoint).get("id")
+            Id=video.live_info.get("mediapackage")
+            .get("endpoints")
+            .get(endpoint)
+            .get("id")
         )
 
     # Then delete channel

--- a/src/backend/marsha/core/utils/medialive_utils.py
+++ b/src/backend/marsha/core/utils/medialive_utils.py
@@ -64,7 +64,7 @@ def create_mediapackage_channel(key):
         Tags=[{"Key": "environment", "Value": settings.AWS_BASE_NAME}],
     )
 
-    # Create an endpoint. This endpoint will be used to watch the stream.
+    # Create a HLS endpoint. This endpoint will be used to watch the stream.
     hls_endpoint = mediapackage_client.create_origin_endpoint(
         ChannelId=channel["Id"],
         Id=f"{channel['Id']}_hls",
@@ -82,7 +82,21 @@ def create_mediapackage_channel(key):
         Tags={"environment": settings.AWS_BASE_NAME},
     )
 
-    return [channel, hls_endpoint]
+    # Create a DASH endpoint. This endpoint will be used to watch the stream.
+    dash_endpoint = mediapackage_client.create_origin_endpoint(
+        ChannelId=channel["Id"],
+        Id=f"{channel['Id']}_dash",
+        ManifestName=f"{channel['Id']}_dash",
+        StartoverWindowSeconds=86400,
+        TimeDelaySeconds=0,
+        DashPackage={
+            "ManifestWindowSeconds": 2,
+            "SegmentDurationSeconds": 1,
+        },
+        Tags={"environment": settings.AWS_BASE_NAME},
+    )
+
+    return [channel, hls_endpoint, dash_endpoint]
 
 
 def get_or_create_input_security_group():
@@ -231,7 +245,7 @@ def create_live_stream(key):
         Dictionary containing all information to store in order to manage
         a live stream life cycle.
     """
-    mediapackage_channel, hls_endpoint = create_mediapackage_channel(key)
+    mediapackage_channel, hls_endpoint, dash_endpoint = create_mediapackage_channel(key)
     medialive_input = create_medialive_input(key)
 
     medialive_channel = create_medialive_channel(
@@ -256,6 +270,7 @@ def create_live_stream(key):
             "channel": {"id": mediapackage_channel["Id"]},
             "endpoints": {
                 "hls": {"id": hls_endpoint["Id"], "url": hls_endpoint["Url"]},
+                "dash": {"id": dash_endpoint["Id"], "url": dash_endpoint["Url"]},
             },
         },
     }
@@ -279,10 +294,11 @@ def delete_aws_element_stack(video):
         - mediapackage channel and endpoints
     """
     # Mediapackage
-    # First delete mediapackage endpoint
-    mediapackage_client.delete_origin_endpoint(
-        Id=video.live_info.get("mediapackage").get("endpoints").get("hls").get("id")
-    )
+    # First delete mediapackage endpoints
+    for endpoint in ["hls", "dash"]:
+        mediapackage_client.delete_origin_endpoint(
+            Id=video.live_info.get("mediapackage").get("endpoints").get(endpoint).get("id")
+        )
 
     # Then delete channel
     mediapackage_client.delete_channel(

--- a/src/frontend/Player/createPlyrPlayer.spec.ts
+++ b/src/frontend/Player/createPlyrPlayer.spec.ts
@@ -266,13 +266,13 @@ describe('createPlyrPlayer', () => {
       type: 'video',
     });
   });
-  it('creates Plyr player and configure hls if video in live mode', () => {
+  it('creates Plyr player and configures hls if video in live mode and dash is not available', () => {
     mockIsMSESupported.mockReturnValue(false);
     mockIsHlsSupported.mockReturnValue(false);
     jest.spyOn(Hls, 'isSupported').mockReturnValue(true);
 
     const ref = 'ref' as any;
-    const player = createPlyrPlayer(ref, jest.fn(), {
+    createPlyrPlayer(ref, jest.fn(), {
       ...video,
       upload_state: 'pending',
       live_state: 'idle',
@@ -280,5 +280,19 @@ describe('createPlyrPlayer', () => {
 
     expect(mockCreateHlsPlayer).toHaveBeenCalled();
     expect(mockCreateDashPlayer).not.toHaveBeenCalled();
+  });
+  it('creates Plyr player and configures dash if video in live mode and dash is available', () => {
+    mockIsMSESupported.mockReturnValue(true);
+    mockIsHlsSupported.mockReturnValue(false);
+
+    const ref = 'ref' as any;
+    createPlyrPlayer(ref, jest.fn(), {
+      ...video,
+      upload_state: 'pending',
+      live_state: 'idle',
+    } as Video);
+
+    expect(mockCreateHlsPlayer).not.toHaveBeenCalled();
+    expect(mockCreateDashPlayer).toHaveBeenCalled();
   });
 });

--- a/src/frontend/Player/createPlyrPlayer.ts
+++ b/src/frontend/Player/createPlyrPlayer.ts
@@ -161,11 +161,7 @@ export const createPlyrPlayer = (
     player.source = sources;
   }
 
-  if (video.live_state !== null && Hls.isSupported()) {
-    createHlsPlayer(video, videoNode);
-  }
-
-  if (video.live_state === null && isMSESupported()) {
+  if (isMSESupported()) {
     dash = createDashPlayer(video, videoNode);
     dash.on('qualityChangeRendered', (e) => {
       if (isNaN(e.oldQuality)) {
@@ -180,6 +176,8 @@ export const createPlyrPlayer = (
         player.quality = newQuality.height;
       }
     });
+  } else if (video.live_state !== null && Hls.isSupported()) {
+    createHlsPlayer(video, videoNode);
   }
 
   if (player.elements.buttons.play) {


### PR DESCRIPTION
## Purpose

Since now, only HLS endpoint was created in a mediapackage channel. We
decided to also add a dash one in order to use it on compatible
browsers.

## Proposal

- [x] create and manage dash endpoint in mediapackage channel
- [x] use in in the player.

