### PR TITLE
♻️(aws) copy object from source to destination s3 bucket in lambda-encode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - use input to execute lambda_migrate intead of env var
+- copy document from s3 source to s3 destination in lambda copying document
 
 ### Fixed
 

--- a/src/aws/lambda-encode/src/copyDocument.js
+++ b/src/aws/lambda-encode/src/copyDocument.js
@@ -7,17 +7,12 @@ module.exports = async (objectKey, sourceBucket) => {
 
   console.log(`Copying document ${objectKey} to destination bucket.`);
 
-  const sourceDocument = await s3
-    .getObject({ Bucket: sourceBucket, Key: objectKey })
-    .promise();
-
-
   const parts = objectKey.split('/');
-  await s3
-    .putObject({
-      Body: sourceDocument.Body,
+  return s3.
+    copyObject({
       Bucket: destinationBucket,
       Key: `${parts[0]}/document/${parts[3]}`,
+      CopySource: `${sourceBucket}/${objectKey}`
     })
     .promise();
 };

--- a/src/aws/lambda-encode/src/copyDocument.spec.js
+++ b/src/aws/lambda-encode/src/copyDocument.spec.js
@@ -1,15 +1,13 @@
-process.env.S3_DESTINATION_BUCKET = 'destination bucket';
+process.env.S3_DESTINATION_BUCKET = 'destination_bucket';
 
 // Don't pollute tests with logs intended for CloudWatch
 jest.spyOn(console, 'log');
 
 // Mock the AWS SDK calls used in encodeTimedTextTrack
-const mockGetObject = jest.fn();
-const mockPutObject = jest.fn();
+const mockCopyObject = jest.fn();
 jest.mock('aws-sdk', () => ({
   S3: function() {
-    this.getObject = mockGetObject;
-    this.putObject = mockPutObject;
+    this.copyObject = mockCopyObject;
   },
 }));
 
@@ -22,20 +20,16 @@ describe('lambda-encore/src/copyDocument', () => {
   });
 
   it('copy a document from a source to a destination bucket', async () => {
-    mockGetObject.mockReturnValue({
-      promise: () =>
-        new Promise(resolve => resolve({ Body: 'input timed text' })),
-    });
-    mockPutObject.mockReturnValue({
+    mockCopyObject.mockReturnValue({
       promise: () => new Promise(resolve => resolve()),
     });
 
-    await copyDocument('foo/document/foo/bar', 'source bucket')
+    await copyDocument('a3e213a7-9c56-4bd3-b71c-fe567b0cfe12/document/a3e213a7-9c56-4bd3-b71c-fe567b0cfe12/1606230873.zip', 'source_bucket')
 
-    expect(mockPutObject).toHaveBeenCalledWith({
-      Body: 'input timed text',
-      Bucket: 'destination bucket',
-      Key: 'foo/document/bar',
+    expect(mockCopyObject).toHaveBeenCalledWith({
+      Bucket: 'destination_bucket',
+      Key: 'a3e213a7-9c56-4bd3-b71c-fe567b0cfe12/document/1606230873.zip',
+      CopySource: `source_bucket/a3e213a7-9c56-4bd3-b71c-fe567b0cfe12/document/a3e213a7-9c56-4bd3-b71c-fe567b0cfe12/1606230873.zip`
     })
   });
 })


### PR DESCRIPTION
## Purpose

In lambda-encode, the function copying a document from a source bucket
to a destination was downloaded all the document in the lambda and then
upload it in the destination bucket. This code can be highly optimized
by using the CopyObject function, no data are downloaded in the lambda.

## Proposal

- [x] copy object from source to destination s3 bucket in lambda-encode

