### PR TITLE
🐛(back) handle Django ValidationError as an accepted exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Switch to QVBR rate control mode in live profiles
 
+### Fixed
+
+- Handle Django ValidationError as an accepted exception
+
 ### Removed
 
 - Dash endpoint in mediapackage channel

--- a/src/backend/marsha/core/api.py
+++ b/src/backend/marsha/core/api.py
@@ -377,14 +377,7 @@ class DocumentViewSet(
         return Response(presigned_post)
 
 
-class TimedTextTrackViewSet(
-    mixins.CreateModelMixin,
-    mixins.DestroyModelMixin,
-    mixins.ListModelMixin,
-    mixins.RetrieveModelMixin,
-    mixins.UpdateModelMixin,
-    viewsets.GenericViewSet,
-):
+class TimedTextTrackViewSet(viewsets.ModelViewSet):
     """Viewset for the API of the TimedTextTrack object."""
 
     serializer_class = serializers.TimedTextTrackSerializer

--- a/src/backend/marsha/core/views.py
+++ b/src/backend/marsha/core/views.py
@@ -6,7 +6,10 @@ import uuid
 
 from django.conf import settings
 from django.core.cache import cache
-from django.core.exceptions import ImproperlyConfigured
+from django.core.exceptions import (
+    ImproperlyConfigured,
+    ValidationError as DjangoValidationError,
+)
 from django.templatetags.static import static
 from django.utils.decorators import method_decorator
 from django.views.decorators.clickjacking import xframe_options_exempt
@@ -15,6 +18,8 @@ from django.views.generic import View
 from django.views.generic.base import TemplateResponseMixin, TemplateView
 
 from pylti.common import LTIException
+from rest_framework.exceptions import ValidationError as DRFValidationError
+from rest_framework.views import exception_handler as drf_exception_handler
 from rest_framework_simplejwt.tokens import AccessToken
 from waffle import switch_is_active
 
@@ -28,6 +33,26 @@ from .utils.react_locales_utils import react_locale
 
 
 logger = getLogger(__name__)
+
+
+def exception_handler(exc, context):
+    """Handle Django ValidationError as an accepted exception.
+
+    For the parameters, see ``exception_handler``
+    This code comes from twidi's gist:
+    https://gist.github.com/twidi/9d55486c36b6a51bdcb05ce3a763e79f
+    """
+    if isinstance(exc, DjangoValidationError):
+        if hasattr(exc, "message_dict"):
+            detail = exc.message_dict
+        elif hasattr(exc, "message"):
+            detail = exc.message
+        elif hasattr(exc, "messages"):
+            detail = exc.messages
+
+        exc = DRFValidationError(detail=detail)
+
+    return drf_exception_handler(exc, context)
 
 
 @method_decorator(csrf_exempt, name="dispatch")

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -152,7 +152,8 @@ class Base(Configuration):
     REST_FRAMEWORK = {
         "DEFAULT_AUTHENTICATION_CLASSES": (
             "rest_framework_simplejwt.authentication.JWTTokenUserAuthentication",
-        )
+        ),
+        "EXCEPTION_HANDLER": "marsha.core.views.exception_handler",
     }
 
     # WAFFLE


### PR DESCRIPTION
## Purpose

When the django model raised a ValidationError, this exception is not managed by DRF. To fix this issue we have to override the DRF exception_handler.
The solution was found in this gist :
https://gist.github.com/twidi/9d55486c36b6a51bdcb05ce3a763e79f

Also, the `TimedTextTrackViewSet` now uses the `ModelViewSet` because it was using all the mixin used in the `ModelViewSet`.

## Proposal

- [x] use ModelViewSet for TimedTextTrackViewSet
- [x] Handle Django ValidationError as an accepted exception
