### PR TITLE
Introduce creating live state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Component to switch a live to VOD
 - Switch to enable sentry in front application
 - Management command checking live stuck in IDLE
+- Add new live state CREATING
 
 ### Changed
 

--- a/src/aws/lambda-medialive/src/channelStateChanged.js
+++ b/src/aws/lambda-medialive/src/channelStateChanged.js
@@ -4,16 +4,22 @@ const { DISABLE_SSL_VALIDATION, MARSHA_URL, SHARED_SECRET } = process.env;
 module.exports = async (channel, event, context) => {
   const status = event.detail.state;
 
-  if (!['RUNNING', 'STOPPED'].includes(status)) {
+  const correspondingStatus = {
+    'CREATED': 'idle',
+    'RUNNING': 'running',
+    'STOPPED': 'stopped',
+  }
+
+  if (!correspondingStatus[status]) {
     throw new Error(
-      `Expected status are RUNNING and STOPPED. ${status} received`,
+      `Expected status are CREATED, RUNNING and STOPPED. ${status} received`,
     );
   }
 
   const videoId = channel.Name.split('_')[1];
   const body = {
     logGroupName: context.logGroupName,
-    state: status.toLowerCase(),
+    state: correspondingStatus[status],
   };
 
   const signature = computeSignature(SHARED_SECRET, JSON.stringify(body));

--- a/src/aws/lambda-medialive/src/channelStateChanged.spec.js
+++ b/src/aws/lambda-medialive/src/channelStateChanged.spec.js
@@ -46,7 +46,7 @@ describe('src/channel_state_changed', () => {
       await channelStateChanged(channel, event, context);
     } catch (error) {
       expect(error.message).toEqual(
-        'Expected status are RUNNING and STOPPED. STARTING received',
+        'Expected status are CREATED, RUNNING and STOPPED. STARTING received',
       );
     }
 
@@ -127,6 +127,51 @@ describe('src/channel_state_changed', () => {
     const expectedBody = {
       logGroupName: '/aws/lambda/dev-test-marsha-medialive',
       state: 'stopped',
+    };
+
+    await channelStateChanged(channel, event, context);
+
+    expect(mockComputeSignature).toHaveBeenCalledWith(
+      'some secret',
+      JSON.stringify(expectedBody),
+    );
+    expect(mockSendRequest).toHaveBeenCalledWith(
+      expectedBody,
+      'foo',
+      false,
+      `${marshaUrl}/api/videos/video-id/update-live-state/`,
+      'PATCH',
+    );
+  });
+
+  it('receives a CREATED event and updates live state', async () => {
+    const event = {
+      version: '0',
+      id: '0495e5eb-9b99-56f2-7849-96389238fb55',
+      'detail-type': 'MediaLive Channel State Change',
+      source: 'aws.medialive',
+      account: 'account_id',
+      time: '2020-06-15T15:18:29Z',
+      region: 'eu-west-1',
+      resources: ['arn:aws:medialive:eu-west-1:account_id:channel:1234567'],
+      detail: {
+        channel_arn: 'arn:aws:medialive:eu-west-1:account_id:channel:1234567',
+        state: 'CREATED',
+        message: 'Created channel',
+        pipelines_running_count: 0,
+      },
+    };
+
+    const context = {
+      logGroupName: '/aws/lambda/dev-test-marsha-medialive',
+    };
+
+    const channel = { Name: 'test_video-id_stamp' };
+
+    mockComputeSignature.mockReturnValue('foo');
+    const expectedBody = {
+      logGroupName: '/aws/lambda/dev-test-marsha-medialive',
+      state: 'idle',
     };
 
     await channelStateChanged(channel, event, context);

--- a/src/backend/marsha/core/api.py
+++ b/src/backend/marsha/core/api.py
@@ -356,7 +356,7 @@ class VideoViewSet(viewsets.ModelViewSet):
         Video.objects.filter(pk=pk).update(
             live_info=live_info,
             upload_state=defaults.PENDING,
-            live_state=defaults.IDLE,
+            live_state=defaults.CREATING,
             uploaded_on=None,
         )
 

--- a/src/backend/marsha/core/defaults.py
+++ b/src/backend/marsha/core/defaults.py
@@ -15,6 +15,7 @@ from django.utils.translation import gettext_lazy as _
     STOPPING,
     RUNNING,
     DELETED,
+    CREATING,
 ) = (
     "pending",
     "processing",
@@ -28,6 +29,7 @@ from django.utils.translation import gettext_lazy as _
     "stopping",
     "running",
     "deleted",
+    "creating",
 )
 STATE_CHOICES = (
     (PENDING, _("pending")),
@@ -40,6 +42,7 @@ STATE_CHOICES = (
 )
 
 LIVE_CHOICES = (
+    (CREATING, _("creating")),
     (IDLE, _("idle")),
     (STARTING, _("starting")),
     (RUNNING, _("running")),

--- a/src/backend/marsha/core/serializers.py
+++ b/src/backend/marsha/core/serializers.py
@@ -17,6 +17,7 @@ from rest_framework_simplejwt.models import TokenUser
 from .defaults import (
     ERROR,
     HARVESTED,
+    IDLE,
     LIVE_CHOICES,
     PROCESSING,
     READY,
@@ -663,7 +664,7 @@ class UpdateLiveStateSerializer(serializers.Serializer):
     """A serializer to validate data submitted on the UpdateLiveState API endpoint."""
 
     state = serializers.ChoiceField(
-        tuple(c for c in LIVE_CHOICES if c[0] in (RUNNING, STOPPED))
+        tuple(c for c in LIVE_CHOICES if c[0] in (IDLE, RUNNING, STOPPED))
     )
     logGroupName = serializers.CharField()
 

--- a/src/frontend/components/ObjectStatusPicker/index.spec.tsx
+++ b/src/frontend/components/ObjectStatusPicker/index.spec.tsx
@@ -15,7 +15,7 @@ const {
   READY,
   UPLOADING,
 } = uploadState;
-const { IDLE, STARTING, RUNNING, STOPPED, STOPPING } = liveState;
+const { CREATING, IDLE, STARTING, RUNNING, STOPPED, STOPPING } = liveState;
 
 describe('<ObjectStatusPicker />', () => {
   it('renders the status list for upload state PENDING', () => {
@@ -116,5 +116,15 @@ describe('<ObjectStatusPicker />', () => {
     );
 
     screen.getByText('Live is stopping');
+  });
+
+  it('renders the status list for live state CREATING', () => {
+    render(
+      wrapInIntlProvider(
+        <ObjectStatusPicker state={PENDING} liveState={CREATING} />,
+      ),
+    );
+
+    screen.getByText('Creating');
   });
 });

--- a/src/frontend/components/ObjectStatusPicker/index.tsx
+++ b/src/frontend/components/ObjectStatusPicker/index.tsx
@@ -15,9 +15,14 @@ const {
   READY,
   UPLOADING,
 } = uploadState;
-const { IDLE, STARTING, RUNNING, STOPPED, STOPPING } = liveStateTrack;
+const { CREATING, IDLE, STARTING, RUNNING, STOPPED, STOPPING } = liveStateTrack;
 
 const messages = defineMessages({
+  [CREATING]: {
+    defaultMessage: 'Creating',
+    description: 'Live video in creation status',
+    id: 'components.ObjectStatusPicker.CREATING',
+  },
   [DELETED]: {
     defaultMessage: 'Deleted',
     description: 'Status information for a video/audio/timed text track',

--- a/src/frontend/types/tracks.ts
+++ b/src/frontend/types/tracks.ts
@@ -32,6 +32,7 @@ export enum uploadState {
 }
 
 export enum liveState {
+  CREATING = 'creating',
   IDLE = 'idle',
   STARTING = 'starting',
   RUNNING = 'running',


### PR DESCRIPTION
## Purpose

When a medialive channel is created, it is not possible to start it directly. We have to wait a few seconds. A `CREATED` event is fired. Once this event managed then the channel can be started.

## Proposal

- [x] accept CREATED medialive status in medialive lambda
- [x] use CREATING live state when a live is initialized
- [x] manage CREATING live state in front application 

Fix #796
