### PR TITLE
🔖(patch) bump release to 3.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.12.1] - 2020-11-25
+
 ### Fixed
 
 - Allow to serialize a timed text track without extension
@@ -608,6 +610,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Minor fixes and improvements on features and tests
 
 [unreleased]: https://github.com/openfun/marsha/compare/v3.12.0...master
+[3.12.1]: https://github.com/openfun/marsha/compare/v3.12.0...v3.12.1
 [3.12.0]: https://github.com/openfun/marsha/compare/v3.11.0...v3.12.0
 [3.11.0]: https://github.com/openfun/marsha/compare/v3.10.2...v3.11.0
 [3.10.2]: https://github.com/openfun/marsha/compare/v3.10.1...v3.10.2

--- a/src/aws/lambda-complete/package.json
+++ b/src/aws/lambda-complete/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-complete",
-  "version": "3.12.0",
+  "version": "3.12.1",
   "engines": {
     "node": "10"
   },

--- a/src/aws/lambda-configure/package.json
+++ b/src/aws/lambda-configure/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-configure",
-  "version": "3.12.0",
+  "version": "3.12.1",
   "engines": {
     "node": "10"
   },

--- a/src/aws/lambda-encode/package.json
+++ b/src/aws/lambda-encode/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-convert",
-  "version": "3.12.0",
+  "version": "3.12.1",
   "engines": {
     "node": "10"
   },

--- a/src/aws/lambda-medialive-routing/package.json
+++ b/src/aws/lambda-medialive-routing/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-medialive-routing",
-  "version": "3.12.0",
+  "version": "3.12.1",
   "engines": {
     "node": "10"
   },

--- a/src/aws/lambda-medialive/package.json
+++ b/src/aws/lambda-medialive/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-medialive",
-  "version": "3.12.0",
+  "version": "3.12.1",
   "engines": {
     "node": "10"
   },

--- a/src/aws/lambda-migrate/package.json
+++ b/src/aws/lambda-migrate/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-migrate",
-  "version": "3.12.0",
+  "version": "3.12.1",
   "engines": {
     "node": "10"
   },

--- a/src/aws/utils/update-state/package.json
+++ b/src/aws/utils/update-state/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-update-state",
-  "version": "3.12.0",
+  "version": "3.12.1",
   "engines": {
     "node": "10"
   },

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = marsha
 description = A FUN video provider for Open edX
-version = 3.12.0
+version = 3.12.1
 author = Open FUN (France Universite Numerique)
 author_email = fun.dev@fun-mooc.fr
 license = MIT

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marsha",
-  "version": "3.12.0",
+  "version": "3.12.1",
   "description": "🐠 a FUN LTI video provider",
   "main": "front/index.tsx",
   "scripts": {


### PR DESCRIPTION
### Fixed

- Allow to serialize a timed text track without extension



