### PR TITLE
Manage live to vod lifecycle in backend application

### DIFF
--- a/src/aws/lambda-mediapackage/src/check.js
+++ b/src/aws/lambda-mediapackage/src/check.js
@@ -35,7 +35,7 @@ module.exports = async (event) => {
   }
 
   // update state
-  return updateState(event.videoEndpoint, 'pending_live', {
+  return updateState(event.videoEndpoint, 'harvested', {
     resolutions: expectedFiles.resolutions.map(Number), // force casting resolutions in number
   });
 };

--- a/src/aws/lambda-mediapackage/src/check.spec.js
+++ b/src/aws/lambda-mediapackage/src/check.spec.js
@@ -134,7 +134,7 @@ describe('check', () => {
 
     expect(mockUpdateState).toHaveBeenCalledWith(
       'a3e213a7-9c56-4bd3-b71c-fe567b0cfe19/video/a3e213a7-9c56-4bd3-b71c-fe567b0cfe19/1610458282',
-      'pending_live',
+      'harvested',
       {
         resolutions: [540, 720],
       },

--- a/src/backend/marsha/core/api.py
+++ b/src/backend/marsha/core/api.py
@@ -318,6 +318,7 @@ class VideoViewSet(
 
         if video.live_state == defaults.STOPPED:
             live_info.update({"stopped_at": stamp})
+            video.upload_state = defaults.HARVESTING
             video.live_info = live_info
             create_mediapackage_harvest_job(video)
             delete_aws_element_stack(video)

--- a/src/backend/marsha/core/api.py
+++ b/src/backend/marsha/core/api.py
@@ -86,7 +86,7 @@ def update_state(request):
     object_instance.update_upload_state(
         upload_state=serializer.validated_data["state"],
         uploaded_on=key_elements.get("uploaded_on")
-        if serializer.validated_data["state"] == defaults.READY
+        if serializer.validated_data["state"] in [defaults.READY, defaults.HARVESTED]
         else None,
         **extra_parameters,
     )

--- a/src/backend/marsha/core/defaults.py
+++ b/src/backend/marsha/core/defaults.py
@@ -2,9 +2,22 @@
 from django.utils.translation import gettext_lazy as _
 
 
-PENDING, PROCESSING, ERROR, READY, IDLE, STARTING, STOPPED, RUNNING = (
+(
+    PENDING,
+    PROCESSING,
+    HARVESTING,
+    HARVESTED,
+    ERROR,
+    READY,
+    IDLE,
+    STARTING,
+    STOPPED,
+    RUNNING,
+) = (
     "pending",
     "processing",
+    "harvesting",
+    "harvested",
     "error",
     "ready",
     "idle",
@@ -15,8 +28,10 @@ PENDING, PROCESSING, ERROR, READY, IDLE, STARTING, STOPPED, RUNNING = (
 STATE_CHOICES = (
     (PENDING, _("pending")),
     (PROCESSING, _("processing")),
+    (HARVESTING, _("processing live to VOD")),
     (ERROR, _("error")),
     (READY, _("ready")),
+    (HARVESTED, _("harvested")),
 )
 
 LIVE_CHOICES = (

--- a/src/backend/marsha/core/defaults.py
+++ b/src/backend/marsha/core/defaults.py
@@ -13,6 +13,7 @@ from django.utils.translation import gettext_lazy as _
     STARTING,
     STOPPED,
     RUNNING,
+    DELETED,
 ) = (
     "pending",
     "processing",
@@ -24,6 +25,7 @@ from django.utils.translation import gettext_lazy as _
     "starting",
     "stopped",
     "running",
+    "deleted",
 )
 STATE_CHOICES = (
     (PENDING, _("pending")),
@@ -32,6 +34,7 @@ STATE_CHOICES = (
     (ERROR, _("error")),
     (READY, _("ready")),
     (HARVESTED, _("harvested")),
+    (DELETED, _("deleted")),
 )
 
 LIVE_CHOICES = (

--- a/src/backend/marsha/core/management/commands/check_harvested.py
+++ b/src/backend/marsha/core/management/commands/check_harvested.py
@@ -1,0 +1,80 @@
+"""Check video in harvested state management command."""
+from datetime import timedelta
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+import boto3
+
+from marsha.core.defaults import DELETED, HARVESTED
+from marsha.core.models import Video
+
+
+aws_credentials = {
+    "aws_access_key_id": settings.AWS_ACCESS_KEY_ID,
+    "aws_secret_access_key": settings.AWS_SECRET_ACCESS_KEY,
+    "region_name": settings.AWS_S3_REGION_NAME,
+}
+
+# Configure medialive client
+s3_client = boto3.client("s3", **aws_credentials)
+
+
+def generate_expired_date():
+    """Generate a datetime object NB_DAYS_BEFORE_DELETING_LIVE_RECORDINGS days in the past."""
+    return timezone.now() - timedelta(
+        days=settings.NB_DAYS_BEFORE_DELETING_LIVE_RECORDINGS
+    )
+
+
+class Command(BaseCommand):
+    """Check every video in harvested and remove them if they are too old."""
+
+    help = (
+        "Check every video having harvested upload state and remove them if "
+        "they are too old."
+    )
+
+    def handle(self, *args, **options):
+        """Execute management command."""
+        videos = Video.objects.filter(
+            upload_state=HARVESTED,
+            updated_on__lte=generate_expired_date(),
+        )
+        for video in videos:
+            """
+            For each video harvested we check the updated_at value and if it's
+            setting.NB_DAYS_BEFORE_DELETING_LIVE_RECORDINGS old, the video must be put offline and
+            all related objects on aws removed.
+            """
+            self.stdout.write(f"Processing video {video.id}")
+            self._delete_video_objects(video)
+            video.upload_state = DELETED
+            video.save()
+
+    def _delete_video_objects(self, video, continuation_token=None):
+        """Fetch all existing objects for a given video."""
+        params = {
+            "Bucket": settings.AWS_DESTINATION_BUCKET_NAME,
+            "Prefix": str(video.pk),
+        }
+        if continuation_token:
+            params["ContinuationToken"] = continuation_token
+
+        data = s3_client.list_objects_v2(**params)
+
+        if data.get("KeyCount") == 0:
+            return None
+
+        s3_objects = []
+        for s3_object in data.get("Contents"):
+            s3_objects.append({"Key": s3_object.get("Key")})
+
+        s3_client.delete_objects(
+            Bucket=settings.AWS_DESTINATION_BUCKET_NAME,
+            Delete={"Objects": s3_objects},
+        )
+
+        if data.get("IsTruncated"):
+            self._delete_video_objects(video, data.get("NextContinuationToken"))

--- a/src/backend/marsha/core/serializers.py
+++ b/src/backend/marsha/core/serializers.py
@@ -15,6 +15,7 @@ from rest_framework_simplejwt.models import TokenUser
 
 from .defaults import (
     ERROR,
+    HARVESTED,
     LIVE_CHOICES,
     PROCESSING,
     READY,
@@ -559,7 +560,7 @@ class UpdateStateSerializer(serializers.Serializer):
 
     key = serializers.RegexField(KEY_REGEX)
     state = serializers.ChoiceField(
-        tuple(c for c in STATE_CHOICES if c[0] in (PROCESSING, READY, ERROR))
+        tuple(c for c in STATE_CHOICES if c[0] in (PROCESSING, READY, ERROR, HARVESTED))
     )
     extraParameters = serializers.DictField()
 

--- a/src/backend/marsha/core/tests/test_api_video.py
+++ b/src/backend/marsha/core/tests/test_api_video.py
@@ -11,7 +11,16 @@ from rest_framework_simplejwt.tokens import AccessToken
 
 from .. import api
 from ..api import timezone
-from ..defaults import IDLE, LIVE_CHOICES, PENDING, RUNNING, STATE_CHOICES, STOPPED
+from ..defaults import (
+    HARVESTING,
+    IDLE,
+    LIVE_CHOICES,
+    PENDING,
+    RUNNING,
+    STATE_CHOICES,
+    STOPPED,
+    PROCESSING_LIVE_TO_VOD,
+)
 from ..factories import (
     ThumbnailFactory,
     TimedTextTrackFactory,
@@ -1539,6 +1548,7 @@ class VideoAPITest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(json.loads(response.content), {"success": True})
         self.assertEqual(video.live_state, STOPPED)
+        self.assertEqual(video.upload_state, HARVESTING)
         self.assertEqual(
             video.live_info,
             {

--- a/src/backend/marsha/core/tests/test_api_video.py
+++ b/src/backend/marsha/core/tests/test_api_video.py
@@ -19,7 +19,6 @@ from ..defaults import (
     RUNNING,
     STATE_CHOICES,
     STOPPED,
-    PROCESSING_LIVE_TO_VOD,
 )
 from ..factories import (
     ThumbnailFactory,

--- a/src/backend/marsha/core/tests/test_command_check_harvested.py
+++ b/src/backend/marsha/core/tests/test_command_check_harvested.py
@@ -1,0 +1,100 @@
+"""Tests for check_harvested command."""
+from datetime import timedelta
+from io import StringIO
+from unittest import mock
+
+from django.core.management import call_command
+from django.test import TestCase
+from django.utils import timezone
+
+from botocore.stub import Stubber
+
+from ..defaults import DELETED, HARVESTED
+from ..factories import VideoFactory
+from ..management.commands import check_harvested
+
+
+class CheckWaitingLiveToVodTest(TestCase):
+    """Test check_harvested command."""
+
+    def test_check_harvested_no_video_to_process(self):
+        """Command should do nothing when there is no video to process."""
+        out = StringIO()
+        with Stubber(check_harvested.s3_client) as s3_client_stubber:
+            call_command("check_harvested", stdout=out)
+            s3_client_stubber.assert_no_pending_responses()
+
+        self.assertEqual("", out.getvalue())
+        out.close()
+
+    def test_check_harvested_video_to_process_and_expired(self):
+        """Command should delete objects related to an expired video."""
+        video = VideoFactory(
+            id="9847c1c9-88a1-4afa-bce6-8a9d3ddd4e5b",
+            upload_state=HARVESTED,
+        )
+
+        out = StringIO()
+        with Stubber(check_harvested.s3_client) as s3_client_stubber, mock.patch(
+            "marsha.core.management.commands.check_harvested.generate_expired_date"
+        ) as generate_expired_date_mock:
+            s3_client_stubber.add_response(
+                "list_objects_v2",
+                service_response={
+                    "Contents": [
+                        {"Key": "object_key_1"},
+                        {"Key": "object_key_2"},
+                        {"Key": "object_key_3"},
+                    ],
+                    "KeyCount": 3,
+                    "IsTruncated": False,
+                },
+                expected_params={
+                    "Bucket": "test-marsha-destination",
+                    "Prefix": "9847c1c9-88a1-4afa-bce6-8a9d3ddd4e5b",
+                },
+            )
+
+            s3_client_stubber.add_response(
+                "delete_objects",
+                service_response={},
+                expected_params={
+                    "Bucket": "test-marsha-destination",
+                    "Delete": {
+                        "Objects": [
+                            {"Key": "object_key_1"},
+                            {"Key": "object_key_2"},
+                            {"Key": "object_key_3"},
+                        ],
+                    },
+                },
+            )
+
+            generate_expired_date_mock.return_value = timezone.now() + timedelta(days=1)
+
+            call_command("check_harvested", stdout=out)
+            s3_client_stubber.assert_no_pending_responses()
+
+        video.refresh_from_db()
+        self.assertEqual(video.upload_state, DELETED)
+        self.assertIn(
+            "Processing video 9847c1c9-88a1-4afa-bce6-8a9d3ddd4e5b", out.getvalue()
+        )
+        out.close()
+
+    def test_check_harvested_video_to_process_not_expired(self):
+        """Command should do nothing when there is no video expired."""
+        VideoFactory(
+            id="9847c1c9-88a1-4afa-bce6-8a9d3ddd4e5b",
+            upload_state=HARVESTED,
+        )
+        out = StringIO()
+        with Stubber(check_harvested.s3_client) as s3_client_stubber, mock.patch(
+            "marsha.core.management.commands.check_harvested.generate_expired_date"
+        ) as generate_expired_date_mock:
+            generate_expired_date_mock.return_value = timezone.now() - timedelta(days=1)
+            call_command("check_harvested", stdout=out)
+            s3_client_stubber.assert_no_pending_responses()
+
+        self.assertEqual("", out.getvalue())
+        out.close()

--- a/src/backend/marsha/core/tests/test_views_lti_video.py
+++ b/src/backend/marsha/core/tests/test_views_lti_video.py
@@ -13,7 +13,15 @@ from pylti.common import LTIException
 from rest_framework_simplejwt.tokens import AccessToken
 from waffle.testutils import override_switch
 
-from ..defaults import IDLE, PENDING, READY, RUNNING, STATE_CHOICES, VIDEO_LIVE
+from ..defaults import (
+    HARVESTED,
+    IDLE,
+    PENDING,
+    READY,
+    RUNNING,
+    STATE_CHOICES,
+    VIDEO_LIVE,
+)
 from ..factories import (
     ConsumerSiteLTIPassportFactory,
     TimedTextTrackFactory,
@@ -652,6 +660,114 @@ class VideoLTIViewTestCase(TestCase):
                         "thumbnails/1569309880_240.0000000.jpg",
                         "480": "https://abc.cloudfront.net/59c0fc7a-0f64-46c0-993f-bdf47ecd837f/"
                         "thumbnails/1569309880_480.0000000.jpg",
+                    },
+                    "manifests": {
+                        "dash": "https://abc.cloudfront.net/59c0fc7a-0f64-46c0-993f-bdf47ecd837f/"
+                        "cmaf/1569309880.mpd",
+                        "hls": "https://abc.cloudfront.net/59c0fc7a-0f64-46c0-993f-bdf47ecd837f/"
+                        "cmaf/1569309880.m3u8",
+                    },
+                    "previews": "https://abc.cloudfront.net/59c0fc7a-0f64-46c0-993f-bdf47ecd837f/"
+                    "previews/1569309880_100.jpg",
+                },
+                "should_use_subtitle_as_transcript": False,
+                "has_transcript": False,
+                "playlist": {
+                    "title": "playlist-002",
+                    "lti_id": "course-v1:ufr+mathematics+00001",
+                },
+                "live_state": None,
+                "live_info": {},
+            },
+        )
+        self.assertEqual(context.get("modelName"), "videos")
+        # Make sure we only go through LTI verification once as it is costly (getting passport +
+        # signature)
+        self.assertEqual(mock_verify.call_count, 1)
+
+    @mock.patch.object(LTI, "verify")
+    @mock.patch.object(LTI, "get_consumer_site")
+    def test_views_lti_video_harvested_upload_state(
+        self, mock_get_consumer_site, mock_verify
+    ):
+        """upload_state harvested should return urls and is_ready_to_show False."""
+        passport = ConsumerSiteLTIPassportFactory()
+        video = VideoFactory(
+            id="59c0fc7a-0f64-46c0-993f-bdf47ecd837f",
+            playlist__lti_id="course-v1:ufr+mathematics+00001",
+            playlist__consumer_site=passport.consumer_site,
+            playlist__title="playlist-002",
+            upload_state=HARVESTED,
+            uploaded_on="2019-09-24 07:24:40+00",
+            resolutions=[240, 480, 720],
+        )
+        data = {
+            "resource_link_id": video.lti_id,
+            "context_id": video.playlist.lti_id,
+            "roles": "student",
+            "oauth_consumer_key": passport.oauth_consumer_key,
+            "user_id": "56255f3807599c377bf0e5bf072359fd",
+        }
+        mock_get_consumer_site.return_value = passport.consumer_site
+
+        response = self.client.post("/lti/videos/{!s}".format(video.pk), data)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "<html>")
+        content = response.content.decode("utf-8")
+
+        match = re.search(
+            '<div id="marsha-frontend-data" data-context="(.*)">', content
+        )
+
+        context = json.loads(unescape(match.group(1)))
+        jwt_token = AccessToken(context.get("jwt"))
+        self.assertEqual(jwt_token.payload["resource_id"], str(video.id))
+        self.assertEqual(jwt_token.payload["user_id"], data["user_id"])
+        self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
+        self.assertEqual(jwt_token.payload["roles"], [data["roles"]])
+        self.assertEqual(jwt_token.payload["locale"], "en_US")
+        self.assertEqual(
+            jwt_token.payload["permissions"],
+            {"can_access_dashboard": False, "can_update": False},
+        )
+        self.assertDictEqual(
+            jwt_token.payload["course"],
+            {"school_name": "ufr", "course_name": "mathematics", "course_run": "00001"},
+        )
+
+        self.assertEqual(context.get("state"), "success")
+
+        self.assertEqual(
+            context.get("resource"),
+            {
+                "active_stamp": "1569309880",
+                "is_ready_to_show": False,
+                "show_download": True,
+                "description": video.description,
+                "id": str(video.id),
+                "upload_state": video.upload_state,
+                "timed_text_tracks": [],
+                "thumbnail": None,
+                "title": video.title,
+                "urls": {
+                    "mp4": {
+                        "240": "https://abc.cloudfront.net/59c0fc7a-0f64-46c0-993f-bdf47ecd837f/"
+                        "mp4/1569309880_240.mp4?response-content-disposition=attachment%3B+"
+                        "filename%3Dplaylist-002_1569309880.mp4",
+                        "480": "https://abc.cloudfront.net/59c0fc7a-0f64-46c0-993f-bdf47ecd837f/"
+                        "mp4/1569309880_480.mp4?response-content-disposition=attachment%3B+"
+                        "filename%3Dplaylist-002_1569309880.mp4",
+                        "720": "https://abc.cloudfront.net/59c0fc7a-0f64-46c0-993f-bdf47ecd837f/"
+                        "mp4/1569309880_720.mp4?response-content-disposition=attachment%3B+"
+                        "filename%3Dplaylist-002_1569309880.mp4",
+                    },
+                    "thumbnails": {
+                        "240": "https://abc.cloudfront.net/59c0fc7a-0f64-46c0-993f-bdf47ecd837f/"
+                        "thumbnails/1569309880_240.0000000.jpg",
+                        "480": "https://abc.cloudfront.net/59c0fc7a-0f64-46c0-993f-bdf47ecd837f/"
+                        "thumbnails/1569309880_480.0000000.jpg",
+                        "720": "https://abc.cloudfront.net/59c0fc7a-0f64-46c0-993f-bdf47ecd837f/"
+                        "thumbnails/1569309880_720.0000000.jpg",
                     },
                     "manifests": {
                         "dash": "https://abc.cloudfront.net/59c0fc7a-0f64-46c0-993f-bdf47ecd837f/"

--- a/src/backend/marsha/core/tests/test_views_public_video.py
+++ b/src/backend/marsha/core/tests/test_views_public_video.py
@@ -30,7 +30,9 @@ class VideoPublicViewTestCase(TestCase):
             playlist__lti_id="course-v1:ufr+mathematics+00001",
             is_public=True,
             resolutions=[144, 240, 480, 720, 1080],
-            upload_state=random.choice([s[0] for s in STATE_CHOICES]),
+            upload_state=random.choice(
+                [s[0] for s in STATE_CHOICES if s[0] != "harvested"]
+            ),
             uploaded_on="2019-09-24 07:24:40+00",
         )
 

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -256,6 +256,7 @@ class Base(Configuration):
     VIDEO_PLAYER = values.Value("videojs")
 
     MAINTENANCE_MODE = values.BooleanValue(False)
+    NB_DAYS_BEFORE_DELETING_LIVE_RECORDINGS = values.Value(14)
 
     # pylint: disable=invalid-name
     @property


### PR DESCRIPTION
## Purpose

To manage the video lifecycle when a live has ended, we need new `upload_state` values and a management command to clean the lives that were not converted to VOD.

The 2 new upload states are : 

- harvesting: set when the harvest job is created
- harvested: set when the video transmuxing process is done

When the transmux process is done, all live info in the video object is clean and the `is_ready_to_show` property is `False`. Doing this, only an instructor can see the video.

## Proposal

- [x] create new states `harvesting` and `harvested`
- [x] reset live info when `harvested` state is set on the video
- [x] create a management command to clean expired videos

