### PR TITLE
🐛(aws) change all container preset value by CMFC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - manage ready clauses in LTI resource finder
+- Change preset container by CMFC
 
 ## [3.11.0] - 2020-10-08
 

--- a/src/aws/lambda-configure/presets/cmaf_audio_aac_128kbps.json
+++ b/src/aws/lambda-configure/presets/cmaf_audio_aac_128kbps.json
@@ -23,7 +23,7 @@
       }
     ],
     "ContainerSettings": {
-      "Container": "MPD"
+      "Container": "CMFC"
     }
   }
 }

--- a/src/aws/lambda-configure/presets/cmaf_audio_aac_160kbps.json
+++ b/src/aws/lambda-configure/presets/cmaf_audio_aac_160kbps.json
@@ -23,7 +23,7 @@
       }
     ],
     "ContainerSettings": {
-      "Container": "MPD"
+      "Container": "CMFC"
     }
   }
 }

--- a/src/aws/lambda-configure/presets/cmaf_audio_aac_192kbps.json
+++ b/src/aws/lambda-configure/presets/cmaf_audio_aac_192kbps.json
@@ -23,7 +23,7 @@
       }
     ],
     "ContainerSettings": {
-      "Container": "MPD"
+      "Container": "CMFC"
     }
   }
 }

--- a/src/aws/lambda-configure/presets/cmaf_audio_aac_64kbps.json
+++ b/src/aws/lambda-configure/presets/cmaf_audio_aac_64kbps.json
@@ -23,7 +23,7 @@
       }
     ],
     "ContainerSettings": {
-      "Container": "MPD"
+      "Container": "CMFC"
     }
   }
 }

--- a/src/aws/lambda-configure/presets/cmaf_audio_aac_96kbps.json
+++ b/src/aws/lambda-configure/presets/cmaf_audio_aac_96kbps.json
@@ -23,7 +23,7 @@
       }
     ],
     "ContainerSettings": {
-      "Container": "MPD"
+      "Container": "CMFC"
     }
   }
 }

--- a/src/aws/lambda-configure/presets/cmaf_video_h264_1080p_30fps_5400kbps.json
+++ b/src/aws/lambda-configure/presets/cmaf_video_h264_1080p_30fps_5400kbps.json
@@ -51,7 +51,7 @@
       "ColorMetadata": "INSERT"
     },
     "ContainerSettings": {
-      "Container": "MPD"
+      "Container": "CMFC"
     }
   }
 }

--- a/src/aws/lambda-configure/presets/cmaf_video_h264_144p_30fps_300kbps.json
+++ b/src/aws/lambda-configure/presets/cmaf_video_h264_144p_30fps_300kbps.json
@@ -51,7 +51,7 @@
       "ColorMetadata": "INSERT"
     },
     "ContainerSettings": {
-      "Container": "MPD"
+      "Container": "CMFC"
     }
   }
 }

--- a/src/aws/lambda-configure/presets/cmaf_video_h264_240p_30fps_600kbps.json
+++ b/src/aws/lambda-configure/presets/cmaf_video_h264_240p_30fps_600kbps.json
@@ -51,7 +51,7 @@
       "ColorMetadata": "INSERT"
     },
     "ContainerSettings": {
-      "Container": "MPD"
+      "Container": "CMFC"
     }
   }
 }

--- a/src/aws/lambda-configure/presets/cmaf_video_h264_480p_30fps_1200kbps.json
+++ b/src/aws/lambda-configure/presets/cmaf_video_h264_480p_30fps_1200kbps.json
@@ -51,7 +51,7 @@
       "ColorMetadata": "INSERT"
     },
     "ContainerSettings": {
-      "Container": "MPD"
+      "Container": "CMFC"
     }
   }
 }

--- a/src/aws/lambda-configure/presets/cmaf_video_h264_720p_30fps_2400kbps.json
+++ b/src/aws/lambda-configure/presets/cmaf_video_h264_720p_30fps_2400kbps.json
@@ -51,7 +51,7 @@
       "ColorMetadata": "INSERT"
     },
     "ContainerSettings": {
-      "Container": "MPD"
+      "Container": "CMFC"
     }
   }
 }


### PR DESCRIPTION
## Purpose

since 2020/11/20 AWS has fix an issue in job creation on container
value. The value we used (MPD) was not valid for CMAF content but the
job was not rejected. It is not the case anymore, we must use CMFC
value.

AWS warn with this mail : 

```
We have found that certain jobs with invalid job settings are not being properly rejected and can successfully be submitted to the service. These jobs will sometimes complete, but do not produce the desired results. In other cases, they eventually fail and return an error. We are in the process of adding a validation to reject jobs containing these invalid job settings. This change will go into effect by November 20, 2020.

We have reviewed past job creation data and found you have submitted one of these job configurations. Please review your job configurations and update as needed.

Please make the following changes to your job settings in order to avoid job creation impact:

Output Group Type: Apple HLS
Container type must be: RAW or M3U8

Output Group Type: DASH ISO
Container type must be: MPD or CMFC

Output Group Type: CMAF
Container type must be: CMFC

Output Group Type: Microsoft Smooth Streaming
Container type must be: ISMV

If you are using an SDK or the API to create your jobs please reference the following documentation on finding your Output Group type [1] and the container [2] you are using with it.

[1] https://docs.aws.amazon.com/mediaconvert/latest/apireference/jobs.html#jobs-prop-outputgroup-outputgroupsettings
[2] https://docs.aws.amazon.com/mediaconvert/latest/apireference/jobs.html#jobs-prop-containersettings-container
```

## Proposal

- [x] change all container preset value by CMFC

