### PR TITLE
🔧(front) enable videojs useDevicePixelRatio VHS option 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Create a videojs plugin to manage MP4 selection
 
+### Changed
+
+- Enable videojs useDevicePixelRatio VHS option
+
 ## [3.15.0] - 2021-02-04
 
 ### Changed

--- a/src/frontend/Player/createVideojsPlayer.spec.tsx
+++ b/src/frontend/Player/createVideojsPlayer.spec.tsx
@@ -139,7 +139,9 @@ describe('createVideoJsPlayer', () => {
     expect(player.options_.responsive).toBe(true);
     expect(player.options_.html5).toEqual({
       vhs: {
+        limitRenditionByPlayerDimensions: true,
         overrideNative: true,
+        useDevicePixelRatio: true,
       },
     });
   });
@@ -202,7 +204,9 @@ describe('createVideoJsPlayer', () => {
     expect(player.options_.responsive).toBe(true);
     expect(player.options_.html5).toEqual({
       vhs: {
+        limitRenditionByPlayerDimensions: true,
         overrideNative: true,
+        useDevicePixelRatio: true,
       },
     });
     expect(player.options_.plugins).toEqual({

--- a/src/frontend/Player/createVideojsPlayer.ts
+++ b/src/frontend/Player/createVideojsPlayer.ts
@@ -33,7 +33,15 @@ export const createVideojsPlayer = (
     fluid: true,
     html5: {
       vhs: {
+        // prevent to have a resolution selected higher than
+        // the player size. By default this is set to true.
+        // We set it to true here to remember this undocumented option.
+        limitRenditionByPlayerDimensions: true,
         overrideNative: !videojs.browser.IS_SAFARI,
+        // take the device pixel ratio into account when doing rendition switching.
+        // This means that if you have a player with the width of 540px in a high density
+        // display with a device pixel ratio of 2, a rendition of 1080p will be allowed.
+        useDevicePixelRatio: true,
       },
     },
     language: intl.locale,


### PR DESCRIPTION
## Purpose

By default, Videojs Http Streaming component disable an option called
`useDevicePixelRatio`. This option take the device pixel ratio into
account when doing rendition switching. This means that if you have a
player with the width of 540px in a high density display with a device
pixel ratio of 2, a rendition of 1080p will be allowed. This option
enabled combined with the undocumented option `limitRenditionByPlayerDimensions`
set to true by default will allow to use a higher rendition on devices
allowing it.
## Proposal

- [x] Enable videojs useDevicePixelRatio VHS option 

