### PR TITLE
🐛(front) disable native audio and video tracks in Videojs conf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Disable native audio and video tracks in Videojs conf
+
 ## [3.16.0] - 2021-02-17
 
 ### Added

--- a/src/frontend/Player/createVideojsPlayer.spec.tsx
+++ b/src/frontend/Player/createVideojsPlayer.spec.tsx
@@ -143,6 +143,8 @@ describe('createVideoJsPlayer', () => {
         overrideNative: true,
         useDevicePixelRatio: true,
       },
+      nativeAudioTracks: false,
+      nativeVideoTracks: false,
     });
   });
 
@@ -208,6 +210,8 @@ describe('createVideoJsPlayer', () => {
         overrideNative: true,
         useDevicePixelRatio: true,
       },
+      nativeAudioTracks: false,
+      nativeVideoTracks: false,
     });
     expect(player.options_.plugins).toEqual({
       qualitySelector: {

--- a/src/frontend/Player/createVideojsPlayer.ts
+++ b/src/frontend/Player/createVideojsPlayer.ts
@@ -43,6 +43,8 @@ export const createVideojsPlayer = (
         // display with a device pixel ratio of 2, a rendition of 1080p will be allowed.
         useDevicePixelRatio: true,
       },
+      nativeAudioTracks: videojs.browser.IS_SAFARI,
+      nativeVideoTracks: videojs.browser.IS_SAFARI,
     },
     language: intl.locale,
     liveui: video.live_state !== null,


### PR DESCRIPTION
## Purpose

In the VHS conf we enable the overrideNative option, except for safari
browser. This option must be combined with deactivating native audio and
video tracks support.

## Proposal

- [x] disable native audio and video tracks in Videojs conf

