### PR TITLE
Update API endpoint permission implementations

### DIFF
--- a/src/backend/marsha/core/api.py
+++ b/src/backend/marsha/core/api.py
@@ -227,7 +227,7 @@ def update_state(request):
     return Response({"success": True})
 
 
-class VideoViewSet(viewsets.ModelViewSet):
+class VideoViewSet(ObjectPkMixin, viewsets.ModelViewSet):
     """Viewset for the API of the video object."""
 
     queryset = Video.objects.all()

--- a/src/backend/marsha/core/permissions.py
+++ b/src/backend/marsha/core/permissions.py
@@ -205,14 +205,11 @@ class IsParamsOrganizationAdmin(permissions.BasePermission):
         organization_id = request.data.get("organization") or request.query_params.get(
             "organization"
         )
-        try:
-            return models.OrganizationAccess.objects.filter(
-                role=ADMINISTRATOR,
-                organization__id=organization_id,
-                user__id=request.user.id,
-            ).exists()
-        except models.OrganizationAccess.DoesNotExist:
-            return False
+        return models.OrganizationAccess.objects.filter(
+            role=ADMINISTRATOR,
+            organization__id=organization_id,
+            user__id=request.user.id,
+        ).exists()
 
 
 class IsParamsPlaylistAdmin(permissions.BasePermission):
@@ -233,14 +230,9 @@ class IsParamsPlaylistAdmin(permissions.BasePermission):
         playlist_id = request.data.get("playlist") or request.query_params.get(
             "playlist"
         )
-        try:
-            return models.PlaylistAccess.objects.filter(
-                role=ADMINISTRATOR,
-                playlist__id=playlist_id,
-                user__id=request.user.id,
-            ).exists()
-        except models.PlaylistAccess.DoesNotExist:
-            return False
+        return models.PlaylistAccess.objects.filter(
+            role=ADMINISTRATOR, playlist__id=playlist_id, user__id=request.user.id,
+        ).exists()
 
 
 class IsParamsPlaylistAdminThroughOrganization(permissions.BasePermission):
@@ -261,14 +253,11 @@ class IsParamsPlaylistAdminThroughOrganization(permissions.BasePermission):
         playlist_id = request.data.get("playlist") or request.query_params.get(
             "playlist"
         )
-        try:
-            return models.OrganizationAccess.objects.filter(
-                role=ADMINISTRATOR,
-                organization__playlists__id=playlist_id,
-                user__id=request.user.id,
-            ).exists()
-        except models.OrganizationAccess.DoesNotExist:
-            return False
+        return models.OrganizationAccess.objects.filter(
+            role=ADMINISTRATOR,
+            organization__playlists__id=playlist_id,
+            user__id=request.user.id,
+        ).exists()
 
 
 class IsOrganizationAdmin(permissions.BasePermission):
@@ -355,15 +344,11 @@ class IsVideoPlaylistAdmin(permissions.BasePermission):
         Allow the request only if there is a video id in the path of the request, which exists,
         and if the current user is an admin for the playlist this video is a part of.
         """
-        try:
-            return models.PlaylistAccess.objects.filter(
-                role=ADMINISTRATOR,
-                # Avoid making extra requests to get the video or playlist id through get_object
-                playlist__videos__id=request.path.split("/")[3],
-                user__id=request.user.id,
-            ).exists()
-        except (models.PlaylistAccess.DoesNotExist, IndexError):
-            return False
+        return models.PlaylistAccess.objects.filter(
+            role=ADMINISTRATOR,
+            playlist__videos__id=view.get_object_pk(),
+            user__id=request.user.id,
+        ).exists()
 
 
 class IsVideoOrganizationAdmin(permissions.BasePermission):
@@ -382,12 +367,8 @@ class IsVideoOrganizationAdmin(permissions.BasePermission):
         and if the current user is an admin for the organization linked to the playlist this video
         is a part of.
         """
-        try:
-            return models.OrganizationAccess.objects.filter(
-                role=ADMINISTRATOR,
-                # Avoid making extra requests to get the video/playlist/org id through get_object
-                organization__playlists__videos__id=request.path.split("/")[3],
-                user__id=request.user.id,
-            ).exists()
-        except (models.OrganizationAccess.DoesNotExist, IndexError):
-            return False
+        return models.OrganizationAccess.objects.filter(
+            role=ADMINISTRATOR,
+            organization__playlists__videos__id=view.get_object_pk(),
+            user__id=request.user.id,
+        ).exists()

--- a/src/backend/marsha/core/tests/test_api_thumbnail.py
+++ b/src/backend/marsha/core/tests/test_api_thumbnail.py
@@ -353,7 +353,7 @@ class ThumbnailApiTest(TestCase):
             "/api/thumbnails/{!s}/".format(thumbnail.id),
             HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token),
         )
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 403)
 
     def test_api_thumbnail_initiate_upload_anonymous(self):
         """Anonymous users are not allowed to initiate an upload."""

--- a/src/backend/marsha/core/tests/test_api_timed_text_track.py
+++ b/src/backend/marsha/core/tests/test_api_timed_text_track.py
@@ -196,9 +196,11 @@ class TimedTextTrackAPITest(TestCase):
             "/api/timedtexttracks/{!s}/".format(other_timed_text_track.id),
             HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token),
         )
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 403)
         content = json.loads(response.content)
-        self.assertEqual(content, {"detail": "Not found."})
+        self.assertEqual(
+            content, {"detail": "You do not have permission to perform this action."}
+        )
 
     @override_settings(CLOUDFRONT_SIGNED_URLS_ACTIVE=False)
     def test_api_timed_text_track_without_extension_read_detail_token_user(self):
@@ -249,9 +251,11 @@ class TimedTextTrackAPITest(TestCase):
             "/api/timedtexttracks/{!s}/".format(other_timed_text_track.id),
             HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token),
         )
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 403)
         content = json.loads(response.content)
-        self.assertEqual(content, {"detail": "Not found."})
+        self.assertEqual(
+            content, {"detail": "You do not have permission to perform this action."}
+        )
 
     @override_settings(CLOUDFRONT_SIGNED_URLS_ACTIVE=False)
     def test_api_timed_text_track_read_detail_admin_user(self):
@@ -307,9 +311,11 @@ class TimedTextTrackAPITest(TestCase):
             "/api/timedtexttracks/{!s}/".format(other_timed_text_track.id),
             HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token),
         )
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 403)
         content = json.loads(response.content)
-        self.assertEqual(content, {"detail": "Not found."})
+        self.assertEqual(
+            content, {"detail": "You do not have permission to perform this action."}
+        )
 
     def test_api_timed_text_track_read_instructor_in_read_only(self):
         """Instructor should not be able to read a timed text track in read_only mode."""
@@ -767,7 +773,7 @@ class TimedTextTrackAPITest(TestCase):
             HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token),
             content_type="application/json",
         )
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 403)
         timed_text_track_update.refresh_from_db()
         self.assertEqual(timed_text_track_update.language, "en")
 
@@ -861,7 +867,7 @@ class TimedTextTrackAPITest(TestCase):
         response = self.client.delete(
             "/api/timedtexttracks/", HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token)
         )
-        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.status_code, 403)
         self.assertTrue(TimedTextTrack.objects.filter(id=timed_text_track.id).exists())
 
     def test_api_timed_text_track_delete_list_staff_or_user(self):
@@ -993,9 +999,11 @@ class TimedTextTrackAPITest(TestCase):
             ),
             HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token),
         )
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 403)
         content = json.loads(response.content)
-        self.assertEqual(content, {"detail": "Not found."})
+        self.assertEqual(
+            content, {"detail": "You do not have permission to perform this action."}
+        )
 
     def test_api_timed_text_track_initiate_upload_staff_or_user(self):
         """Users authenticated via a session should not be able to initiate an upload."""


### PR DESCRIPTION
## Purpose

As we see it, permissions as currently implemented in Django-rest-framework are currently broken. More specifically, the `OR` (`|`) combination of permissions is completely broken when attempting to combine permissions that use both `has_permission()` and `has_object_permission()`.

As can be seen [in the DRF source code](https://github.com/encode/django-rest-framework/blob/master/rest_framework/permissions.py#L68), the semantics of the `OR` combination are: `if any of the combined permissions' has_permission() and any of the combined permissions' has_object_permission() return True, return True`.

This results in undefined behavior when permissions are written in a straightforward way: to avoid any issue, all `has_object_permission()` calls should re-call `has_permission()` to make sure the matching check has passed, and not another unrelated one. This is compounded by the fact that any permission that omits to implement `has_object_permission()` is assumed to return `True` always.

Combining unrelated permissions thus becomes pretty complicated. However, we absolutely need that feature, especially given that our API supports two authorization mechanisms: through resource-level JWTs for LTI originated calls, and through user tokens for open web originated calls.

## Proposal

We suggest that all our permissions should only ever use `has_permission()` and forgo `has_object_permission()` entirely. This way combination semantics become simple again, `OR` is just "or" as the programmer understands it. And the number of DB calls is limited: a lot of our permissions don't need the `object` and will not get it from the DB;

We do lose some simplicity in the existing LTI relevant permissions, but those had to be heavily modified if we wanted to make it possible to combine them with open web relevant permissions.

Tests were untouched apart from some details in error codes, some of which were already wrong anyway. In our opinion, it's preferable to return `403` most of the time, rather than add "if-else soup" to return `404` or `405` for some of those requests.

- [x] clean up some existing permissions to use `ObjectPkMixin` (irrelevant to the issue, we just took this opportunity to update some code)
- [x] rework permissions to never use `has_object_permission()` and make it possible to combine them

