### PR TITLE
🐛(circle) change working_dir for hub-ffmpeg-transmux job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -783,7 +783,7 @@ jobs:
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
-    working_directory: ~/marsha/src/aws/ffmpeg-transmux-live-image
+    working_directory: ~/marsha
     steps:
       # Checkout repository sources
       - checkout
@@ -800,8 +800,7 @@ jobs:
           command: |
             docker build \
               -t marsha-ffmpeg-transmux:${CIRCLE_SHA1} \
-              .
-
+              src/aws/ffmpeg-transmux-live-image/
       # Tag docker images with the same pattern used in Git (Semantic Versioning)
       #
       # Git tag: v1.0.1


### PR DESCRIPTION
## Purpose

The working_dir used in the job build-ffmpeg-transmux-docker was not
working as expected. The docker context is still the root project. So we
are changing the working directory to the root project and build the
image from this directory.

## Proposal

- [x] change working_dir for hub-ffmpeg-transmux job

