### PR TITLE
Add mass upload of videos through a new Marsha site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Create a videojs plugin to manage MP4 selection
+- Create a CRUD video management site for Marsha, only open
+  in development until release.
 
 ### Changed
 
@@ -130,7 +132,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Use `UploadableFileMixin` on `AbstractImage` model
-- Fix dashboard read versus update permissions in situations 
+- Fix dashboard read versus update permissions in situations
   of playlist portability
 
 ## [3.9.1] - 2020-06-24
@@ -144,7 +146,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Detect original video framerate and use it in lambda encode
-- Limit video encoding resolution to that of the source 
+- Limit video encoding resolution to that of the source
 
 ## [3.8.1] - 2020-05-18
 
@@ -214,7 +216,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- New setting MAINTENANCE_MODE to disable the dashboard when Marsha is 
+- New setting MAINTENANCE_MODE to disable the dashboard when Marsha is
   in maintenance
 
 ### Changed

--- a/src/backend/marsha/core/api.py
+++ b/src/backend/marsha/core/api.py
@@ -206,6 +206,10 @@ class VideoViewSet(viewsets.ModelViewSet):
                 permissions.IsParamsPlaylistAdmin
                 | permissions.IsParamsPlaylistAdminThroughOrganization
             ]
+        elif self.action in ["destroy"]:
+            permission_classes = [
+                permissions.IsVideoPlaylistAdmin | permissions.IsVideoOrganizationAdmin
+            ]
         else:
             try:
                 permission_classes = (
@@ -322,7 +326,9 @@ class VideoViewSet(viewsets.ModelViewSet):
     )
     # pylint: disable=unused-argument
     def initiate_live(
-        self, request, pk=None,
+        self,
+        request,
+        pk=None,
     ):
         """Create a live stack on AWS ready to stream.
 
@@ -458,7 +464,9 @@ class VideoViewSet(viewsets.ModelViewSet):
     )
     # pylint: disable=unused-argument
     def update_live_state(
-        self, request, pk=None,
+        self,
+        request,
+        pk=None,
     ):
         """View handling AWS POST request to update the video live state.
 
@@ -550,7 +558,9 @@ class DocumentViewSet(
         key = document.get_source_s3_key(stamp=stamp, extension=extension)
 
         presigned_post = create_presigned_post(
-            [["content-length-range", 0, settings.DOCUMENT_SOURCE_MAX_SIZE]], {}, key,
+            [["content-length-range", 0, settings.DOCUMENT_SOURCE_MAX_SIZE]],
+            {},
+            key,
         )
 
         # Reset the upload state of the document
@@ -609,7 +619,9 @@ class TimedTextTrackViewSet(viewsets.ModelViewSet):
         key = timed_text_track.get_source_s3_key(stamp=stamp)
 
         presigned_post = create_presigned_post(
-            [["content-length-range", 0, settings.SUBTITLE_SOURCE_MAX_SIZE]], {}, key,
+            [["content-length-range", 0, settings.SUBTITLE_SOURCE_MAX_SIZE]],
+            {},
+            key,
         )
 
         # Reset the upload state of the timed text track

--- a/src/backend/marsha/core/api.py
+++ b/src/backend/marsha/core/api.py
@@ -79,7 +79,9 @@ class PlaylistViewSet(viewsets.ModelViewSet):
         Default to the actions' self defined permissions if applicable or
         to the ViewSet's default permissions.
         """
-        if self.action in ["list"]:
+        if self.action in ["create"]:
+            permission_classes = [permissions.IsParamsOrganizationAdmin]
+        elif self.action in ["list"]:
             permission_classes = [IsAuthenticated]
         else:
             try:

--- a/src/backend/marsha/core/forms.py
+++ b/src/backend/marsha/core/forms.py
@@ -1,0 +1,14 @@
+"""Marsha forms module."""
+from django.forms import ModelForm
+
+from . import models
+
+
+class VideoForm(ModelForm):
+    """Form to create or update videos."""
+
+    class Meta:
+        """Meta for VideoForm."""
+
+        model = models.Video
+        fields = ["description", "is_public", "lti_id", "playlist", "title"]

--- a/src/backend/marsha/core/permissions.py
+++ b/src/backend/marsha/core/permissions.py
@@ -269,3 +269,56 @@ class IsParamsPlaylistAdminThroughOrganization(permissions.BasePermission):
             ).exists()
         except models.OrganizationAccess.DoesNotExist:
             return False
+
+
+class IsVideoPlaylistAdmin(permissions.BasePermission):
+    """
+    Allow a request to proceed. Permission class.
+
+    Permission to allow a request to proceed only if the user is an admin for the playlist
+    the video is a part of.
+    """
+
+    def has_permission(self, request, view):
+        """
+        Allow the request.
+
+        Allow the request only if there is a video id in the path of the request, which exists,
+        and if the current user is an admin for the playlist this video is a part of.
+        """
+        try:
+            return models.PlaylistAccess.objects.filter(
+                role=ADMINISTRATOR,
+                # Avoid making extra requests to get the video or playlist id through get_object
+                playlist__videos__id=request.path.split("/")[3],
+                user__id=request.user.id,
+            ).exists()
+        except (models.PlaylistAccess.DoesNotExist, IndexError):
+            return False
+
+
+class IsVideoOrganizationAdmin(permissions.BasePermission):
+    """
+    Allow a request to proceed. Permission class.
+
+    Permission to allow a request to proceed only if the user is an admin for the organization
+    linked to the playlist the video is a part of.
+    """
+
+    def has_permission(self, request, view):
+        """
+        Allow the request.
+
+        Allow the request only if there is a video id in the path of the request, which exists,
+        and if the current user is an admin for the organization linked to the playlist this video
+        is a part of.
+        """
+        try:
+            return models.OrganizationAccess.objects.filter(
+                role=ADMINISTRATOR,
+                # Avoid making extra requests to get the video/playlist/org id through get_object
+                organization__playlists__videos__id=request.path.split("/")[3],
+                user__id=request.user.id,
+            ).exists()
+        except (models.OrganizationAccess.DoesNotExist, IndexError):
+            return False

--- a/src/backend/marsha/core/permissions.py
+++ b/src/backend/marsha/core/permissions.py
@@ -5,6 +5,18 @@ from rest_framework_simplejwt.models import TokenUser
 from .models.account import ADMINISTRATOR, INSTRUCTOR, LTI_ROLES
 
 
+class NotAllowed(permissions.BasePermission):
+    """
+    Utility permission class denies all requests.
+
+    This is used as a default to close requests to unsupported actions.
+    """
+
+    def has_permission(self, request, view):
+        """Deny permission always."""
+        return False
+
+
 class BaseResourcePermission(permissions.BasePermission):
     """Base permission class for JWT Tokens related to a resource object.
 

--- a/src/backend/marsha/core/permissions.py
+++ b/src/backend/marsha/core/permissions.py
@@ -213,3 +213,59 @@ class IsParamsOrganizationAdmin(permissions.BasePermission):
             ).exists()
         except models.OrganizationAccess.DoesNotExist:
             return False
+
+
+class IsParamsPlaylistAdmin(permissions.BasePermission):
+    """
+    Allow a request to proceed. Permission class.
+
+    Permission to allow a request to proceed only if the user provides the ID for an existing
+    playlist, and has an access to this playlist with an administrator role.
+    """
+
+    def has_permission(self, request, view):
+        """
+        Allow the request.
+
+        Allow the request only if the playlist from the params of body of the request exists
+        and the current logged in user is one of its administrators.
+        """
+        playlist_id = request.data.get("playlist") or request.query_params.get(
+            "playlist"
+        )
+        try:
+            return models.PlaylistAccess.objects.filter(
+                role=ADMINISTRATOR,
+                playlist__id=playlist_id,
+                user__id=request.user.id,
+            ).exists()
+        except models.PlaylistAccess.DoesNotExist:
+            return False
+
+
+class IsParamsPlaylistAdminThroughOrganization(permissions.BasePermission):
+    """
+    Allow a request to proceed. Permission class.
+
+    Permission to allow a request to proceed only if the user provides the ID for an existing
+    playlist, and has an access to this playlist's parent organization with an administrator role.
+    """
+
+    def has_permission(self, request, view):
+        """
+        Allow the request.
+
+        Allow the request only if the playlist from the params of body of the request exists
+        and the current logged in user is one of the administrators of its parent organization.
+        """
+        playlist_id = request.data.get("playlist") or request.query_params.get(
+            "playlist"
+        )
+        try:
+            return models.OrganizationAccess.objects.filter(
+                role=ADMINISTRATOR,
+                organization__playlists__id=playlist_id,
+                user__id=request.user.id,
+            ).exists()
+        except models.OrganizationAccess.DoesNotExist:
+            return False

--- a/src/backend/marsha/core/serializers.py
+++ b/src/backend/marsha/core/serializers.py
@@ -439,6 +439,10 @@ class PlaylistSerializer(serializers.ModelSerializer):
             "users",
         ]
 
+    def create(self, validated_data):
+        """Create the Playlist object with the passed data."""
+        return Playlist.objects.create(**validated_data)
+
 
 class PlaylistLiteSerializer(serializers.ModelSerializer):
     """A serializer to display a Playlist resource."""

--- a/src/backend/marsha/core/serializers.py
+++ b/src/backend/marsha/core/serializers.py
@@ -418,6 +418,29 @@ class ThumbnailSerializer(serializers.ModelSerializer):
 
 
 class PlaylistSerializer(serializers.ModelSerializer):
+    """Serializer to display a complete Playlist resource."""
+
+    class Meta:
+        """Meta for Playlistserializer."""
+
+        model = Playlist
+        fields = [
+            "consumer_site",
+            "created_by",
+            "duplicated_from",
+            "id",
+            "is_portable_to_playlist",
+            "is_portable_to_consumer_site",
+            "is_public",
+            "lti_id",
+            "organization",
+            "portable_to",
+            "title",
+            "users",
+        ]
+
+
+class PlaylistLiteSerializer(serializers.ModelSerializer):
     """A serializer to display a Playlist resource."""
 
     class Meta:  # noqa
@@ -466,7 +489,7 @@ class VideoSerializer(serializers.ModelSerializer):
         source="timedtexttracks", many=True, read_only=True
     )
     thumbnail = ThumbnailSerializer(read_only=True, allow_null=True)
-    playlist = PlaylistSerializer(read_only=True)
+    playlist = PlaylistLiteSerializer(read_only=True)
     urls = serializers.SerializerMethodField()
     is_ready_to_show = serializers.BooleanField(read_only=True)
     has_transcript = serializers.SerializerMethodField()
@@ -716,7 +739,7 @@ class DocumentSerializer(serializers.ModelSerializer):
     filename = serializers.SerializerMethodField()
     url = serializers.SerializerMethodField()
     is_ready_to_show = serializers.BooleanField(read_only=True)
-    playlist = PlaylistSerializer(read_only=True)
+    playlist = PlaylistLiteSerializer(read_only=True)
 
     def _get_extension_string(self, obj):
         """Document extension with the leading dot.

--- a/src/backend/marsha/core/templates/core/site.html
+++ b/src/backend/marsha/core/templates/core/site.html
@@ -1,0 +1,18 @@
+{% load static %}
+
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" type="text/css" href="{% static 'css/main.css' %}" />
+    <meta name="public-path" value="{{ static_base_url }}" />
+  </head>
+  <body>
+    <div id="marsha-frontend-data" data-context="{{ app_data }}"></div>
+
+    <div id="marsha-frontend-root"></div>
+    <script src='{% static "js/index.js" %}'></script>
+    {% for external_script in external_javascript_scripts %}
+    <script src="{{ external_script }}"></script>
+    {% endfor %}
+  </body>
+</html>

--- a/src/backend/marsha/core/templates/core/site.html
+++ b/src/backend/marsha/core/templates/core/site.html
@@ -1,15 +1,15 @@
 {% load static %}
 
 <!DOCTYPE html>
-<html>
+<html style="height: 100%;">
   <head>
     <link rel="stylesheet" type="text/css" href="{% static 'css/main.css' %}" />
     <meta name="public-path" value="{{ static_base_url }}" />
   </head>
-  <body>
+  <body style="height: 100%;">
     <div id="marsha-frontend-data" data-context="{{ app_data }}"></div>
 
-    <div id="marsha-frontend-root"></div>
+    <div id="marsha-frontend-root" style="height: 100%;"></div>
     <script src='{% static "js/index.js" %}'></script>
     {% for external_script in external_javascript_scripts %}
     <script src="{{ external_script }}"></script>

--- a/src/backend/marsha/core/tests/test_api_playlist.py
+++ b/src/backend/marsha/core/tests/test_api_playlist.py
@@ -1,0 +1,160 @@
+"""Tests for the Playlist API of the Marsha project."""
+from django.test import TestCase
+
+from rest_framework_simplejwt.tokens import AccessToken
+
+from .. import factories
+
+
+class PlaylistAPITest(TestCase):
+    """Test the API for playlist objects."""
+
+    def test_list_playlists_by_anonymous_user(self):
+        """Anonymous users cannot make list requests for playlists."""
+        factories.PlaylistFactory()
+        response = self.client.get("/api/playlists/")
+        self.assertEqual(response.status_code, 401)
+
+    def test_list_playlists_by_random_logged_in_user(self):
+        """
+        Random logged-in users can make list requests.
+
+        Will not receive playlists for organizations they are not a member of.
+        """
+        user = factories.UserFactory()
+        factories.PlaylistFactory()
+
+        jwt_token = AccessToken()
+        jwt_token.payload["resource_id"] = str(user.id)
+        jwt_token.payload["user_id"] = str(user.id)
+
+        response = self.client.get(
+            "/api/playlists/",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["count"], 0)
+        self.assertEqual(response.json()["results"], [])
+
+    def test_list_playlists_by_logged_in_user_with_organization_memberships(self):
+        """Organization members get all playlists they have access to."""
+        user = factories.UserFactory()
+
+        org_1 = factories.OrganizationFactory()
+        org_1.users.add(user)
+        playlist_1 = factories.PlaylistFactory(
+            lti_id="playlist#one", organization=org_1, title="First playlist"
+        )
+
+        org_2 = factories.OrganizationFactory()
+        org_2.users.add(user)
+        playlist_2 = factories.PlaylistFactory(
+            lti_id="playlist#two", organization=org_2, title="Second playlist"
+        )
+
+        # User is not a member of this organization
+        org_3 = factories.OrganizationFactory()
+        factories.PlaylistFactory(organization=org_3)
+
+        jwt_token = AccessToken()
+        jwt_token.payload["resource_id"] = str(user.id)
+        jwt_token.payload["user_id"] = str(user.id)
+
+        response = self.client.get(
+            "/api/playlists/",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["count"], 2)
+        self.assertEqual(
+            response.json()["results"],
+            [
+                {
+                    "consumer_site": str(playlist_1.consumer_site.id),
+                    "created_by": None,
+                    "duplicated_from": None,
+                    "id": str(playlist_1.id),
+                    "is_portable_to_consumer_site": False,
+                    "is_portable_to_playlist": True,
+                    "is_public": False,
+                    "lti_id": "playlist#one",
+                    "organization": str(org_1.id),
+                    "portable_to": [],
+                    "title": "First playlist",
+                    "users": [],
+                },
+                {
+                    "consumer_site": str(playlist_2.consumer_site.id),
+                    "created_by": None,
+                    "duplicated_from": None,
+                    "id": str(playlist_2.id),
+                    "is_portable_to_consumer_site": False,
+                    "is_portable_to_playlist": True,
+                    "is_public": False,
+                    "lti_id": "playlist#two",
+                    "organization": str(org_2.id),
+                    "portable_to": [],
+                    "title": "Second playlist",
+                    "users": [],
+                },
+            ],
+        )
+
+    def test_list_playlists_for_organization_by_logged_in_user_with_organization_memberships(
+        self,
+    ):
+        """
+        Organization members.
+
+        They can list all the playlists for a given organization of which
+        they are a member.
+        """
+        user = factories.UserFactory()
+
+        org_1 = factories.OrganizationFactory()
+        org_1.users.add(user)
+        playlist_1 = factories.PlaylistFactory(
+            lti_id="playlist#eleven", organization=org_1, title="First playlist"
+        )
+
+        # User is a member of this organization, but it is not included in the request below
+        org_2 = factories.OrganizationFactory()
+        org_2.users.add(user)
+        factories.PlaylistFactory(organization=org_2, title="Second playlist")
+
+        # User is not a member of this organization
+        org_3 = factories.OrganizationFactory()
+        factories.PlaylistFactory(organization=org_3)
+
+        jwt_token = AccessToken()
+        jwt_token.payload["resource_id"] = str(user.id)
+        jwt_token.payload["user_id"] = str(user.id)
+
+        response = self.client.get(
+            f"/api/playlists/?organization={str(org_1.id)}",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["count"], 1)
+        self.assertEqual(
+            response.json()["results"],
+            [
+                {
+                    "consumer_site": str(playlist_1.consumer_site.id),
+                    "created_by": None,
+                    "duplicated_from": None,
+                    "id": str(playlist_1.id),
+                    "is_portable_to_consumer_site": False,
+                    "is_portable_to_playlist": True,
+                    "is_public": False,
+                    "lti_id": "playlist#eleven",
+                    "organization": str(org_1.id),
+                    "portable_to": [],
+                    "title": "First playlist",
+                    "users": [],
+                },
+            ],
+        )

--- a/src/backend/marsha/core/tests/test_api_timed_text_track.py
+++ b/src/backend/marsha/core/tests/test_api_timed_text_track.py
@@ -468,12 +468,15 @@ class TimedTextTrackAPITest(TestCase):
         )
         self.assertEqual(response.status_code, 200)
         timed_text_track_list = json.loads(response.content)
-        self.assertEqual(len(timed_text_track_list), 2)
+        self.assertEqual(len(timed_text_track_list["results"]), 2)
+        self.assertEqual(timed_text_track_list["count"], 2)
         self.assertTrue(
-            str(timed_text_track_one.id) in (ttt["id"] for ttt in timed_text_track_list)
+            str(timed_text_track_one.id)
+            in (ttt["id"] for ttt in timed_text_track_list["results"])
         )
         self.assertTrue(
-            str(timed_text_track_two.id) in (ttt["id"] for ttt in timed_text_track_list)
+            str(timed_text_track_two.id)
+            in (ttt["id"] for ttt in timed_text_track_list["results"])
         )
 
     def test_api_timed_text_track_read_list_staff_or_user(self):

--- a/src/backend/marsha/core/tests/test_api_user.py
+++ b/src/backend/marsha/core/tests/test_api_user.py
@@ -1,0 +1,86 @@
+"""Tests for the User API of the Marsha project."""
+from django.test import TestCase
+
+from rest_framework_simplejwt.tokens import AccessToken
+
+from .. import factories
+
+
+class UserAPITest(TestCase):
+    """Test the API for user objects."""
+
+    # WHOAMI TESTS
+    def test_whoami_by_anonymous_user(self):
+        """
+        Anonymous users can make `whoami` requests.
+
+        They receive a 401 response confirming they are not logged in.
+        """
+        response = self.client.get("/api/users/whoami/")
+        self.assertEqual(response.status_code, 401)
+
+    def test_whoami_by_logged_in_user(self):
+        """
+        Logged-in users can make `whoami` requests.
+
+        They receive their own user object.
+        """
+        user = factories.UserFactory(
+            first_name="Jane", last_name="Doe", email="jane.doe@example.com"
+        )
+        org_1 = factories.OrganizationFactory()
+        org_access_1 = factories.OrganizationAccessFactory(
+            user=user, organization=org_1
+        )
+        org_2 = factories.OrganizationFactory()
+        org_access_2 = factories.OrganizationAccessFactory(
+            user=user, organization=org_2
+        )
+
+        jwt_token = AccessToken()
+        jwt_token.payload["resource_id"] = str(user.id)
+        jwt_token.payload["user_id"] = str(user.id)
+
+        with self.assertNumQueries(3):
+            response = self.client.get(
+                "/api/users/whoami/",
+                HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json()["date_joined"],
+            user.date_joined.isoformat()[:-6] + "Z",  # NB: DRF literally does this
+        )
+        self.assertEqual(response.json()["email"], "jane.doe@example.com")
+        self.assertEqual(response.json()["first_name"], "Jane")
+        self.assertEqual(response.json()["id"], str(user.id))
+        self.assertEqual(response.json()["is_staff"], False)
+        self.assertEqual(response.json()["is_superuser"], False)
+        self.assertEqual(response.json()["last_name"], "Doe")
+
+        resp_accesses = response.json()["organization_accesses"]
+        resp_org_access_1 = (
+            resp_accesses.pop(0)
+            if resp_accesses[0]["organization"] == str(org_1.id)
+            else resp_accesses.pop(1)
+        )
+        self.assertEqual(
+            resp_org_access_1,
+            {
+                "organization": str(org_1.id),
+                "organization_name": org_1.name,
+                "role": org_access_1.role,
+                "user": str(user.id),
+            },
+        )
+        resp_org_access_2 = resp_accesses.pop(0)
+        self.assertEqual(
+            resp_org_access_2,
+            {
+                "organization": str(org_2.id),
+                "organization_name": org_2.name,
+                "role": org_access_2.role,
+                "user": str(user.id),
+            },
+        )

--- a/src/backend/marsha/core/tests/test_api_video.py
+++ b/src/backend/marsha/core/tests/test_api_video.py
@@ -400,7 +400,7 @@ class VideoAPITest(TestCase):
         """Anonymous users should not be able to read a list of videos."""
         VideoFactory()
         response = self.client.get("/api/videos/")
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 401)
 
     def test_api_video_read_list_token_user(self):
         """A token user associated to a video should not be able to read a list of videos."""
@@ -412,7 +412,7 @@ class VideoAPITest(TestCase):
         response = self.client.get(
             "/api/videos/", HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token)
         )
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 403)
 
     @override_settings(CLOUDFRONT_SIGNED_URLS_ACTIVE=False)
     def test_api_video_with_a_thumbnail(self):
@@ -487,12 +487,12 @@ class VideoAPITest(TestCase):
             self.client.login(username=user.username, password="test")
             VideoFactory()
             response = self.client.get("/api/videos/")
-            self.assertEqual(response.status_code, 404)
+            self.assertEqual(response.status_code, 401)
 
     def test_api_video_create_anonymous(self):
         """Anonymous users should not be able to create a new video."""
         response = self.client.post("/api/videos/")
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 401)
         self.assertFalse(Video.objects.exists())
 
     def test_api_video_create_token_user_playlist_preexists(self):
@@ -501,7 +501,7 @@ class VideoAPITest(TestCase):
         response = self.client.post(
             "/api/videos/", HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token)
         )
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 401)
         self.assertFalse(Video.objects.exists())
 
     def test_api_video_create_staff_or_user(self):
@@ -509,7 +509,7 @@ class VideoAPITest(TestCase):
         for user in [UserFactory(), UserFactory(is_staff=True)]:
             self.client.login(username=user.username, password="test")
             response = self.client.post("/api/videos/")
-            self.assertEqual(response.status_code, 404)
+            self.assertEqual(response.status_code, 401)
             self.assertFalse(Video.objects.exists())
 
     def test_api_video_update_detail_anonymous(self):
@@ -774,9 +774,7 @@ class VideoAPITest(TestCase):
                 "/api/videos/{!s}/".format(video.id),
                 HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token),
             )
-            self.assertEqual(response.status_code, 405)
-            content = json.loads(response.content)
-            self.assertEqual(content, {"detail": 'Method "DELETE" not allowed.'})
+            self.assertEqual(response.status_code, 403)
             self.assertTrue(Video.objects.filter(id=video.id).exists())
 
     def test_api_video_delete_detail_staff_or_user(self):
@@ -814,7 +812,7 @@ class VideoAPITest(TestCase):
 
         response = self.client.delete("/api/videos/")
 
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 401)
         self.assertTrue(Video.objects.filter(id=video.id).exists())
 
     def test_api_video_delete_list_token_user(self):
@@ -827,7 +825,7 @@ class VideoAPITest(TestCase):
         response = self.client.delete(
             "/api/videos/", HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token)
         )
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 403)
         self.assertTrue(Video.objects.filter(id=video.id).exists())
 
     def test_api_video_delete_list_staff_or_user(self):
@@ -838,7 +836,7 @@ class VideoAPITest(TestCase):
 
             response = self.client.delete("/api/videos/")
 
-            self.assertEqual(response.status_code, 404)
+            self.assertEqual(response.status_code, 401)
         self.assertTrue(Video.objects.filter(id=video.id).exists())
 
     def test_api_video_initiate_upload_anonymous_user(self):

--- a/src/backend/marsha/core/views.py
+++ b/src/backend/marsha/core/views.py
@@ -265,7 +265,9 @@ class BaseLTIView(ABC, TemplateResponseMixin, View):
         An instance of the model
         """
         return self.model.objects.select_related("playlist").get(
-            self.model.get_ready_clause(), is_public=True, pk=resource_id,
+            self.model.get_ready_clause(),
+            is_public=True,
+            pk=resource_id,
         )
 
     def get_public_data(self):

--- a/src/backend/marsha/core/views.py
+++ b/src/backend/marsha/core/views.py
@@ -68,7 +68,12 @@ class SiteView(mixins.WaffleSwitchMixin, TemplateView):
 
     def get_context_data(self, **kwargs):
         """Build the context necessary to run the frontend app for the site."""
-        app_data = {"frontend": "Site"}
+        jwt_token = AccessToken()
+        jwt_token.payload["resource_id"] = str(self.request.user.id)
+        jwt_token.payload["user_id"] = str(self.request.user.id)
+
+        app_data = {"frontend": "Site", "jwt": str(jwt_token)}
+
         return {
             "app_data": json.dumps(app_data),
             "external_javascript_scripts": settings.EXTERNAL_JAVASCRIPT_SCRIPTS,

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -154,6 +154,8 @@ class Base(Configuration):
             "rest_framework_simplejwt.authentication.JWTTokenUserAuthentication",
         ),
         "EXCEPTION_HANDLER": "marsha.core.views.exception_handler",
+        "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.LimitOffsetPagination",
+        "PAGE_SIZE": 50,
     }
 
     # WAFFLE

--- a/src/backend/marsha/urls.py
+++ b/src/backend/marsha/urls.py
@@ -17,7 +17,7 @@ from marsha.core.api import (
     XAPIStatementView,
     update_state,
 )
-from marsha.core.views import DevelopmentLTIView, DocumentView, VideoView
+from marsha.core.views import DevelopmentLTIView, DocumentView, SiteView, VideoView
 
 
 router = DefaultRouter()
@@ -48,6 +48,7 @@ urlpatterns = [
     ),
     path("api/", include(router.urls)),
     path("xapi/", XAPIStatementView.as_view(), name="xapi"),
+    path("", SiteView.as_view(), name="site"),
 ]
 
 if settings.DEBUG:

--- a/src/backend/marsha/urls.py
+++ b/src/backend/marsha/urls.py
@@ -11,6 +11,7 @@ from marsha.core import models
 from marsha.core.admin import admin_site
 from marsha.core.api import (
     DocumentViewSet,
+    PlaylistViewSet,
     ThumbnailViewSet,
     TimedTextTrackViewSet,
     UserViewSet,
@@ -30,6 +31,7 @@ router.register(
     basename="timed_text_tracks",
 )
 router.register(models.Thumbnail.RESOURCE_NAME, ThumbnailViewSet, basename="thumbnails")
+router.register("playlists", PlaylistViewSet, basename="playlists")
 router.register("users", UserViewSet, basename="users")
 
 urlpatterns = [

--- a/src/backend/marsha/urls.py
+++ b/src/backend/marsha/urls.py
@@ -13,6 +13,7 @@ from marsha.core.api import (
     DocumentViewSet,
     ThumbnailViewSet,
     TimedTextTrackViewSet,
+    UserViewSet,
     VideoViewSet,
     XAPIStatementView,
     update_state,
@@ -29,6 +30,7 @@ router.register(
     basename="timed_text_tracks",
 )
 router.register(models.Thumbnail.RESOURCE_NAME, ThumbnailViewSet, basename="thumbnails")
+router.register("users", UserViewSet, basename="users")
 
 urlpatterns = [
     # Admin

--- a/src/frontend/components/DashboardTimedTextPane/index.spec.tsx
+++ b/src/frontend/components/DashboardTimedTextPane/index.spec.tsx
@@ -70,30 +70,35 @@ describe('<DashboardTimedTextPane />', () => {
   });
 
   it('gets the list of timedtexttracks and displays them by mode', async () => {
-    fetchMock.get('/api/timedtexttracks/?limit=20&offset=0', [
-      {
-        active_stamp: 2094219242,
-        id: '142',
-        is_ready_to_show: true,
-        language: 'en',
-        mode: timedTextMode.SUBTITLE,
-        upload_state: uploadState.READY,
-        source_url: 'https://example.com/ttt/142',
-        url: 'https://example.com/ttt/142.vtt',
-        video: '43',
-      },
-      {
-        active_stamp: 2094219242,
-        id: '144',
-        is_ready_to_show: true,
-        language: 'fr',
-        mode: timedTextMode.CLOSED_CAPTIONING,
-        upload_state: uploadState.READY,
-        source_url: 'https://example.com/ttt/144',
-        url: 'https://example.com/ttt/144.vtt',
-        video: '43',
-      },
-    ]);
+    fetchMock.get('/api/timedtexttracks/?limit=20&offset=0', {
+      count: 2,
+      next: null,
+      previous: null,
+      results: [
+        {
+          active_stamp: 2094219242,
+          id: '142',
+          is_ready_to_show: true,
+          language: 'en',
+          mode: timedTextMode.SUBTITLE,
+          upload_state: uploadState.READY,
+          source_url: 'https://example.com/ttt/142',
+          url: 'https://example.com/ttt/142.vtt',
+          video: '43',
+        },
+        {
+          active_stamp: 2094219242,
+          id: '144',
+          is_ready_to_show: true,
+          language: 'fr',
+          mode: timedTextMode.CLOSED_CAPTIONING,
+          upload_state: uploadState.READY,
+          source_url: 'https://example.com/ttt/144',
+          url: 'https://example.com/ttt/144.vtt',
+          video: '43',
+        },
+      ],
+    });
 
     render(wrapInIntlProvider(wrapInRouter(<DashboardTimedTextPane />)));
 

--- a/src/frontend/components/LTIRoutes/index.tsx
+++ b/src/frontend/components/LTIRoutes/index.tsx
@@ -18,7 +18,7 @@ const Dashboard = lazy(() => import('../Dashboard'));
 const DocumentPlayer = lazy(() => import('../DocumentPlayer'));
 const VideoPlayer = lazy(() => import('../VideoPlayer'));
 
-export const AppRoutes = () => (
+export const Routes = () => (
   <MemoryRouter>
     <Suspense fallback={<Loader />}>
       <Switch>

--- a/src/frontend/components/SiteHeader/index.tsx
+++ b/src/frontend/components/SiteHeader/index.tsx
@@ -1,0 +1,50 @@
+import { Anchor, Button, Header, Text } from 'grommet';
+import React from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+
+import {
+  AnonymousUser,
+  useCurrentUser,
+} from '../../data/stores/useCurrentUser';
+import { Loader } from '../Loader';
+import { withLink } from '../withLink/withLink';
+
+const messages = defineMessages({
+  logInBtn: {
+    defaultMessage: 'Log in',
+    description: 'Text for the login button in the header of the marsha site',
+    id: 'components.SiteHeader.logInBtn',
+  },
+});
+
+const TitleLink = withLink(Anchor);
+
+export const SiteHeader: React.FC = () => {
+  const currentUser = useCurrentUser().getCurrentUser();
+
+  return (
+    <Header
+      gridArea="header"
+      direction="row"
+      align="center"
+      justify="between"
+      pad={{ horizontal: 'medium', vertical: 'small' }}
+      background="dark-2"
+    >
+      <TitleLink to="/" size="large" color="white">
+        marsha.education
+      </TitleLink>
+      {currentUser ? (
+        currentUser === AnonymousUser.ANONYMOUS ? (
+          <Button>
+            <FormattedMessage {...messages.logInBtn} />
+          </Button>
+        ) : (
+          <Text>{currentUser.email}</Text>
+        )
+      ) : (
+        <Loader />
+      )}
+    </Header>
+  );
+};

--- a/src/frontend/components/SiteLayout/index.tsx
+++ b/src/frontend/components/SiteLayout/index.tsx
@@ -1,0 +1,48 @@
+import { Anchor, Box, Button, Grid, Header, Nav, Sidebar, Text } from 'grommet';
+import React from 'react';
+
+import { withLink } from '../withLink/withLink';
+
+const TitleLink = withLink(Anchor);
+
+const SidebarLink = withLink(Anchor);
+
+export const SiteLayout: React.FC = ({ children }) => (
+  <Grid
+    fill
+    rows={['auto', 'flex']}
+    columns={['20%', '80%']}
+    areas={[
+      { name: 'header', start: [0, 0], end: [1, 0] },
+      { name: 'sidebar', start: [0, 1], end: [0, 1] },
+      { name: 'main', start: [1, 1], end: [1, 1] },
+    ]}
+  >
+    <Header
+      gridArea="header"
+      direction="row"
+      align="center"
+      justify="between"
+      pad={{ horizontal: 'medium', vertical: 'small' }}
+      background="dark-2"
+    >
+      <TitleLink to="/" size="large" color="white">
+        marsha.education
+      </TitleLink>
+      <Text>user@example.com</Text>
+    </Header>
+    <Sidebar gridArea="sidebar" background="dark-3" width="medium">
+      <Nav>
+        <SidebarLink
+          to="/"
+          margin={{ horizontal: 'medium', vertical: 'small' }}
+        >
+          My organization
+        </SidebarLink>
+      </Nav>
+    </Sidebar>
+    <Box gridArea="main" justify="start" align="start">
+      {children}
+    </Box>
+  </Grid>
+);

--- a/src/frontend/components/SiteLayout/index.tsx
+++ b/src/frontend/components/SiteLayout/index.tsx
@@ -1,9 +1,8 @@
-import { Anchor, Box, Button, Grid, Header, Nav, Sidebar, Text } from 'grommet';
+import { Anchor, Box, Grid, Nav, Sidebar } from 'grommet';
 import React from 'react';
 
+import { SiteHeader } from '../SiteHeader';
 import { withLink } from '../withLink/withLink';
-
-const TitleLink = withLink(Anchor);
 
 const SidebarLink = withLink(Anchor);
 
@@ -18,19 +17,7 @@ export const SiteLayout: React.FC = ({ children }) => (
       { name: 'main', start: [1, 1], end: [1, 1] },
     ]}
   >
-    <Header
-      gridArea="header"
-      direction="row"
-      align="center"
-      justify="between"
-      pad={{ horizontal: 'medium', vertical: 'small' }}
-      background="dark-2"
-    >
-      <TitleLink to="/" size="large" color="white">
-        marsha.education
-      </TitleLink>
-      <Text>user@example.com</Text>
-    </Header>
+    <SiteHeader />
     <Sidebar gridArea="sidebar" background="dark-3" width="medium">
       <Nav>
         <SidebarLink

--- a/src/frontend/components/SiteLayout/index.tsx
+++ b/src/frontend/components/SiteLayout/index.tsx
@@ -1,10 +1,8 @@
-import { Anchor, Box, Grid, Nav, Sidebar } from 'grommet';
+import { Box, Grid } from 'grommet';
 import React from 'react';
 
 import { SiteHeader } from '../SiteHeader';
-import { withLink } from '../withLink/withLink';
-
-const SidebarLink = withLink(Anchor);
+import { SiteSidebar } from '../SiteSidebar';
 
 export const SiteLayout: React.FC = ({ children }) => (
   <Grid
@@ -18,16 +16,7 @@ export const SiteLayout: React.FC = ({ children }) => (
     ]}
   >
     <SiteHeader />
-    <Sidebar gridArea="sidebar" background="dark-3" width="medium">
-      <Nav>
-        <SidebarLink
-          to="/"
-          margin={{ horizontal: 'medium', vertical: 'small' }}
-        >
-          My organization
-        </SidebarLink>
-      </Nav>
-    </Sidebar>
+    <SiteSidebar />
     <Box gridArea="main" justify="start" align="start">
       {children}
     </Box>

--- a/src/frontend/components/SiteRoutes/index.tsx
+++ b/src/frontend/components/SiteRoutes/index.tsx
@@ -1,8 +1,19 @@
+import { Heading, Main } from 'grommet';
 import React from 'react';
-import { BrowserRouter, Switch } from 'react-router-dom';
+import { BrowserRouter, Route, Switch } from 'react-router-dom';
+
+import { SiteLayout } from '../SiteLayout';
 
 export const Routes = () => (
   <BrowserRouter>
-    <Switch></Switch>
+    <SiteLayout>
+      <Switch>
+        <Route>
+          <Main>
+            <Heading margin="medium">The main content</Heading>
+          </Main>
+        </Route>
+      </Switch>
+    </SiteLayout>
   </BrowserRouter>
 );

--- a/src/frontend/components/SiteRoutes/index.tsx
+++ b/src/frontend/components/SiteRoutes/index.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { BrowserRouter, Switch } from 'react-router-dom';
+
+export const Routes = () => (
+  <BrowserRouter>
+    <Switch></Switch>
+  </BrowserRouter>
+);

--- a/src/frontend/components/SiteSidebar/index.tsx
+++ b/src/frontend/components/SiteSidebar/index.tsx
@@ -1,0 +1,39 @@
+import { Anchor, Nav, Sidebar } from 'grommet';
+import React from 'react';
+
+import {
+  AnonymousUser,
+  useCurrentUser,
+} from '../../data/stores/useCurrentUser';
+import { OrganizationAccessRole } from '../../types/User';
+import { withLink } from '../withLink/withLink';
+
+const SidebarLink = withLink(Anchor);
+
+export const SiteSidebar: React.FC = () => {
+  const currentUser = useCurrentUser().getCurrentUser();
+
+  return (
+    <Sidebar gridArea="sidebar" background="dark-3" width="medium">
+      <Nav>
+        {currentUser && currentUser !== AnonymousUser.ANONYMOUS ? (
+          <React.Fragment>
+            {currentUser.organization_accesses
+              .filter(
+                (orgAccess) =>
+                  orgAccess.role === OrganizationAccessRole.ADMINISTRATOR,
+              )
+              .map((orgAccess) => (
+                <SidebarLink
+                  to={`/organization/${orgAccess.organization}`}
+                  margin={{ horizontal: 'medium', vertical: 'small' }}
+                >
+                  {orgAccess.organization_name}
+                </SidebarLink>
+              ))}
+          </React.Fragment>
+        ) : null}
+      </Nav>
+    </Sidebar>
+  );
+};

--- a/src/frontend/data/sideEffects/getCurrentUser/index.tsx
+++ b/src/frontend/data/sideEffects/getCurrentUser/index.tsx
@@ -1,0 +1,40 @@
+import { API_ENDPOINT } from '../../../settings';
+import { requestStatus } from '../../../types/api';
+import { report } from '../../../utils/errors/report';
+import { appData } from '../../appData';
+import { AnonymousUser } from '../../stores/useCurrentUser';
+
+/**
+ * Makes and handles the GET request for the current user.
+ * @returns a promise for a request status, so the side effect caller can simply wait for it if needed.
+ */
+export const getCurrentUser = async (): Promise<requestStatus> => {
+  try {
+    const { useCurrentUser } = await import('../../stores/useCurrentUser');
+
+    const response = await fetch(`${API_ENDPOINT}/users/whoami/`, {
+      headers: {
+        Authorization: `Bearer ${appData.jwt}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (response.status === 401) {
+      useCurrentUser.getState().setCurrentUser(AnonymousUser.ANONYMOUS);
+      return requestStatus.SUCCESS;
+    }
+
+    if (!response.ok) {
+      // Push remote errors to the error channel for consistency
+      throw new Error(`Failed to get current user : ${response.status}.`);
+    }
+
+    const currentUser = await response.json();
+    useCurrentUser.getState().setCurrentUser(currentUser);
+
+    return requestStatus.SUCCESS;
+  } catch (error) {
+    report(error);
+    return requestStatus.FAILURE;
+  }
+};

--- a/src/frontend/data/sideEffects/getResourceList/index.spec.tsx
+++ b/src/frontend/data/sideEffects/getResourceList/index.spec.tsx
@@ -46,7 +46,12 @@ describe('sideEffects/getResourceList', () => {
   it('requests the resource list, handles the response and resolves with a success', async () => {
     fetchMock.mock(
       '/api/videos/?limit=2&offset=43',
-      JSON.stringify([video42, video43]),
+      JSON.stringify({
+        count: 2,
+        next: null,
+        previous: null,
+        results: [video42, video43],
+      }),
     );
 
     const status = await getResourceList(modelName.VIDEOS, {

--- a/src/frontend/data/sideEffects/getResourceList/index.ts
+++ b/src/frontend/data/sideEffects/getResourceList/index.ts
@@ -39,8 +39,8 @@ export const getResourceList = async (
       );
     }
 
-    const resources = await response.json();
-    await addMultipleResources(resourceName, resources);
+    const resourcesResponse = await response.json();
+    await addMultipleResources(resourceName, resourcesResponse.results);
     return requestStatus.SUCCESS;
   } catch (error) {
     report(error);

--- a/src/frontend/data/stores/useCurrentUser/index.tsx
+++ b/src/frontend/data/stores/useCurrentUser/index.tsx
@@ -1,0 +1,29 @@
+import create from 'zustand';
+
+import { getCurrentUser } from '../../sideEffects/getCurrentUser';
+import { User } from '../../../types/User';
+import { Nullable } from '../../../utils/types';
+
+export enum AnonymousUser {
+  ANONYMOUS = 'AnonymousUser',
+}
+
+type CurrentUserState = {
+  getCurrentUser: () => Nullable<User | AnonymousUser>;
+  setCurrentUser: (user: User | AnonymousUser) => void;
+  currentUser: Nullable<User | AnonymousUser>;
+};
+
+export const useCurrentUser = create<CurrentUserState>((set, get) => ({
+  currentUser: null,
+  setCurrentUser: (currentUser) => {
+    set({ currentUser });
+  },
+  getCurrentUser: () => {
+    const currentUser = get().currentUser;
+    if (!currentUser) {
+      getCurrentUser();
+    }
+    return get().currentUser;
+  },
+}));

--- a/src/frontend/index.tsx
+++ b/src/frontend/index.tsx
@@ -99,7 +99,7 @@ document.addEventListener('DOMContentLoaded', async (event) => {
   // Render our actual component tree
   ReactDOM.render(
     <RawIntlProvider value={intl}>
-      <Grommet theme={theme}>
+      <Grommet theme={theme} style={{ height: '100%' }}>
         <App />
         <GlobalStyles />
       </Grommet>

--- a/src/frontend/index.tsx
+++ b/src/frontend/index.tsx
@@ -11,7 +11,6 @@ import {
   RawIntlProvider,
 } from 'react-intl';
 
-import { AppRoutes } from './components/AppRoutes';
 import { appData, getDecodedJwt } from './data/appData';
 import { report } from './utils/errors/report';
 // Load our style reboot into the DOM
@@ -87,11 +86,21 @@ document.addEventListener('DOMContentLoaded', async (event) => {
     cache,
   );
 
+  let App: () => JSX.Element;
+  try {
+    const { Routes } = await import(`./components/${appData.frontend}Routes`);
+    App = Routes;
+  } catch (e) {
+    throw new Error(
+      `${appData.frontend} is not an expected value for appData.frontend`,
+    );
+  }
+
   // Render our actual component tree
   ReactDOM.render(
     <RawIntlProvider value={intl}>
       <Grommet theme={theme}>
-        <AppRoutes />
+        <App />
         <GlobalStyles />
       </Grommet>
     </RawIntlProvider>,

--- a/src/frontend/types/AppData.ts
+++ b/src/frontend/types/AppData.ts
@@ -20,6 +20,7 @@ export interface AppData {
   modelName: modelName.VIDEOS | modelName.DOCUMENTS;
   sentry_dsn: Nullable<string>;
   environment: string;
+  frontend: string;
   release: string;
   static: {
     svg: {

--- a/src/frontend/types/User.ts
+++ b/src/frontend/types/User.ts
@@ -1,0 +1,23 @@
+export enum OrganizationAccessRole {
+  ADMINISTRATOR = 'administrator',
+  INSTRUCTOR = 'instructor',
+  STUDENT = 'student',
+}
+
+export interface OrganizationAccess {
+  organization: string;
+  organization_name: string;
+  role: OrganizationAccessRole;
+  user: string;
+}
+
+export interface User {
+  date_joined: string;
+  email: string;
+  first_name: string;
+  id: string;
+  is_staff: boolean;
+  is_superuser: boolean;
+  last_name: string;
+  organization_accesses: OrganizationAccess[];
+}


### PR DESCRIPTION
## Purpose

We want to enable users to upload several videos at once, so they can easily add them to courses in a CMS later on.

To do this, we chose to create a new Marsha site, in a new frontend with a separate entry point from the LTI frontend.

## Proposal

- [x] create a django View/template/url and a frontend entry point through `index.tsx` for the new site frontend
- [x] set up a basic layout for the site (to be improved)
- [x] open a `whoami` endpoint to get the current user
- [x] add a "current user store" to the frontend, use it to list orgs the user has access to in the sidebar 
- [x]  add a `ViewSet` to list/create playlists in organizations
- [x] update the `VideoViewSet` to list & filter videos
- [x] ... and to create and delete videos

We chose to defer more frontend building wrt. CRUD management of playlists & videos as well as the videos & timed text track upload experience to later PRs.

By hiding the site behind a DEBUG flag, we can move forward with this PR, continually merge our work into main (hopefully breaking it down to smaller pieces), and only release the site when we're ready.

In our opinion this PR is a good starting point with the basic architecture of a new site as well as a bunch of basic API routes we need to go any further.


