### PR TITLE
♻️(frontend) rework <ErrorComponent /> to reuse it in site

### DIFF
--- a/src/frontend/components/DashboardTimedTextPane/index.spec.tsx
+++ b/src/frontend/components/DashboardTimedTextPane/index.spec.tsx
@@ -12,7 +12,7 @@ import { report } from '../../utils/errors/report';
 import { videoMockFactory } from '../../utils/tests/factories';
 import { wrapInIntlProvider } from '../../utils/tests/intl';
 import { wrapInRouter } from '../../utils/tests/router';
-import { ERROR_COMPONENT_ROUTE } from '../ErrorComponent/route';
+import { FULL_SCREEN_ERROR_ROUTE } from '../ErrorComponents/route';
 
 jest.mock('../../data/appData', () => ({
   appData: {
@@ -118,7 +118,7 @@ describe('<DashboardTimedTextPane />', () => {
       wrapInIntlProvider(
         wrapInRouter(<DashboardTimedTextPane />, [
           {
-            path: ERROR_COMPONENT_ROUTE(),
+            path: FULL_SCREEN_ERROR_ROUTE(),
             render: ({ match }) => (
               <span>{`Error Component: ${match.params.code}`}</span>
             ),

--- a/src/frontend/components/DashboardTimedTextPane/index.tsx
+++ b/src/frontend/components/DashboardTimedTextPane/index.tsx
@@ -10,7 +10,7 @@ import { modelName } from '../../types/models';
 import { timedTextMode } from '../../types/tracks';
 import { useAsyncEffect } from '../../utils/useAsyncEffect';
 import { DashboardTimedTextManager } from '../DashboardTimedTextManager';
-import { ERROR_COMPONENT_ROUTE } from '../ErrorComponent/route';
+import { FULL_SCREEN_ERROR_ROUTE } from '../ErrorComponents/route';
 
 const messages = defineMessages({
   [timedTextMode.CLOSED_CAPTIONING]: {
@@ -48,7 +48,7 @@ export const DashboardTimedTextPane = () => {
   );
 
   if (status === requestStatus.FAILURE) {
-    return <Redirect push to={ERROR_COMPONENT_ROUTE('notFound')} />;
+    return <Redirect push to={FULL_SCREEN_ERROR_ROUTE('notFound')} />;
   }
 
   return (

--- a/src/frontend/components/DashboardVideoHarvested/index.spec.tsx
+++ b/src/frontend/components/DashboardVideoHarvested/index.spec.tsx
@@ -3,7 +3,7 @@ import fetchMock from 'fetch-mock';
 import React from 'react';
 import { ImportMock } from 'ts-mock-imports';
 
-import { ERROR_COMPONENT_ROUTE } from '../ErrorComponent/route';
+import { FULL_SCREEN_ERROR_ROUTE } from '../ErrorComponents/route';
 import * as useVideoModule from '../../data/stores/useVideo';
 import { uploadState } from '../../types/tracks';
 import { report } from '../../utils/errors/report';
@@ -134,7 +134,7 @@ describe('DashboardVideoHarvested', () => {
       wrapInIntlProvider(
         wrapInRouter(<DashboardVideoHarvested video={video} />, [
           {
-            path: ERROR_COMPONENT_ROUTE(),
+            path: FULL_SCREEN_ERROR_ROUTE(),
             render: ({ match }) => (
               <span>{`Error Component: ${match.params.code}`}</span>
             ),

--- a/src/frontend/components/DashboardVideoHarvested/index.tsx
+++ b/src/frontend/components/DashboardVideoHarvested/index.tsx
@@ -8,7 +8,7 @@ import {
   DashboardButtonWithLink,
 } from '../DashboardPaneButtons';
 import { PLAYER_ROUTE } from '../routes';
-import { ERROR_COMPONENT_ROUTE } from '../ErrorComponent/route';
+import { FULL_SCREEN_ERROR_ROUTE } from '../ErrorComponents/route';
 import { updateResource } from '../../data/sideEffects/updateResource';
 import { useVideo } from '../../data/stores/useVideo';
 import { modelName } from '../../types/models';
@@ -56,7 +56,7 @@ export const DashboardVideoHarvested = ({
   };
 
   if (error) {
-    return <Redirect push to={ERROR_COMPONENT_ROUTE('liveToVod')} />;
+    return <Redirect push to={FULL_SCREEN_ERROR_ROUTE('liveToVod')} />;
   }
 
   return (

--- a/src/frontend/components/DashboardVideoLiveConfigureButton/index.spec.tsx
+++ b/src/frontend/components/DashboardVideoLiveConfigureButton/index.spec.tsx
@@ -6,7 +6,7 @@ import { appData } from '../../data/appData';
 import { wrapInIntlProvider } from '../../utils/tests/intl';
 import { wrapInRouter } from '../../utils/tests/router';
 import { DASHBOARD_ROUTE } from '../Dashboard/route';
-import { ERROR_COMPONENT_ROUTE } from '../ErrorComponent/route';
+import { FULL_SCREEN_ERROR_ROUTE } from '../ErrorComponents/route';
 import { DashboardVideoLiveConfigureButton } from '.';
 
 jest.mock('../../data/appData', () => ({
@@ -120,7 +120,7 @@ describe('components/DashboardVideoLiveConfigureButton', () => {
           <DashboardVideoLiveConfigureButton video={appData.video!} />,
           [
             {
-              path: ERROR_COMPONENT_ROUTE('liveInit'),
+              path: FULL_SCREEN_ERROR_ROUTE('liveInit'),
               render: () => <span>error</span>,
             },
           ],

--- a/src/frontend/components/DashboardVideoLiveConfigureButton/index.tsx
+++ b/src/frontend/components/DashboardVideoLiveConfigureButton/index.tsx
@@ -9,7 +9,7 @@ import { Video } from '../../types/tracks';
 import { Nullable } from '../../utils/types';
 import { DASHBOARD_ROUTE } from '../Dashboard/route';
 import { DashboardButton } from '../DashboardPaneButtons';
-import { ERROR_COMPONENT_ROUTE } from '../ErrorComponent/route';
+import { FULL_SCREEN_ERROR_ROUTE } from '../ErrorComponents/route';
 import { Loader } from '../Loader';
 
 const messages = defineMessages({
@@ -51,7 +51,7 @@ export const DashboardVideoLiveConfigureButton = ({
   }
 
   if (status === 'error') {
-    return <Redirect push to={ERROR_COMPONENT_ROUTE('liveInit')} />;
+    return <Redirect push to={FULL_SCREEN_ERROR_ROUTE('liveInit')} />;
   }
 
   return (

--- a/src/frontend/components/DashboardVideoLiveStartButton/index.spec.tsx
+++ b/src/frontend/components/DashboardVideoLiveStartButton/index.spec.tsx
@@ -7,7 +7,7 @@ import * as useVideoModule from '../../data/stores/useVideo';
 import { uploadState, liveState } from '../../types/tracks';
 import { wrapInIntlProvider } from '../../utils/tests/intl';
 import { wrapInRouter } from '../../utils/tests/router';
-import { ERROR_COMPONENT_ROUTE } from '../ErrorComponent/route';
+import { FULL_SCREEN_ERROR_ROUTE } from '../ErrorComponents/route';
 import { DashboardVideoLiveStartButton } from '.';
 
 jest.mock('jwt-decode', () => jest.fn());
@@ -97,7 +97,7 @@ describe('components/DashboardVideoLiveStartButton', () => {
       wrapInIntlProvider(
         wrapInRouter(<DashboardVideoLiveStartButton video={video} />, [
           {
-            path: ERROR_COMPONENT_ROUTE('liveInit'),
+            path: FULL_SCREEN_ERROR_ROUTE('liveInit'),
             render: () => <span>error</span>,
           },
         ]),

--- a/src/frontend/components/DashboardVideoLiveStartButton/index.tsx
+++ b/src/frontend/components/DashboardVideoLiveStartButton/index.tsx
@@ -7,7 +7,7 @@ import { useVideo } from '../../data/stores/useVideo';
 import { Video } from '../../types/tracks';
 import { Nullable } from '../../utils/types';
 import { DashboardButton } from '../DashboardPaneButtons';
-import { ERROR_COMPONENT_ROUTE } from '../ErrorComponent/route';
+import { FULL_SCREEN_ERROR_ROUTE } from '../ErrorComponents/route';
 import { Loader } from '../Loader';
 
 const messages = defineMessages({
@@ -43,7 +43,7 @@ export const DashboardVideoLiveStartButton = ({
   }, [video]);
 
   if (status === 'error') {
-    return <Redirect push to={ERROR_COMPONENT_ROUTE('liveInit')} />;
+    return <Redirect push to={FULL_SCREEN_ERROR_ROUTE('liveInit')} />;
   }
 
   return (

--- a/src/frontend/components/DashboardVideoLiveStopButton/index.spec.tsx
+++ b/src/frontend/components/DashboardVideoLiveStopButton/index.spec.tsx
@@ -7,7 +7,7 @@ import * as useVideoModule from '../../data/stores/useVideo';
 import { uploadState, liveState } from '../../types/tracks';
 import { wrapInIntlProvider } from '../../utils/tests/intl';
 import { wrapInRouter } from '../../utils/tests/router';
-import { ERROR_COMPONENT_ROUTE } from '../ErrorComponent/route';
+import { FULL_SCREEN_ERROR_ROUTE } from '../ErrorComponents/route';
 import { DashboardVideoLiveStopButton } from '.';
 
 jest.mock('jwt-decode', () => jest.fn());
@@ -97,7 +97,7 @@ describe('components/DashboardVideoLiveStopButton', () => {
       wrapInIntlProvider(
         wrapInRouter(<DashboardVideoLiveStopButton video={video} />, [
           {
-            path: ERROR_COMPONENT_ROUTE('liveInit'),
+            path: FULL_SCREEN_ERROR_ROUTE('liveInit'),
             render: () => <span>error</span>,
           },
         ]),

--- a/src/frontend/components/DashboardVideoLiveStopButton/index.tsx
+++ b/src/frontend/components/DashboardVideoLiveStopButton/index.tsx
@@ -7,7 +7,7 @@ import { useVideo } from '../../data/stores/useVideo';
 import { Video } from '../../types/tracks';
 import { Nullable } from '../../utils/types';
 import { DashboardButton } from '../DashboardPaneButtons';
-import { ERROR_COMPONENT_ROUTE } from '../ErrorComponent/route';
+import { FULL_SCREEN_ERROR_ROUTE } from '../ErrorComponents/route';
 import { Loader } from '../Loader';
 
 const messages = defineMessages({
@@ -43,7 +43,7 @@ export const DashboardVideoLiveStopButton = ({
   }, [video]);
 
   if (status === 'error') {
-    return <Redirect push to={ERROR_COMPONENT_ROUTE('liveInit')} />;
+    return <Redirect push to={FULL_SCREEN_ERROR_ROUTE('liveInit')} />;
   }
 
   return (

--- a/src/frontend/components/DashboardVideoPane/index.spec.tsx
+++ b/src/frontend/components/DashboardVideoPane/index.spec.tsx
@@ -9,7 +9,7 @@ import { Deferred } from '../../utils/tests/Deferred';
 import { videoMockFactory } from '../../utils/tests/factories';
 import { wrapInIntlProvider } from '../../utils/tests/intl';
 import { wrapInRouter } from '../../utils/tests/router';
-import { ERROR_COMPONENT_ROUTE } from '../ErrorComponent/route';
+import { FULL_SCREEN_ERROR_ROUTE } from '../ErrorComponents/route';
 
 jest.mock('jwt-decode', () => jest.fn());
 jest.mock('../../data/appData', () => ({
@@ -42,7 +42,7 @@ describe('<DashboardVideoPane />', () => {
           />,
           [
             {
-              path: ERROR_COMPONENT_ROUTE(),
+              path: FULL_SCREEN_ERROR_ROUTE(),
               render: ({ match }) => (
                 <span>{`Error Component: ${match.params.code}`}</span>
               ),
@@ -137,7 +137,7 @@ describe('<DashboardVideoPane />', () => {
           />,
           [
             {
-              path: ERROR_COMPONENT_ROUTE(),
+              path: FULL_SCREEN_ERROR_ROUTE(),
               render: ({ match }) => (
                 <span>{`Error Component: ${match.params.code}`}</span>
               ),

--- a/src/frontend/components/DashboardVideoPane/index.tsx
+++ b/src/frontend/components/DashboardVideoPane/index.tsx
@@ -18,7 +18,7 @@ import { DashboardVideoHarvested } from '../DashboardVideoHarvested';
 import { DashboardVideoLive } from '../DashboardVideoLive';
 import { DashboardVideoPaneDownloadOption } from '../DashboardVideoPaneDownloadOption';
 import { DashboardVideoPaneTranscriptOption } from '../DashboardVideoPaneTranscriptOption';
-import { ERROR_COMPONENT_ROUTE } from '../ErrorComponent/route';
+import { FULL_SCREEN_ERROR_ROUTE } from '../ErrorComponents/route';
 import { ObjectStatusPicker } from '../ObjectStatusPicker';
 
 const {
@@ -154,11 +154,11 @@ export const DashboardVideoPane = ({ video }: DashboardVideoPaneProps) => {
   }, []);
 
   if (error) {
-    return <Redirect push to={ERROR_COMPONENT_ROUTE('notFound')} />;
+    return <Redirect push to={FULL_SCREEN_ERROR_ROUTE('notFound')} />;
   }
 
   if (!video.is_ready_to_show && video.upload_state === ERROR) {
-    return <Redirect push to={ERROR_COMPONENT_ROUTE('upload')} />;
+    return <Redirect push to={FULL_SCREEN_ERROR_ROUTE('upload')} />;
   }
 
   const CommonStatusLine = () => (

--- a/src/frontend/components/ErrorComponent/route.ts
+++ b/src/frontend/components/ErrorComponent/route.ts
@@ -1,8 +1,0 @@
-import { ErrorComponentProps } from '.';
-
-/**
- * Route for the `<ErrorComponent />` component.
- * @param code One of the error codes (strings) supported by `<ErrorComponent />`
- */
-export const ERROR_COMPONENT_ROUTE = (code?: ErrorComponentProps['code']) =>
-  code ? `/errors/${code}` : '/errors/:code';

--- a/src/frontend/components/ErrorComponents/index.spec.tsx
+++ b/src/frontend/components/ErrorComponents/index.spec.tsx
@@ -1,13 +1,13 @@
 import { render } from '@testing-library/react';
 import React from 'react';
 
-import { ErrorComponent } from '.';
+import { FullScreenError } from '.';
 import { wrapInIntlProvider } from '../../utils/tests/intl';
 
-describe('<ErrorComponent />', () => {
+describe('<FullScreenError />', () => {
   it('displays the content for 404 not found errors', () => {
     const { getByText } = render(
-      wrapInIntlProvider(<ErrorComponent code="notFound" />),
+      wrapInIntlProvider(<FullScreenError code="notFound" />),
     );
     getByText('The video you are looking for could not be found');
     getByText(
@@ -17,7 +17,7 @@ describe('<ErrorComponent />', () => {
 
   it('displays the content for lti related errors', () => {
     const { getByText } = render(
-      wrapInIntlProvider(<ErrorComponent code="lti" />),
+      wrapInIntlProvider(<FullScreenError code="lti" />),
     );
     getByText('There was an error loading this video');
     getByText(

--- a/src/frontend/components/ErrorComponents/index.tsx
+++ b/src/frontend/components/ErrorComponents/index.tsx
@@ -1,3 +1,4 @@
+import { Box, Heading, Paragraph } from 'grommet';
 import React from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import styled from 'styled-components';
@@ -5,8 +6,9 @@ import styled from 'styled-components';
 import { H2 } from '../Headings';
 import { LayoutMainArea } from '../LayoutMainArea';
 
-export interface ErrorComponentProps {
+export interface ErrorComponentsProps {
   code:
+    | 'generic'
     | 'lti'
     | 'notFound'
     | 'policy'
@@ -16,7 +18,7 @@ export interface ErrorComponentProps {
     | 'liveToVod';
 }
 
-const ErrorComponentStyled = styled(LayoutMainArea)`
+const FullScreenErrorStyled = styled(LayoutMainArea)`
   display: flex;
   flex-direction: column;
   padding: 0 2rem;
@@ -34,17 +36,32 @@ const ErrorContent = styled.div`
 `;
 
 const messages = {
+  generic: defineMessages({
+    text: {
+      defaultMessage: `We could not access the appropriate resources. You can try reloating the page
+      or try again at a later time.`,
+      description:
+        'Helpful text for the generic error message (random API request failure).',
+      id: 'components.ErrorComponents.generic.text',
+    },
+    title: {
+      defaultMessage: 'There was an unexpected error',
+      description:
+        'Title for the generic error message (random API request failure).',
+      id: 'components.ErrorComponents.generic.title',
+    },
+  }),
   lti: defineMessages({
     text: {
       defaultMessage: `We could not validate your access to this video. Please contact your instructor.
       If you are the instructor, please check your settings.`,
       description: 'Helpful text for the LTI error page',
-      id: 'components.ErrorComponent.lti.text',
+      id: 'components.ErrorComponents.lti.text',
     },
     title: {
       defaultMessage: 'There was an error loading this video',
       description: 'Title for the LTI error page',
-      id: 'components.ErrorComponent.lti.title',
+      id: 'components.ErrorComponents.lti.title',
     },
   }),
   notFound: defineMessages({
@@ -52,12 +69,12 @@ const messages = {
       defaultMessage: `This video does not exist or has not been published yet.
       If you are an instructor, please make sure you are properly authenticated.`,
       description: 'Helpful text for the 404 Not Found error page',
-      id: 'components.ErrorComponent.notFound.text',
+      id: 'components.ErrorComponents.notFound.text',
     },
     title: {
       defaultMessage: 'The video you are looking for could not be found',
       description: 'Title for the 404 Not Found error page',
-      id: 'components.ErrorComponent.notFound.title',
+      id: 'components.ErrorComponents.notFound.title',
     },
   }),
   policy: defineMessages({
@@ -65,12 +82,12 @@ const messages = {
       defaultMessage:
         'We could not make sure you are allowed to upload a video file. Please check your settings and/or try again.',
       description: 'Title for the upload permission error page',
-      id: 'components.ErrorComponent.policy.text',
+      id: 'components.ErrorComponents.policy.text',
     },
     title: {
       defaultMessage: 'Failed to authenticate your permission to upload',
       description: 'Helpful text for the upload permission error page',
-      id: 'components.ErrorComponent.policy.title',
+      id: 'components.ErrorComponents.policy.title',
     },
   }),
   upload: defineMessages({
@@ -78,12 +95,12 @@ const messages = {
       defaultMessage:
         'You can try again later. You may want to check your Internet connection quality.',
       description: 'Helpful text for the Upload error page',
-      id: 'components.ErrorComponent.upload.text',
+      id: 'components.ErrorComponents.upload.text',
     },
     title: {
       defaultMessage: 'Failed to upload your video file',
       description: 'Title for the video upload error page',
-      id: 'components.ErrorComponent.upload.title',
+      id: 'components.ErrorComponents.upload.title',
     },
   }),
   liveIncompatible: defineMessages({
@@ -91,12 +108,12 @@ const messages = {
       defaultMessage:
         'You can try again later. You may want to check your Internet connection quality.',
       description: 'Helpful text for the Upload error page',
-      id: 'components.ErrorComponent.upload.text',
+      id: 'components.ErrorComponents.upload.text',
     },
     title: {
       defaultMessage: 'Live mode incompatible with this object',
       description: 'Title when the object is incompatible with live mode',
-      id: 'components.ErrorComponent.liveIncompatible.title',
+      id: 'components.ErrorComponents.liveIncompatible.title',
     },
   }),
   liveInit: {
@@ -104,40 +121,49 @@ const messages = {
       defaultMessage:
         'We could not make sure you are allowed to modify a live. Please check your settings and/or try again.',
       description: 'Title for the live permission error page',
-      id: 'components.ErrorComponent.liveInit.text',
+      id: 'components.ErrorComponents.liveInit.text',
     },
     title: {
       defaultMessage: 'Failed to authenticate your permission to modify a live',
       description: 'Helpful text for the upload permission error page',
-      id: 'components.ErrorComponent.liveInit.title',
+      id: 'components.ErrorComponents.liveInit.title',
     },
   },
   liveToVod: {
     text: {
       defaultMessage: 'Failed to publish a VOD',
       description: 'Error title when publish a live to VOD fails.',
-      id: 'components.ErrorComponent.liveToVod.title',
+      id: 'components.ErrorComponents.liveToVod.title',
     },
     title: {
       defaultMessage:
         'We could not publish this video as a VOD. Please retry later',
       description: 'Error message when publish a live to VOD fails.',
-      id: 'components.ErrorComponent.liveToVod.text',
+      id: 'components.ErrorComponents.liveToVod.text',
     },
   },
 };
 
-export const ErrorComponent = (props: ErrorComponentProps) => {
-  return (
-    <ErrorComponentStyled>
-      <ErrorContent>
-        <H2>
-          <FormattedMessage {...messages[props.code].title} />
-        </H2>
-        <p>
-          <FormattedMessage {...messages[props.code].text} />
-        </p>
-      </ErrorContent>
-    </ErrorComponentStyled>
-  );
-};
+export const ErrorMessage: React.FC<ErrorComponentsProps> = ({ code }) => (
+  <Box direction="column">
+    <Heading level={6}>
+      <FormattedMessage {...messages[code].title} />
+    </Heading>
+    <Paragraph>
+      <FormattedMessage {...messages[code].text} />
+    </Paragraph>
+  </Box>
+);
+
+export const FullScreenError: React.FC<ErrorComponentsProps> = ({ code }) => (
+  <FullScreenErrorStyled>
+    <ErrorContent>
+      <H2>
+        <FormattedMessage {...messages[code].title} />
+      </H2>
+      <Paragraph>
+        <FormattedMessage {...messages[code].text} />
+      </Paragraph>
+    </ErrorContent>
+  </FullScreenErrorStyled>
+);

--- a/src/frontend/components/ErrorComponents/route.ts
+++ b/src/frontend/components/ErrorComponents/route.ts
@@ -1,0 +1,8 @@
+import { ErrorComponentsProps } from '.';
+
+/**
+ * Route for the `<FullScreenError />` component.
+ * @param code One of the error codes (strings) supported by `<FullScreenError />`
+ */
+export const FULL_SCREEN_ERROR_ROUTE = (code?: ErrorComponentsProps['code']) =>
+  code ? `/errors/${code}` : '/errors/:code';

--- a/src/frontend/components/LTIRoutes/index.tsx
+++ b/src/frontend/components/LTIRoutes/index.tsx
@@ -4,8 +4,8 @@ import { MemoryRouter, Redirect, Route, Switch } from 'react-router-dom';
 import { appData } from '../../data/appData';
 import { modelName } from '../../types/models';
 import { DASHBOARD_ROUTE } from '../Dashboard/route';
-import { ErrorComponent } from '../ErrorComponent';
-import { ERROR_COMPONENT_ROUTE } from '../ErrorComponent/route';
+import { FullScreenError } from '../ErrorComponents';
+import { FULL_SCREEN_ERROR_ROUTE } from '../ErrorComponents/route';
 import { InstructorWrapper } from '../InstructorWrapper';
 import { Loader } from '../Loader';
 import { RedirectOnLoad } from '../RedirectOnLoad';
@@ -48,7 +48,7 @@ export const Routes = () => (
               );
             }
 
-            return <Redirect push to={ERROR_COMPONENT_ROUTE('notFound')} />;
+            return <Redirect push to={FULL_SCREEN_ERROR_ROUTE('notFound')} />;
           }}
         />
         <Route
@@ -63,8 +63,8 @@ export const Routes = () => (
         />
         <Route
           exact
-          path={ERROR_COMPONENT_ROUTE()}
-          render={({ match }) => <ErrorComponent code={match.params.code} />}
+          path={FULL_SCREEN_ERROR_ROUTE()}
+          render={({ match }) => <FullScreenError code={match.params.code} />}
         />
         <Route
           exact
@@ -88,7 +88,7 @@ export const Routes = () => (
               );
             }
 
-            return <Redirect push to={ERROR_COMPONENT_ROUTE('notFound')} />;
+            return <Redirect push to={FULL_SCREEN_ERROR_ROUTE('notFound')} />;
           }}
         />
         <Route path={REDIRECT_ON_LOAD_ROUTE()} component={RedirectOnLoad} />

--- a/src/frontend/components/RedirectOnLoad/index.spec.tsx
+++ b/src/frontend/components/RedirectOnLoad/index.spec.tsx
@@ -6,7 +6,7 @@ import { modelName } from '../../types/models';
 import { uploadState } from '../../types/tracks';
 import { wrapInRouter } from '../../utils/tests/router';
 import { DASHBOARD_ROUTE } from '../Dashboard/route';
-import { ERROR_COMPONENT_ROUTE } from '../ErrorComponent/route';
+import { FULL_SCREEN_ERROR_ROUTE } from '../ErrorComponents/route';
 import { PLAYER_ROUTE } from '../routes';
 import { UPLOAD_FORM_ROUTE } from '../UploadForm/route';
 import { RedirectOnLoad } from './index';
@@ -53,7 +53,7 @@ describe('<RedirectOnLoad />', () => {
     const { getByText } = render(
       wrapInRouter(<RedirectOnLoad />, [
         {
-          path: ERROR_COMPONENT_ROUTE(),
+          path: FULL_SCREEN_ERROR_ROUTE(),
           render: ({ match }) => (
             <span>{`Error Component: ${match.params.code}`}</span>
           ),
@@ -73,7 +73,7 @@ describe('<RedirectOnLoad />', () => {
     const { getByText } = render(
       wrapInRouter(<RedirectOnLoad />, [
         {
-          path: ERROR_COMPONENT_ROUTE(),
+          path: FULL_SCREEN_ERROR_ROUTE(),
           render: ({ match }) => (
             <span>{`Error Component: ${match.params.code}`}</span>
           ),
@@ -189,7 +189,7 @@ describe('<RedirectOnLoad />', () => {
     const { getByText } = render(
       wrapInRouter(<RedirectOnLoad />, [
         {
-          path: ERROR_COMPONENT_ROUTE(),
+          path: FULL_SCREEN_ERROR_ROUTE(),
           render: ({ match }) => (
             <span>{`Error Component: ${match.params.code}`}</span>
           ),
@@ -213,7 +213,7 @@ describe('<RedirectOnLoad />', () => {
     const { getByText } = render(
       wrapInRouter(<RedirectOnLoad />, [
         {
-          path: ERROR_COMPONENT_ROUTE(),
+          path: FULL_SCREEN_ERROR_ROUTE(),
           render: ({ match }) => (
             <span>{`Error Component: ${match.params.code}`}</span>
           ),

--- a/src/frontend/components/RedirectOnLoad/index.tsx
+++ b/src/frontend/components/RedirectOnLoad/index.tsx
@@ -5,7 +5,7 @@ import { appData, getDecodedJwt } from '../../data/appData';
 import { appState } from '../../types/AppData';
 import { uploadState } from '../../types/tracks';
 import { DASHBOARD_ROUTE } from '../Dashboard/route';
-import { ERROR_COMPONENT_ROUTE } from '../ErrorComponent/route';
+import { FULL_SCREEN_ERROR_ROUTE } from '../ErrorComponents/route';
 import { PLAYER_ROUTE } from '../routes';
 
 // RedirectOnLoad assesses the initial state of the application using appData and determines the proper
@@ -14,11 +14,11 @@ export const RedirectOnLoad = () => {
   const resource = appData.document || appData.video || null;
   // Get LTI errors out of the way
   if (appData.state === appState.ERROR) {
-    return <Redirect push to={ERROR_COMPONENT_ROUTE('lti')} />;
+    return <Redirect push to={FULL_SCREEN_ERROR_ROUTE('lti')} />;
   }
 
   if (!resource) {
-    return <Redirect push to={ERROR_COMPONENT_ROUTE('notFound')} />;
+    return <Redirect push to={FULL_SCREEN_ERROR_ROUTE('notFound')} />;
   }
 
   if (resource && resource.is_ready_to_show) {
@@ -31,5 +31,5 @@ export const RedirectOnLoad = () => {
 
   // For safety default to the 404 view: this is for users not able to edit the current resource
   // when this one is not ready.
-  return <Redirect push to={ERROR_COMPONENT_ROUTE('notFound')} />;
+  return <Redirect push to={FULL_SCREEN_ERROR_ROUTE('notFound')} />;
 };

--- a/src/frontend/components/TimedTextCreationForm/index.spec.tsx
+++ b/src/frontend/components/TimedTextCreationForm/index.spec.tsx
@@ -7,7 +7,7 @@ import { timedTextMode, uploadState } from '../../types/tracks';
 import { report } from '../../utils/errors/report';
 import { wrapInIntlProvider } from '../../utils/tests/intl';
 import { wrapInRouter } from '../../utils/tests/router';
-import { ERROR_COMPONENT_ROUTE } from '../ErrorComponent/route';
+import { FULL_SCREEN_ERROR_ROUTE } from '../ErrorComponents/route';
 import { UPLOAD_FORM_ROUTE } from '../UploadForm/route';
 
 jest.mock('../../utils/errors/report', () => ({ report: jest.fn() }));
@@ -126,7 +126,7 @@ describe('<TimedTextCreationForm />', () => {
           />,
           [
             {
-              path: ERROR_COMPONENT_ROUTE(),
+              path: FULL_SCREEN_ERROR_ROUTE(),
               render: ({ match }) => (
                 <span>{`Error Component: ${match.params.code}`}</span>
               ),

--- a/src/frontend/components/TimedTextCreationForm/index.tsx
+++ b/src/frontend/components/TimedTextCreationForm/index.tsx
@@ -15,7 +15,7 @@ import { TimedText, timedTextMode } from '../../types/tracks';
 import { report } from '../../utils/errors/report';
 import { theme } from '../../utils/theme/theme';
 import { Maybe } from '../../utils/types';
-import { ERROR_COMPONENT_ROUTE } from '../ErrorComponent/route';
+import { FULL_SCREEN_ERROR_ROUTE } from '../ErrorComponents/route';
 import { UPLOAD_FORM_ROUTE } from '../UploadForm/route';
 
 const messages = defineMessages({
@@ -112,7 +112,7 @@ export const TimedTextCreationForm = ({
   };
 
   if (error === 'schema') {
-    return <Redirect push to={ERROR_COMPONENT_ROUTE('notFound')} />;
+    return <Redirect push to={FULL_SCREEN_ERROR_ROUTE('notFound')} />;
   }
 
   if (newTTUploadId) {

--- a/src/frontend/components/TimedTextListItem/index.spec.tsx
+++ b/src/frontend/components/TimedTextListItem/index.spec.tsx
@@ -10,7 +10,7 @@ import fetchMock from 'fetch-mock';
 import React from 'react';
 
 import { TimedTextListItem } from '.';
-import { ERROR_COMPONENT_ROUTE } from '../../components/ErrorComponent/route';
+import { FULL_SCREEN_ERROR_ROUTE } from '../ErrorComponents/route';
 import { timedTextMode, uploadState } from '../../types/tracks';
 import { wrapInIntlProvider } from '../../utils/tests/intl';
 import { Deferred } from '../../utils/tests/Deferred';
@@ -104,7 +104,7 @@ describe('<TimedTextListItem />', () => {
         wrapInIntlProvider(
           wrapInRouter(<TimedTextListItem track={track} />, [
             {
-              path: ERROR_COMPONENT_ROUTE(),
+              path: FULL_SCREEN_ERROR_ROUTE(),
               render: ({ match }) => (
                 <span>{`Error Component: ${match.params.code}`}</span>
               ),

--- a/src/frontend/components/TimedTextListItem/index.tsx
+++ b/src/frontend/components/TimedTextListItem/index.tsx
@@ -13,7 +13,7 @@ import { modelName } from '../../types/models';
 import { TimedText, uploadState } from '../../types/tracks';
 import { Maybe } from '../../utils/types';
 import { ActionLink } from '../ActionLink/ActionLink';
-import { ERROR_COMPONENT_ROUTE } from '../ErrorComponent/route';
+import { FULL_SCREEN_ERROR_ROUTE } from '../ErrorComponents/route';
 import { UPLOAD_FORM_ROUTE } from '../UploadForm/route';
 import { ObjectStatusPicker } from '../ObjectStatusPicker';
 
@@ -95,7 +95,7 @@ export const TimedTextListItem = ({ track }: TimedTextListItemProps) => {
   }, []);
 
   if (error) {
-    return <Redirect push to={ERROR_COMPONENT_ROUTE('notFound')} />;
+    return <Redirect push to={FULL_SCREEN_ERROR_ROUTE('notFound')} />;
   }
 
   const language: Maybe<LanguageChoice> =

--- a/src/frontend/components/UploadForm/index.spec.tsx
+++ b/src/frontend/components/UploadForm/index.spec.tsx
@@ -15,7 +15,7 @@ import { wrapInIntlProvider } from '../../utils/tests/intl';
 import { wrapInRouter } from '../../utils/tests/router';
 import { jestMockOf } from '../../utils/types';
 import { DASHBOARD_ROUTE } from '../Dashboard/route';
-import { ERROR_COMPONENT_ROUTE } from '../ErrorComponent/route';
+import { FULL_SCREEN_ERROR_ROUTE } from '../ErrorComponents/route';
 import { UploadForm } from './index';
 
 jest.mock('jwt-decode', () => jest.fn());
@@ -184,7 +184,7 @@ describe('UploadForm', () => {
           <UploadForm objectId={object.id} objectType={modelName.VIDEOS} />,
           [
             {
-              path: ERROR_COMPONENT_ROUTE('policy'),
+              path: FULL_SCREEN_ERROR_ROUTE('policy'),
               render: () => <span>error policy</span>,
             },
           ],

--- a/src/frontend/components/UploadForm/index.tsx
+++ b/src/frontend/components/UploadForm/index.tsx
@@ -12,7 +12,7 @@ import { TimedText, timedTextMode, UploadableObject } from '../../types/tracks';
 import { Maybe } from '../../utils/types';
 import { useAsyncEffect } from '../../utils/useAsyncEffect';
 import { DASHBOARD_ROUTE } from '../Dashboard/route';
-import { ERROR_COMPONENT_ROUTE } from '../ErrorComponent/route';
+import { FULL_SCREEN_ERROR_ROUTE } from '../ErrorComponents/route';
 import { IframeHeading } from '../Headings';
 import { LayoutMainArea } from '../LayoutMainArea';
 import { Loader } from '../Loader';
@@ -129,10 +129,10 @@ export const UploadForm = ({ objectId, objectType }: UploadFormProps) => {
       return <Redirect push to={DASHBOARD_ROUTE(appData.modelName)} />;
 
     case 'not_found_error':
-      return <Redirect push to={ERROR_COMPONENT_ROUTE('notFound')} />;
+      return <Redirect push to={FULL_SCREEN_ERROR_ROUTE('notFound')} />;
 
     case 'policy_error':
-      return <Redirect push to={ERROR_COMPONENT_ROUTE('policy')} />;
+      return <Redirect push to={FULL_SCREEN_ERROR_ROUTE('policy')} />;
 
     default:
       return (

--- a/src/frontend/components/VideoPlayer/index.tsx
+++ b/src/frontend/components/VideoPlayer/index.tsx
@@ -18,7 +18,7 @@ import {
 import { VideoPlayerInterface } from '../../types/VideoPlayer';
 import { Maybe, Nullable } from '../../utils/types';
 import { DownloadVideo } from '../DownloadVideo';
-import { ERROR_COMPONENT_ROUTE } from '../ErrorComponent/route';
+import { FULL_SCREEN_ERROR_ROUTE } from '../ErrorComponents/route';
 import { Transcripts } from '../Transcripts';
 import './VideoPlayer.css'; // Improve some plyr styles
 
@@ -99,7 +99,7 @@ const VideoPlayer = ({
 
   // The video is somehow missing and jwt must be set
   if (!video) {
-    return <Redirect push to={ERROR_COMPONENT_ROUTE('notFound')} />;
+    return <Redirect push to={FULL_SCREEN_ERROR_ROUTE('notFound')} />;
   }
 
   const transcripts = timedTextTracks


### PR DESCRIPTION
## Purpose

The general use error component already in marsha is meant to take up the whole screen in the context of the LTI iframe Marsha operates in.

This is not appropriate for the new marsha site, where we want most errors to be colocated with the content they are linked with instead.

## Proposal

Instead of creating a second error component, we added a "generic" kind of error to the available codes and created a second component in the same file that can display a simple error message in the page flow instead of taking up the whole screen.

