### PR TITLE
Disable usage of sentry in the front application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Create a new lambda (lamba-mediapackage) called when an harvest job is done
 - Create a harvest job when a live is ended
 - Component to switch a live to VOD
+- Switch to enable sentry in front application
 
 ### Changed
 

--- a/src/backend/marsha/core/defaults.py
+++ b/src/backend/marsha/core/defaults.py
@@ -49,3 +49,4 @@ LIVE_CHOICES = (
 
 # FLAGS
 VIDEO_LIVE = "video_live"
+SENTRY = "sentry"

--- a/src/backend/marsha/core/tests/test_views_lti_cache.py
+++ b/src/backend/marsha/core/tests/test_views_lti_cache.py
@@ -10,7 +10,7 @@ from django.test import TestCase
 
 from waffle.testutils import override_switch
 
-from ..defaults import STATE_CHOICES, VIDEO_LIVE
+from ..defaults import SENTRY, STATE_CHOICES, VIDEO_LIVE
 from ..factories import ConsumerSiteFactory, VideoFactory
 from ..lti import LTI
 
@@ -38,6 +38,7 @@ class CacheLTIViewTestCase(TestCase):
     @mock.patch.object(LTI, "verify")
     @mock.patch.object(LTI, "get_consumer_site")
     @override_switch(VIDEO_LIVE, active=True)
+    @override_switch(SENTRY, active=True)
     def test_views_lti_cache_student(self, mock_get_consumer_site, mock_verify):
         """Validate that responses are cached for students."""
         video1, video2 = VideoFactory.create_batch(
@@ -59,7 +60,7 @@ class CacheLTIViewTestCase(TestCase):
             "user_id": "111",
         }
 
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(6):
             elapsed, resource_origin = self._fetch_lti_request(url, data)
         self.assertEqual(resource_origin["id"], str(video1.id))
         self.assertTrue(elapsed < 0.1)
@@ -119,6 +120,7 @@ class CacheLTIViewTestCase(TestCase):
     @mock.patch.object(LTI, "verify")
     @mock.patch.object(LTI, "get_consumer_site")
     @override_switch(VIDEO_LIVE, active=True)
+    @override_switch(SENTRY, active=True)
     def test_views_lti_cache_instructor(self, mock_get_consumer_site, mock_verify):
         """Validate that responses are not cached for instructors."""
         video = VideoFactory(
@@ -137,7 +139,7 @@ class CacheLTIViewTestCase(TestCase):
             "user_id": "111",
         }
 
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(6):
             elapsed, resource_origin = self._fetch_lti_request(url, data)
         self.assertEqual(resource_origin["id"], str(video.id))
         self.assertTrue(elapsed < 0.1)
@@ -150,6 +152,7 @@ class CacheLTIViewTestCase(TestCase):
         self.assertTrue(elapsed < 0.1)
 
     @override_switch(VIDEO_LIVE, active=True)
+    @override_switch(SENTRY, active=True)
     def test_views_public_resource(self):
         """Validate that response for public resources are cached."""
         video = VideoFactory(
@@ -160,7 +163,7 @@ class CacheLTIViewTestCase(TestCase):
         )
         url = "/videos/{!s}".format(video.pk)
 
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(6):
             elapsed, resource_origin = self._fetch_lti_request(url)
         self.assertEqual(resource_origin["id"], str(video.id))
         self.assertTrue(elapsed < 0.1)

--- a/src/backend/marsha/core/tests/test_views_lti_video.py
+++ b/src/backend/marsha/core/tests/test_views_lti_video.py
@@ -19,6 +19,7 @@ from ..defaults import (
     PENDING,
     READY,
     RUNNING,
+    SENTRY,
     STATE_CHOICES,
     VIDEO_LIVE,
 )
@@ -45,6 +46,7 @@ class VideoLTIViewTestCase(TestCase):
     @override_settings(RELEASE="1.2.3")
     @override_settings(VIDEO_PLAYER="videojs")
     @override_switch(VIDEO_LIVE, active=True)
+    @override_switch(SENTRY, active=True)
     def test_views_lti_video_post_instructor(self, mock_get_consumer_site, mock_verify):
         """Validate the format of the response returned by the view for an instructor request."""
         passport = ConsumerSiteLTIPassportFactory()
@@ -120,7 +122,7 @@ class VideoLTIViewTestCase(TestCase):
         self.assertEqual(context.get("environment"), "test")
         self.assertEqual(context.get("release"), "1.2.3")
         self.assertEqual(context.get("player"), "videojs")
-        self.assertEqual(context.get("flags"), {"video_live": True})
+        self.assertEqual(context.get("flags"), {"video_live": True, "sentry": True})
         # Make sure we only go through LTI verification once as it is costly (getting passport +
         # signature)
         self.assertEqual(mock_verify.call_count, 1)

--- a/src/backend/marsha/core/views.py
+++ b/src/backend/marsha/core/views.py
@@ -23,7 +23,7 @@ from rest_framework.views import exception_handler as drf_exception_handler
 from rest_framework_simplejwt.tokens import AccessToken
 from waffle import mixins, switch_is_active
 
-from .defaults import VIDEO_LIVE
+from .defaults import SENTRY, VIDEO_LIVE
 from .lti import LTI
 from .lti.utils import PortabilityError, get_or_create_resource
 from .models import Document, Video
@@ -187,7 +187,10 @@ class BaseLTIView(ABC, TemplateResponseMixin, View):
             app_data = {
                 "environment": settings.ENVIRONMENT,
                 "frontend": "LTI",
-                "flags": {VIDEO_LIVE: switch_is_active(VIDEO_LIVE)},
+                "flags": {
+                    VIDEO_LIVE: switch_is_active(VIDEO_LIVE),
+                    SENTRY: switch_is_active(SENTRY),
+                },
                 "modelName": self.model.RESOURCE_NAME,
                 "release": settings.RELEASE,
                 "resource": self.serializer_class(

--- a/src/frontend/Player/createPlayer.spec.ts
+++ b/src/frontend/Player/createPlayer.spec.ts
@@ -13,6 +13,7 @@ jest.mock('jwt-decode', () => {
 
 jest.mock('../data/appData', () => ({
   appData: {
+    flags: {},
     jwt: 'foo',
   },
 }));

--- a/src/frontend/index.tsx
+++ b/src/frontend/index.tsx
@@ -12,12 +12,14 @@ import {
 } from 'react-intl';
 
 import { appData, getDecodedJwt } from './data/appData';
+import { flags } from './types/AppData';
 import { report } from './utils/errors/report';
+import { isFeatureEnabled } from './utils/isFeatureEnabled';
 // Load our style reboot into the DOM
 import { GlobalStyles } from './utils/theme/baseStyles';
 import { theme } from './utils/theme/theme';
 
-if (appData.sentry_dsn) {
+if (isFeatureEnabled(flags.SENTRY) && appData.sentry_dsn) {
   Sentry.init({
     dsn: appData.sentry_dsn,
     environment: appData.environment,

--- a/src/frontend/types/AppData.ts
+++ b/src/frontend/types/AppData.ts
@@ -10,6 +10,7 @@ export enum appState {
 
 export enum flags {
   VIDEO_LIVE = 'video_live',
+  SENTRY = 'sentry',
 }
 
 export interface AppData {


### PR DESCRIPTION
## Purpose

We want to easily enable or disable sentry in the front application. To do that we choose to use a feature flag like we did to enable the video live. 

## Proposal

- [x] add sentry feature flag
- [x] use it in front application to enable or disable sentry usage

