### PR TITLE
🚨(back) ignore pylint error in settings file

### DIFF
--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -4,6 +4,7 @@ Uses django-configurations to manage environments inheritance and the loading of
 config from the environment
 
 """
+# pylint: disable=abstract-class-instantiated
 
 from datetime import timedelta
 import json


### PR DESCRIPTION
## Purpose

In settings file, pylint is throwing an error since its last update
(2.7.4) when we configure sentry. We don't have alternative to configure
pylint so we choose to ignore this error.

## Proposal

- [x] ignore pylint error in settings file

