### PR TITLE
✨(frontend) add a set of components to manage breadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Add a series of components to power breadcrumbs.
+
 ## [3.17.0] - 2021-03-04
 
 ### Added

--- a/src/frontend/components/BreadCrumbs/index.spec.tsx
+++ b/src/frontend/components/BreadCrumbs/index.spec.tsx
@@ -1,0 +1,83 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { Link, MemoryRouter, Route, Switch } from 'react-router-dom';
+
+import { BreadCrumbs, BreadCrumbsProvider, Crumb } from '.';
+
+describe('<BreadCrumbs />', () => {
+  it('picks up the Crumbs from the React tree and displays them in the breadcrumbs', () => {
+    render(
+      <MemoryRouter initialEntries={['/route-a']}>
+        <BreadCrumbsProvider>
+          <BreadCrumbs />
+          <Link to="/route-a">Link to route A</Link>
+          <Link to="/route-b">Link to route B</Link>
+          <Link to="/route-b/route-c">Link to route C</Link>
+          <Link to="/route-b/route-d">Link to route D</Link>
+          <Switch>
+            <Route path="/route-a">
+              <Crumb title="Parent route A crumb" />
+              <h1>Parent route A title</h1>
+            </Route>
+
+            <Route path="/route-b">
+              <Crumb title="Parent route B crumb" />
+              <Switch>
+                <Route path="/route-b/route-c">
+                  <Crumb title="Child route C crumb" />
+                  <h1>Child route C title</h1>
+                </Route>
+
+                <Route path="/route-b/route-d">
+                  <Crumb title="Child route D crumb" />
+                  <h1>Child route D title</h1>
+                </Route>
+
+                <Route path="/route-b">
+                  <h1>Parent route B title</h1>
+                </Route>
+              </Switch>
+            </Route>
+          </Switch>
+        </BreadCrumbsProvider>
+      </MemoryRouter>,
+    );
+
+    // Route A is loaded and appears in crumbs, with no links as it is the current page
+    screen.getByRole('heading', { name: 'Parent route A title' });
+    expect(
+      screen
+        .getAllByRole('listitem')
+        .filter((item) => item.textContent === 'Parent route A crumb').length,
+    ).toEqual(1);
+    expect(
+      screen.queryByRole('link', { name: 'Parent route A crumb' }),
+    ).toBeNull();
+    // Crumbs for other routes do not appear on the page
+    for (const crumbText of [
+      'Parent route B crumb',
+      'Child route C crumb',
+      'Child route D crumb',
+    ]) {
+      expect(screen.queryByText(crumbText)).toBeNull();
+    }
+
+    // Move to route D, make sure crumbs for routes B and D are shown
+    fireEvent.click(screen.getByRole('link', { name: 'Link to route D' }));
+    screen.getByRole('heading', { name: 'Child route D title' });
+    expect(
+      screen.queryByRole('heading', { name: 'Parent route B title' }),
+    ).toBeNull();
+    screen.getByRole('link', { name: 'Parent route B crumb' });
+    expect(
+      screen
+        .getAllByRole('listitem')
+        .filter((item) => item.textContent === 'Child route D crumb').length,
+    ).toEqual(1);
+    // Crumbs for other routes do not appear on the page
+    // Crumbs for other routes do not appear on the page
+    for (const crumbText of ['Parent route A crumb', 'Child route C crumb']) {
+      expect(screen.queryByText(crumbText)).toBeNull();
+    }
+  });
+});

--- a/src/frontend/components/BreadCrumbs/index.tsx
+++ b/src/frontend/components/BreadCrumbs/index.tsx
@@ -1,0 +1,97 @@
+import { Box } from 'grommet';
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import { Link, useRouteMatch } from 'react-router-dom';
+import styled from 'styled-components';
+import { v4 as uuidv4 } from 'uuid';
+
+interface Crumb {
+  key: string;
+  title: JSX.Element | string;
+  url: string;
+}
+
+const BreadCrumbsContext = createContext<
+  [Crumb[], React.Dispatch<React.SetStateAction<Crumb[]>>]
+>([[], () => {}]);
+
+/**
+ * Wraps the app and allows our breadcrumbs components to work together
+ */
+export const BreadCrumbsProvider: React.FC = ({ children }) => {
+  const [crumbs, setCrumbs] = useState<Crumb[]>([]);
+
+  return (
+    <BreadCrumbsContext.Provider value={[crumbs, setCrumbs]}>
+      {children}
+    </BreadCrumbsContext.Provider>
+  );
+};
+
+const BreadCrumbLink = styled(Link)`
+  color: black;
+  text-decoration: underline;
+
+  &:hover {
+    text-decoration: none;
+  }
+`;
+
+/**
+ * Display all current breadcrumbs entries as generated from the `<Crumbs />`.
+ * NB: needs to be inside a `<BreadCrumbsProvider />`.
+ */
+export const BreadCrumbs: React.FC = () => {
+  const [crumbs] = useContext(BreadCrumbsContext);
+
+  const orderedCrumbs = crumbs.sort(
+    (crumbA, crumbB) => crumbA.url.length - crumbB.url.length,
+  );
+
+  return (
+    <Box as="ul" direction="row" margin="none" pad="medium" gap="medium">
+      {orderedCrumbs.map((crumb, index, list) => (
+        <Box as="li" key={crumb.key}>
+          {index === list.length - 1 ? (
+            crumb.title
+          ) : (
+            <Box direction="row" gap="medium">
+              <BreadCrumbLink to={crumb.url}>{crumb.title}</BreadCrumbLink>
+              <span aria-hidden="true">{'>'}</span>
+            </Box>
+          )}
+        </Box>
+      ))}
+    </Box>
+  );
+};
+
+interface CrumbProps {
+  title: Crumb['title'];
+}
+
+/**
+ * Add an entry to the breadcrumbs from anywhere in the React tree.
+ * Thanks to react-router, crumbs know where they sit in the tree as they can get their own url themselves.
+ * NB: needs to be inside a `<BreadCrumbsProvider />`.
+ * @param title The title for the entry to be displayed in the breadcrumbs.
+ */
+export const Crumb: React.FC<CrumbProps> = ({ title }) => {
+  const key = uuidv4();
+  const { url } = useRouteMatch();
+  const [_, setCrumbs] = useContext(BreadCrumbsContext);
+
+  useEffect(() => {
+    setCrumbs((crumbs) => [
+      ...crumbs.filter((currentCrumb) => currentCrumb.key !== key),
+      { key, title, url },
+    ]);
+
+    return () => {
+      setCrumbs((crumbs) =>
+        crumbs.filter((currentCrumb) => currentCrumb.key !== key),
+      );
+    };
+  }, [title]);
+
+  return null;
+};


### PR DESCRIPTION
## Purpose

We're using react-router-dom to build the new Marsha site. We're creating a page tree, using nested switches to enable easy routing and to keep our "place" in the app even if we reuse the same routes in different locations, in different sub-switches in the site.


## Proposal

To help users navigate this and provide them affordances for going back and forth, we decided to use breadcrumbs. This is a somewhat automatic implementation that attempts to make it as easy as possible to add the crumbs dynamically throughout the app.
