### PR TITLE
🔖(minor) bump release to 3.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.17.0] - 2021-03-04
+
 ### Added
 
 - Create a new lambda (lamba-mediapackage) called when an harvest job is done
@@ -697,7 +699,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Minor fixes and improvements on features and tests
 
-[unreleased]: https://github.com/openfun/marsha/compare/v3.16.1...master
+[unreleased]: https://github.com/openfun/marsha/compare/v3.17.0...master
+[3.17.0]: https://github.com/openfun/marsha/compare/v3.16.1...v3.17.0
 [3.16.1]: https://github.com/openfun/marsha/compare/v3.16.0...v3.16.1
 [3.16.0]: https://github.com/openfun/marsha/compare/v3.15.0...v3.16.0
 [3.15.0]: https://github.com/openfun/marsha/compare/v3.14.0...v3.15.0

--- a/src/aws/lambda-complete/package.json
+++ b/src/aws/lambda-complete/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-complete",
-  "version": "3.16.1",
+  "version": "3.17.0",
   "engines": {
     "node": "14"
   },

--- a/src/aws/lambda-configure/package.json
+++ b/src/aws/lambda-configure/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-configure",
-  "version": "3.16.1",
+  "version": "3.17.0",
   "engines": {
     "node": "14"
   },

--- a/src/aws/lambda-elemental-routing/package.json
+++ b/src/aws/lambda-elemental-routing/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-elemental-routing",
-  "version": "3.16.1",
+  "version": "3.17.0",
   "engines": {
     "node": "14"
   },

--- a/src/aws/lambda-encode/package.json
+++ b/src/aws/lambda-encode/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-convert",
-  "version": "3.16.1",
+  "version": "3.17.0",
   "engines": {
     "node": "14"
   },

--- a/src/aws/lambda-medialive/package.json
+++ b/src/aws/lambda-medialive/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-medialive",
-  "version": "3.16.1",
+  "version": "3.17.0",
   "engines": {
     "node": "14"
   },

--- a/src/aws/lambda-mediapackage/package.json
+++ b/src/aws/lambda-mediapackage/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-mediapackage",
-  "version": "3.14.0",
+  "version": "3.17.0",
   "engines": {
     "node": "14"
   },

--- a/src/aws/lambda-migrate/package.json
+++ b/src/aws/lambda-migrate/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-migrate",
-  "version": "3.16.1",
+  "version": "3.17.0",
   "engines": {
     "node": "14"
   },

--- a/src/aws/utils/update-state/package.json
+++ b/src/aws/utils/update-state/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-update-state",
-  "version": "3.16.1",
+  "version": "3.17.0",
   "engines": {
     "node": "14"
   },

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = marsha
 description = A FUN video provider for Open edX
-version = 3.16.1
+version = 3.17.0
 author = Open FUN (France Universite Numerique)
 author_email = fun.dev@fun-mooc.fr
 license = MIT

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marsha",
-  "version": "3.16.1",
+  "version": "3.17.0",
   "description": "🐠 a FUN LTI video provider",
   "main": "front/index.tsx",
   "scripts": {


### PR DESCRIPTION
### Added

- Create a new lambda (lamba-mediapackage) called when an harvest job is done
- Create a harvest job when a live is ended
- Component to switch a live to VOD
- Switch to enable sentry in front application
- Management command checking live stuck in IDLE
- Add new live state CREATING
- Open retrieve endpoints for organizations & playlists

### Changed

- Medialive profiles use 24FPS instead of 30
- Increase Medialive profiles segment to 4 seconds
- Increase Mediapackage endpoint segment to 4 seconds
- Rollback Medialive control rate mode to CBR
- Static files are managed using whitenoise

### Fixed

- Display higher resolution thumbnail available
