### PR TITLE
🐛(aws) change env file used in bin/terraform

### DIFF
--- a/src/aws/bin/terraform
+++ b/src/aws/bin/terraform
@@ -56,7 +56,7 @@ function terraform() {
         -u "$(id -u)" \
         -v "${PWD}/:/app" \
         -w "/app" \
-        --env-file ./env.d/development \
+        --env-file ./env.d/${MARSHA_TERRAFORM_ENV_FILE} \
         "hashicorp/terraform:0.14.5" \
         "$@"
     else
@@ -64,14 +64,14 @@ function terraform() {
         -u "$(id -u)" \
         -v "${PWD}/:/app" \
         -w "/app" \
-        --env-file ./env.d/development \
+        --env-file ./env.d/${MARSHA_TERRAFORM_ENV_FILE} \
         -e TF_VAR_marsha_base_url="${NGROK_URL}" \
         "hashicorp/terraform:0.14.5" \
         "$@"
     fi
 }
 
-OPTS=$(getopt -o "e" --long "env:" -- "$@")
+OPTS=$(getopt -o "e:" --long "env:" -- "$@")
 eval set -- "$OPTS"
 # Parse options
 while true; do


### PR DESCRIPTION
## Purpose

The PR #904 was made to change the env file used by the bin/terraform
script. Unfortunately when rebasing this PR the usage of the good env
file was erased...

## Proposal

- [x] change env file used in bin/terraform

