### PR TITLE
Upgrade terraform to version 0.14

### DIFF
--- a/src/aws/.terraform.lock.hcl
+++ b/src/aws/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.25.0"
+  constraints = "~> 3.25"
+  hashes = [
+    "h1:9bXU5cFO/2DX8z5whaGMA7wcCalKQJZrBm89AuePuEM=",
+    "zh:2d3c65461bc63ec39bce7b5afdbed9a3b4dd5c2c8ee94616ad1866e24cf9b8f0",
+    "zh:2fb2ea6ccac30b909b603e183433737a30c58ec1f9a6a8b5565f0f051490c07a",
+    "zh:31a5f192c8cf29fb677cd639824f9a685578a2564c6b790517db33ea56229045",
+    "zh:437a12cf9a4d7bc92c9bf14ee7e224d5d3545cbd2154ba113ae82c4bb68edc27",
+    "zh:4bbdc3155a5dea90b2d50adfa460b0759c4dd959efaf7f66b2a0385a53b469b2",
+    "zh:63a8cd523ba31358692a34a06e111d88769576ac6d0e5adad8e0b4ae0a2d8882",
+    "zh:c4301ce86e8cb2c464949bb99e729ffe7b0c55eaf34b82ba526bb5039bca36f3",
+    "zh:c97b84861c6c550b8d2feb12d089660fffbf51dc7d660dcc9d54d4a7b3c2c882",
+    "zh:d6a103570e2d5c387b068fac4b88654dfa21d44ca1bdfa4bc8ab94c88effd71a",
+    "zh:f08cf2faf960a8ca374ac860f37c31c88ed2bab460116ac74678e0591babaac5",
+  ]
+}

--- a/src/aws/bin/terraform
+++ b/src/aws/bin/terraform
@@ -9,5 +9,5 @@ docker run --rm -it \
     -v "${PWD}/:/app" \
     -w "/app" \
     --env-file ./env.d/development \
-    "hashicorp/terraform:0.13.5" \
+    "hashicorp/terraform:0.14.5" \
     "$@"

--- a/src/aws/provider.tf
+++ b/src/aws/provider.tf
@@ -1,3 +1,8 @@
-provider "aws" {
-  version = "~> 3.25"
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.25"
+    }
+  }
 }

--- a/src/aws/provider.tf
+++ b/src/aws/provider.tf
@@ -1,3 +1,3 @@
 provider "aws" {
-  version = "~> 3.22"
+  version = "~> 3.25"
 }

--- a/src/aws/shared_resources/provider.tf
+++ b/src/aws/shared_resources/provider.tf
@@ -1,3 +1,3 @@
 provider "aws" {
-  version = "~> 3.22"
+  version = "~> 3.25"
 }


### PR DESCRIPTION
## Purpose

Terraform 0.14 is available. We want to upgrade it before a new version is released to ease its upgrade.
A lock file is now generated and committed here.

## Proposal

- [x] upgrade terraform to version 0.14
- [x] upgrade aws provider to version 3.25 

