### PR TITLE
🐛(aws) remove docker in docker for lambda-publish job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -597,9 +597,6 @@ jobs:
       - checkout
       # Generate a version.json file describing app release
       - <<: *generate-version-file
-      # Activate docker-in-docker (with layers caching enabled)
-      - setup_remote_docker:
-          docker_layer_caching: true
       - *docker_login
       - run:
           name: Build production image (using cached layers)

--- a/bin/lambda
+++ b/bin/lambda
@@ -110,7 +110,7 @@ TAG:  The tag to publish (default: production)
   done
 
   tag="${1:-production}"
-  docker run --rm -it \
+  docker run --rm \
     --env AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}" \
     --env AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}" \
     --env AWS_REGION="${AWS_REGION}" \


### PR DESCRIPTION
## Purpose

lambda-publish job use a machine executor. It is not possible to
activate docker in docker with this executor. This step must be removed

## Proposal

- [x] Remove docker in docker for lambda-publish job

