### PR TITLE
✨(back) management command checking live stuck in idle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Create a harvest job when a live is ended
 - Component to switch a live to VOD
 - Switch to enable sentry in front application
+- Management command checking live stuck in IDLE
 
 ### Changed
 

--- a/src/backend/marsha/core/management/commands/check_live_idle.py
+++ b/src/backend/marsha/core/management/commands/check_live_idle.py
@@ -1,0 +1,36 @@
+"""Check live in idle state management command."""
+from datetime import timedelta
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+from marsha.core.defaults import DELETED, IDLE
+from marsha.core.models import Video
+from marsha.core.utils.medialive_utils import delete_aws_element_stack
+
+
+def generate_expired_date():
+    """Generate a datetime object NB_DAYS_KEEPING_LIVE_IDLE days in the past."""
+    return timezone.now() - timedelta(days=settings.NB_DAYS_KEEPING_LIVE_IDLE)
+
+
+class Command(BaseCommand):
+    """Check every live streaming in idle state."""
+
+    help = "Check all live in IDLE state and close them if there are with no activity"
+
+    def handle(self, *args, **options):
+        """Execute management command."""
+        videos = Video.objects.filter(
+            live_state=IDLE,
+            updated_on__lte=generate_expired_date(),
+        )
+
+        for video in videos:
+            """Stop and delete the video."""
+            self.stdout.write(f"Deleting video {video.id}")
+            delete_aws_element_stack(video)
+            video.upload_state = DELETED
+            video.live_state = None
+            video.save()

--- a/src/backend/marsha/core/tests/test_command_check_live_idle.py
+++ b/src/backend/marsha/core/tests/test_command_check_live_idle.py
@@ -1,0 +1,47 @@
+"""Tests for check_live_idle command."""
+from datetime import timedelta
+from io import StringIO
+from unittest import mock
+
+from django.core.management import call_command
+from django.test import TestCase
+from django.utils import timezone
+
+from ..defaults import DELETED, IDLE
+from ..factories import VideoFactory
+
+
+class CheckLiveIdleTest(TestCase):
+    """Test check_live_idle command."""
+
+    def test_check_live_idle_no_video_to_process(self):
+        """Command should do nothing when there is no video to process."""
+        out = StringIO()
+        with mock.patch(
+            "marsha.core.management.commands.check_live_idle.delete_aws_element_stack"
+        ) as mock_delete_aws_element_stack:
+            call_command("check_live_idle", stdout=out)
+            mock_delete_aws_element_stack.assert_not_called()
+
+        self.assertEqual("", out.getvalue())
+        out.close()
+
+    def test_check_live_idle_video_to_delete(self):
+        """Command should delete a video in idle state too long."""
+        video = VideoFactory(id="36b82a5e-f2a6-4c11-bdf4-aa435a5dffc2", live_state=IDLE)
+        out = StringIO()
+        with mock.patch(
+            "marsha.core.management.commands.check_live_idle.delete_aws_element_stack"
+        ) as mock_delete_aws_element_stack, mock.patch(
+            "marsha.core.management.commands.check_live_idle.generate_expired_date"
+        ) as generate_expired_date_mock:
+            generate_expired_date_mock.return_value = timezone.now() + timedelta(days=1)
+            call_command("check_live_idle", stdout=out)
+            mock_delete_aws_element_stack.assert_called_once()
+
+        video.refresh_from_db()
+        self.assertEqual(video.upload_state, DELETED)
+        self.assertIn(
+            "Deleting video 36b82a5e-f2a6-4c11-bdf4-aa435a5dffc2", out.getvalue()
+        )
+        out.close()

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -260,6 +260,7 @@ class Base(Configuration):
 
     MAINTENANCE_MODE = values.BooleanValue(False)
     NB_DAYS_BEFORE_DELETING_LIVE_RECORDINGS = values.Value(14)
+    NB_DAYS_KEEPING_LIVE_IDLE = values.Value(7)
 
     # pylint: disable=invalid-name
     @property


### PR DESCRIPTION
## Purpose

It is possible to configure a live and never use it. The medialive
channel stays in IDLE state but we pay its allocation. The management
commande check_live_idle is here to check these live and delete them
after 7 days stuck in idle state.

## Proposal

- [x] management command checking live stuck in idle

closes #797 
