### PR TITLE
📝(terraform) add a bit of information on `getopt` for mac users

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ $ docker-compose --version
 
 All tasks related to this environment are run from the `./src/aws` directory. We use `Terraform` to keep this infrastructure configuration as code and easily manage several independent deployments of the whole `AWS` infrastructure.
 
+> Note for Mac users: Marsha's AWS development setup uses `getopt`. The version that comes with macOS is not suitable for our use case. You need to install the GNU version and add it to your path so it is used by default.
+>
+> `brew install gnu-getopt`
+>
+> `echo 'export PATH="/usr/local/opt/gnu-getopt/bin:$PATH"' >> ~/.zshrc`
+
 There are 2 Terraform projects in Marsha with two different purposes:
 
 - `./src/aws/shared_resources`: this project manages resources common to all marsha environments on the same AWS account. These resources must not live in different workspaces so you must work in the `default` workspace. To ease the use of this project, a dedicated script is available in `./src/aws/bin/shared-resources` which uses and configures the `Terraform` docker image. You have to run a Terraform command as if you were using the terraform cli. (eg: `./bin/shared-resources plan` will execute Terraform's "plan" command).


### PR DESCRIPTION
## Purpose

Scripts related to the AWS part of Marsha's stack are broken for Mac users by default, as the version of `getopt` available by default in macOS is not compatible with versions on other Unixes.

## Proposal

It can be fixed by installing the GNU version and adding it to the PATH. We decided to add a small disclaimer in the docs so new users don't waste time trying to figure this out.

