### PR TITLE
Refactor how app_data is computed in backend views

### DIFF
--- a/src/backend/marsha/core/tests/test_views_lti_video.py
+++ b/src/backend/marsha/core/tests/test_views_lti_video.py
@@ -997,6 +997,9 @@ class VideoLTIViewTestCase(TestCase):
         # signature)
         self.assertEqual(mock_verify.call_count, 1)
 
+    @override_settings(SENTRY_DSN="https://sentry.dsn")
+    @override_settings(RELEASE="1.2.3")
+    @override_switch(SENTRY, active=True)
     @mock.patch.object(Logger, "warning")
     @mock.patch.object(LTI, "verify", side_effect=LTIException("lti error"))
     def test_views_lti_video_post_error(self, mock_verify, mock_logger):
@@ -1018,6 +1021,27 @@ class VideoLTIViewTestCase(TestCase):
         self.assertEqual(context.get("state"), "error")
         self.assertIsNone(context.get("resource"))
         self.assertEqual(context.get("modelName"), "videos")
+        self.assertEqual(
+            context,
+            {
+                "environment": "test",
+                "flags": {
+                    "sentry": True,
+                },
+                "frontend": "LTI",
+                "modelName": "videos",
+                "release": "1.2.3",
+                "resource": None,
+                "sentry_dsn": "https://sentry.dsn",
+                "state": "error",
+                "static": {
+                    "svg": {
+                        "icons": "/static/svg/icons.svg",
+                        "plyr": "/static/svg/plyr.svg",
+                    }
+                },
+            },
+        )
 
     @mock.patch.object(LTI, "verify")
     @mock.patch.object(LTI, "get_consumer_site")

--- a/src/frontend/types/AppData.ts
+++ b/src/frontend/types/AppData.ts
@@ -30,7 +30,7 @@ export interface AppData {
     };
   };
   player?: string;
-  flags: {
+  flags?: {
     [key in flags]?: boolean;
   };
 }

--- a/src/frontend/utils/isFeatureEnabled.spec.ts
+++ b/src/frontend/utils/isFeatureEnabled.spec.ts
@@ -1,28 +1,41 @@
 import { isFeatureEnabled } from './isFeatureEnabled';
 import { flags } from '../types/AppData';
 
-let mockFlags = {};
+let mockAppData = {};
 jest.mock('../data/appData', () => ({
-  appData: {
-    get flags() {
-      return mockFlags;
-    },
+  get appData() {
+    return mockAppData;
   },
 }));
 
 describe('isFeatureEnabled', () => {
   it('returns true is flag is enabled', () => {
-    mockFlags = { [flags.VIDEO_LIVE]: true };
+    mockAppData = {
+      flags: {
+        [flags.VIDEO_LIVE]: true,
+      },
+    };
     expect(isFeatureEnabled(flags.VIDEO_LIVE)).toBe(true);
   });
 
   it('returns false if flag is disabled', () => {
-    mockFlags = { [flags.VIDEO_LIVE]: false };
+    mockAppData = {
+      flags: {
+        [flags.VIDEO_LIVE]: false,
+      },
+    };
+    expect(isFeatureEnabled(flags.VIDEO_LIVE)).toBe(false);
+  });
+
+  it('returns false when the wanted flag is undefined', () => {
+    mockAppData = {
+      flags: {},
+    };
     expect(isFeatureEnabled(flags.VIDEO_LIVE)).toBe(false);
   });
 
   it('returns false when flag is undefined', () => {
-    mockFlags = {};
+    mockAppData = {};
     expect(isFeatureEnabled(flags.VIDEO_LIVE)).toBe(false);
   });
 });

--- a/src/frontend/utils/isFeatureEnabled.ts
+++ b/src/frontend/utils/isFeatureEnabled.ts
@@ -2,5 +2,5 @@ import { appData } from '../data/appData';
 import { flags } from '../types/AppData';
 
 export const isFeatureEnabled = (name: flags): boolean => {
-  return appData.flags[name] ?? false;
+  return appData.flags ? appData.flags[name] ?? false : false;
 };


### PR DESCRIPTION
## Purpose

We have now many views and all are rendering `app_data` and some of them are common to all views. We must refactor how they are computed because we had several cases where some new attributes are added at one place and not in an other.

## Proposal

- [x] create functions to manage common app data in views
- [x] `flags` can be missing in `app_data` leading to a white page 

