### PR TITLE
✨(docker) add a prosody server in docker-compose stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Chat feature implementing XMPP protocol
+- Add a prosody server in docker-compose stack
 
 ### Changed
 

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,8 @@
 # ==============================================================================
 # VARIABLES
 
+include env.d/development
+
 # -- Project
 PROJECT_NAME := $(shell python src/backend/setup.py --name)
 PROJECT_VERSION := $(shell python src/backend/setup.py --version)
@@ -56,7 +58,8 @@ bootstrap: \
 	build-lambda-dev \
 	run \
 	migrate \
-	i18n-compile-back
+	i18n-compile-back \
+	prosody-admin
 .PHONY: bootstrap
 
 # -- Docker/compose
@@ -82,6 +85,7 @@ run: ## start the development server using Docker
 	@$(COMPOSE) up -d app
 	@echo "Wait for postgresql to be up..."
 	@$(COMPOSE_RUN) dockerize -wait tcp://db:5432 -timeout 60s
+	@$(COMPOSE) up -d prosody-nginx
 .PHONY: run
 
 ngrok: ## start the development server using Docker through ngrok
@@ -181,6 +185,11 @@ superuser: ## create a Django superuser
 	@echo "$(BOLD)Creating a Django superuser$(RESET)"
 	@$(COMPOSE_RUN_APP) python manage.py createsuperuser
 .PHONY: superuser
+
+prosody-admin: ## create prosody admin user
+	@echo "$(BOLD)Creating a prosody admin$(RESET)"
+	$(COMPOSE_RUN) prosody-app prosodyctl register admin prosody-app "${DJANGO_XMPP_PRIVATE_SERVER_PASSWORD}"
+.PHONY: 
 
 .PHONY: test
 test:  ## Run django tests for the marsha project.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
   db:
     image: postgres:10.3
     env_file: env.d/${ENV_FILE:-development}
+    volumes:
+      - ./docker/files/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
     ports:
       - "5452:5432"
 
@@ -178,3 +180,23 @@ services:
       - "./src/.prettierrc:/var/task/.prettierrc"
     depends_on:
       - lambda_base
+
+  prosody-app:
+    image: fundocker/prosody
+    ports: 
+      - 5222:5222
+    volumes:
+      - "./docker/files/etc/prosody:/etc/prosody"
+    depends_on: 
+      - db
+
+  prosody-nginx:
+    image: nginx
+    ports: 
+      - 8061:80
+    volumes:
+      - "./docker/files/etc/nginx/conf.d:/etc/nginx/conf.d"
+    depends_on: 
+      - prosody-app
+    links:
+      - "prosody-app:prosody"

--- a/docker/files/docker-entrypoint-initdb.d/init_user_db.sh
+++ b/docker/files/docker-entrypoint-initdb.d/init_user_db.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+    CREATE USER prosody PASSWORD 'prosody';
+    CREATE DATABASE prosody;
+    GRANT ALL PRIVILEGES ON DATABASE prosody TO prosody;
+EOSQL

--- a/docker/files/etc/nginx/conf.d/default.conf
+++ b/docker/files/etc/nginx/conf.d/default.conf
@@ -1,23 +1,14 @@
 server {
 
-    listen 80;
+	listen 80;
     server_name localhost;
-    charset utf-8;
 
-    location /static {
-        alias /data/static;
-    }
-
-    location /media {
-        alias /data/media;
-    }
-
-    location / {
-        proxy_pass http://app:8000;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
+	location /http-bind {
+        proxy_pass  http://prosody:5280/http-bind;
+        proxy_set_header Host prosody;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    }
-
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_buffering off;
+        tcp_nodelay on;
+	}
 }
-

--- a/docker/files/etc/prosody/prosody.cfg.lua
+++ b/docker/files/etc/prosody/prosody.cfg.lua
@@ -1,0 +1,197 @@
+-- Prosody XMPP Server Configuration
+--
+-- Information on configuring Prosody can be found on our
+-- website at https://prosody.im/doc/configure
+--
+-- Tip: You can check that the syntax of this file is correct
+-- when you have finished by running this command:
+--     prosodyctl check config
+-- If there are any errors, it will let you know what and where
+-- they are, otherwise it will keep quiet.
+--
+-- Good luck, and happy Jabbering!
+
+
+---------- Server-wide settings ----------
+-- Settings in this section apply to the whole server and are the default settings
+-- for any virtual hosts
+
+-- Prosody will always look in its source directory for modules, but
+-- this option allows you to specify additional locations where Prosody
+-- will look for modules first. For community modules, see https://modules.prosody.im/
+plugin_paths = { "/usr/share/prosody/modules" }
+
+-- The daemonize and pidfile are used to run prosody in foreground
+daemonize = false
+pidfile = "prosody.pid"
+
+-- This is a (by default, empty) list of accounts that are admins
+-- for the server. Note that you must create the accounts separately
+-- (see https://prosody.im/doc/creating_accounts for info)
+-- Example: admins = { "user1@example.com", "user2@example.net" }
+admins = { }
+
+
+
+-- Enable use of libevent for better performance under high load
+-- For more information see: https://prosody.im/doc/libevent
+use_libevent = true
+
+
+cross_domain_bosh = true
+consider_bosh_secure = true
+
+-- This is the list of modules Prosody will load on startup.
+-- It looks for mod_modulename.lua in the plugins folder, so make sure that exists too.
+-- Documentation for bundled modules can be found at: https://prosody.im/doc/modules
+modules_enabled = {
+  "roster";
+  "saslauth";
+  "dialback";
+  "disco";
+  "carbons";
+  "pep";
+  "private";
+  "blocklist";
+  "vcard4";
+  "vcard_legacy";
+  "version";
+  "uptime";
+  "time";
+  "ping";
+  "register";
+  "admin_adhoc";
+}
+
+-- These modules are auto-loaded, but should you want
+-- to disable them then uncomment them here:
+modules_disabled = {}
+
+-- Disable account creation by default, for security
+-- For more information see https://prosody.im/doc/creating_accounts
+allow_registration = false
+
+-- Force clients to use encrypted connections? This option will
+-- prevent clients from authenticating unless they are using encryption.
+
+c2s_require_encryption = false
+allow_unencrypted_plain_auth = true
+
+-- Force servers to use encrypted connections? This option will
+-- prevent servers from authenticating unless they are using encryption.
+
+s2s_require_encryption = false
+
+-- Force certificate authentication for server-to-server connections?
+
+s2s_secure_auth = false
+
+-- Some servers have invalid or self-signed certificates. You can list
+-- remote domains here that will not be required to authenticate using
+-- certificates. They will be authenticated using DNS instead, even
+-- when s2s_secure_auth is enabled.
+
+s2s_insecure_domains = { }
+
+-- Even if you disable s2s_secure_auth, you can still require valid
+-- certificates for some domains by specifying a list here.
+
+s2s_secure_domains = { }
+
+-- Required for init scripts and prosodyctl
+
+-- Select the authentication backend to use. The 'internal' providers
+-- use Prosody's configured data storage to store the authentication data.
+
+authentication = "internal_hashed" 
+
+-- Select the storage backend to use. By default Prosody uses flat files
+-- in its configured data directory, but it also supports more backends
+-- through modules. An "sql" backend is included by default, but requires
+-- additional dependencies. See https://prosody.im/doc/storage for more info.
+
+storage = "sql"
+
+sql = { 
+    driver = "PostgreSQL",
+    database = "prosody",
+    username = "prosody",
+    password = "prosody",
+    host = "db",
+    port =  5432
+  }
+
+-- Archiving configuration
+-- If mod_mam is enabled, Prosody will store a copy of every message. This
+-- is used to synchronize conversations between multiple clients, even if
+-- they are offline. This setting controls how long Prosody will keep
+-- messages in the archive before removing them.
+
+archive_expires_after = "1w"
+
+-- You can also configure messages to be stored in-memory only. For more
+-- archiving options, see https://prosody.im/doc/modules/mod_mam
+
+-- Logging configuration
+-- For advanced logging see https://prosody.im/doc/logging
+log = {
+	{ levels = {min = "debug"}, to = "console"};
+}
+
+-- Uncomment to enable statistics
+-- For more info see https://prosody.im/doc/statistics
+-- statistics = "internal"
+
+-- Certificates
+-- Every virtual host and component needs a certificate so that clients and
+-- servers can securely verify its identity. Prosody will automatically load
+-- certificates/keys from the directory specified here.
+-- For more information, including how to use 'prosodyctl' to auto-import certificates
+-- (from e.g. Let's Encrypt) see https://prosody.im/doc/certificates
+
+-- Location of directory to find certificates in (relative to main config file):
+certificates = "certs"
+
+-- HTTPS currently only supports a single certificate, specify it here:
+--https_certificate = "/etc/prosody/certs/localhost.crt"
+
+asap_accepted_issuers = { "marsha" }
+asap_accepted_audiences = { "marsha" }
+
+----------- Virtual hosts -----------
+-- You need to add a VirtualHost entry for each domain you wish Prosody to serve.
+-- Settings under each VirtualHost entry apply *only* to that host.
+
+VirtualHost "prosody"
+    authentication = "token"
+    -- Properties below are modified by jitsi-meet-tokens package config
+    -- and authentication above is switched to "token"
+    app_id="marsha"
+    app_secret="ThisIsNotAPrivateProsodyJwtSigningKey"
+
+    allow_empty_token = false;  
+    modules_enabled = {
+        "bosh";
+    }
+    c2s_require_encryption = false
+
+VirtualHost "prosody-app"
+    authentication = "internal_hashed"
+    admins = { "admin@prosody-app" }
+
+
+------ Components ------
+-- You can specify components to add hosts that provide special services,
+-- like multi-user conferences, and transports.
+-- For more information on components, see https://prosody.im/doc/components
+
+---Set up a MUC (multi-user chat) room server on conference.example.com:
+Component "conference.prosody" "muc"
+    modules_enabled = { "muc_mam", "token_verification", "token_affiliation" }
+    admins = { "admin@prosody-app" }
+    restrict_room_creation = true
+    muc_room_default_persistent = true
+    log_all_rooms = true
+
+
+

--- a/env.d/development.dist
+++ b/env.d/development.dist
@@ -33,13 +33,13 @@ DJANGO_AWS_MEDIALIVE_ROLE_ARN=aws:medialive:arn:role
 DJANGO_AWS_MEDIAPACKAGE_HARVEST_JOB_ARN=aws:mediapackage:arn:role
 
 # XMPP
-DJANGO_LIVE_CHAT_ENABLED=False
-DJANGO_XMPP_BOSH_URL=https://your-xmpp-server.com/http-bind
-DJANGO_XMPP_CONFERENCE_DOMAIN=conference.your-xmpp-server.com
-DJANGO_XMPP_DOMAIN=your-xmpp-server.com
-DJANGO_XMPP_PRIVATE_ADMIN_JID=admin@your-xmpp-server.com
-DJANGO_XMPP_PRIVATE_SERVER_PASSWORD=ThisIsNotAPassword
-DJANGO_XMPP_JWT_SHARED_SECRET=ThisIsNotASharedSecret
+DJANGO_LIVE_CHAT_ENABLED=True
+DJANGO_XMPP_BOSH_URL=http://localhost:8061/http-bind
+DJANGO_XMPP_CONFERENCE_DOMAIN=conference.prosody
+DJANGO_XMPP_PRIVATE_ADMIN_JID=admin@prosody-app
+DJANGO_XMPP_PRIVATE_SERVER_PASSWORD=jm2bafdxJRzxR9SDJEEMsv2b2
+DJANGO_XMPP_JWT_SHARED_SECRET=ThisIsNotAPrivateProsodyJwtSigningKey
+DJANGO_XMPP_DOMAIN=prosody
 
 DJANGO_UPDATE_STATE_SHARED_SECRETS=ThisIsAFirstSharedSecret,ThisOneTheSecondSharedSecret
 


### PR DESCRIPTION
## Purpose

To easily work on the marsha chat we added and configured a prosody
server in the docker-compose stack. The server is ready to be used, is
starting using the `make run` command and an admin can be created by
running `make prosody-admin`.

## Proposal

- [x] add a prosody server in docker-compose stack

