### PR TITLE
🔖(minor) bump release to 3.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.15.0] - 2021-02-04
+
 ### Changed
 
 - Switch to QVBR rate control mode in live profiles
@@ -652,7 +654,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Minor fixes and improvements on features and tests
 
-[unreleased]: https://github.com/openfun/marsha/compare/v3.14.0...master
+[unreleased]: https://github.com/openfun/marsha/compare/v3.15.0...master
+[3.15.0]: https://github.com/openfun/marsha/compare/v3.14.0...v3.15.0
 [3.14.0]: https://github.com/openfun/marsha/compare/v3.13.1...v3.14.0
 [3.13.1]: https://github.com/openfun/marsha/compare/v3.13.0...v3.13.1
 [3.13.0]: https://github.com/openfun/marsha/compare/v3.12.1...v3.13.0

--- a/src/aws/lambda-complete/package.json
+++ b/src/aws/lambda-complete/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-complete",
-  "version": "3.14.0",
+  "version": "3.15.0",
   "engines": {
     "node": "12"
   },

--- a/src/aws/lambda-configure/package.json
+++ b/src/aws/lambda-configure/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-configure",
-  "version": "3.14.0",
+  "version": "3.15.0",
   "engines": {
     "node": "12"
   },

--- a/src/aws/lambda-encode/package.json
+++ b/src/aws/lambda-encode/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-convert",
-  "version": "3.14.0",
+  "version": "3.15.0",
   "engines": {
     "node": "12"
   },

--- a/src/aws/lambda-medialive-routing/package.json
+++ b/src/aws/lambda-medialive-routing/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-medialive-routing",
-  "version": "3.14.0",
+  "version": "3.15.0",
   "engines": {
     "node": "12"
   },

--- a/src/aws/lambda-medialive/package.json
+++ b/src/aws/lambda-medialive/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-medialive",
-  "version": "3.14.0",
+  "version": "3.15.0",
   "engines": {
     "node": "12"
   },

--- a/src/aws/lambda-migrate/package.json
+++ b/src/aws/lambda-migrate/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-migrate",
-  "version": "3.14.0",
+  "version": "3.15.0",
   "engines": {
     "node": "12"
   },

--- a/src/aws/utils/update-state/package.json
+++ b/src/aws/utils/update-state/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-update-state",
-  "version": "3.14.0",
+  "version": "3.15.0",
   "engines": {
     "node": "12"
   },

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = marsha
 description = A FUN video provider for Open edX
-version = 3.14.0
+version = 3.15.0
 author = Open FUN (France Universite Numerique)
 author_email = fun.dev@fun-mooc.fr
 license = MIT

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marsha",
-  "version": "3.14.0",
+  "version": "3.15.0",
   "description": "🐠 a FUN LTI video provider",
   "main": "front/index.tsx",
   "scripts": {


### PR DESCRIPTION
### Changed

- Switch to QVBR rate control mode in live profiles

### Fixed

- Handle Django ValidationError as an accepted exception

### Removed

- Dash endpoint in mediapackage channel
- Useless medialive profiles
- All dash usage
