### PR TITLE
Add retrieve endpoints for playlist & organization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Switch to enable sentry in front application
 - Management command checking live stuck in IDLE
 - Add new live state CREATING
+- Open retrieve endpoints for organizations & playlists
 
 ### Changed
 

--- a/src/backend/marsha/core/api.py
+++ b/src/backend/marsha/core/api.py
@@ -20,7 +20,7 @@ from rest_framework_simplejwt.models import TokenUser
 
 from . import defaults, forms, permissions, serializers
 from .lti import LTIUser
-from .models import Document, Playlist, Thumbnail, TimedTextTrack, Video
+from .models import Document, Organization, Playlist, Thumbnail, TimedTextTrack, Video
 from .utils.api_utils import validate_signature
 from .utils.medialive_utils import (
     create_live_stream,
@@ -83,6 +83,32 @@ class UserViewSet(viewsets.GenericViewSet):
             return Response(status=401)
 
         return Response(data=self.get_serializer(user).data)
+
+
+class OrganizationViewSet(ObjectPkMixin, viewsets.ModelViewSet):
+    """ViewSet for all organization-related interactions."""
+
+    permission_classes = [permissions.NotAllowed]
+    queryset = Organization.objects.all()
+    serializer_class = serializers.OrganizationSerializer
+
+    def get_permissions(self):
+        """
+        Manage permissions for built-in DRF methods.
+
+        Default to the actions' self defined permissions if applicable or
+        to the ViewSet's default permissions.
+        """
+        if self.action in ["retrieve"]:
+            permission_classes = [permissions.IsOrganizationAdmin]
+        else:
+            try:
+                permission_classes = getattr(self, self.action).kwargs.get(
+                    "permission_classes"
+                )
+            except AttributeError:
+                permission_classes = self.permission_classes
+        return [permission() for permission in permission_classes]
 
 
 class PlaylistViewSet(ObjectPkMixin, viewsets.ModelViewSet):

--- a/src/backend/marsha/core/permissions.py
+++ b/src/backend/marsha/core/permissions.py
@@ -271,6 +271,52 @@ class IsParamsPlaylistAdminThroughOrganization(permissions.BasePermission):
             return False
 
 
+class IsPlaylistAdmin(permissions.BasePermission):
+    """
+    Allow a request to proceed. Permission class.
+
+    Only if the user has an access to the playlist in the path, with
+    an administrator role.
+    """
+
+    def has_permission(self, request, view):
+        """
+        Allow the request.
+
+        Only if the playlist exists and the current logged in user is one
+        of its administrator.
+        """
+        return models.PlaylistAccess.objects.filter(
+            role=ADMINISTRATOR,
+            # Avoid making extra requests to get the playlist id through get_object
+            playlist__id=view.get_object_pk(),
+            user__id=request.user.id,
+        ).exists()
+
+
+class IsPlaylistOrganizationAdmin(permissions.BasePermission):
+    """
+    Allow a request to proceed. Permission class.
+
+    Only if the user is a member of the organization related to the playlist
+    in the path, with an administrator role.
+    """
+
+    def has_permission(self, request, view):
+        """
+        Allow the request.
+
+        Only if the playlist exists and the current logged in user is one
+        of the administrators of its related organization.
+        """
+        return models.OrganizationAccess.objects.filter(
+            role=ADMINISTRATOR,
+            # Avoid making extra requests to get the playlist id through get_object
+            organization__playlists__id=view.get_object_pk(),
+            user__id=request.user.id,
+        ).exists()
+
+
 class IsVideoPlaylistAdmin(permissions.BasePermission):
     """
     Allow a request to proceed. Permission class.

--- a/src/backend/marsha/core/permissions.py
+++ b/src/backend/marsha/core/permissions.py
@@ -271,6 +271,29 @@ class IsParamsPlaylistAdminThroughOrganization(permissions.BasePermission):
             return False
 
 
+class IsOrganizationAdmin(permissions.BasePermission):
+    """
+    Allow a request to proceed. Permission class.
+
+    Only if the user is a member of the organization in the path, with
+    an administrator role.
+    """
+
+    def has_permission(self, request, view):
+        """
+        Allow the request.
+
+        Only if the organization exists and the current logged in user is one
+        of its administrators.
+        """
+        return models.OrganizationAccess.objects.filter(
+            role=ADMINISTRATOR,
+            # Avoid making extra requests to get the organization id through get_object
+            organization__id=view.get_object_pk(),
+            user__id=request.user.id,
+        ).exists()
+
+
 class IsPlaylistAdmin(permissions.BasePermission):
     """
     Allow a request to proceed. Permission class.

--- a/src/backend/marsha/core/serializers.py
+++ b/src/backend/marsha/core/serializers.py
@@ -27,6 +27,7 @@ from .defaults import (
 )
 from .models import (
     Document,
+    Organization,
     OrganizationAccess,
     Playlist,
     Thumbnail,
@@ -417,6 +418,22 @@ class ThumbnailSerializer(serializers.ModelSerializer):
                 )
             return urls
         return None
+
+
+class OrganizationSerializer(serializers.ModelSerializer):
+    """Serializer to display a complete Organization resource."""
+
+    class Meta:
+        """Meta for OrganizationSerializer."""
+
+        model = Organization
+        fields = [
+            "consumer_sites",
+            "created_on",
+            "id",
+            "name",
+            "users",
+        ]
 
 
 class PlaylistSerializer(serializers.ModelSerializer):

--- a/src/backend/marsha/core/tests/test_api_organization.py
+++ b/src/backend/marsha/core/tests/test_api_organization.py
@@ -1,0 +1,244 @@
+"""Tests for the Organization API of the Marsha project."""
+from django.test import TestCase
+
+from rest_framework_simplejwt.tokens import AccessToken
+
+from .. import factories, models
+
+
+class OrganizationAPITest(TestCase):
+    """Test the API for organization objects."""
+
+    def test_create_organization_by_anonymous_user(self):
+        """Anonymous users cannot create organizations."""
+        response = self.client.post(
+            "/api/organizations/", {"name": "organization name"}
+        )
+
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(models.Organization.objects.count(), 0)
+
+    def test_create_organization_by_random_logged_in_user(self):
+        """Random logged-in users cannot create organizations."""
+        user = factories.UserFactory()
+
+        jwt_token = AccessToken()
+        jwt_token.payload["resource_id"] = str(user.id)
+        jwt_token.payload["user_id"] = str(user.id)
+
+        response = self.client.post(
+            "/api/organizations/",
+            {"name": "organization name"},
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(models.Organization.objects.count(), 0)
+
+    def test_retrieve_organization_by_anonymous_user(self):
+        """Anonymous users cannot retrieve organizations."""
+        organization = factories.OrganizationFactory()
+        response = self.client.get(f"/api/organizations/{organization.id}/")
+        self.assertEqual(response.status_code, 401)
+
+    def test_retrieve_organization_by_random_logged_in_user(self):
+        """Random logged-in users cannot retrieve organizations unrelated to them."""
+        user = factories.UserFactory()
+        organization = factories.OrganizationFactory()
+
+        jwt_token = AccessToken()
+        jwt_token.payload["resource_id"] = str(user.id)
+        jwt_token.payload["user_id"] = str(user.id)
+
+        response = self.client.get(
+            f"/api/organizations/{organization.id}/",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_retrieve_organization_by_instructor(self):
+        """Organization instructors cannot retrieve organizations."""
+        user = factories.UserFactory()
+        organization = factories.OrganizationFactory()
+        factories.OrganizationAccessFactory(
+            user=user, organization=organization, role=models.INSTRUCTOR
+        )
+
+        jwt_token = AccessToken()
+        jwt_token.payload["resource_id"] = str(user.id)
+        jwt_token.payload["user_id"] = str(user.id)
+
+        response = self.client.get(
+            f"/api/organizations/{organization.id}/",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_retrieve_organization_by_admin(self):
+        """Organization administrators can retrieve organizations."""
+        user = factories.UserFactory()
+        organization = factories.OrganizationFactory()
+        factories.OrganizationAccessFactory(
+            user=user, organization=organization, role=models.ADMINISTRATOR
+        )
+
+        jwt_token = AccessToken()
+        jwt_token.payload["resource_id"] = str(user.id)
+        jwt_token.payload["user_id"] = str(user.id)
+
+        response = self.client.get(
+            f"/api/organizations/{organization.id}/",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {
+                "consumer_sites": [],
+                "created_on": organization.created_on.isoformat()[:-6]
+                + "Z",  # NB: DRF literally does this
+                "id": str(organization.id),
+                "name": organization.name,
+                "users": [str(user.id)],
+            },
+        )
+
+    def test_list_organizations_by_anonymous_user(self):
+        """Anonymous users cannot list organizations."""
+        factories.OrganizationFactory()
+        response = self.client.get("/api/organizations/")
+        self.assertEqual(response.status_code, 401)
+
+    def test_list_organizations_by_random_logged_in_user(self):
+        """Random logged-in users cannot list organizations."""
+        user = factories.UserFactory()
+        factories.OrganizationFactory()
+
+        jwt_token = AccessToken()
+        jwt_token.payload["resource_id"] = str(user.id)
+        jwt_token.payload["user_id"] = str(user.id)
+
+        response = self.client.get(
+            "/api/organizations/",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_list_organizations_by_admin(self):
+        """Organization admins cannot list organizations."""
+        user = factories.UserFactory()
+        organization = factories.OrganizationFactory()
+        factories.OrganizationAccessFactory(
+            user=user, organization=organization, role=models.ADMINISTRATOR
+        )
+
+        jwt_token = AccessToken()
+        jwt_token.payload["resource_id"] = str(user.id)
+        jwt_token.payload["user_id"] = str(user.id)
+
+        response = self.client.get(
+            "/api/organizations/",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_delete_organization_by_anonymous_user(self):
+        """Anonymous users cannot delete organizations."""
+        organization = factories.OrganizationFactory()
+        self.assertEqual(models.Organization.objects.count(), 1)
+
+        response = self.client.delete(f"/api/organizations/{organization.id}/")
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(models.Organization.objects.count(), 1)
+
+    def test_delete_organization_by_random_logged_in_user(self):
+        """Random logged-in users cannot delete organizations."""
+        user = factories.UserFactory()
+        organization = factories.OrganizationFactory()
+        self.assertEqual(models.Organization.objects.count(), 1)
+
+        jwt_token = AccessToken()
+        jwt_token.payload["resource_id"] = str(user.id)
+        jwt_token.payload["user_id"] = str(user.id)
+
+        response = self.client.delete(
+            f"/api/organizations/{organization.id}/",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(models.Organization.objects.count(), 1)
+
+    def test_delete_organization_by_admin(self):
+        """Organization admins cannot delete organizations."""
+        user = factories.UserFactory()
+        organization = factories.OrganizationFactory()
+        factories.OrganizationAccessFactory(
+            user=user, organization=organization, role=models.ADMINISTRATOR
+        )
+        self.assertEqual(models.Organization.objects.count(), 1)
+
+        jwt_token = AccessToken()
+        jwt_token.payload["resource_id"] = str(user.id)
+        jwt_token.payload["user_id"] = str(user.id)
+
+        response = self.client.delete(
+            f"/api/organizations/{organization.id}/",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(models.Organization.objects.count(), 1)
+
+    def test_update_organization_by_anonymous_user(self):
+        """Anonymous users cannot update organizations."""
+        organization = factories.OrganizationFactory(name="existing name")
+        response = self.client.put(
+            f"/api/organizations/{organization.id}/", {"name": "new name"}
+        )
+
+        self.assertEqual(response.status_code, 401)
+        organization.refresh_from_db()
+        self.assertEqual(organization.name, "existing name")
+
+    def test_update_organization_by_random_logged_in_user(self):
+        """Random logged-in users cannot update organizations."""
+        user = factories.UserFactory()
+        organization = factories.OrganizationFactory(name="existing name")
+
+        jwt_token = AccessToken()
+        jwt_token.payload["resource_id"] = str(user.id)
+        jwt_token.payload["user_id"] = str(user.id)
+
+        response = self.client.put(
+            f"/api/organizations/{organization.id}/",
+            {"name": "new name"},
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+
+        self.assertEqual(response.status_code, 403)
+        organization.refresh_from_db()
+        self.assertEqual(organization.name, "existing name")
+
+    def test_update_organization_by_admin(self):
+        """Organization admins cannot update organizations."""
+        user = factories.UserFactory()
+        organization = factories.OrganizationFactory(name="existing name")
+        factories.OrganizationAccessFactory(
+            user=user, organization=organization, role=models.ADMINISTRATOR
+        )
+
+        jwt_token = AccessToken()
+        jwt_token.payload["resource_id"] = str(user.id)
+        jwt_token.payload["user_id"] = str(user.id)
+
+        response = self.client.put(
+            f"/api/organizations/{organization.id}/",
+            {"name": "new name"},
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+
+        self.assertEqual(response.status_code, 403)
+        organization.refresh_from_db()
+        self.assertEqual(organization.name, "existing name")

--- a/src/backend/marsha/core/tests/test_api_playlist.py
+++ b/src/backend/marsha/core/tests/test_api_playlist.py
@@ -169,7 +169,8 @@ class PlaylistAPITest(TestCase):
         jwt_token.payload["user_id"] = str(user.id)
 
         response = self.client.get(
-            f"/api/playlists/{playlist.id}/", HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+            f"/api/playlists/{playlist.id}/",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
         self.assertEqual(response.status_code, 403)
@@ -187,7 +188,8 @@ class PlaylistAPITest(TestCase):
         jwt_token.payload["user_id"] = str(user.id)
 
         response = self.client.get(
-            f"/api/playlists/{playlist.id}/", HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+            f"/api/playlists/{playlist.id}/",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
         self.assertEqual(response.status_code, 403)
@@ -205,7 +207,8 @@ class PlaylistAPITest(TestCase):
         jwt_token.payload["user_id"] = str(user.id)
 
         response = self.client.get(
-            f"/api/playlists/{playlist.id}/", HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+            f"/api/playlists/{playlist.id}/",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
         self.assertEqual(response.status_code, 200)
@@ -241,7 +244,8 @@ class PlaylistAPITest(TestCase):
         jwt_token.payload["user_id"] = str(user.id)
 
         response = self.client.get(
-            f"/api/playlists/{playlist.id}/", HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+            f"/api/playlists/{playlist.id}/",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
         self.assertEqual(response.status_code, 200)

--- a/src/backend/marsha/urls.py
+++ b/src/backend/marsha/urls.py
@@ -11,6 +11,7 @@ from marsha.core import models
 from marsha.core.admin import admin_site
 from marsha.core.api import (
     DocumentViewSet,
+    OrganizationViewSet,
     PlaylistViewSet,
     ThumbnailViewSet,
     TimedTextTrackViewSet,
@@ -31,6 +32,7 @@ router.register(
     basename="timed_text_tracks",
 )
 router.register(models.Thumbnail.RESOURCE_NAME, ThumbnailViewSet, basename="thumbnails")
+router.register("organizations", OrganizationViewSet, basename="organizations")
 router.register("playlists", PlaylistViewSet, basename="playlists")
 router.register("users", UserViewSet, basename="users")
 


### PR DESCRIPTION
## Purpose

As part of our new Marsha site, we want to be able to display the name and related meta-data for an organization or a playlist on its detailed view.

## Proposal

- [x] open a retrieve endpoint for playlists
- [x] open a retrieve endpoint for organizations

For now, only administrators are granted access to these views, so we're likewise restricting the API route to administrators.


