### PR TITLE
➖(back) remove flake8-per-file-ignores dev dependency

### DIFF
--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -74,7 +74,6 @@ dev =
     flake8-formatter-abspath==1.0.1
     flake8-docstrings==1.5.0
     flake8-pep3101==1.3.0
-    flake8-per-file-ignores==0.8.1
     ipython==7.19.0
     isort==5.6.4
     oauthlib==3.1.0


### PR DESCRIPTION
## Purpose

package flake8-per-file-ignores is not compatible anymore with the
version of flake8 we use, we don;t use it and is integrated in flake8
now.

## Proposal

- [x] remove flake8-per-file-ignores dev dependency

