### PR TITLE
📌(front) temporary ping mux.js to version 5.7.0

### DIFF
--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -105,10 +105,6 @@
     "zustand": "3.2.0"
   },
   "resolutions": {
-    "@types/styled-components": "5.1.4",
-    "babel-core": "7.0.0-bridge.0",
-    "js-yaml": "3.14.0",
-    "@videojs/http-streaming/mux.js": "5.7.0",
-    "zustand": "3.2.0"
+    "@videojs/http-streaming/mux.js": "5.7.0"
   }
 }

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -108,6 +108,7 @@
     "@types/styled-components": "5.1.4",
     "babel-core": "7.0.0-bridge.0",
     "js-yaml": "3.14.0",
+    "@videojs/http-streaming/mux.js": "5.7.0",
     "zustand": "3.2.0"
   }
 }

--- a/src/frontend/yarn.lock
+++ b/src/frontend/yarn.lock
@@ -5035,6 +5035,11 @@ mux.js@5.6.7:
   resolved "https://registry.yarnpkg.com/mux.js/-/mux.js-5.6.7.tgz#d39fc85cded5a1257de9f6eeb5cf1578c4a63eb8"
   integrity sha512-YSr6B8MUgE4S18MptbY2XM+JKGbw9JDkgs7YkuE/T2fpDKjOhZfb/nD6vmsVxvLYOExWNaQn1UGBp6PGsnTtew==
 
+mux.js@5.7.0:
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/mux.js/-/mux.js-5.7.0.tgz#0d49ea653d25dcb256080c21c1bac4ef85e82605"
+  integrity sha512-SINb/qE0iN7YdpbGHtcj8JoHAJWXITUcN9ZCmakThZ8pVGvWukBMCDfJbEVmY2+GqmmrUkLkwUN9Ec2YLUSbuA==
+
 nanoid@^3.1.16:
   version "3.1.16"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.16.tgz#b21f0a7d031196faf75314d7c65d36352beeef64"


### PR DESCRIPTION
## Purpose

We have identified an [issue](https://github.com/videojs/http-streaming/issues/1013) in videojs. The bug is in a nested
dependency, [mux.js](https://github.com/videojs/mux.js). A new version of mux.js containing a fix is
available and we don't to wait a new videojs release to have this fix. A
temporary solution is to add a resolution in our package.json file. This
resolution will be removed once a new release of videojs available.

## Proposal

- [x] ping mux.js to version 5.7.0

