### PR TITLE
🧐(backend) improve backend debugging experience

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,8 @@ services:
     depends_on:
       - "base"
       - "db"
+    stdin_open: true
+    tty: true
 
   ngrok:
     image: wernight/ngrok


### PR DESCRIPTION
## Purpose

We'd like to be able to use the python debugger on the live app in development.

## Proposal

Our docker-compose file needs some updates to enable developers to `docker attach` to the app container and allow them to use the python debugger.

We basically did the exact same thing in Richie earlier (https://github.com/openfun/richie/commit/6cac32d4273b60bb53c896de7dbdd8a3b2441d3c)


