### PR TITLE
🐛(front) remove HLS source in <VideoPlayer />

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Disable native audio and video tracks in Videojs conf
+- Remove HLS source in <VideoPlayer />
 
 ## [3.16.0] - 2021-02-17
 

--- a/src/frontend/Player/createVideojsPlayer.spec.tsx
+++ b/src/frontend/Player/createVideojsPlayer.spec.tsx
@@ -94,31 +94,6 @@ describe('createVideoJsPlayer', () => {
 
     expect(player.currentSources()).toEqual([
       { type: 'application/x-mpegURL', src: 'https://example.com/hls' },
-      {
-        type: 'video/mp4',
-        src: 'https://example.com/mp4/1080',
-        size: '1080',
-      },
-      {
-        type: 'video/mp4',
-        src: 'https://example.com/mp4/720',
-        size: '720',
-      },
-      {
-        type: 'video/mp4',
-        src: 'https://example.com/mp4/480',
-        size: '480',
-      },
-      {
-        type: 'video/mp4',
-        src: 'https://example.com/mp4/240',
-        size: '240',
-      },
-      {
-        type: 'video/mp4',
-        src: 'https://example.com/mp4/144',
-        size: '144',
-      },
     ]);
 
     expect(player.options_.playbackRates).toEqual([

--- a/src/frontend/components/VideoPlayer/index.spec.tsx
+++ b/src/frontend/components/VideoPlayer/index.spec.tsx
@@ -6,23 +6,18 @@ import { ImportMock } from 'ts-mock-imports';
 import * as useTimedTextTrackModule from '../../data/stores/useTimedTextTrack';
 import { createPlayer } from '../../Player/createPlayer';
 import { uploadState } from '../../types/tracks';
-import { isMSESupported } from '../../utils/isMSESupported';
 import { videoMockFactory } from '../../utils/tests/factories';
 import { wrapInIntlProvider } from '../../utils/tests/intl';
 import { jestMockOf } from '../../utils/types';
 import VideoPlayer from './index';
 
 jest.mock('jwt-decode', () => jest.fn());
-jest.mock('../../utils/isMSESupported', () => ({
-  isMSESupported: jest.fn(),
-}));
 
 jest.mock('../../Player/createPlayer', () => ({
   createPlayer: jest.fn(),
 }));
 
 const mockCreatePlayer = createPlayer as jestMockOf<typeof createPlayer>;
-const mockIsMSESupported = isMSESupported as jestMockOf<typeof isMSESupported>;
 
 const useTimedTextTrackStub = ImportMock.mockFunction(
   useTimedTextTrackModule,
@@ -130,8 +125,6 @@ describe('VideoPlayer', () => {
       },
     ]);
 
-    mockIsMSESupported.mockReturnValue(true);
-
     const { container, getByText, queryByText } = render(
       wrapInIntlProvider(
         <VideoPlayer video={mockVideo} playerType={'videojs'} />,
@@ -149,45 +142,6 @@ describe('VideoPlayer', () => {
 
     expect(queryByText(/Download this video/i)).toBeNull();
     getByText('Show a transcript');
-    expect(
-      container.querySelector('source[type="application/x-mpegURL"]'),
-    ).not.toBeNull();
-    expect(container.querySelectorAll('track')).toHaveLength(2);
-    expect(
-      container.querySelector('source[src="https://example.com/144p.mp4"]'),
-    ).not.toBeNull();
-    expect(
-      container.querySelector('source[src="https://example.com/1080p.mp4"]'),
-    ).not.toBeNull();
-    expect(container.querySelectorAll('source[type="video/mp4"]')).toHaveLength(
-      2,
-    );
-    expect(container.querySelector('video')!.tabIndex).toEqual(-1);
-  });
-
-  it('renders without HLS sources but with MP4 ones', async () => {
-    mockIsMSESupported.mockReturnValue(false);
-
-    const { container, getByText, queryByText } = render(
-      wrapInIntlProvider(
-        <VideoPlayer video={mockVideo} playerType={'videojs'} />,
-      ),
-    );
-    await waitFor(() =>
-      // The player is created and initialized with DashJS for adaptive bitrate
-      expect(mockCreatePlayer).toHaveBeenCalledWith(
-        'videojs',
-        expect.any(Element),
-        expect.anything(),
-        mockVideo,
-      ),
-    );
-
-    expect(queryByText(/Download this video/i)).toBeNull();
-    getByText('Show a transcript');
-    expect(
-      container.querySelector('source[type="application/x-mpegURL"]'),
-    ).toBeNull();
     expect(container.querySelectorAll('track')).toHaveLength(2);
     expect(
       container.querySelector('source[src="https://example.com/144p.mp4"]'),

--- a/src/frontend/components/VideoPlayer/index.tsx
+++ b/src/frontend/components/VideoPlayer/index.tsx
@@ -16,7 +16,6 @@ import {
   videoSize,
 } from '../../types/tracks';
 import { VideoPlayerInterface } from '../../types/VideoPlayer';
-import { isMSESupported } from '../../utils/isMSESupported';
 import { Maybe, Nullable } from '../../utils/types';
 import { DownloadVideo } from '../DownloadVideo';
 import { ERROR_COMPONENT_ROUTE } from '../ErrorComponent/route';
@@ -131,14 +130,6 @@ const VideoPlayer = ({
         poster={thumbnailUrls[resolutions[resolutions.length - 1]]}
         tabIndex={-1}
       >
-        {isMSESupported() && (
-          <source
-            src={video.urls.manifests.hls}
-            size="auto"
-            type="application/x-mpegURL"
-          />
-        )}
-
         {resolutions.map((size) => (
           <source
             key={video.urls.mp4[size]}


### PR DESCRIPTION
## Purpose

When we set the HLS source in the `<video />` tag, the browser try to load
it but fails if the browser is not able to do it. Videojs will load it
because it has polyfills to play HLS source in a browser havinf
MediaSource extension. The solution is to remove the HLS source in the
`<video />` tag and configure directly videojs player with accurate
sources dependening if media sources are available or not.

## Proposal

- [x] remove HLS source in `<VideoPlayer />`

