### PR TITLE
🐛(timed text track) manage resource without extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow to serialize a timed text track without extension
+
 ## [3.12.0] - 2020-11-24
 
 ### Added

--- a/src/backend/marsha/core/serializers.py
+++ b/src/backend/marsha/core/serializers.py
@@ -221,7 +221,7 @@ class TimedTextTrackSerializer(serializers.ModelSerializer):
             None if the timed text track is still not uploaded to S3 with success.
 
         """
-        if obj.uploaded_on:
+        if obj.uploaded_on and obj.extension:
             stamp = time_utils.to_timestamp(obj.uploaded_on)
             filename = "{playlist_title:s}_{stamp:s}.{extension:s}".format(
                 playlist_title=slugify(obj.video.playlist.title),

--- a/src/frontend/components/TimedTextListItem/index.tsx
+++ b/src/frontend/components/TimedTextListItem/index.tsx
@@ -127,7 +127,7 @@ export const TimedTextListItem = ({ track }: TimedTextListItemProps) => {
               : messages.replace)}
           />
         </Link>
-        {track.upload_state === uploadState.READY && (
+        {track.upload_state === uploadState.READY && track.source_url && (
           <React.Fragment>
             &nbsp;/&nbsp;
             <a href={track.source_url}>

--- a/src/frontend/types/tracks.ts
+++ b/src/frontend/types/tracks.ts
@@ -59,7 +59,7 @@ export interface TimedText extends Resource {
   language: string;
   mode: timedTextMode;
   upload_state: uploadState;
-  source_url: string;
+  source_url: Nullable<string>;
   url: string;
   video: Video['id'];
   title: string;


### PR DESCRIPTION
## Purpose

Existing videos don't have extension property set. To be compatible
with this case we allow to serialize a timed text track object with
source_url set to None. A migration must be done to set the extension
field.

## Proposal

- [x] allow to serialize a timed text track without extension

