### PR TITLE
🐛(front) enable videojs override native feature except on safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Enable videojs override native feature except on safari
+
 ## [3.13.0] - 2020-12-02
 
 ### Added

--- a/src/frontend/Player/createVideojsPlayer.spec.tsx
+++ b/src/frontend/Player/createVideojsPlayer.spec.tsx
@@ -142,6 +142,11 @@ describe('createVideoJsPlayer', () => {
       },
     });
     expect(player.options_.responsive).toBe(true);
+    expect(player.options_.html5).toEqual({
+      vhs: {
+        overrideNative: true,
+      },
+    });
   });
 
   it('configures for a live video', () => {

--- a/src/frontend/Player/createVideojsPlayer.ts
+++ b/src/frontend/Player/createVideojsPlayer.ts
@@ -27,6 +27,11 @@ export const createVideojsPlayer = (
     controls: true,
     debug: false,
     fluid: true,
+    html5: {
+      vhs: {
+        overrideNative: !videojs.browser.IS_SAFARI,
+      },
+    },
     language: intl.locale,
     playbackRates: [0.5, 0.75, 1, 1.25, 1.5, 1.75, 2, 4],
     plugins: {


### PR DESCRIPTION
## Purpose

Videojs can override ARB native browser feature. When enabled,
videojs-http-streaming is used instead of native support of ABR. Lot of
broser have capabilities to run ABR content but lot of features can be
missing. Exception made for safari.

## Proposal

- [x] enable videojs override native feature except on safari

