### PR TITLE
Display chat box without video player

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Chat feature implementing XMPP protocol
 - Add a prosody server in docker-compose stack
 - Add a LTI select view to allow LTI consumers to add a LTI content through Deep Linking
+- Display chat box without video player
 
 ### Changed
 

--- a/src/frontend/components/Chat/index.spec.tsx
+++ b/src/frontend/components/Chat/index.spec.tsx
@@ -1,15 +1,17 @@
 import { render } from '@testing-library/react';
 import React from 'react';
 
+import { converseMounter } from '../../utils/converse';
 import { videoMockFactory } from '../../utils/tests/factories';
-import * as mockWindow from '../../utils/window';
 import { Chat } from '.';
 
-jest.mock('../../utils/window', () => ({
-  converse: {
-    initialize: jest.fn(),
-  },
+jest.mock('../../utils/converse', () => ({
+  converseMounter: jest.fn(() => jest.fn()),
 }));
+
+const mockConverseMounter = converseMounter as jest.MockedFunction<
+  typeof converseMounter
+>;
 
 describe('<Chat />', () => {
   afterEach(() => {
@@ -28,33 +30,14 @@ describe('<Chat />', () => {
       },
     });
 
+    expect(mockConverseMounter).toHaveBeenCalled();
     render(<Chat xmpp={video.xmpp!} />);
 
-    expect(mockWindow.converse.initialize).toHaveBeenCalledWith({
-      allow_contact_requests: false,
-      allow_logout: false,
-      allow_message_corrections: 'last',
-      allow_message_retraction: 'all',
-      allow_muc_invitations: false,
-      allow_registration: false,
-      authentication: 'anonymous',
-      auto_login: true,
-      auto_join_rooms: [
-        '870c467b-d66e-4949-8ee5-fcf460c72e88@conference.xmpp-server.com',
-      ],
-      bosh_service_url: 'https://xmpp-server.com/http-bind',
-      discover_connection_methods: false,
-      hide_muc_participants: true,
-      jid: 'xmpp-server.com',
-      modtools_disable_assign: true,
-      singleton: true,
-      view_mode: 'embedded',
-      visible_toolbar_buttons: {
-        call: false,
-        spoiler: false,
-        emoji: true,
-        toggle_occupants: false,
-      },
-    });
+    // mockConverseMounter returns itself a mock. We want to inspect this mock to be sure that
+    // is was called with the container name and the xmpp object
+    expect(mockConverseMounter.mock.results[0].value).toHaveBeenCalledWith(
+      '#converse-container',
+      video.xmpp,
+    );
   });
 });

--- a/src/frontend/components/Chat/index.tsx
+++ b/src/frontend/components/Chat/index.tsx
@@ -1,48 +1,27 @@
-import 'converse.js/dist/converse.min.css';
-import 'converse.js/dist/converse.min.js';
-import 'converse.js/dist/emojis.js';
-import 'converse.js/dist/icons.js';
 import { Box } from 'grommet';
 import React, { useEffect } from 'react';
 
 import { XMPP } from '../../types/tracks';
-import { converse } from '../../utils/window';
+import { converseMounter } from '../../utils/converse';
 
 interface ChatProps {
   xmpp: XMPP;
 }
 
+const converseManager = converseMounter();
+
 export const Chat = ({ xmpp }: ChatProps) => {
   useEffect(() => {
-    converse.initialize({
-      allow_contact_requests: false,
-      allow_logout: false,
-      allow_message_corrections: 'last',
-      allow_message_retraction: 'all',
-      allow_muc_invitations: false,
-      allow_registration: false,
-      authentication: 'anonymous',
-      auto_login: true,
-      auto_join_rooms: [xmpp.conference_url],
-      bosh_service_url: xmpp.bosh_url,
-      discover_connection_methods: false,
-      hide_muc_participants: true,
-      jid: xmpp.jid,
-      modtools_disable_assign: true,
-      singleton: true,
-      view_mode: 'embedded',
-      visible_toolbar_buttons: {
-        call: false,
-        emoji: true,
-        spoiler: false,
-        toggle_occupants: false,
-      },
-    });
+    converseManager('#converse-container', xmpp);
   }, []);
 
   return (
-    <Box align="start" direction="row" height="large" pad={{ top: 'small' }}>
-      <div id="conversejs"></div>
-    </Box>
+    <Box
+      align="start"
+      direction="row"
+      height="large"
+      pad={{ top: 'small' }}
+      id="converse-container"
+    />
   );
 };

--- a/src/frontend/components/Chat/route.ts
+++ b/src/frontend/components/Chat/route.ts
@@ -1,0 +1,6 @@
+/**
+ * Route for the `<Chat />` component.
+ */
+export const CHAT_ROUTE = () => {
+  return `/chat`;
+};

--- a/src/frontend/components/DashboardVideoLive/index.spec.tsx
+++ b/src/frontend/components/DashboardVideoLive/index.spec.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import fetchMock from 'fetch-mock';
 import React from 'react';
 
+import { CHAT_ROUTE } from '../Chat/route';
 import { PLAYER_ROUTE } from '../routes';
 import { modelName } from '../../types/models';
 import { liveState, uploadState } from '../../types/tracks';
@@ -89,6 +90,7 @@ describe('components/DashboardVideoLive', () => {
       ),
     );
 
+    screen.getByRole('button', { name: /show chat only/i });
     screen.getByRole('button', { name: /show live/i });
     screen.getByRole('button', { name: /stop streaming/i });
   });
@@ -116,6 +118,33 @@ describe('components/DashboardVideoLive', () => {
     fireEvent.click(showLiveButton);
 
     screen.getByText('video player');
+  });
+
+  it('clicks on show chat only and redirects to the chat component', () => {
+    render(
+      wrapInIntlProvider(
+        wrapInRouter(
+          <DashboardVideoLive
+            video={{ ...video, live_state: liveState.RUNNING }}
+          />,
+          [
+            {
+              path: CHAT_ROUTE(),
+              render: () => <span>chat component</span>,
+            },
+          ],
+        ),
+      ),
+    );
+
+    const showChatOnlyButton = screen.getByRole('button', {
+      name: /show chat only/i,
+    });
+    expect(screen.queryByText('chat component')).not.toBeInTheDocument();
+
+    fireEvent.click(showChatOnlyButton);
+
+    screen.getByText('chat component');
   });
 
   it('polls the video when live state is STARTING', async () => {

--- a/src/frontend/components/DashboardVideoLive/index.tsx
+++ b/src/frontend/components/DashboardVideoLive/index.tsx
@@ -1,5 +1,5 @@
 import { Box, Heading, Text } from 'grommet';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 
 import { appData } from '../../data/appData';
@@ -8,6 +8,7 @@ import { API_ENDPOINT } from '../../settings';
 import { modelName } from '../../types/models';
 import { Video, liveState } from '../../types/tracks';
 import { report } from '../../utils/errors/report';
+import { CHAT_ROUTE } from '../Chat/route';
 import { PLAYER_ROUTE } from '../routes';
 import { DashboardVideoLiveStartButton } from '../DashboardVideoLiveStartButton';
 import { DashboardVideoLiveStopButton } from '../DashboardVideoLiveStopButton';
@@ -38,6 +39,11 @@ const messages = defineMessages({
     defaultMessage: 'show live',
     description: 'button to redirect use to video player.',
     id: 'components.DashboardVideoLive.showLive',
+  },
+  chatOnly: {
+    defaultMessage: 'show chat only',
+    description: 'button to redirect to the chat only view.',
+    id: 'components.DashboardVideoLive.chatOnly',
   },
   liveCreating: {
     defaultMessage:
@@ -156,6 +162,11 @@ export const DashboardVideoLive = ({ video }: DashboardVideoLiveProps) => {
         )}
         {video.live_state === liveState.RUNNING && (
           <React.Fragment>
+            <DashboardButtonWithLink
+              label={<FormattedMessage {...messages.chatOnly} />}
+              primary={false}
+              to={CHAT_ROUTE()}
+            />
             <DashboardButtonWithLink
               label={<FormattedMessage {...messages.showLive} />}
               primary={false}

--- a/src/frontend/components/LTIRoutes/index.tsx
+++ b/src/frontend/components/LTIRoutes/index.tsx
@@ -3,6 +3,8 @@ import { MemoryRouter, Redirect, Route, Switch } from 'react-router-dom';
 
 import { appData } from '../../data/appData';
 import { modelName } from '../../types/models';
+import { Chat } from '../Chat';
+import { CHAT_ROUTE } from '../Chat/route';
 import { DASHBOARD_ROUTE } from '../Dashboard/route';
 import { FullScreenError } from '../ErrorComponents';
 import { FULL_SCREEN_ERROR_ROUTE } from '../ErrorComponents/route';
@@ -78,6 +80,21 @@ export const Routes = () => (
               lti_select_form_data={appData.lti_select_form_data!}
             />
           )}
+        />
+        <Route
+          exact
+          path={CHAT_ROUTE()}
+          render={() => {
+            if (appData.modelName === modelName.VIDEOS && appData.video?.xmpp) {
+              return (
+                <InstructorWrapper resource={appData.video}>
+                  <Chat xmpp={appData.video.xmpp} />
+                </InstructorWrapper>
+              );
+            }
+
+            return <Redirect push to={FULL_SCREEN_ERROR_ROUTE('notFound')} />;
+          }}
         />
         <Route
           exact

--- a/src/frontend/types/libs/window.d.ts
+++ b/src/frontend/types/libs/window.d.ts
@@ -4,6 +4,9 @@ export {};
 declare global {
   interface Window {
     converse: {
+      plugins: {
+        add: (name: string, {}: any) => void;
+      };
       initialize: (options: any) => void;
     };
   }

--- a/src/frontend/types/libs/window.d.ts
+++ b/src/frontend/types/libs/window.d.ts
@@ -4,9 +4,7 @@ export {};
 declare global {
   interface Window {
     converse: {
-      plugins: {
-        add: (name: string, {}: any) => void;
-      };
+      insertInto: (container: HTMLElement) => void;
       initialize: (options: any) => void;
     };
   }

--- a/src/frontend/utils/converse.spec.ts
+++ b/src/frontend/utils/converse.spec.ts
@@ -1,0 +1,73 @@
+import { converseMounter } from './converse';
+import * as mockWindow from './window';
+
+jest.mock('./window', () => ({
+  converse: {
+    initialize: jest.fn(),
+    insertInto: jest.fn(),
+  },
+}));
+
+describe('converseMounter', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('initializes once converse.js', () => {
+    document.body.innerHTML = '<div id="converse-container"></div>';
+
+    const xmpp = {
+      bosh_url: 'https://xmpp-server.com/http-bind',
+      conference_url:
+        '870c467b-d66e-4949-8ee5-fcf460c72e88@conference.xmpp-server.com',
+      prebind_url: 'https://xmpp-server.com/http-pre-bind',
+      jid: 'xmpp-server.com',
+    };
+
+    const converseManager = converseMounter();
+
+    // The converse mounter is initialized and converse has not been initialized nor inserted.
+    expect(mockWindow.converse.initialize).not.toHaveBeenCalled();
+    expect(mockWindow.converse.insertInto).not.toHaveBeenCalled();
+
+    // first call, converse is initialized
+    converseManager('#converse-container', xmpp);
+
+    expect(mockWindow.converse.initialize).toHaveBeenCalledTimes(1);
+    expect(mockWindow.converse.initialize).toHaveBeenCalledWith({
+      allow_contact_requests: false,
+      allow_logout: false,
+      allow_message_corrections: 'last',
+      allow_message_retraction: 'all',
+      allow_muc_invitations: false,
+      allow_registration: false,
+      authentication: 'anonymous',
+      auto_login: true,
+      auto_join_rooms: [
+        '870c467b-d66e-4949-8ee5-fcf460c72e88@conference.xmpp-server.com',
+      ],
+      bosh_service_url: 'https://xmpp-server.com/http-bind',
+      clear_cache_on_logout: true,
+      discover_connection_methods: false,
+      hide_muc_participants: true,
+      jid: 'xmpp-server.com',
+      modtools_disable_assign: true,
+      root: expect.any(HTMLDivElement),
+      singleton: true,
+      view_mode: 'embedded',
+      visible_toolbar_buttons: {
+        call: false,
+        emoji: true,
+        spoiler: false,
+        toggle_occupants: false,
+      },
+    });
+    expect(mockWindow.converse.insertInto).not.toHaveBeenCalled();
+
+    // second call, converse is already initialized, we mount it in the dom.
+    converseManager('#converse-container', xmpp);
+
+    expect(mockWindow.converse.initialize).toHaveBeenCalledTimes(1);
+    expect(mockWindow.converse.insertInto).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/frontend/utils/converse.ts
+++ b/src/frontend/utils/converse.ts
@@ -1,0 +1,45 @@
+import 'converse.js/dist/converse.min.css';
+import 'converse.js/dist/converse.min.js';
+import 'converse.js/dist/emojis.js';
+import 'converse.js/dist/icons.js';
+
+import { converse } from './window';
+import { XMPP } from '../types/tracks';
+
+export const converseMounter = () => {
+  let hasBeenInitialized = false;
+
+  return (containerName: string, xmpp: XMPP) => {
+    if (hasBeenInitialized) {
+      converse.insertInto(document.querySelector(containerName)!);
+    } else {
+      converse.initialize({
+        allow_contact_requests: false,
+        allow_logout: false,
+        allow_message_corrections: 'last',
+        allow_message_retraction: 'all',
+        allow_muc_invitations: false,
+        allow_registration: false,
+        authentication: 'anonymous',
+        auto_login: true,
+        auto_join_rooms: [xmpp.conference_url],
+        bosh_service_url: xmpp.bosh_url,
+        clear_cache_on_logout: true,
+        discover_connection_methods: false,
+        hide_muc_participants: true,
+        jid: xmpp.jid,
+        modtools_disable_assign: true,
+        root: document.querySelector(containerName),
+        singleton: true,
+        view_mode: 'embedded',
+        visible_toolbar_buttons: {
+          call: false,
+          emoji: true,
+          spoiler: false,
+          toggle_occupants: false,
+        },
+      });
+      hasBeenInitialized = true;
+    }
+  };
+};


### PR DESCRIPTION
## Purpose

As an instructor I would like to see only the chat box during a live
without seeing the video itself. A route is added redirecting to the
chat component and a button is added in the dashboard. An instructor can
see the chat only or the video and the chat in the same page.

## Proposal

Description...

- [x] display chat box without video player
- [x] clean chat session when component is unmounted

