### PR TITLE
♻️(back) change status in check_live_state command

### DIFF
--- a/src/backend/marsha/core/management/commands/check_live_state.py
+++ b/src/backend/marsha/core/management/commands/check_live_state.py
@@ -9,8 +9,9 @@ from django.core.management.base import BaseCommand
 import boto3
 from dateutil.parser import isoparse
 
-from marsha.core.defaults import RUNNING, STOPPED
+from marsha.core.defaults import RUNNING, STOPPING
 from marsha.core.models import Video
+from marsha.core.utils.medialive_utils import stop_live_channel
 
 
 aws_credentials = {
@@ -116,9 +117,8 @@ class Command(BaseCommand):
                     self.stdout.write(
                         f"Stopping channel with id {live_info['medialive']['channel']['id']}"
                     )
-                    medialive_client.stop_channel(
-                        ChannelId=live_info["medialive"]["channel"]["id"]
-                    )
-                    video.live_state = STOPPED
+                    stop_live_channel(live_info["medialive"]["channel"]["id"])
+
+                    video.live_state = STOPPING
                     video.save()
                     self.stdout.write("Channel stopped")

--- a/src/backend/marsha/core/tests/test_command_check_live_state.py
+++ b/src/backend/marsha/core/tests/test_command_check_live_state.py
@@ -221,9 +221,9 @@ class CheckLiveStateTest(TestCase):
             },
         )
         out = StringIO()
-        with Stubber(check_live_state.logs_client) as logs_client_stubber, Stubber(
-            check_live_state.medialive_client
-        ) as medialive_stubber, mock.patch(
+        with Stubber(check_live_state.logs_client) as logs_client_stubber, mock.patch(
+            "marsha.core.management.commands.check_live_state.stop_live_channel"
+        ) as mock_stop_live_channel, mock.patch(
             "marsha.core.management.commands.check_live_state.generate_expired_date"
         ) as generate_expired_date_mock:
             logs_client_stubber.add_response(
@@ -276,17 +276,13 @@ class CheckLiveStateTest(TestCase):
                     ],
                 },
             )
-            medialive_stubber.add_response(
-                "stop_channel",
-                expected_params={"ChannelId": "123456"},
-                service_response={},
-            )
+
             generate_expired_date_mock.return_value = datetime(
                 2020, 8, 25, 12, 30, 0, tzinfo=pytz.utc
             )
             call_command("check_live_state", stdout=out)
             logs_client_stubber.assert_no_pending_responses()
-            medialive_stubber.assert_no_pending_responses()
+            mock_stop_live_channel.assert_called_once()
 
         self.assertIn(
             "Checking video 0b791906-ccb3-4450-97cb-7b66fd9ad419", out.getvalue()


### PR DESCRIPTION
## Purpose

In the check_live_state management command, when a live need to be
stopped, we set the live state to STOPPED. That was good before we made
the live to VOD feature. Since we have to first set with STOPPING state.
The STOPPED will by set by calling the update live state endpoint.

## Proposal

- [x] change status in check_live_state command from `stopped to stopping.