### PR TITLE
🙈(frontend) remove data from gitignore entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,7 +129,7 @@ src/backend/marsha/static/css
 src/backend/marsha/static/js
 
 # Assets
-data/
+./data/
 
 # Terraform
 .terraform


### PR DESCRIPTION
## Purpose

We had `data` in gitignore entries as we used to use a folder of that name for statics. However, it is also used as a folder name in the frontend.

## Proposal

Remove the entry from gitignore to enable us to add new files in the data folder.

