### PR TITLE
♻️(back) avoid concurrent requests on video live update state endpoint

### DIFF
--- a/src/aws/lambda-medialive/index.js
+++ b/src/aws/lambda-medialive/index.js
@@ -7,10 +7,6 @@ exports.handler = async (event, context, callback) => {
   console.log('Received event:', JSON.stringify(event_origin));
   const type = event_origin['detail-type'];
 
-  if (event_origin.detail.pipeline !== '0') {
-    return Promise.resolve('Lambda listening only pipeline 0');
-  }
-
   switch (type) {
     case 'MediaLive Channel State Change':
       try {

--- a/src/backend/marsha/core/defaults.py
+++ b/src/backend/marsha/core/defaults.py
@@ -12,6 +12,7 @@ from django.utils.translation import gettext_lazy as _
     IDLE,
     STARTING,
     STOPPED,
+    STOPPING,
     RUNNING,
     DELETED,
 ) = (
@@ -24,6 +25,7 @@ from django.utils.translation import gettext_lazy as _
     "idle",
     "starting",
     "stopped",
+    "stopping",
     "running",
     "deleted",
 )
@@ -42,6 +44,7 @@ LIVE_CHOICES = (
     (STARTING, _("starting")),
     (RUNNING, _("running")),
     (STOPPED, _("stopped")),
+    (STOPPING, _("stopping")),
 )
 
 # FLAGS

--- a/src/frontend/components/DashboardVideoLive/index.tsx
+++ b/src/frontend/components/DashboardVideoLive/index.tsx
@@ -7,7 +7,6 @@ import { useVideo } from '../../data/stores/useVideo';
 import { API_ENDPOINT } from '../../settings';
 import { modelName } from '../../types/models';
 import { Video, liveState } from '../../types/tracks';
-import { Nullable } from '../../utils/types';
 import { report } from '../../utils/errors/report';
 import { PLAYER_ROUTE } from '../routes';
 import { DashboardVideoLiveStartButton } from '../DashboardVideoLiveStartButton';
@@ -48,10 +47,17 @@ const messages = defineMessages({
   },
   liveStopped: {
     defaultMessage:
-      'Live streaming is ended. The process to transform the live in VOD will begin soon.',
+      'Live streaming is ended. The process to transform the live to VOD has started. You can close the window and come back later.',
     description:
-      'Helptext explaining that the live is ended and the live to VOD process will start.',
+      'Helptext explaining that the live is ended and the live to VOD process has started.',
     id: 'components.DashboardVideoLive.liveStopped',
+  },
+  liveStopping: {
+    defaultMessage:
+      'Live streaming is ending. The process to transform the live to VOD will begin soon. You can close the window and come back later.',
+    description:
+      'Helptext explaining that the live is ending and the live to VOD process will start.',
+    id: 'components.DashboardVideoLive.liveStopping',
   },
 });
 
@@ -140,6 +146,11 @@ export const DashboardVideoLive = ({ video }: DashboardVideoLiveProps) => {
         {video.live_state === liveState.STOPPED && (
           <Text>
             <FormattedMessage {...messages.liveStopped} />
+          </Text>
+        )}
+        {video.live_state === liveState.STOPPING && (
+          <Text>
+            <FormattedMessage {...messages.liveStopping} />
           </Text>
         )}
       </Box>

--- a/src/frontend/components/ObjectStatusPicker/index.spec.tsx
+++ b/src/frontend/components/ObjectStatusPicker/index.spec.tsx
@@ -15,7 +15,7 @@ const {
   READY,
   UPLOADING,
 } = uploadState;
-const { IDLE, STARTING, RUNNING, STOPPED } = liveState;
+const { IDLE, STARTING, RUNNING, STOPPED, STOPPING } = liveState;
 
 describe('<ObjectStatusPicker />', () => {
   it('renders the status list for upload state PENDING', () => {
@@ -106,5 +106,15 @@ describe('<ObjectStatusPicker />', () => {
     );
 
     screen.getByText('Live ended');
+  });
+
+  it('renders the status list for live state STOPPING', () => {
+    render(
+      wrapInIntlProvider(
+        <ObjectStatusPicker state={PENDING} liveState={STOPPING} />,
+      ),
+    );
+
+    screen.getByText('Live is stopping');
   });
 });

--- a/src/frontend/components/ObjectStatusPicker/index.tsx
+++ b/src/frontend/components/ObjectStatusPicker/index.tsx
@@ -15,7 +15,7 @@ const {
   READY,
   UPLOADING,
 } = uploadState;
-const { IDLE, STARTING, RUNNING, STOPPED } = liveStateTrack;
+const { IDLE, STARTING, RUNNING, STOPPED, STOPPING } = liveStateTrack;
 
 const messages = defineMessages({
   [DELETED]: {
@@ -77,6 +77,11 @@ const messages = defineMessages({
     defaultMessage: 'Live ended',
     description: 'The video is in live state and has ended',
     id: 'components.ObjectStatusPicker.STOPPED',
+  },
+  [STOPPING]: {
+    defaultMessage: 'Live is stopping',
+    description: 'The video is in live state and is stopping',
+    id: 'components.ObjectStatusPicker.STOPPING',
   },
 });
 

--- a/src/frontend/types/tracks.ts
+++ b/src/frontend/types/tracks.ts
@@ -36,6 +36,7 @@ export enum liveState {
   STARTING = 'starting',
   RUNNING = 'running',
   STOPPED = 'stopped',
+  STOPPING = 'stopping',
 }
 
 /** Possible modes for a timed text track.


### PR DESCRIPTION
## Purpose

A medialive channel has many pipelines. One by RTMP input. Each pipeline
triggers events and these events are listen by the medialive lambda. In
a first time we thought that this events are always triggers twice (one
by pipeline) and choose to listen only pipeline 0. In reality, this
assert is not always true. Sometimes, I didn't found why, only one
pipelin is triggering an event so we can miss them if they are not on
the pipeline 0. To solve this issue, all the events are listened again
and we update first the live state in the update_live_state endpoint. If
the state is already updated, we stop the process and return a status
200 to stop lambda retries mechanism.

## Proposal

- [x] avoid concurrent requests on video live update state endpoint
- [x] update front application with new live_state `stopping`

