### PR TITLE
Add chat feature implementing XMPP protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Chat feature implementing XMPP protocol
+
 ### Changed
 
 - The `lti_id` field is optional on Videos and Documents.

--- a/docs/env.md
+++ b/docs/env.md
@@ -291,6 +291,89 @@ that will be used to distribute processed files to end users.
 - Required: Yes
 - Default: None
 
+### XMPP settings
+
+#### DJANGO_LIVE_CHAT_ENABLED
+
+To enable or disable the global chat feature.
+
+- Type: boolean
+- Required: No
+- Default: False
+
+#### DJANGO_XMPP_DOMAIN
+
+Main XMPP server domain.
+
+- Type: string
+- Required: Only when `DJANGO_LIVE_CHAT_ENABLED` is set to True
+- Default: None
+
+#### DJANGO_XMPP_BOSH_URL
+
+The Bosh endpoint defined by your XMPP server. This url is used by Marsha's front application to excahnge with the XMPP server.
+Required when `DJANGO_LIVE_CHAT_ENABLED` is set to True
+
+- Type: string
+- Required: Only when `DJANGO_LIVE_CHAT_ENABLED` is set to True
+- Default: None
+
+#### DJANGO_XMPP_CONFERENCE_DOMAIN
+
+Your XMPP MUC component domain.
+
+- Type: string
+- Required: Only when `DJANGO_LIVE_CHAT_ENABLED` is set to True
+- Default: None
+
+#### DJANGO_XMPP_PRIVATE_ADMIN_JID
+
+The JID of an admin configured on your XMPP server. Example: `admin@your-xmpp-server.com`
+
+- Type: string
+- Required: Only when `DJANGO_LIVE_CHAT_ENABLED` is set to True
+- Default: None
+
+#### DJANGO_XMPP_PRIVATE_SERVER_PORT
+
+XMPP server port to use for client connections
+
+- Type: number
+- Required: No
+- Default: 5222
+
+#### DJANGO_XMPP_PRIVATE_SERVER_PASSWORD
+
+The password associated to your admin user set in the setting `DJANGO_XMPP_PRIVATE_ADMIN_JID`
+
+- Type: string
+- Required: Only when `DJANGO_LIVE_CHAT_ENABLED` is set to True
+- Default: None
+
+#### DJANGO_XMPP_JWT_SHARED_SECRET
+
+Secret key used to sign JWTs.
+
+- Type: string
+- Required: Only when `DJANGO_LIVE_CHAT_ENABLED` is set to True
+- Default: None
+
+#### DJANGO_XMPP_JWT_ISSUER
+
+The JWT issuer accepted by the XMPP server
+
+- Type: string
+- Required: No
+- Default: marsha
+
+#### DJANGO_XMPP_JWT_AUDIENCE
+
+The JWT audience accepted by the XMPP server
+
+- Type: string
+- Required: No
+- Default: marsha
+
 ### Crowdin API access related settings
 
 #### CROWDIN_API_KEY

--- a/env.d/development.dist
+++ b/env.d/development.dist
@@ -32,6 +32,15 @@ DJANGO_CLOUDFRONT_DOMAIN=yourCloudfrontUrl
 DJANGO_AWS_MEDIALIVE_ROLE_ARN=aws:medialive:arn:role
 DJANGO_AWS_MEDIAPACKAGE_HARVEST_JOB_ARN=aws:mediapackage:arn:role
 
+# XMPP
+DJANGO_LIVE_CHAT_ENABLED=False
+DJANGO_XMPP_BOSH_URL=https://your-xmpp-server.com/http-bind
+DJANGO_XMPP_BOSH_PRE_BIND_URL=http://localhost:8061/http-pre-bind
+DJANGO_XMPP_CONFERENCE_URL=conference.your-xmpp-server.com
+DJANGO_XMPP_JID=your-xmpp-server.com
+DJANGO_XMPP_PRIVATE_SERVER_JID=admin@your-xmpp-server.com
+DJANGO_XMPP_PRIVATE_SERVER_PASSWORD=ThisIsNotAPassword
+
 DJANGO_UPDATE_STATE_SHARED_SECRETS=ThisIsAFirstSharedSecret,ThisOneTheSecondSharedSecret
 
 # CROWDIN API Credentials

--- a/env.d/development.dist
+++ b/env.d/development.dist
@@ -35,11 +35,11 @@ DJANGO_AWS_MEDIAPACKAGE_HARVEST_JOB_ARN=aws:mediapackage:arn:role
 # XMPP
 DJANGO_LIVE_CHAT_ENABLED=False
 DJANGO_XMPP_BOSH_URL=https://your-xmpp-server.com/http-bind
-DJANGO_XMPP_BOSH_PRE_BIND_URL=http://localhost:8061/http-pre-bind
-DJANGO_XMPP_CONFERENCE_URL=conference.your-xmpp-server.com
-DJANGO_XMPP_JID=your-xmpp-server.com
-DJANGO_XMPP_PRIVATE_SERVER_JID=admin@your-xmpp-server.com
+DJANGO_XMPP_CONFERENCE_DOMAIN=conference.your-xmpp-server.com
+DJANGO_XMPP_DOMAIN=your-xmpp-server.com
+DJANGO_XMPP_PRIVATE_ADMIN_JID=admin@your-xmpp-server.com
 DJANGO_XMPP_PRIVATE_SERVER_PASSWORD=ThisIsNotAPassword
+DJANGO_XMPP_JWT_SHARED_SECRET=ThisIsNotASharedSecret
 
 DJANGO_UPDATE_STATE_SHARED_SECRETS=ThisIsAFirstSharedSecret,ThisOneTheSecondSharedSecret
 

--- a/src/backend/marsha/core/api.py
+++ b/src/backend/marsha/core/api.py
@@ -31,6 +31,7 @@ from .utils.medialive_utils import (
 )
 from .utils.s3_utils import create_presigned_post
 from .utils.time_utils import to_timestamp
+from .utils.xmpp_utils import close_room, create_room
 from .xapi import XAPI, XAPIStatement
 
 
@@ -449,6 +450,8 @@ class VideoViewSet(viewsets.ModelViewSet):
             )
 
         start_live_channel(video.live_info.get("medialive").get("channel").get("id"))
+        if settings.LIVE_CHAT_ENABLED:
+            create_room(video.id)
 
         video.live_state = defaults.STARTING
         video.save()
@@ -574,6 +577,8 @@ class VideoViewSet(viewsets.ModelViewSet):
             video.live_info = live_info
             create_mediapackage_harvest_job(video)
             delete_aws_element_stack(video)
+            if settings.LIVE_CHAT_ENABLED:
+                close_room(video.id)
 
         video.save()
 

--- a/src/backend/marsha/core/api.py
+++ b/src/backend/marsha/core/api.py
@@ -273,6 +273,11 @@ class VideoViewSet(viewsets.ModelViewSet):
         # The API is only reachable by admin users.
         context["can_return_live_info"] = True
 
+        user = self.request.user
+        if isinstance(user, TokenUser):
+            context["roles"] = user.token.payload.get("roles", [])
+            context["user_id"] = user.token.payload.get("user_id", None)
+
         return context
 
     def create(self, request, *args, **kwargs):

--- a/src/backend/marsha/core/serializers.py
+++ b/src/backend/marsha/core/serializers.py
@@ -493,6 +493,7 @@ class VideoSerializer(serializers.ModelSerializer):
             "playlist",
             "live_info",
             "live_state",
+            "xmpp",
         )
         read_only_fields = (
             "id",
@@ -516,6 +517,29 @@ class VideoSerializer(serializers.ModelSerializer):
     is_ready_to_show = serializers.BooleanField(read_only=True)
     has_transcript = serializers.SerializerMethodField()
     live_info = serializers.SerializerMethodField()
+    xmpp = serializers.SerializerMethodField()
+
+    def get_xmpp(self, obj):
+        """Chat info.
+
+        Parameters
+        ----------
+        obj : Type[models.Video]
+            The video that we want to serialize
+
+        Returns
+        -------
+        Dictionnary
+            A dictionary containing all info needed to manage a connection to a xmpp server.
+        """
+        if settings.LIVE_CHAT_ENABLED:
+            return {
+                "bosh_url": f"{settings.XMPP_BOSH_URL}",
+                "conference_url": f"{obj.id}@{settings.XMPP_CONFERENCE_DOMAIN}",
+                "jid": settings.XMPP_DOMAIN,
+            }
+
+        return None
 
     def get_live_info(self, obj):
         """Live streaming informations.

--- a/src/backend/marsha/core/tests/test_utils_xmpp_utils.py
+++ b/src/backend/marsha/core/tests/test_utils_xmpp_utils.py
@@ -1,0 +1,36 @@
+"""Test the xmpp module for marsha core app."""
+from unittest import mock
+
+from django.test import TestCase, override_settings
+
+from ..utils import xmpp_utils
+
+
+class XmppUtilsTestCase(TestCase):
+    """Test xmpp utils."""
+
+    @override_settings(XMPP_JWT_AUDIENCE="marsha")
+    @override_settings(XMPP_JWT_ISSUER="marsha")
+    @override_settings(XMPP_DOMAIN="exemple.com")
+    @override_settings(XMPP_JWT_SHARED_SECRET="thisIsASecret")
+    def test_generate_jwt(self):
+        """Test generating a JWT token."""
+        with mock.patch.object(xmpp_utils.jwt, "encode") as jwt_encode_mock:
+            xmpp_utils.generate_jwt("room_name", "user_id", "affiliation", 1617889150)
+
+            jwt_encode_mock.assert_called_once_with(
+                {
+                    "context": {
+                        "user": {
+                            "id": "user_id",
+                            "affiliation": "affiliation",
+                        },
+                    },
+                    "aud": "marsha",
+                    "iss": "marsha",
+                    "sub": "exemple.com",
+                    "room": "room_name",
+                    "exp": 1617889150,
+                },
+                "thisIsASecret",
+            )

--- a/src/backend/marsha/core/tests/test_views_lti_development.py
+++ b/src/backend/marsha/core/tests/test_views_lti_development.py
@@ -152,6 +152,7 @@ class DevelopmentLTIViewTestCase(TestCase):
                 },
                 "live_state": None,
                 "live_info": {},
+                "xmpp": None,
             },
         )
         self.assertEqual(context.get("modelName"), "videos")
@@ -214,6 +215,7 @@ class DevelopmentLTIViewTestCase(TestCase):
                 },
                 "live_state": None,
                 "live_info": {},
+                "xmpp": None,
             },
         )
         self.assertEqual(context.get("modelName"), "videos")

--- a/src/backend/marsha/core/tests/test_views_public_video.py
+++ b/src/backend/marsha/core/tests/test_views_public_video.py
@@ -111,6 +111,7 @@ class VideoPublicViewTestCase(TestCase):
                 },
                 "live_state": None,
                 "live_info": {},
+                "xmpp": None,
             },
         )
         self.assertEqual(context.get("state"), "success")

--- a/src/backend/marsha/core/utils/xmpp_utils.py
+++ b/src/backend/marsha/core/utils/xmpp_utils.py
@@ -1,6 +1,7 @@
 """Utils for XMPP server."""
 from django.conf import settings
 
+import jwt
 import xmpp
 
 
@@ -15,8 +16,8 @@ def _connect():
 
     Returns
     -------
-    xmmp.Client
-        A xmmp client authenticated to a XMPP server.
+    xmpp.Client
+        A xmpp client authenticated to a XMPP server.
     """
     jid = xmpp.protocol.JID(settings.XMPP_PRIVATE_ADMIN_JID)
 
@@ -133,4 +134,39 @@ def close_room(room_name):
                 )
             ],
         )
+    )
+
+
+def generate_jwt(room_name, user_id, affiliation, expires_at):
+    """Generate the JWT token used by xmpp server.
+
+    Parameters
+    ----------
+    room_name: string
+        The name of the room the token is associated with
+
+    user_id: string
+        User's id who try to access to the XMPP conference
+
+    affiliations: string
+        User affiliation (owner or member)
+
+    expires_at: number
+        Expiration time in timestamp format
+    """
+    return jwt.encode(
+        {
+            "context": {
+                "user": {
+                    "id": user_id,
+                    "affiliation": affiliation,
+                },
+            },
+            "aud": settings.XMPP_JWT_AUDIENCE,
+            "iss": settings.XMPP_JWT_ISSUER,
+            "sub": settings.XMPP_DOMAIN,
+            "room": room_name,
+            "exp": expires_at,
+        },
+        settings.XMPP_JWT_SHARED_SECRET,
     )

--- a/src/backend/marsha/core/utils/xmpp_utils.py
+++ b/src/backend/marsha/core/utils/xmpp_utils.py
@@ -1,0 +1,136 @@
+"""Utils for XMPP server."""
+from django.conf import settings
+
+import xmpp
+
+
+"""
+The XEP used to manage a Multi User Chat is XEP-0045 aka MUC.
+Spec are available at https://xmpp.org/extensions/xep-0045.html
+"""
+
+
+def _connect():
+    """Connect to a XMPP server and return the connection.
+
+    Returns
+    -------
+    xmmp.Client
+        A xmmp client authenticated to a XMPP server.
+    """
+    jid = xmpp.protocol.JID(settings.XMPP_PRIVATE_ADMIN_JID)
+
+    client = xmpp.Client(server=jid.getDomain(), port=settings.XMPP_PRIVATE_SERVER_PORT)
+    client.connect()
+    client.auth(
+        user=jid.getNode(),
+        password=settings.XMPP_PRIVATE_SERVER_PASSWORD,
+        resource=jid.getResource(),
+    )
+
+    return client
+
+
+def create_room(room_name):
+    """Create and configure a room.
+
+    Documentation to create and configure a room:
+    https://xmpp.org/extensions/xep-0045.html#createroom
+
+    Parameters
+    ----------
+    room_name: string
+        The name of the room you want to create.
+    """
+    client = _connect()
+
+    client.send(
+        xmpp.Presence(
+            to=f"{room_name}@{settings.XMPP_CONFERENCE_DOMAIN}/admin",
+            payload=[xmpp.Node(tag="x", attrs={"xmlns": xmpp.NS_MUC})],
+        )
+    )
+
+    client.send(
+        xmpp.Iq(
+            to=f"{room_name}@{settings.XMPP_CONFERENCE_DOMAIN}",
+            frm=settings.XMPP_PRIVATE_ADMIN_JID,
+            typ="set",
+            queryNS=xmpp.NS_MUC_OWNER,
+            payload=[
+                xmpp.DataForm(
+                    typ="submit",
+                    data=[
+                        xmpp.DataField(
+                            typ="hidden", name="FORM_TYPE", value=xmpp.NS_MUC_ROOMCONFIG
+                        ),
+                        # Make Room Persistent?
+                        xmpp.DataField(
+                            typ="boolean", name="muc#roomconfig_persistentroom", value=1
+                        ),
+                        # Make room publicly searchable?
+                        xmpp.DataField(
+                            typ="boolean", name="muc#roomconfig_publicroom", value=0
+                        ),
+                        # Nobody can send private message
+                        xmpp.DataField(
+                            typ="list-single",
+                            name="muc#roomconfig_allowpm",
+                            value="none",
+                        ),
+                        # Nobody can send private message
+                        xmpp.DataField(
+                            typ="boolean", name="muc#roomconfig_allowinvites", value=0
+                        ),
+                        # Nobody can change the subject
+                        xmpp.DataField(
+                            typ="boolean", name="muc#roomconfig_changesubject", value=0
+                        ),
+                    ],
+                )
+            ],
+        )
+    )
+
+
+def close_room(room_name):
+    """Close a room to anonymous users.
+
+    members only documentation:
+    https://xmpp.org/extensions/xep-0045.html#enter-members
+
+    Parameters
+    ----------
+    room_name: string
+        The name of the room you want to destroy.
+    """
+    client = _connect()
+
+    client.send(
+        xmpp.Presence(
+            to=f"{room_name}@{settings.XMPP_CONFERENCE_DOMAIN}/admin",
+            payload=[xmpp.Node(tag="x", attrs={"xmlns": xmpp.NS_MUC})],
+        )
+    )
+
+    client.send(
+        xmpp.Iq(
+            to=f"{room_name}@{settings.XMPP_CONFERENCE_DOMAIN}",
+            frm=settings.XMPP_PRIVATE_ADMIN_JID,
+            typ="set",
+            queryNS=xmpp.NS_MUC_OWNER,
+            payload=[
+                xmpp.DataForm(
+                    typ="submit",
+                    data=[
+                        xmpp.DataField(
+                            typ="hidden", name="FORM_TYPE", value=xmpp.NS_MUC_ROOMCONFIG
+                        ),
+                        xmpp.DataField(
+                            typ="boolean", name="muc#roomconfig_membersonly", value=1
+                        ),
+                    ],
+                )
+            ],
+        )
+    )

--- a/src/backend/marsha/core/views.py
+++ b/src/backend/marsha/core/views.py
@@ -210,6 +210,8 @@ class BaseLTIView(ABC, TemplateResponseMixin, View):
 
         permissions = {"can_access_dashboard": False, "can_update": False}
 
+        user_id = getattr(lti, "user_id", None) if lti else None
+
         if app_data is None:
             resource = (
                 get_or_create_resource(self.model, lti)
@@ -234,7 +236,9 @@ class BaseLTIView(ABC, TemplateResponseMixin, View):
                         context={
                             "can_return_live_info": lti.is_admin or lti.is_instructor
                             if lti
-                            else False
+                            else False,
+                            "roles": lti.roles if lti else [],
+                            "user_id": user_id,
                         },
                     ).data
                     if resource
@@ -275,11 +279,8 @@ class BaseLTIView(ABC, TemplateResponseMixin, View):
                 }
             )
 
-            if lti:
-                try:
-                    jwt_token.payload["user_id"] = lti.user_id
-                except AttributeError:
-                    pass
+            if user_id:
+                jwt_token.payload["user_id"] = user_id
 
             app_data["jwt"] = str(jwt_token)
 

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -270,6 +270,9 @@ class Base(Configuration):
     XMPP_PRIVATE_ADMIN_JID = values.Value(None)
     XMPP_PRIVATE_SERVER_PORT = values.Value(5222)
     XMPP_PRIVATE_SERVER_PASSWORD = values.Value(None)
+    XMPP_JWT_SHARED_SECRET = values.Value(None)
+    XMPP_JWT_ISSUER = values.Value("marsha")
+    XMPP_JWT_AUDIENCE = values.Value("marsha")
     XMPP_DOMAIN = values.Value(None)
 
     # pylint: disable=invalid-name

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -263,6 +263,15 @@ class Base(Configuration):
     NB_DAYS_BEFORE_DELETING_LIVE_RECORDINGS = values.Value(14)
     NB_DAYS_KEEPING_LIVE_IDLE = values.Value(7)
 
+    # XMPP Settings
+    LIVE_CHAT_ENABLED = values.BooleanValue(False)
+    XMPP_BOSH_URL = values.Value(None)
+    XMPP_CONFERENCE_DOMAIN = values.Value(None)
+    XMPP_PRIVATE_ADMIN_JID = values.Value(None)
+    XMPP_PRIVATE_SERVER_PORT = values.Value(5222)
+    XMPP_PRIVATE_SERVER_PASSWORD = values.Value(None)
+    XMPP_DOMAIN = values.Value(None)
+
     # pylint: disable=invalid-name
     @property
     def AWS_SOURCE_BUCKET_NAME(self):
@@ -426,6 +435,7 @@ class Test(Base):
     AWS_BASE_NAME = values.Value("test")
     # Enable it to speed up tests by stopping WhiteNoise from scanning your static files
     WHITENOISE_AUTOREFRESH = True
+    LIVE_CHAT_ENABLED = False
 
 
 class Production(Base):

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -50,6 +50,7 @@ install_requires =
     requests==2.25.1
     urllib3==1.26.4
     whitenoise==5.2.0
+    xmpppy==0.6.2
 packages = find:
 package_dir =
     =.

--- a/src/frontend/components/Chat/index.spec.tsx
+++ b/src/frontend/components/Chat/index.spec.tsx
@@ -1,0 +1,60 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+
+import { videoMockFactory } from '../../utils/tests/factories';
+import * as mockWindow from '../../utils/window';
+import { Chat } from '.';
+
+jest.mock('../../utils/window', () => ({
+  converse: {
+    initialize: jest.fn(),
+  },
+}));
+
+describe('<Chat />', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('renders the Chat component', () => {
+    const video = videoMockFactory({
+      id: '870c467b-d66e-4949-8ee5-fcf460c72e88',
+      xmpp: {
+        bosh_url: 'https://xmpp-server.com/http-bind',
+        conference_url:
+          '870c467b-d66e-4949-8ee5-fcf460c72e88@conference.xmpp-server.com',
+        prebind_url: 'https://xmpp-server.com/http-pre-bind',
+        jid: 'xmpp-server.com',
+      },
+    });
+
+    render(<Chat xmpp={video.xmpp!} />);
+
+    expect(mockWindow.converse.initialize).toHaveBeenCalledWith({
+      allow_contact_requests: false,
+      allow_logout: false,
+      allow_message_corrections: 'last',
+      allow_message_retraction: 'all',
+      allow_muc_invitations: false,
+      allow_registration: false,
+      authentication: 'anonymous',
+      auto_login: true,
+      auto_join_rooms: [
+        '870c467b-d66e-4949-8ee5-fcf460c72e88@conference.xmpp-server.com',
+      ],
+      bosh_service_url: 'https://xmpp-server.com/http-bind',
+      discover_connection_methods: false,
+      hide_muc_participants: true,
+      jid: 'xmpp-server.com',
+      modtools_disable_assign: true,
+      singleton: true,
+      view_mode: 'embedded',
+      visible_toolbar_buttons: {
+        call: false,
+        spoiler: false,
+        emoji: true,
+        toggle_occupants: false,
+      },
+    });
+  });
+});

--- a/src/frontend/components/Chat/index.tsx
+++ b/src/frontend/components/Chat/index.tsx
@@ -1,0 +1,48 @@
+import 'converse.js/dist/converse.min.css';
+import 'converse.js/dist/converse.min.js';
+import 'converse.js/dist/emojis.js';
+import 'converse.js/dist/icons.js';
+import { Box } from 'grommet';
+import React, { useEffect } from 'react';
+
+import { XMPP } from '../../types/tracks';
+import { converse } from '../../utils/window';
+
+interface ChatProps {
+  xmpp: XMPP;
+}
+
+export const Chat = ({ xmpp }: ChatProps) => {
+  useEffect(() => {
+    converse.initialize({
+      allow_contact_requests: false,
+      allow_logout: false,
+      allow_message_corrections: 'last',
+      allow_message_retraction: 'all',
+      allow_muc_invitations: false,
+      allow_registration: false,
+      authentication: 'anonymous',
+      auto_login: true,
+      auto_join_rooms: [xmpp.conference_url],
+      bosh_service_url: xmpp.bosh_url,
+      discover_connection_methods: false,
+      hide_muc_participants: true,
+      jid: xmpp.jid,
+      modtools_disable_assign: true,
+      singleton: true,
+      view_mode: 'embedded',
+      visible_toolbar_buttons: {
+        call: false,
+        emoji: true,
+        spoiler: false,
+        toggle_occupants: false,
+      },
+    });
+  }, []);
+
+  return (
+    <Box align="start" direction="row" height="large" pad={{ top: 'small' }}>
+      <div id="conversejs"></div>
+    </Box>
+  );
+};

--- a/src/frontend/components/DashboardVideoLive/index.spec.tsx
+++ b/src/frontend/components/DashboardVideoLive/index.spec.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { PLAYER_ROUTE } from '../routes';
 import { modelName } from '../../types/models';
 import { liveState, uploadState } from '../../types/tracks';
+import { videoMockFactory } from '../../utils/tests/factories';
 import { wrapInIntlProvider } from '../../utils/tests/intl';
 import { wrapInRouter } from '../../utils/tests/router';
 import { DashboardVideoLive } from '.';
@@ -22,7 +23,7 @@ describe('components/DashboardVideoLive', () => {
     jest.resetAllMocks();
   });
 
-  const video = {
+  const video = videoMockFactory({
     description: '',
     has_transcript: false,
     id: '9e02ae7d-6c18-40ce-95e8-f87bbeae31c5',
@@ -34,7 +35,6 @@ describe('components/DashboardVideoLive', () => {
     upload_state: uploadState.PENDING,
     urls: {
       manifests: {
-        dash: 'https://example.com/dash',
         hls: 'https://example.com/hls',
       },
       mp4: {},
@@ -56,7 +56,7 @@ describe('components/DashboardVideoLive', () => {
         },
       },
     },
-  };
+  });
 
   it('displays steraming links', () => {
     render(

--- a/src/frontend/components/DashboardVideoLiveStartButton/index.spec.tsx
+++ b/src/frontend/components/DashboardVideoLiveStartButton/index.spec.tsx
@@ -5,6 +5,7 @@ import { ImportMock } from 'ts-mock-imports';
 
 import * as useVideoModule from '../../data/stores/useVideo';
 import { uploadState, liveState } from '../../types/tracks';
+import { videoMockFactory } from '../../utils/tests/factories';
 import { wrapInIntlProvider } from '../../utils/tests/intl';
 import { wrapInRouter } from '../../utils/tests/router';
 import { FULL_SCREEN_ERROR_ROUTE } from '../ErrorComponents/route';
@@ -32,7 +33,7 @@ describe('components/DashboardVideoLiveStartButton', () => {
 
   afterAll(useVideoStub.restore);
 
-  const video = {
+  const video = videoMockFactory({
     description: '',
     has_transcript: false,
     id: '94da33b7-a38b-4efc-a8d5-99566056e8c6',
@@ -44,7 +45,6 @@ describe('components/DashboardVideoLiveStartButton', () => {
     upload_state: uploadState.PENDING,
     urls: {
       manifests: {
-        dash: 'https://example.com/dash',
         hls: 'https://example.com/hls',
       },
       mp4: {},
@@ -66,7 +66,7 @@ describe('components/DashboardVideoLiveStartButton', () => {
         },
       },
     },
-  };
+  });
 
   it('renders the start button', () => {
     useVideoStub.returns({

--- a/src/frontend/components/DashboardVideoLiveStopButton/index.spec.tsx
+++ b/src/frontend/components/DashboardVideoLiveStopButton/index.spec.tsx
@@ -5,6 +5,7 @@ import { ImportMock } from 'ts-mock-imports';
 
 import * as useVideoModule from '../../data/stores/useVideo';
 import { uploadState, liveState } from '../../types/tracks';
+import { videoMockFactory } from '../../utils/tests/factories';
 import { wrapInIntlProvider } from '../../utils/tests/intl';
 import { wrapInRouter } from '../../utils/tests/router';
 import { FULL_SCREEN_ERROR_ROUTE } from '../ErrorComponents/route';
@@ -32,7 +33,7 @@ describe('components/DashboardVideoLiveStopButton', () => {
 
   afterAll(useVideoStub.restore);
 
-  const video = {
+  const video = videoMockFactory({
     description: '',
     has_transcript: false,
     id: 'f0e4835f-f126-457e-8e27-16898cd0b5d5',
@@ -44,7 +45,6 @@ describe('components/DashboardVideoLiveStopButton', () => {
     upload_state: uploadState.PENDING,
     urls: {
       manifests: {
-        dash: 'https://example.com/dash',
         hls: 'https://example.com/hls',
       },
       mp4: {},
@@ -66,7 +66,7 @@ describe('components/DashboardVideoLiveStopButton', () => {
         },
       },
     },
-  };
+  });
 
   it('renders the stop button', () => {
     useVideoStub.returns({

--- a/src/frontend/components/VideoPlayer/index.tsx
+++ b/src/frontend/components/VideoPlayer/index.tsx
@@ -17,6 +17,7 @@ import {
 } from '../../types/tracks';
 import { VideoPlayerInterface } from '../../types/VideoPlayer';
 import { Maybe, Nullable } from '../../utils/types';
+import { Chat } from '../Chat';
 import { DownloadVideo } from '../DownloadVideo';
 import { FULL_SCREEN_ERROR_ROUTE } from '../ErrorComponents/route';
 import { Transcripts } from '../Transcripts';
@@ -160,6 +161,7 @@ const VideoPlayer = ({
       {transcripts.length > 0 && (
         <Transcripts transcripts={transcripts as TimedTextTranscript[]} />
       )}
+      {video.live_state !== null && video.xmpp && <Chat xmpp={video.xmpp} />}
     </Box>
   );
 };

--- a/src/frontend/data/sideEffects/initiateLive/index.spec.ts
+++ b/src/frontend/data/sideEffects/initiateLive/index.spec.ts
@@ -1,6 +1,7 @@
 import fetchMock from 'fetch-mock';
 
 import { liveState, uploadState } from '../../../types/tracks';
+import { videoMockFactory } from '../../../utils/tests/factories';
 import { initiateLive } from '.';
 
 jest.mock('../../appData', () => ({ appData: { jwt: 'some token' } }));
@@ -8,7 +9,7 @@ jest.mock('../../appData', () => ({ appData: { jwt: 'some token' } }));
 describe('sideEffects/initiateLive', () => {
   afterEach(() => fetchMock.restore());
 
-  const video = {
+  const video = videoMockFactory({
     description: 'Some description',
     has_transcript: false,
     id: '36',
@@ -20,7 +21,6 @@ describe('sideEffects/initiateLive', () => {
     upload_state: uploadState.PENDING,
     urls: {
       manifests: {
-        dash: 'https://example.com/dash.mpd',
         hls: 'https://example.com/hls.m3u8',
       },
       mp4: {
@@ -45,7 +45,7 @@ describe('sideEffects/initiateLive', () => {
     },
     live_state: null,
     live_info: {},
-  };
+  });
 
   it('makes a POST request on the initiate-live route & returns the updated video', async () => {
     fetchMock.mock(

--- a/src/frontend/data/sideEffects/startLive/index.spec.ts
+++ b/src/frontend/data/sideEffects/startLive/index.spec.ts
@@ -1,6 +1,7 @@
 import fetchMock from 'fetch-mock';
 
 import { uploadState, liveState } from '../../../types/tracks';
+import { videoMockFactory } from '../../../utils/tests/factories';
 import { startLive } from '.';
 
 jest.mock('../../appData', () => ({ appData: { jwt: 'some token' } }));
@@ -8,7 +9,7 @@ jest.mock('../../appData', () => ({ appData: { jwt: 'some token' } }));
 describe('sideEffects/startLive', () => {
   afterEach(() => fetchMock.restore());
 
-  const video = {
+  const video = videoMockFactory({
     description: 'Some description',
     has_transcript: false,
     id: '36',
@@ -20,7 +21,6 @@ describe('sideEffects/startLive', () => {
     upload_state: uploadState.PENDING,
     urls: {
       manifests: {
-        dash: 'https://example.com/dash.mpd',
         hls: 'https://example.com/hls.m3u8',
       },
       mp4: {
@@ -51,7 +51,7 @@ describe('sideEffects/startLive', () => {
         },
       },
     },
-  };
+  });
 
   it('makes a POST request on the start-live route & returns the updated video', async () => {
     fetchMock.mock(

--- a/src/frontend/data/sideEffects/stopLive/index.spec.ts
+++ b/src/frontend/data/sideEffects/stopLive/index.spec.ts
@@ -1,6 +1,7 @@
 import fetchMock from 'fetch-mock';
 
 import { uploadState, liveState } from '../../../types/tracks';
+import { videoMockFactory } from '../../../utils/tests/factories';
 import { stopLive } from '.';
 
 jest.mock('../../appData', () => ({ appData: { jwt: 'some token' } }));
@@ -8,7 +9,7 @@ jest.mock('../../appData', () => ({ appData: { jwt: 'some token' } }));
 describe('sideEffects/stopLive', () => {
   afterEach(() => fetchMock.restore());
 
-  const video = {
+  const video = videoMockFactory({
     description: 'Some description',
     has_transcript: false,
     id: '36',
@@ -20,7 +21,6 @@ describe('sideEffects/stopLive', () => {
     upload_state: uploadState.PENDING,
     urls: {
       manifests: {
-        dash: 'https://example.com/dash.mpd',
         hls: 'https://example.com/hls.m3u8',
       },
       mp4: {
@@ -51,7 +51,7 @@ describe('sideEffects/stopLive', () => {
         },
       },
     },
-  };
+  });
 
   it('makes a POST request on the stop-live route & returns the updated video', async () => {
     fetchMock.mock(

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "tsc --noEmit && webpack",
     "build-dev": "yarn copy-iframe-resizer; yarn build",
+    "clean": "find ../backend/marsha/static/js/ -type f ! -iname 'iframeResizer.min.js' -delete",
     "extract-translations": "formatjs extract './**/*.ts*' --ignore ./node_modules --ignore './**/*.d.ts' --out-file i18n/frontend.json --id-interpolation-pattern '[sha512:contenthash:base64:6]' --format crowdin",
     "compile-translations": "formatjs compile-folder --format crowdin ./i18n ./translations",
     "copy-iframe-resizer": "cp node_modules/iframe-resizer/js/iframeResizer.min.js ../backend/marsha/static/js",
@@ -71,6 +72,7 @@
     "@sentry/browser": "6.3.1",
     "@types/intl": "1.2.0",
     "buffer": "6.0.3",
+    "converse.js": "7.0.4",
     "core-js": "3.11.0",
     "custom-event-polyfill": "1.0.7",
     "grommet": "2.17.1",

--- a/src/frontend/types/libs/window.d.ts
+++ b/src/frontend/types/libs/window.d.ts
@@ -1,0 +1,10 @@
+// Ensure this is treated as a module.
+export {};
+
+declare global {
+  interface Window {
+    converse: {
+      initialize: (options: any) => void;
+    };
+  }
+}

--- a/src/frontend/types/tracks.ts
+++ b/src/frontend/types/tracks.ts
@@ -56,6 +56,14 @@ export interface Playlist {
   lti_id: string;
 }
 
+/* XMPP representation */
+export interface XMPP {
+  bosh_url: string;
+  conference_url: string;
+  prebind_url: string;
+  jid: string;
+}
+
 /** A timed text track record as it exists on the backend. */
 export interface TimedText extends Resource {
   active_stamp: Nullable<number>;
@@ -115,6 +123,7 @@ export interface Video extends Resource {
       };
     };
   };
+  xmpp: Nullable<XMPP>;
 }
 
 export type UploadableObject = TimedText | Video | Thumbnail | Document;

--- a/src/frontend/utils/tests/factories.ts
+++ b/src/frontend/utils/tests/factories.ts
@@ -37,6 +37,7 @@ export const videoMockFactory = (video: Partial<Video> = {}): Video => ({
   },
   live_state: null,
   live_info: {},
+  xmpp: null,
   ...video,
 });
 

--- a/src/frontend/utils/window.ts
+++ b/src/frontend/utils/window.ts
@@ -1,0 +1,1 @@
+export const { converse } = window;

--- a/src/frontend/webpack.config.js
+++ b/src/frontend/webpack.config.js
@@ -42,6 +42,14 @@ module.exports = {
     rules: [
       { test: /\.css$/, use: ['style-loader', 'css-loader'] },
       {
+        test: /\.(png|svg|jpg|jpeg|gif)$/i,
+        type: 'asset/resource',
+      },
+      {
+        test: /\.(woff|woff2|eot|ttf|otf)$/i,
+        type: 'asset/resource',
+      },
+      {
         test: /(public-path\.js|\.tsx?$|(memoize-one|react-intl|zustand).*\.(jsx?))/,
         use: [
           {

--- a/src/frontend/yarn.lock
+++ b/src/frontend/yarn.lock
@@ -2913,6 +2913,11 @@ consolidate@^0.16.0:
   dependencies:
     bluebird "^3.7.2"
 
+converse.js@7.0.4:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/converse.js/-/converse.js-7.0.4.tgz#83b1a6648256b8badc7ec5ed870cadd07bc03eb1"
+  integrity sha512-U07RJB71nG88IRlfhlcxOlJAnH4pVNH1H8jF39OANxZbqSikOX3qJO3e3fV0Tem0I9oNgDqkRW60pI22zjeP0w==
+
 convert-source-map@^1.4.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.7.0.tgz#17a2cb882d7f77d3490585e2ce6c524424a3a442"


### PR DESCRIPTION
## Purpose

To add more interactivity during a live video, we want to add a chat. We choose to use the XMPP protocol, marsha will not be responsible to manage the XMPP server.
The back application will create a room when a live is started and then destroy it once a live ended.
In the front application, converse.js lib will be responsible to create the chat UI and interaction

## Proposal

### Prosody configuration

During development of this PR we used a [prosody](https://prosody.im/) server. We used the last version available and installed several community modules : 
- [jitsi-meet-tokens](https://github.com/jitsi/lib-jitsi-meet/blob/master/doc/tokens.md): Allow to use a `JWT` authentication. The token is created by the marsha's backend and added to the BOSH url. 
- [mod_token_affiliation](https://github.com/emrahcom/emrah-buster-templates/blob/master/machines/eb-jitsi/usr/share/jitsi-meet/prosody-plugins/mod_token_affiliation.lua): it allows to promote an `Instructor` as owner in the current room. The affiliation is set in the `JWT` token.

To install and use the `jitsi-meet-token` module, we had to install dependencies before:

```
# Install lua5.2 and luarocks to manage lua packages
$ apt-get install lua5.2 liblua5.2 luarocks
# Install luajwtjitsi and basexx lua packages
$ luarocks install basexx
$ luarocks install luajwtjitsi
```

After installing this dependencies, the module listed before can be installed.

Prosody configuration : 

The idea is to create a private host accessible only for users having a user account on the server. this host will be the entrypoint to administrate the server, create and configure rooms.
The public host will be used by the front application. It can be access without user account but with a `JWT` token only issuable by marsha itself.


```
-- Prosody XMPP Server Configuration
--
-- Information on configuring Prosody can be found on our
-- website at https://prosody.im/doc/configure
--
-- Tip: You can check that the syntax of this file is correct
-- when you have finished by running this command:
--     prosodyctl check config
-- If there are any errors, it will let you know what and where
-- they are, otherwise it will keep quiet.
--
-- Good luck, and happy Jabbering!


---------- Server-wide settings ----------
-- Settings in this section apply to the whole server and are the default settings
-- for any virtual hosts

-- Prosody will always look in its source directory for modules, but
-- this option allows you to specify additional locations where Prosody
-- will look for modules first. For community modules, see https://modules.prosody.im/
plugin_paths = { "/usr/share/jitsi-meet/prosody-plugins/" }

-- This is a (by default, empty) list of accounts that are admins
-- for the server. Note that you must create the accounts separately
-- (see https://prosody.im/doc/creating_accounts for info)
-- Example: admins = { "user1@example.com", "user2@example.net" }
admins = { }


cross_domain_bosh = true
consider_bosh_secure = true

-- This is the list of modules Prosody will load on startup.
-- It looks for mod_modulename.lua in the plugins folder, so make sure that exists too.
-- Documentation for bundled modules can be found at: https://prosody.im/doc/modules
modules_enabled = {

	-- Generally required
		"roster"; -- Allow users to have a roster. Recommended ;)
		"saslauth"; -- Authentication for clients and servers. Recommended if you want to log in.
		"tls"; -- Add support for secure TLS on c2s/s2s connections
		"dialback"; -- s2s dialback support
		"disco"; -- Service discovery

	-- Not essential, but recommended
		"carbons"; -- Keep multiple clients in sync
		"pep"; -- Enables users to publish their avatar, mood, activity, playing music and more
		"private"; -- Private XML storage (for room bookmarks, etc.)
		"blocklist"; -- Allow users to block communications with other users
		"vcard4"; -- User profiles (stored in PEP)
		"vcard_legacy"; -- Conversion between legacy vCard and PEP Avatar, vcard

	-- Nice to have
		"version"; -- Replies to server version requests
		"uptime"; -- Report how long server has been running
		"time"; -- Let others know the time here on this server
		"ping"; -- Replies to XMPP pings with pongs
		"register"; -- Allow users to register on this server using a client and change passwords

	-- Admin interfaces
		"admin_adhoc"; -- Allows administration via an XMPP client that supports ad-hoc commands

	-- HTTP modules
		"bosh"; -- Enable BOSH clients, aka "Jabber over HTTP"
}

-- These modules are auto-loaded, but should you want
-- to disable them then uncomment them here:
modules_disabled = {}

-- Disable account creation by default, for security
-- For more information see https://prosody.im/doc/creating_accounts
allow_registration = false

-- Force clients to use encrypted connections? This option will
-- prevent clients from authenticating unless they are using encryption.

c2s_require_encryption = true

-- Force servers to use encrypted connections? This option will
-- prevent servers from authenticating unless they are using encryption.

s2s_require_encryption = true

-- Force certificate authentication for server-to-server connections?

s2s_secure_auth = false


-- Required for init scripts and prosodyctl
pidfile = "/var/run/prosody/prosody.pid"

-- Select the authentication backend to use. The 'internal' providers
-- use Prosody's configured data storage to store the authentication data.

authentication = "internal_hashed"

-- Archiving configuration
-- If mod_mam is enabled, Prosody will store a copy of every message. This
-- is used to synchronize conversations between multiple clients, even if
-- they are offline. This setting controls how long Prosody will keep
-- messages in the archive before removing them.

archive_expires_after = "1w" -- Remove archived messages after 1 week

-- Logging configuration
-- For advanced logging see https://prosody.im/doc/logging
log = {
	debug = "/var/log/prosody/prosody.log"; -- Change 'info' to 'debug' for verbose logging
	error = "/var/log/prosody/prosody.err";
	-- "*syslog"; -- Uncomment this for logging to syslog
	-- "*console"; -- Log to the console, useful for debugging with daemonize=false
}

-- Location of directory to find certificates in (relative to main config file):
certificates = "certs"

asap_accepted_issuers = { "jitsi", "marsha" }
asap_accepted_audiences = { "jitsi", "marsha" }

VirtualHost "staging.xmpp.marsha.education"
    authentication = "token"
    -- Properties below are modified by jitsi-meet-tokens package config
    -- and authentication above is switched to "token"
    app_id="marsha"
    app_secret="thisIsNotASecret"

    allow_empty_token = false;  
    modules_enabled = {
        "bosh";
    }
    c2s_require_encryption = false

VirtualHost "private.staging.xmpp.marsha.education"
    authentication = "internal_hashed"
    admins = { "manu@private.staging.xmpp.marsha.education" }
    modules_enabled = {
        "bosh"
    }

Component "conference.staging.xmpp.marsha.education" "muc"
    modules_enabled = { "muc_mam", "token_verification", "token_affiliation" }
    admins = { "manu@private.staging.xmpp.marsha.education" }
    restrict_room_creation = true
    muc_room_default_persistent = true
    log_all_rooms = true

Include "conf.d/*.cfg.lua"
```

ToDo:

- [x] create and destroy a XMPP chat room
- [x] create a `<Chat />` component

