### PR TITLE
🐛(front) display higher resolution thumbnail available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Increase Mediapackage endpoint segment to 4 seconds
 - Rollback Medialive control rate mode to CBR
 
+### Fixed
+
+- Display higher resolution thumbnail available
+
 ## [3.16.1] - 2021-02-23
 
 ### Fixed

--- a/src/frontend/components/VideoPlayer/index.spec.tsx
+++ b/src/frontend/components/VideoPlayer/index.spec.tsx
@@ -42,7 +42,8 @@ const mockVideo = videoMockFactory({
       1080: 'https://example.com/1080p.mp4',
     },
     thumbnails: {
-      720: 'https://example.com/144p.jpg',
+      144: 'https://example.com/thumbnail/144p.jpg',
+      1080: 'https://example.com/thumbnail/1080p.jpg',
     },
   },
 });
@@ -152,7 +153,11 @@ describe('VideoPlayer', () => {
     expect(container.querySelectorAll('source[type="video/mp4"]')).toHaveLength(
       2,
     );
-    expect(container.querySelector('video')!.tabIndex).toEqual(-1);
+    const videoElement = container.querySelector('video')!;
+    expect(videoElement.tabIndex).toEqual(-1);
+    expect(videoElement.poster).toEqual(
+      'https://example.com/thumbnail/1080p.jpg',
+    );
   });
 
   it('allows video download when the video object specifies it', async () => {

--- a/src/frontend/components/VideoPlayer/index.tsx
+++ b/src/frontend/components/VideoPlayer/index.tsx
@@ -127,7 +127,7 @@ const VideoPlayer = ({
       <video
         ref={videoNodeRef}
         crossOrigin="anonymous"
-        poster={thumbnailUrls[resolutions[resolutions.length - 1]]}
+        poster={thumbnailUrls[resolutions[0]]}
         tabIndex={-1}
       >
         {resolutions.map((size) => (


### PR DESCRIPTION
## Purpose

We recently reorder how sources are added in the video tag. Since, the
resolution array is order from the higher resolution to the lowest. To
display the higher thumbnail available we have to keep the first
resolution in this array and not the last like we did before.

## Proposal

- [x] display higher resolution thumbnail available
