### PR TITLE
♻️(frontend) rework <Loader /> to expand use cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Enable videojs useDevicePixelRatio VHS option
+- Update the frontend <Loader /> with a <Spinner /> sidekick and
+  make some accessibility improvements.
 
 ## [3.15.0] - 2021-02-04
 

--- a/src/frontend/components/Loader/index.spec.tsx
+++ b/src/frontend/components/Loader/index.spec.tsx
@@ -1,14 +1,40 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import React from 'react';
 
-import { Loader } from '.';
+import { Loader, Spinner } from '.';
 
-describe('<Loader />', () => {
-  it('renders', () => {
-    const { container } = render(<Loader />);
+for (const Component of [Spinner, Loader]) {
+  describe(`<${Component.name} />`, () => {
+    it('renders a spinner as an accessible status region', () => {
+      render(
+        <Component>
+          <span>Loading some object...</span>
+        </Component>,
+      );
 
-    const divSelector = container.querySelector('div[aria-busy]')!;
-    expect(divSelector.getAttribute('aria-busy')).toEqual('true');
-    expect(divSelector.getAttribute('aria-live')).toEqual('polite');
+      const region = screen.getByRole('status', {
+        name: 'Loading some object...',
+      });
+      expect(region).toHaveAttribute('aria-live', 'polite');
+    });
+
+    it('renders a spinner as an accessible alert region', () => {
+      render(
+        <Component role="alert">
+          <span>Loading some important object...</span>
+        </Component>,
+      );
+
+      const region = screen.getByRole('alert', {
+        name: 'Loading some important object...',
+      });
+      expect(region).toHaveAttribute('aria-live', 'assertive');
+    });
+
+    it('renders a spinner that is hidden from the accessibility tree', () => {
+      render(<Component aria-hidden={true} />);
+      expect(screen.queryByRole('status')).toBeNull();
+      expect(screen.queryByRole('alert')).toBeNull();
+    });
   });
-});
+}

--- a/src/frontend/components/Loader/index.tsx
+++ b/src/frontend/components/Loader/index.tsx
@@ -1,10 +1,13 @@
+import { Box } from 'grommet';
 import { normalizeColor } from 'grommet/utils';
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
+import { v4 as uuidv4 } from 'uuid';
 
 import { theme } from '../../utils/theme/theme';
+import { Offscreen } from '../Offscreen';
 
-const Preloader = styled.div`
+const Preloader = styled(Box)`
   width: 100%;
   height: 100%;
   top: 0px;
@@ -13,17 +16,27 @@ const Preloader = styled.div`
   background-color: rgba(255, 255, 255, 0.4);
 `;
 
-const Spinner = styled.div`
-  position: absolute;
-  top: calc(50% - 3.5px);
-  left: calc(50% - 3.5px);
+interface SpinnerLookProps {
+  size?: 'small' | 'medium' | 'large';
+}
 
+const SpinnerLook = styled.div<SpinnerLookProps>`
   border: 0.125rem solid transparent;
   border-left-color: ${normalizeColor('brand', theme)};
   border-top-color: ${normalizeColor('brand', theme)};
   border-radius: 50%;
-  width: 31px;
-  height: 31px;
+  width: ${(props) =>
+    props.size === 'small'
+      ? '1rem'
+      : props.size === 'medium'
+      ? '2rem'
+      : '3rem'};
+  height: ${(props) =>
+    props.size === 'small'
+      ? '1rem'
+      : props.size === 'medium'
+      ? '2rem'
+      : '3rem'};
   animation: spin 0.8s linear infinite;
   display: inline-block;
   margin: 0 auto;
@@ -38,9 +51,55 @@ const Spinner = styled.div`
   }
 `;
 
-/** Component. Displays a rotating CSS loader. */
-export const Loader = () => (
-  <Preloader>
-    <Spinner aria-busy="true" aria-live="polite" />
-  </Preloader>
-);
+interface SpinnerProps extends SpinnerLookProps {
+  'aria-hidden'?: boolean;
+  role?: 'alert' | 'status';
+}
+
+/**
+ * Displays a rotating CSS loader
+ * @param aria-hidden Passthrough to remove the whole spinner from accessible tree.
+ * @param role The role of the aria region. Informs aria-live. Defaults to "status".
+ * @param size Set of available sizes for the spinner. Defaults to "medium".
+ */
+export const Spinner: React.FC<SpinnerProps> = (props) => {
+  const { children } = props;
+  const ariaHidden = props['aria-hidden'] || false;
+  const role = props.role || 'status';
+  const size = props.size || 'medium';
+
+  const [uniqueID] = useState(uuidv4());
+
+  return (
+    <Box
+      role={role}
+      aria-live={role === 'alert' ? 'assertive' : 'polite'}
+      aria-labelledby={uniqueID}
+      aria-hidden={ariaHidden}
+      margin="none"
+      pad="none"
+    >
+      <SpinnerLook size={size} />
+      <Offscreen id={uniqueID}>{children}</Offscreen>
+    </Box>
+  );
+};
+
+// tslint:disable:no-empty-interface
+interface LoaderProps extends SpinnerProps {}
+
+/**
+ * Displays a full-page, fixed transparent gray overlay with a rotating CSS loader.
+ * @param aria-hidden Passthrough to remove the whole spinner from accessible tree.
+ * @param role The role of the aria region. Informs aria-live. Defaults to "status".
+ * @param size Set of available sizes for the spinner. Defaults to "medium".
+ */
+export const Loader: React.FC<LoaderProps> = (props) => {
+  const ariaHidden = props['aria-hidden'] || false;
+
+  return (
+    <Preloader justify="center" aria-hidden={ariaHidden}>
+      <Spinner {...props} />
+    </Preloader>
+  );
+};

--- a/src/frontend/components/ObjectStatusPicker/UploadStatus.spec.tsx
+++ b/src/frontend/components/ObjectStatusPicker/UploadStatus.spec.tsx
@@ -1,43 +1,38 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import React from 'react';
 
 import { statusIconKey, UploadStatus } from './UploadStatus';
 
 describe('<UploadStatus />', () => {
   it('renders with children', () => {
-    const { getByText } = render(
-      <UploadStatus>Some child content</UploadStatus>,
-    );
-    getByText('Some child content');
+    render(<UploadStatus>Some child content</UploadStatus>);
+    screen.getByText('Some child content');
   });
 
   it('displays the status icon ❌', () => {
-    const { getByText } = render(
+    render(
       <UploadStatus statusIcon={statusIconKey.X}>
         Some child content
       </UploadStatus>,
     );
-
-    getByText('Some child content ❌');
+    screen.getByText('Some child content ❌');
   });
 
   it('displays the status icon ✔️', () => {
-    const { getByText } = render(
+    render(
       <UploadStatus statusIcon={statusIconKey.TICK}>
         Some child content
       </UploadStatus>,
     );
-
-    getByText('Some child content ✔️');
+    screen.getByText('Some child content ✔️');
   });
 
   it('displays the Loader status icon ✔️', () => {
-    const { container } = render(
+    render(
       <UploadStatus statusIcon={statusIconKey.LOADER}>
         Some child content
       </UploadStatus>,
     );
-
-    expect(container.querySelector('div[aria-busy="true"]')).not.toBeNull();
+    screen.getByRole('status');
   });
 });

--- a/src/frontend/components/ObjectStatusPicker/UploadStatus.tsx
+++ b/src/frontend/components/ObjectStatusPicker/UploadStatus.tsx
@@ -1,6 +1,7 @@
+import { Box } from 'grommet';
 import React from 'react';
 
-import { Loader } from '../Loader';
+import { Spinner } from '../Loader';
 
 /** Available icon names for statusIcon on the UploadStatus component. */
 export enum statusIconKey {
@@ -21,13 +22,13 @@ export interface UploadStatusProps {
  */
 export const UploadStatus = ({
   children,
-  className,
+  className = '',
   statusIcon,
 }: UploadStatusProps) => {
   let icon;
   switch (statusIcon) {
     case statusIconKey.LOADER:
-      icon = <Loader />;
+      icon = <Spinner size="small" />;
       break;
 
     case statusIconKey.TICK:
@@ -40,10 +41,10 @@ export const UploadStatus = ({
   }
 
   return (
-    <div className={className || ''}>
+    <Box direction="row" margin="none" pad="none" className={className}>
       {children}
       &nbsp;
       {icon}
-    </div>
+    </Box>
   );
 };

--- a/src/frontend/components/Offscreen.tsx
+++ b/src/frontend/components/Offscreen.tsx
@@ -1,0 +1,18 @@
+import styled from 'styled-components';
+
+/**
+ * Visually move an element offscreen, so it is not visible while still present in the
+ * accessibility tree and for screen reader users.
+ */
+export const Offscreen = styled.div`
+  border: 0;
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+`;


### PR DESCRIPTION
## Purpose

The existing <Loader /> in marsha was only appropriate for use in the LTI view as it forced a `fixed` position with an overlay
covering the whole viewport.

It also lacked some accessibility related elements.

## Proposal

We made available a new <Spinner /> component from the same file, which enables users to use only the animated spinner without the whole full-screen overlay.

We also made some accessibility improvements to said <Spinner /> which we refactored into the basis for <Loader />.

