### PR TITLE
🐛(front) align video type with backend serializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - The `lti_id` field is optional on Videos and Documents.
 
+### Fixed
+
+- Frontend video type now allows Nullable urls.
+
 ## [3.17.1] - 2021-03-26
 
 ### Added

--- a/src/frontend/Player/createHlsPlayer.spec.ts
+++ b/src/frontend/Player/createHlsPlayer.spec.ts
@@ -1,6 +1,6 @@
 import { createHlsPlayer } from './createHlsPlayer';
 
-import { Video } from '../types/tracks';
+import { VideoUrls } from '../types/tracks';
 
 jest.mock('hls.js', () => {
   return jest.fn(() => ({
@@ -16,6 +16,8 @@ describe('createHlsPlayer', () => {
       manifests: {
         hls: 'https://example.com/hls.m3u8',
       },
+      mp4: {},
+      thumbnails: {},
     },
   };
 
@@ -24,7 +26,7 @@ describe('createHlsPlayer', () => {
   });
 
   it('creates and configure hls.js player', () => {
-    const player = createHlsPlayer(video as Video, 'ref' as any);
+    const player = createHlsPlayer(video.urls as VideoUrls, 'ref' as any);
     expect(player.attachMedia).toHaveBeenCalledWith('ref');
     expect(player.loadSource).toHaveBeenCalledWith(
       'https://example.com/hls.m3u8',

--- a/src/frontend/Player/createHlsPlayer.ts
+++ b/src/frontend/Player/createHlsPlayer.ts
@@ -1,16 +1,15 @@
 import Hls from 'hls.js';
-
-import { Video } from '../types/tracks';
+import { VideoUrls } from '../types/tracks';
 
 export const createHlsPlayer = (
-  video: Video,
+  urls: VideoUrls,
   videoNode: HTMLVideoElement,
 ): Hls => {
   const hls = new Hls({
     liveDurationInfinity: true,
     liveSyncDuration: 1,
   });
-  hls.loadSource(video.urls.manifests.hls);
+  hls.loadSource(urls.manifests.hls);
   hls.attachMedia(videoNode);
 
   return hls;

--- a/src/frontend/Player/createPlayer.spec.ts
+++ b/src/frontend/Player/createPlayer.spec.ts
@@ -37,7 +37,7 @@ describe('createPlayer', () => {
     expect(createPlyrPlayer).toHaveBeenCalledWith(
       ref,
       dispatchPlayerTimeUpdate,
-      video,
+      video.urls!,
     );
   });
 
@@ -51,7 +51,8 @@ describe('createPlayer', () => {
     expect(createVideojsPlayer).toHaveBeenCalledWith(
       ref,
       dispatchPlayerTimeUpdate,
-      video,
+      video.urls!,
+      video.live_state,
     );
   });
 

--- a/src/frontend/Player/createPlayer.ts
+++ b/src/frontend/Player/createPlayer.ts
@@ -11,9 +11,14 @@ export const createPlayer: VideoPlayerCreator = (
 ) => {
   switch (type) {
     case 'plyr':
-      return createPlyrPlayer(ref, dispatchPlayerTimeUpdate, video);
+      return createPlyrPlayer(ref, dispatchPlayerTimeUpdate, video.urls!);
     case 'videojs':
-      const player = createVideojsPlayer(ref, dispatchPlayerTimeUpdate, video);
+      const player = createVideojsPlayer(
+        ref,
+        dispatchPlayerTimeUpdate,
+        video.urls!,
+        video.live_state,
+      );
       return {
         destroy: () => player.dispose(),
       };

--- a/src/frontend/Player/createPlyrPlayer.spec.ts
+++ b/src/frontend/Player/createPlyrPlayer.spec.ts
@@ -1,6 +1,4 @@
-import Hls from 'hls.js';
-
-import { timedTextMode, uploadState, Video } from '../types/tracks';
+import { timedTextMode, uploadState } from '../types/tracks';
 import { videoMockFactory } from '../utils/tests/factories';
 import { jestMockOf } from '../utils/types';
 import { createHlsPlayer } from './createHlsPlayer';
@@ -134,7 +132,7 @@ describe('createPlyrPlayer', () => {
     jest.clearAllMocks();
   });
   it('creates Plyr player and configure it', () => {
-    const player = createPlyrPlayer('ref' as any, jest.fn(), video as Video);
+    const player = createPlyrPlayer('ref' as any, jest.fn(), video.urls!);
 
     const playButton = player.elements.buttons.play! as HTMLButtonElement[];
     expect(playButton[0].tabIndex).toEqual(-1);

--- a/src/frontend/Player/createPlyrPlayer.ts
+++ b/src/frontend/Player/createPlyrPlayer.ts
@@ -5,7 +5,7 @@ import { appData, getDecodedJwt } from '../data/appData';
 import { useTimedTextTrack } from '../data/stores/useTimedTextTrack';
 import { useTranscriptTimeSelector } from '../data/stores/useTranscriptTimeSelector';
 import { intl } from '../index';
-import { timedTextMode, Video, videoSize, uploadState } from '../types/tracks';
+import { timedTextMode, videoSize, VideoUrls } from '../types/tracks';
 import {
   InitializedContextExtensions,
   InteractedContextExtensions,
@@ -23,11 +23,11 @@ const trackTextKind: { [key in timedTextMode]?: string } = {
 export const createPlyrPlayer = (
   videoNode: HTMLVideoElement,
   dispatchPlayerTimeUpdate: (time: number) => void,
-  video: Video,
+  urls: VideoUrls,
 ): Plyr => {
   let sources;
   const settings = ['captions', 'speed', 'loop', 'quality'];
-  const resolutions = Object.keys(video.urls.mp4).map(
+  const resolutions = Object.keys(urls.mp4).map(
     (size) => Number(size) as videoSize,
   );
 
@@ -37,7 +37,7 @@ export const createPlyrPlayer = (
     sources = {
       sources: resolutions.map((size) => ({
         size,
-        src: video.urls.mp4[size],
+        src: urls.mp4[size],
         type: 'video/mp4',
       })),
       tracks: timedTextTracks
@@ -136,7 +136,7 @@ export const createPlyrPlayer = (
   }
 
   if (Hls.isSupported()) {
-    createHlsPlayer(video, videoNode);
+    createHlsPlayer(urls, videoNode);
   }
 
   if (player.elements.buttons.play) {

--- a/src/frontend/Player/createVideojsPlayer.spec.tsx
+++ b/src/frontend/Player/createVideojsPlayer.spec.tsx
@@ -90,7 +90,12 @@ describe('createVideoJsPlayer', () => {
 
     const videoElement = container.querySelector('video');
 
-    const player = createVideojsPlayer(videoElement!, jest.fn(), mockVideo);
+    const player = createVideojsPlayer(
+      videoElement!,
+      jest.fn(),
+      mockVideo.urls!,
+      mockVideo.live_state,
+    );
 
     expect(player.currentSources()).toEqual([
       { type: 'application/x-mpegURL', src: 'https://example.com/hls' },
@@ -133,7 +138,12 @@ describe('createVideoJsPlayer', () => {
 
     const videoElement = container.querySelector('video');
 
-    const player = createVideojsPlayer(videoElement!, jest.fn(), mockVideo);
+    const player = createVideojsPlayer(
+      videoElement!,
+      jest.fn(),
+      mockVideo.urls!,
+      mockVideo.live_state,
+    );
 
     expect(player.currentSources()).toEqual([
       {
@@ -213,7 +223,12 @@ describe('createVideoJsPlayer', () => {
 
     const videoElement = container.querySelector('video');
 
-    const player = createVideojsPlayer(videoElement!, jest.fn(), video);
+    const player = createVideojsPlayer(
+      videoElement!,
+      jest.fn(),
+      video.urls!,
+      video.live_state,
+    );
 
     expect(player.currentSources()).toEqual([
       { type: 'application/x-mpegURL', src: 'https://example.com/hls' },
@@ -234,7 +249,8 @@ describe('createVideoJsPlayer', () => {
     const player = createVideojsPlayer(
       videoElement!,
       dispatchPlayerTimeUpdate,
-      mockVideo,
+      mockVideo.urls!,
+      mockVideo.live_state,
     );
 
     expect(XAPIStatementMocked).toHaveBeenCalled();

--- a/src/frontend/Player/createVideojsPlayer.ts
+++ b/src/frontend/Player/createVideojsPlayer.ts
@@ -13,7 +13,7 @@ import {
   QualityLevels,
   VideoJsExtendedSourceObject,
 } from '../types/libs/video.js/extend';
-import { Video, videoSize } from '../types/tracks';
+import { liveState, videoSize, VideoUrls } from '../types/tracks';
 import {
   InitializedContextExtensions,
   InteractedContextExtensions,
@@ -29,7 +29,8 @@ import { Events } from './videojs/qualitySelectorPlugin/types';
 export const createVideojsPlayer = (
   videoNode: HTMLVideoElement,
   dispatchPlayerTimeUpdate: (time: number) => void,
-  video: Video,
+  urls: VideoUrls,
+  live: Nullable<liveState>,
 ): VideoJsPlayer => {
   // add the video-js class name to the video attribute.
   videoNode.classList.add('video-js', 'vjs-big-play-centered');
@@ -41,20 +42,20 @@ export const createVideojsPlayer = (
     plugins.qualitySelector = {
       default: '480',
     };
-    Object.keys(video.urls.mp4)
+    Object.keys(urls.mp4)
       .map((size) => Number(size) as videoSize)
       .sort((a, b) => b - a)
       .forEach((size) => {
         sources.push({
           type: 'video/mp4',
-          src: video.urls.mp4[size]!,
+          src: urls.mp4[size]!,
           size: size.toString(),
         });
       });
   } else {
     sources.push({
       type: 'application/x-mpegURL',
-      src: video.urls.manifests.hls,
+      src: urls.manifests.hls,
     });
   }
 
@@ -78,7 +79,7 @@ export const createVideojsPlayer = (
       nativeVideoTracks: videojs.browser.IS_SAFARI,
     },
     language: intl.locale,
-    liveui: video.live_state !== null,
+    liveui: live !== null,
     playbackRates: [0.5, 0.75, 1, 1.25, 1.5, 1.75, 2, 4],
     plugins,
     responsive: true,

--- a/src/frontend/components/DashboardThumbnailDisplay/index.tsx
+++ b/src/frontend/components/DashboardThumbnailDisplay/index.tsx
@@ -26,7 +26,7 @@ export const DashboardThumbnailDisplay = ({
   const urls =
     thumbnail && thumbnail.is_ready_to_show
       ? thumbnail.urls
-      : video.urls.thumbnails;
+      : video.urls!.thumbnails;
   const resolutions = Object.keys(urls).map(
     (size) => Number(size) as videoSize,
   );

--- a/src/frontend/components/DownloadVideo/index.spec.tsx
+++ b/src/frontend/components/DownloadVideo/index.spec.tsx
@@ -30,7 +30,7 @@ describe('<DownloadVideo />', () => {
     });
 
     const { getByText } = render(
-      wrapInIntlProvider(<DownloadVideo video={video} />),
+      wrapInIntlProvider(<DownloadVideo urls={video.urls!} />),
     );
 
     getByText('1080p');
@@ -60,7 +60,7 @@ describe('<DownloadVideo />', () => {
     });
 
     const { getByText, queryByText } = render(
-      wrapInIntlProvider(<DownloadVideo video={video} />),
+      wrapInIntlProvider(<DownloadVideo urls={video.urls!} />),
     );
 
     expect(queryByText(/1080p/i)).toEqual(null);
@@ -89,7 +89,7 @@ describe('<DownloadVideo />', () => {
     });
 
     const { container } = render(
-      wrapInIntlProvider(<DownloadVideo video={video} />),
+      wrapInIntlProvider(<DownloadVideo urls={video.urls!} />),
     );
     expect(container.firstChild).toBeNull();
   });

--- a/src/frontend/components/DownloadVideo/index.tsx
+++ b/src/frontend/components/DownloadVideo/index.tsx
@@ -5,7 +5,7 @@ import React, { Fragment } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import styled from 'styled-components';
 
-import { Video, videoSize } from '../../types/tracks';
+import { videoSize, VideoUrls } from '../../types/tracks';
 
 const messages = defineMessages({
   downloadVideo: {
@@ -36,8 +36,8 @@ const StatusInfo = styled.span`
 
 type downloadableSize = Extract<videoSize, 1080 | 720 | 480>;
 
-export const DownloadVideo = ({ video }: { video: Video }) => {
-  const resolutions = Object.keys(video.urls.mp4).map(
+export const DownloadVideo = ({ urls }: { urls: VideoUrls }) => {
+  const resolutions = Object.keys(urls.mp4).map(
     (size) => Number(size) as videoSize,
   );
   const elements: JSX.Element[] = ([1080, 720, 480] as downloadableSize[])
@@ -45,7 +45,7 @@ export const DownloadVideo = ({ video }: { video: Video }) => {
     .reduce((acc: JSX.Element[], size: downloadableSize) => {
       acc.push(
         <Fragment key={`fragment-${size}`}>
-          <a href={video.urls.mp4[size]}>{size}p</a>
+          <a href={urls.mp4[size]}>{size}p</a>
           &nbsp;
           <Tooltip
             overlay={<FormattedMessage {...messages[size]} />}

--- a/src/frontend/components/VideoPlayer/index.tsx
+++ b/src/frontend/components/VideoPlayer/index.tsx
@@ -113,8 +113,8 @@ const VideoPlayer = ({
 
   const thumbnailUrls =
     (thumbnail && thumbnail.is_ready_to_show && thumbnail.urls) ||
-    video.urls.thumbnails;
-  const resolutions = Object.keys(video.urls.mp4).map(
+    video.urls!.thumbnails;
+  const resolutions = Object.keys(video.urls!.mp4).map(
     (size) => Number(size) as videoSize,
   );
 
@@ -133,9 +133,9 @@ const VideoPlayer = ({
       >
         {resolutions.map((size) => (
           <source
-            key={video.urls.mp4[size]}
+            key={video.urls!.mp4[size]}
             size={`${size}`}
-            src={video.urls.mp4[size]}
+            src={video.urls!.mp4[size]}
             type="video/mp4"
           />
         ))}
@@ -157,7 +157,7 @@ const VideoPlayer = ({
             />
           ))}
       </video>
-      {video.show_download && <DownloadVideo video={video} />}
+      {video.show_download && <DownloadVideo urls={video.urls!} />}
       {transcripts.length > 0 && (
         <Transcripts transcripts={transcripts as TimedTextTranscript[]} />
       )}

--- a/src/frontend/types/tracks.ts
+++ b/src/frontend/types/tracks.ts
@@ -96,6 +96,14 @@ export interface Thumbnail extends Resource {
   video: Video['id'];
 }
 
+export interface VideoUrls {
+  manifests: {
+    hls: string;
+  };
+  mp4: Partial<urls>;
+  thumbnails: Partial<urls>;
+}
+
 /** A Video record as it exists on the backend. */
 export interface Video extends Resource {
   description: string;
@@ -105,13 +113,7 @@ export interface Video extends Resource {
   timed_text_tracks: TimedText[];
   title: string;
   upload_state: uploadState;
-  urls: {
-    manifests: {
-      hls: string;
-    };
-    mp4: Partial<urls>;
-    thumbnails: Partial<urls>;
-  };
+  urls: Nullable<VideoUrls>;
   should_use_subtitle_as_transcript: boolean;
   has_transcript: boolean;
   playlist: Playlist;


### PR DESCRIPTION
## Purpose

Currently, video urls can be None if the video is not uploaded.


## Proposal

Frontend video type now accepts nullable urls.
Also, player components now takes urls lists as properties, instead of complete video objects.

