### PR TITLE
🔨(ngrok) inject current ngrok url in aws configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,6 @@ transmuxed_video
 
 # Ssh keys
 .ssh
+
+# ngrok
+.ngrok_url

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Add a series of components to power breadcrumbs.
 - Add a frontend component to use SVG icons in Marsha.
+- Add ngrok to serve marsha on a public domain and automate CloudFront configuration
+  via terraform when needed
 
 ### Fixed
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -4,6 +4,7 @@
 - [Mathieu Agopian](https://github.com/magopian) <mathieu@agopian.info>
 - [Stéphane Angel](https://github.com/twidi) <s.angel@twidi.com>
 - [Mehdi Benadda](https://github.com/mbenadda) <me@mbenadda.com>
+- [Nicolas Clerc](https://github.com/kernicpanel) <kernicpanel@nclerc.fr>
 - [Julien Maupetit](https://github.com/jmaupetit) <julien@maupetit.net>
 - [Richard Moch](https://github.com/rmoch) <richard.moch@gmail.com>
 - [Samuel Paccoud](https://github.com/sampaccoud) <samuel.paccoud@fun-mooc.fr>

--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,23 @@ run: ## start the development server using Docker
 	@$(COMPOSE_RUN) dockerize -wait tcp://db:5432 -timeout 60s
 .PHONY: run
 
+ngrok: ## start the development server using Docker through ngrok
+ngrok: run
+	@$(COMPOSE) up -d ngrok
+	@echo
+	@echo "$(BOLD)App running at:$(RESET)"
+	@bin/get_ngrok_url
+.PHONY: ngrok
+
+ngrok-apply: ## start the development server using Docker through ngrok and apply terraform plan
+ngrok-apply: ngrok
+	@make -C src/aws/ apply
+	@echo
+	@echo "$(BOLD)App running at:$(RESET)"
+	@bin/get_ngrok_url
+.PHONY: ngrok-apply
+
+
 stop: ## stop the development server using Docker
 	@$(COMPOSE) stop
 .PHONY: stop

--- a/bin/get_ngrok_url
+++ b/bin/get_ngrok_url
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+# Get current ngrok url from ngrok api launched with command "make ngrok"
+if docker-compose port ngrok 4040 &> /dev/null ; then
+    declare -r JQ="docker run --rm -i fundocker/jq:1.6"
+    curl --no-progress-meter "$(docker-compose port ngrok 4040)/api/tunnels/command_line" | \
+    ${JQ} .public_url  | \
+    sed 's/"//g'
+fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,12 @@ services:
       - "base"
       - "db"
 
+  ngrok:
+    image: wernight/ngrok
+    command: ngrok http app:8000
+    ports:
+      - 4040:4040
+
   crowdin:
     image: crowdin/cli:3.2.1
     volumes:

--- a/src/aws/bin/terraform
+++ b/src/aws/bin/terraform
@@ -2,12 +2,31 @@
 
 set -eo pipefail
 
+# Get current ngrok url from ngrok api launched with command "make ngrok"
+declare NGROK_URL
+declare DIR_NAME
+
+DIR_NAME=$(dirname "$0")
+NGROK_URL=$("$DIR_NAME"/../../../bin/get_ngrok_url)
+
 # Run Terraform commands in the docker container passing our environment variables
 
-docker run --rm -it \
+if [[ -z ${NGROK_URL} ]]; then
+    docker run --rm -it \
     -u "$(id -u)" \
     -v "${PWD}/:/app" \
     -w "/app" \
     --env-file ./env.d/development \
     "hashicorp/terraform:0.14.5" \
     "$@"
+else
+    docker run --rm -it \
+    -u "$(id -u)" \
+    -v "${PWD}/:/app" \
+    -w "/app" \
+    --env-file ./env.d/development \
+    -e TF_VAR_marsha_base_url="${NGROK_URL}" \
+    "hashicorp/terraform:0.14.5" \
+    "$@"
+fi
+


### PR DESCRIPTION
## Purpose

Every time we relaunch ngrok, a new url is used, and we need to edit src/aws/env.d/development to specify it.
Also, ngrok needs to be installed on host machine.

## Proposal

When we run `make ngrok`, a container launches ngrok, and a prompt asks if we want to apply current external url to Cloudfront.
