### PR TITLE
Manage situation where HLS is not usable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Create a videojs plugin to manage MP4 selection
+
 ## [3.15.0] - 2021-02-04
 
 ### Changed

--- a/src/frontend/Player/createVideojsPlayer.ts
+++ b/src/frontend/Player/createVideojsPlayer.ts
@@ -1,19 +1,23 @@
 import 'video.js/dist/video-js.css';
-import videojs, { VideoJsPlayer } from 'video.js';
+import videojs, { VideoJsPlayer, VideoJsPlayerOptions } from 'video.js';
 import 'videojs-contrib-quality-levels';
 import 'videojs-http-source-selector';
+import './videojs/qualitySelectorPlugin';
 
 import { appData, getDecodedJwt } from '../data/appData';
+import { QualityLevels } from '../types/libs/video.js/extend';
 import { Video } from '../types/tracks';
 import {
   InitializedContextExtensions,
   InteractedContextExtensions,
 } from '../types/XAPI';
 import { report } from '../utils/errors/report';
+import { isMSESupported } from '../utils/isMSESupported';
 import { Nullable } from '../utils/types';
 import { XAPIStatement } from '../XAPI/XAPIStatement';
 
 import { intl } from '../index';
+import { Events } from './videojs/qualitySelectorPlugin/types';
 
 export const createVideojsPlayer = (
   videoNode: HTMLVideoElement,
@@ -23,7 +27,7 @@ export const createVideojsPlayer = (
   // add the video-js class name to the video attribute.
   videoNode.classList.add('video-js', 'vjs-big-play-centered');
 
-  const player = videojs(videoNode, {
+  const options: VideoJsPlayerOptions = {
     controls: true,
     debug: false,
     fluid: true,
@@ -35,15 +39,27 @@ export const createVideojsPlayer = (
     language: intl.locale,
     liveui: video.live_state !== null,
     playbackRates: [0.5, 0.75, 1, 1.25, 1.5, 1.75, 2, 4],
-    plugins: {
-      httpSourceSelector: {
-        default: 'auto',
-      },
-    },
     responsive: true,
-  });
-  player.httpSourceSelector();
-  const qualityLevels = player.qualityLevels();
+  };
+
+  if (!isMSESupported()) {
+    options.plugins = {
+      qualitySelector: {
+        default: '480',
+      },
+    };
+  }
+
+  const player = videojs(videoNode, options);
+
+  if (isMSESupported()) {
+    player.httpSourceSelector();
+    const qualityLevels = player.qualityLevels();
+    qualityLevels.on('change', () => interacted(qualityLevels));
+  } else {
+    player.on(Events.PLAYER_SOURCES_CHANGED, () => interacted());
+  }
+
   const tracks = player.remoteTextTracks();
 
   /************************** XAPI **************************/
@@ -128,15 +144,22 @@ export const createVideojsPlayer = (
   });
 
   /**************** Interacted event *************************/
-  const interacted = (): void => {
+  const interacted = (qualityLevels?: QualityLevels): void => {
     if (!isInitialized) {
       return;
+    }
+    let quality: string | number;
+
+    if (qualityLevels) {
+      quality = qualityLevels[qualityLevels.selectedIndex]?.height;
+    } else {
+      quality = player.currentSource().size!;
     }
 
     const contextExtensions: InteractedContextExtensions = {
       ccSubtitleEnabled: currentTrack !== null,
       fullScreen: player.isFullscreen(),
-      quality: qualityLevels[qualityLevels.selectedIndex]?.height,
+      quality,
       speed: `${player.playbackRate()}x`,
       volume: player.volume(),
     };
@@ -151,7 +174,6 @@ export const createVideojsPlayer = (
   player.on('languagechange', () => interacted());
   player.on('ratechange', () => interacted());
   player.on('volumechange', () => interacted());
-  qualityLevels.on('change', () => interacted());
   tracks.addEventListener('change', () => {
     currentTrack = getCurrentTrack();
     interacted();

--- a/src/frontend/Player/videojs/qualitySelectorPlugin/components/QualitySelectorMenuButton.ts
+++ b/src/frontend/Player/videojs/qualitySelectorPlugin/components/QualitySelectorMenuButton.ts
@@ -1,0 +1,36 @@
+import videojs from 'video.js';
+
+import { QualitySelectorMenuItem } from './QualitySelectorMenuItem';
+
+const MenuButton = videojs.getComponent('MenuButton');
+
+export class QualitySelectorMenuButton extends MenuButton {
+  constructor(player: videojs.Player, options?: videojs.MenuItemOptions) {
+    super(player, options);
+  }
+
+  createEl() {
+    return videojs.dom.createEl('div', {
+      className:
+        'vjs-http-source-selector vjs-menu-button vjs-menu-button-popup vjs-control vjs-button',
+    });
+  }
+
+  buildCSSClass() {
+    return super.buildCSSClass() + ' vjs-icon-cog';
+  }
+
+  createItems() {
+    return this.player()
+      .currentSources()
+      .map((source) => {
+        return new QualitySelectorMenuItem(this.player_, {
+          label: `${source.size}p`,
+          size: source.size!,
+          src: source.src,
+          type: source.type!,
+          selected: source.src === this.player().currentSource().src,
+        });
+      });
+  }
+}

--- a/src/frontend/Player/videojs/qualitySelectorPlugin/components/QualitySelectorMenuItem.ts
+++ b/src/frontend/Player/videojs/qualitySelectorPlugin/components/QualitySelectorMenuItem.ts
@@ -1,0 +1,33 @@
+import videojs from 'video.js';
+
+import { Events, QualitySelectorMenuItemOptions } from '../types';
+
+const Component = videojs.getComponent('Component');
+const MenuItem = videojs.getComponent('MenuItem');
+
+export class QualitySelectorMenuItem extends MenuItem {
+  constructor(player: videojs.Player, options: QualitySelectorMenuItemOptions) {
+    options.selectable = true;
+    options.multiSelectable = false;
+
+    super(player, options);
+
+    this.on(player, Events.QUALITY_REQUESTED, this.qualityRequested);
+  }
+
+  qualityRequested(
+    event: Events,
+    selectedItem: QualitySelectorMenuItemOptions,
+  ) {
+    const currentItem = this.options_ as QualitySelectorMenuItemOptions;
+    this.selected(selectedItem.src === currentItem.src);
+  }
+
+  handleClick(event: any) {
+    const selected = this.options_ as QualitySelectorMenuItemOptions;
+    super.handleClick(event);
+
+    this.player().trigger(Events.QUALITY_REQUESTED, selected);
+  }
+}
+Component.registerComponent('QualitySelectorMenuItem', QualitySelectorMenuItem);

--- a/src/frontend/Player/videojs/qualitySelectorPlugin/index.ts
+++ b/src/frontend/Player/videojs/qualitySelectorPlugin/index.ts
@@ -1,0 +1,83 @@
+import videojs from 'video.js';
+
+import { QualitySelectorMenuButton } from './components/QualitySelectorMenuButton';
+import { QualitySelectorMenuItem } from './components/QualitySelectorMenuItem';
+import {
+  Events,
+  QualitySelectorOptions,
+  QualitySelectorMenuItemOptions,
+} from './types';
+import './middleware';
+
+const Plugin = videojs.getPlugin('plugin');
+
+export class QualitySelector extends Plugin {
+  constructor(player: videojs.Player, options?: QualitySelectorOptions) {
+    super(player, options);
+
+    videojs.registerComponent(
+      'QualitySelectorMenuButton',
+      QualitySelectorMenuButton,
+    );
+    videojs.registerComponent(
+      'QualitySelectorMenuItem',
+      QualitySelectorMenuItem,
+    );
+    if (options?.default) {
+      player.videojs_quality_selector_plugin_default = options.default;
+    }
+
+    this.on(player, 'loadedmetadata', this.initPlugin);
+    this.on(player, Events.QUALITY_REQUESTED, this.changeQuality);
+    this.on(player, Events.PLAYER_SOURCES_CHANGED, this.sourcesChanged);
+  }
+
+  private initPlugin() {
+    if (this.player.videojs_quality_selector_plugin_initialized) {
+      return;
+    }
+    const controlBar = this.player.controlBar;
+    const fullscreenToggle = controlBar.getChild('fullscreenToggle')?.el();
+    controlBar
+      .el()
+      .insertBefore(
+        controlBar.addChild('QualitySelectorMenuButton').el(),
+        fullscreenToggle || null,
+      );
+    this.player.videojs_quality_selector_plugin_initialized = true;
+  }
+
+  private changeQuality(
+    event: Events,
+    selectedSource: QualitySelectorMenuItemOptions,
+  ) {
+    const sources = this.player.currentSources();
+    this.player.videojs_quality_selector_plugin_is_paused = this.player.paused();
+    this.player.videojs_quality_selector_plugin_currentime = this.player.currentTime();
+
+    const newSources = sources.map((source) => {
+      source.selected = source.src === selectedSource.src;
+
+      return source;
+    });
+
+    this.player.src(newSources);
+  }
+
+  private sourcesChanged() {
+    if (this.player.videojs_quality_selector_plugin_currentime) {
+      this.player.currentTime(
+        this.player.videojs_quality_selector_plugin_currentime,
+      );
+    }
+
+    if (!this.player.videojs_quality_selector_plugin_is_paused) {
+      this.player.play();
+    }
+
+    this.player.videojs_quality_selector_plugin_currentime = undefined;
+    this.player.videojs_quality_selector_plugin_is_paused = undefined;
+  }
+}
+
+videojs.registerPlugin('qualitySelector', QualitySelector);

--- a/src/frontend/Player/videojs/qualitySelectorPlugin/middleware.ts
+++ b/src/frontend/Player/videojs/qualitySelectorPlugin/middleware.ts
@@ -1,0 +1,27 @@
+import videojs from 'video.js';
+
+import { VideoJsExtendedSourceObject } from '../../../types/libs/video.js/extend';
+import { Maybe } from 'utils/types';
+
+import { Events } from './types';
+
+videojs.use('video/mp4', (player: videojs.Player) => ({
+  setSource: (playerSource, next) => {
+    const sources = player.currentSources();
+
+    let selectedSource: Maybe<VideoJsExtendedSourceObject>;
+
+    selectedSource = sources.find((source) => source.selected);
+
+    if (!selectedSource && player.videojs_quality_selector_plugin_default) {
+      selectedSource = sources.find(
+        (source) =>
+          source.size === player.videojs_quality_selector_plugin_default,
+      );
+    }
+
+    player.trigger(Events.PLAYER_SOURCES_CHANGED);
+
+    next(null, selectedSource || playerSource);
+  },
+}));

--- a/src/frontend/Player/videojs/qualitySelectorPlugin/types.ts
+++ b/src/frontend/Player/videojs/qualitySelectorPlugin/types.ts
@@ -1,0 +1,18 @@
+import videojs from 'video.js';
+
+export enum Events {
+  QUALITY_REQUESTED = 'qualityRequested',
+  PLAYER_SOURCES_CHANGED = 'playerSourcesChanged',
+}
+
+export interface QualitySelectorMenuItemOptions
+  extends videojs.MenuItemOptions {
+  label: string;
+  size: string;
+  src: string;
+  type: string;
+}
+
+export interface QualitySelectorOptions {
+  default?: string;
+}

--- a/src/frontend/components/VideoPlayer/index.tsx
+++ b/src/frontend/components/VideoPlayer/index.tsx
@@ -16,6 +16,7 @@ import {
   videoSize,
 } from '../../types/tracks';
 import { VideoPlayerInterface } from '../../types/VideoPlayer';
+import { isMSESupported } from '../../utils/isMSESupported';
 import { Maybe, Nullable } from '../../utils/types';
 import { DownloadVideo } from '../DownloadVideo';
 import { ERROR_COMPONENT_ROUTE } from '../ErrorComponent/route';
@@ -117,6 +118,9 @@ const VideoPlayer = ({
     (size) => Number(size) as videoSize,
   );
 
+  // order resolutions from the higher to the lower
+  resolutions.sort((a, b) => b - a);
+
   return (
     <Box>
       {/* tabIndex is set to -1 to not take focus on this element when a user is navigating using
@@ -127,11 +131,13 @@ const VideoPlayer = ({
         poster={thumbnailUrls[resolutions[resolutions.length - 1]]}
         tabIndex={-1}
       >
-        <source
-          src={video.urls.manifests.hls}
-          size="auto"
-          type="application/x-mpegURL"
-        />
+        {isMSESupported() && (
+          <source
+            src={video.urls.manifests.hls}
+            size="auto"
+            type="application/x-mpegURL"
+          />
+        )}
 
         {resolutions.map((size) => (
           <source

--- a/src/frontend/types/libs/video.js/extend.d.ts
+++ b/src/frontend/types/libs/video.js/extend.d.ts
@@ -8,22 +8,42 @@ declare module 'video.js' {
 
   interface VideoJsPlayerPluginOptions {
     httpSourceSelector?: VideoJsHttpSourceSelectorPluginOptions;
+    qualitySelector?: QualitySelectorOptions;
   }
 
   interface VideoJsPlayer {
+    // videojs-quality-selector-plugin
+    videojs_quality_selector_plugin_initialized: boolean;
+    videojs_quality_selector_plugin_is_paused?: boolean;
+    videojs_quality_selector_plugin_currentime?: number;
+    videojs_quality_selector_plugin_default?: string;
     // videojs-http-source-selector
     httpSourceSelector: () => void;
-    qualityLevels: () => {
-      [index: number]: VideoJsQualityLevelsPluginRepresentation;
-      lenght: number;
-      selectedIndex: number;
-      on: (
-        event: 'change' | 'addqualitylevel' | 'removequalitylevel',
-        action: () => void,
-      ) => void;
-      trigger: (event: string) => void;
+    qualitySelector: () => {
+      on(type?: string | string[], listener?: (...args: any[]) => void): void;
     };
+    qualityLevels: () => QualityLevels;
+    currentSources(): VideoJsExtendedSourceObject[];
+    currentSource(): VideoJsExtendedSourceObject;
   }
+}
+
+interface QualityLevels {
+  [index: number]: VideoJsQualityLevelsPluginRepresentation;
+  length: number;
+  selectedIndex: number;
+  on: (
+    event: 'change' | 'addqualitylevel' | 'removequalitylevel',
+    action: () => void,
+  ) => void;
+  trigger: (event: string) => void;
+}
+
+interface VideoJsExtendedSourceObject {
+  src: string;
+  type?: string;
+  size?: string;
+  selected?: boolean;
 }
 
 interface VideoJsHttpSourceSelectorPluginOptions {

--- a/src/frontend/utils/isMSESupported.ts
+++ b/src/frontend/utils/isMSESupported.ts
@@ -1,0 +1,5 @@
+// Test if the MediaSource API is available for the current browser
+
+export const isMSESupported = () =>
+  'MediaSource' in window &&
+  typeof window.MediaSource.isTypeSupported === 'function';


### PR DESCRIPTION
## Purpose

All browsers are not compatible with the Media Source Element API. When
they are not, videojs does not fallback on other available sources. To
force using them, we detect if the MSE API is available, if not only MP4
sources are loaded and the quality selector plugin is activated.

A plugin to manage MP4 source is added in this PR. It allows to switch between all available resolutions.

## Proposal

- [x] Create a videojs plugin to manage mp4 sources
- [x] Check browser MSE compat and fallback on MP4 if needed

