### PR TITLE
🔖(patch) bump release to 3.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,16 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.17.1] - 2021-03-26
+
 ### Added
 
 - Add a series of components to power breadcrumbs.
 - Add a frontend component to use SVG icons in Marsha.
+
+### Fixed
+
+- Avoid blank page when feature flags are not set.
 
 ## [3.17.0] - 2021-03-04
 

--- a/src/aws/lambda-complete/package.json
+++ b/src/aws/lambda-complete/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-complete",
-  "version": "3.17.0",
+  "version": "3.17.1",
   "engines": {
     "node": "14"
   },

--- a/src/aws/lambda-configure/package.json
+++ b/src/aws/lambda-configure/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-configure",
-  "version": "3.17.0",
+  "version": "3.17.1",
   "engines": {
     "node": "14"
   },

--- a/src/aws/lambda-elemental-routing/package.json
+++ b/src/aws/lambda-elemental-routing/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-elemental-routing",
-  "version": "3.17.0",
+  "version": "3.17.1",
   "engines": {
     "node": "14"
   },

--- a/src/aws/lambda-encode/package.json
+++ b/src/aws/lambda-encode/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-convert",
-  "version": "3.17.0",
+  "version": "3.17.1",
   "engines": {
     "node": "14"
   },

--- a/src/aws/lambda-medialive/package.json
+++ b/src/aws/lambda-medialive/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-medialive",
-  "version": "3.17.0",
+  "version": "3.17.1",
   "engines": {
     "node": "14"
   },

--- a/src/aws/lambda-mediapackage/package.json
+++ b/src/aws/lambda-mediapackage/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-mediapackage",
-  "version": "3.17.0",
+  "version": "3.17.1",
   "engines": {
     "node": "14"
   },

--- a/src/aws/lambda-migrate/package.json
+++ b/src/aws/lambda-migrate/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-migrate",
-  "version": "3.17.0",
+  "version": "3.17.1",
   "engines": {
     "node": "14"
   },

--- a/src/aws/utils/update-state/package.json
+++ b/src/aws/utils/update-state/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-update-state",
-  "version": "3.17.0",
+  "version": "3.17.1",
   "engines": {
     "node": "14"
   },

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = marsha
 description = A FUN video provider for Open edX
-version = 3.17.0
+version = 3.17.1
 author = Open FUN (France Universite Numerique)
 author_email = fun.dev@fun-mooc.fr
 license = MIT

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marsha",
-  "version": "3.17.0",
+  "version": "3.17.1",
   "description": "🐠 a FUN LTI video provider",
   "main": "front/index.tsx",
   "scripts": {


### PR DESCRIPTION
Added

- Add a series of components to power breadcrumbs.
- Add a frontend component to use SVG icons in Marsha.

Fixed

- Avoid blank page when feature flags are not set.

