### PR TITLE
🚚(frontend) clean built frontend files before each build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - The `lti_id` field is optional on Videos and Documents.
+- Clean built frontend files before each build
 
 ### Fixed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ COPY ./src/frontend /app/
 RUN yarn install --frozen-lockfile && \
     yarn compile-translations && \
     yarn sass scss/_main.scss /app/marsha/static/css/main.css --style=compressed --load-path=node_modules  && \
-    yarn build --mode=production --output-path /app/marsha/static/js/
+    yarn build --mode=production --output-path /app/marsha/static/js/build/
 
 # ---- static link collector ----
 FROM base as link-collector

--- a/docker/tests/statics.sh
+++ b/docker/tests/statics.sh
@@ -8,7 +8,7 @@ MARSHA_IMAGE_TAG="${2:-latest}"
 
 echo "Test statics for image ${MARSHA_IMAGE_NAME}:${MARSHA_IMAGE_TAG}..."
 
-expected_statics_path="/data/static/js/index.js"
+expected_statics_path="/data/static/js/build/index.js"
 
 docker run --rm --env-file=env.d/development.dist "${MARSHA_IMAGE_NAME}:${MARSHA_IMAGE_TAG}" ls $expected_statics_path
 

--- a/src/backend/marsha/core/templates/core/resource.html
+++ b/src/backend/marsha/core/templates/core/resource.html
@@ -10,7 +10,7 @@
     <div id="marsha-frontend-data" data-context="{{ app_data }}"></div>
 
     <div id="marsha-frontend-root"></div>
-    <script src='{% static "js/index.js" %}'></script>
+    <script src='{% static "js/build/index.js" %}'></script>
     {% for external_script in external_javascript_scripts %}
       <script src="{{ external_script }}" ></script>
     {% endfor %}

--- a/src/backend/marsha/core/templates/core/site.html
+++ b/src/backend/marsha/core/templates/core/site.html
@@ -10,7 +10,7 @@
     <div id="marsha-frontend-data" data-context="{{ app_data }}"></div>
 
     <div id="marsha-frontend-root" style="height: 100%;"></div>
-    <script src='{% static "js/index.js" %}'></script>
+    <script src='{% static "js/build/index.js" %}'></script>
     {% for external_script in external_javascript_scripts %}
     <script src="{{ external_script }}"></script>
     {% endfor %}

--- a/src/backend/marsha/core/tests/test_views_lti_video.py
+++ b/src/backend/marsha/core/tests/test_views_lti_video.py
@@ -1256,7 +1256,9 @@ class VideoLTIViewTestCase(TestCase):
         response = self.client.post("/lti/videos/{!s}".format(video.pk), data)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "<html>")
-        self.assertContains(response, '<meta name="public-path" value="/static/js/" />')
+        self.assertContains(
+            response, '<meta name="public-path" value="/static/js/build/" />'
+        )
 
     @mock.patch.object(LTI, "verify")
     @mock.patch.object(LTI, "get_consumer_site")

--- a/src/backend/marsha/core/views.py
+++ b/src/backend/marsha/core/views.py
@@ -101,7 +101,7 @@ class SiteView(mixins.WaffleSwitchMixin, TemplateView):
         return {
             "app_data": json.dumps(app_data),
             "external_javascript_scripts": settings.EXTERNAL_JAVASCRIPT_SCRIPTS,
-            "static_base_url": f"{settings.STATIC_URL}js/",
+            "static_base_url": f"{settings.STATIC_URL}js/build/",
         }
 
 
@@ -177,7 +177,7 @@ class BaseLTIView(ABC, TemplateResponseMixin, View):
 
         return {
             "app_data": json.dumps(app_data),
-            "static_base_url": f"{settings.STATIC_URL}js/",
+            "static_base_url": f"{settings.STATIC_URL}js/build/",
             "external_javascript_scripts": settings.EXTERNAL_JAVASCRIPT_SCRIPTS,
         }
 
@@ -333,7 +333,7 @@ class BaseLTIView(ABC, TemplateResponseMixin, View):
 
         return {
             "app_data": json.dumps(app_data),
-            "static_base_url": f"{settings.STATIC_URL}js/",
+            "static_base_url": f"{settings.STATIC_URL}js/build/",
             "external_javascript_scripts": settings.EXTERNAL_JAVASCRIPT_SCRIPTS,
         }
 

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "build": "tsc --noEmit && webpack",
     "build-dev": "yarn copy-iframe-resizer; yarn build",
-    "clean": "find ../backend/marsha/static/js/ -type f ! -iname 'iframeResizer.min.js' -delete",
     "extract-translations": "formatjs extract './**/*.ts*' --ignore ./node_modules --ignore './**/*.d.ts' --out-file i18n/frontend.json --id-interpolation-pattern '[sha512:contenthash:base64:6]' --format crowdin",
     "compile-translations": "formatjs compile-folder --format crowdin ./i18n ./translations",
     "copy-iframe-resizer": "cp node_modules/iframe-resizer/js/iframeResizer.min.js ../backend/marsha/static/js",

--- a/src/frontend/webpack.config.js
+++ b/src/frontend/webpack.config.js
@@ -22,8 +22,9 @@ module.exports = {
   // is on AWS.
   output: {
     filename: 'index.js',
-    path: __dirname + '/../backend/marsha/static/js',
+    path: __dirname + '/../backend/marsha/static/js/build',
     chunkFilename: '[id].[fullhash].index.js',
+    clean: true,
   },
 
   // Enable sourcemaps for debugging webpack's output.


### PR DESCRIPTION
## Purpose

As webpack use hashes to name files it generate, old files stay in place. So
after several builds, we can have a js folder with a very large amount of files
which is not efficient and furthermore can produce issues and slow down script
executions.
In order to clean these files before each build, we need to put them in a
dedicated directory to not remove other js scripts placed in static/js directory

## Proposal

- [x] clean built frontend files before each build

