### PR TITLE
Feature flag capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Choose video player with the setting VIDEO_PLAYER
-- New player videojs as a alternative to plyr
+- New player videojs as an alternative to plyr
+- Add a fleature flag to control video live streams activation
 
 ## [3.12.1] - 2020-11-25
 

--- a/src/backend/marsha/core/admin.py
+++ b/src/backend/marsha/core/admin.py
@@ -6,6 +6,8 @@ from django.urls import reverse
 from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
 
+from waffle import admin as waffle_admin
+
 from marsha.core.models import (
     AudioTrack,
     ConsumerSite,
@@ -158,6 +160,10 @@ class MarshaAdminSite(admin.AdminSite):
 
 
 admin_site = MarshaAdminSite(name="admin")
+
+admin_site.register(waffle_admin.Flag, waffle_admin.FlagAdmin)
+admin_site.register(waffle_admin.Sample, waffle_admin.SampleAdmin)
+admin_site.register(waffle_admin.Switch, waffle_admin.SwitchAdmin)
 
 
 class UserOrganizationsInline(admin.TabularInline):

--- a/src/backend/marsha/core/defaults.py
+++ b/src/backend/marsha/core/defaults.py
@@ -25,3 +25,6 @@ LIVE_CHOICES = (
     (RUNNING, _("running")),
     (STOPPED, _("stopped")),
 )
+
+# FLAGS
+VIDEO_LIVE = "video_live"

--- a/src/backend/marsha/core/tests/test_views_lti_cache.py
+++ b/src/backend/marsha/core/tests/test_views_lti_cache.py
@@ -8,7 +8,9 @@ from unittest import mock
 
 from django.test import TestCase
 
-from ..defaults import STATE_CHOICES
+from waffle.testutils import override_switch
+
+from ..defaults import STATE_CHOICES, VIDEO_LIVE
 from ..factories import ConsumerSiteFactory, VideoFactory
 from ..lti import LTI
 
@@ -35,6 +37,7 @@ class CacheLTIViewTestCase(TestCase):
 
     @mock.patch.object(LTI, "verify")
     @mock.patch.object(LTI, "get_consumer_site")
+    @override_switch(VIDEO_LIVE, active=True)
     def test_views_lti_cache_student(self, mock_get_consumer_site, mock_verify):
         """Validate that responses are cached for students."""
         video1, video2 = VideoFactory.create_batch(
@@ -56,7 +59,7 @@ class CacheLTIViewTestCase(TestCase):
             "user_id": "111",
         }
 
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(5):
             elapsed, resource_origin = self._post_lti_request(url, data)
         self.assertEqual(resource_origin["id"], str(video1.id))
         self.assertTrue(elapsed < 0.1)
@@ -115,6 +118,7 @@ class CacheLTIViewTestCase(TestCase):
 
     @mock.patch.object(LTI, "verify")
     @mock.patch.object(LTI, "get_consumer_site")
+    @override_switch(VIDEO_LIVE, active=True)
     def test_views_lti_cache_instructor(self, mock_get_consumer_site, mock_verify):
         """Validate that responses are not cached for instructors."""
         video = VideoFactory(
@@ -133,7 +137,7 @@ class CacheLTIViewTestCase(TestCase):
             "user_id": "111",
         }
 
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(5):
             elapsed, resource_origin = self._post_lti_request(url, data)
         self.assertEqual(resource_origin["id"], str(video.id))
         self.assertTrue(elapsed < 0.1)

--- a/src/backend/marsha/core/tests/test_views_lti_video.py
+++ b/src/backend/marsha/core/tests/test_views_lti_video.py
@@ -11,8 +11,9 @@ from django.test import TestCase, override_settings
 
 from pylti.common import LTIException
 from rest_framework_simplejwt.tokens import AccessToken
+from waffle.testutils import override_switch
 
-from ..defaults import IDLE, PENDING, READY, RUNNING, STATE_CHOICES
+from ..defaults import IDLE, PENDING, READY, RUNNING, STATE_CHOICES, VIDEO_LIVE
 from ..factories import (
     ConsumerSiteLTIPassportFactory,
     TimedTextTrackFactory,
@@ -35,6 +36,7 @@ class VideoLTIViewTestCase(TestCase):
     @override_settings(SENTRY_DSN="https://sentry.dsn")
     @override_settings(RELEASE="1.2.3")
     @override_settings(VIDEO_PLAYER="videojs")
+    @override_switch(VIDEO_LIVE, active=True)
     def test_views_lti_video_post_instructor(self, mock_get_consumer_site, mock_verify):
         """Validate the format of the response returned by the view for an instructor request."""
         passport = ConsumerSiteLTIPassportFactory()
@@ -110,6 +112,7 @@ class VideoLTIViewTestCase(TestCase):
         self.assertEqual(context.get("environment"), "test")
         self.assertEqual(context.get("release"), "1.2.3")
         self.assertEqual(context.get("player"), "videojs")
+        self.assertEqual(context.get("flags"), {"video_live": True})
         # Make sure we only go through LTI verification once as it is costly (getting passport +
         # signature)
         self.assertEqual(mock_verify.call_count, 1)

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -110,6 +110,7 @@ class Base(Configuration):
         "django.contrib.staticfiles",
         "django_extensions",
         "dockerflow.django",
+        "waffle",
         "rest_framework",
         "marsha.core.apps.CoreConfig",
     ]
@@ -123,6 +124,7 @@ class Base(Configuration):
         "django.contrib.messages.middleware.MessageMiddleware",
         "django.middleware.clickjacking.XFrameOptionsMiddleware",
         "dockerflow.django.middleware.DockerflowMiddleware",
+        "waffle.middleware.WaffleMiddleware",
     ]
 
     ROOT_URLCONF = "marsha.urls"
@@ -152,6 +154,9 @@ class Base(Configuration):
             "rest_framework_simplejwt.authentication.JWTTokenUserAuthentication",
         )
     }
+
+    # WAFFLE
+    WAFFLE_CREATE_MISSING_SWITCHES = True
 
     # Password validation
     # https://docs.djangoproject.com/en/2.0/ref/settings/#auth-password-validators

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -38,6 +38,7 @@ install_requires =
     djangorestframework_simplejwt==4.6.0
     django-safedelete==0.5.6
     django-storages==1.10.1
+    django-waffle==2.0.0
     dockerflow==2020.10.0
     gunicorn==20.0.4
     logging-ldp==0.0.6

--- a/src/frontend/components/DashboardPaneButtons/index.spec.tsx
+++ b/src/frontend/components/DashboardPaneButtons/index.spec.tsx
@@ -1,22 +1,30 @@
 import { cleanup, render } from '@testing-library/react';
+import { mock } from 'fetch-mock';
 import React from 'react';
 
 import { DashboardPaneButtons } from '.';
+import { flags } from '../../types/AppData';
 import { modelName } from '../../types/models';
-import { uploadState } from '../../types/tracks';
+import { liveState, uploadState } from '../../types/tracks';
 import { videoMockFactory } from '../../utils/tests/factories';
 import { wrapInIntlProvider } from '../../utils/tests/intl';
 import { wrapInRouter } from '../../utils/tests/router';
 
 const { ERROR, PENDING, PROCESSING, READY, UPLOADING } = uploadState;
 
+let mockFlags = {};
 jest.mock('../../data/appData', () => ({
   appData: {
     video: {},
+    get flags() {
+      return mockFlags;
+    },
   },
 }));
 
 describe('<DashboardPaneButtons />', () => {
+  beforeEach(() => (mockFlags = {}));
+
   it('only renders the "Watch" button if the video is ready', async () => {
     const { getByText } = render(
       wrapInIntlProvider(
@@ -46,6 +54,62 @@ describe('<DashboardPaneButtons />', () => {
       expect(queryByText('Watch')).toBeNull();
       await cleanup();
     }
+  });
+
+  it('displays the configure live button', () => {
+    mockFlags = { [flags.VIDEO_LIVE]: true };
+    const { getByRole } = render(
+      wrapInIntlProvider(
+        wrapInRouter(
+          <DashboardPaneButtons
+            object={videoMockFactory({ id: 'vid1', upload_state: PENDING })}
+            objectType={modelName.VIDEOS}
+          />,
+        ),
+      ),
+    );
+
+    getByRole('button', { name: 'Configure a live streaming' });
+  });
+
+  it('hides the configure live button when live state is not null', () => {
+    mockFlags = { [flags.VIDEO_LIVE]: false };
+    const { queryByRole } = render(
+      wrapInIntlProvider(
+        wrapInRouter(
+          <DashboardPaneButtons
+            object={videoMockFactory({
+              id: 'vid1',
+              upload_state: PENDING,
+              live_state: liveState.IDLE,
+            })}
+            objectType={modelName.VIDEOS}
+          />,
+        ),
+      ),
+    );
+
+    expect(
+      queryByRole('button', { name: 'Configure a live streaming' }),
+    ).toBeNull();
+  });
+
+  it('hides the configure live button when the flag is disabled', () => {
+    mockFlags = { [flags.VIDEO_LIVE]: false };
+    const { queryByRole } = render(
+      wrapInIntlProvider(
+        wrapInRouter(
+          <DashboardPaneButtons
+            object={videoMockFactory({ id: 'vid1', upload_state: PENDING })}
+            objectType={modelName.VIDEOS}
+          />,
+        ),
+      ),
+    );
+
+    expect(
+      queryByRole('button', { name: 'Configure a live streaming' }),
+    ).toBeNull();
   });
 
   it('adapts the text of the "Upload" button to the video state', () => {

--- a/src/frontend/components/DashboardPaneButtons/index.tsx
+++ b/src/frontend/components/DashboardPaneButtons/index.tsx
@@ -5,7 +5,9 @@ import styled from 'styled-components';
 
 import { Document } from '../../types/file';
 import { modelName } from '../../types/models';
+import { flags } from '../../types/AppData';
 import { uploadState, Video } from '../../types/tracks';
+import { isFeatureEnabled } from '../../utils/isFeatureEnabled';
 import { DashboardVideoLiveConfigureButton } from '../DashboardVideoLiveConfigureButton';
 import { PLAYER_ROUTE } from '../routes';
 import { UPLOAD_FORM_ROUTE } from '../UploadForm/route';
@@ -94,7 +96,8 @@ export const DashboardPaneButtons = ({
       margin={'small'}
     >
       {objectType === modelName.VIDEOS &&
-        object.upload_state === uploadState.PENDING && (
+        object.upload_state === uploadState.PENDING &&
+        isFeatureEnabled(flags.VIDEO_LIVE) && (
           <DashboardVideoLiveConfigureButton video={object as Video} />
         )}
       <DashboardButtonWithLink

--- a/src/frontend/components/DashboardVideoPane/index.spec.tsx
+++ b/src/frontend/components/DashboardVideoPane/index.spec.tsx
@@ -13,7 +13,10 @@ import { ERROR_COMPONENT_ROUTE } from '../ErrorComponent/route';
 
 jest.mock('jwt-decode', () => jest.fn());
 jest.mock('../../data/appData', () => ({
-  appData: { jwt: 'cool_token_m8' },
+  appData: {
+    jwt: 'cool_token_m8',
+    flags: {},
+  },
 }));
 jest.mock('../../utils/errors/report', () => ({ report: jest.fn() }));
 

--- a/src/frontend/types/AppData.ts
+++ b/src/frontend/types/AppData.ts
@@ -8,6 +8,10 @@ export enum appState {
   SUCCESS = 'success',
 }
 
+export enum flags {
+  VIDEO_LIVE = 'video_live',
+}
+
 export interface AppData {
   jwt?: string;
   state: appState;
@@ -23,4 +27,7 @@ export interface AppData {
     };
   };
   player?: string;
+  flags: {
+    [key in flags]?: boolean;
+  };
 }

--- a/src/frontend/utils/isFeatureEnabled.spec.ts
+++ b/src/frontend/utils/isFeatureEnabled.spec.ts
@@ -1,0 +1,28 @@
+import { isFeatureEnabled } from './isFeatureEnabled';
+import { flags } from '../types/AppData';
+
+let mockFlags = {};
+jest.mock('../data/appData', () => ({
+  appData: {
+    get flags() {
+      return mockFlags;
+    },
+  },
+}));
+
+describe('isFeatureEnabled', () => {
+  it('returns true is flag is enabled', () => {
+    mockFlags = { [flags.VIDEO_LIVE]: true };
+    expect(isFeatureEnabled(flags.VIDEO_LIVE)).toBe(true);
+  });
+
+  it('returns false if flag is disabled', () => {
+    mockFlags = { [flags.VIDEO_LIVE]: false };
+    expect(isFeatureEnabled(flags.VIDEO_LIVE)).toBe(false);
+  });
+
+  it('returns false when flag is undefined', () => {
+    mockFlags = {};
+    expect(isFeatureEnabled(flags.VIDEO_LIVE)).toBe(false);
+  });
+});

--- a/src/frontend/utils/isFeatureEnabled.ts
+++ b/src/frontend/utils/isFeatureEnabled.ts
@@ -1,0 +1,6 @@
+import { appData } from '../data/appData';
+import { flags } from '../types/AppData';
+
+export const isFeatureEnabled = (name: flags): boolean => {
+  return appData.flags[name] ?? false;
+};


### PR DESCRIPTION
## Purpose

We want to manage feature flag. We decided to use [django-waffle](https://waffle.readthedocs.io/en/stable) lib. We
install and configure it. For now a simple flag is added to enable or
not video live feature.

## Proposal

- [x] install and configure django-waffle
- [x] hide configure live button when the feature is disabled

