### PR TITLE
🐛(circle) add missing fi instruction

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -843,6 +843,7 @@ jobs:
             docker push fundocker/marsha-ffmpeg-transmux:${DOCKER_TAG}
             if [[ -n "$CIRCLE_TAG" ]]; then
               docker push fundocker/marsha-ffmpeg-transmux:latest
+            fi
 
   lambda-publish:
     machine:


### PR DESCRIPTION
## Purpose

In the hub-ffmpeg-transmux job, in the step publishing the image on
docker hub, there is a syntax error. The fi closing the if testing if we
have a tag or not is missing.


## Proposal

- [x] fix circleci hub-ffmpeg-transmux job

