### PR TITLE
♻️(tests-back) factorize LTI signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Add a prosody server in docker-compose stack
 - Add a LTI select view to allow LTI consumers to add a LTI content through Deep Linking
 - Display chat box without video player
+- Add a tests.utils module to share LTI request signature and refactor related tests
 
 ### Changed
 

--- a/src/backend/marsha/core/tests/test_views_lti_respond.py
+++ b/src/backend/marsha/core/tests/test_views_lti_respond.py
@@ -1,12 +1,9 @@
 """Test the LTI select view."""
 import random
-from urllib.parse import unquote
 
 from django.test import TestCase
 
-from oauthlib import oauth1
-
-from ..factories import ConsumerSiteLTIPassportFactory
+from .utils import generate_passport_and_signed_lti_parameters
 
 
 # We don't enforce arguments documentation in tests
@@ -18,47 +15,17 @@ class RespondLTIViewTestCase(TestCase):
 
     maxDiff = None
 
-    @staticmethod
-    def _get_signed_lti_parameters():
-        """Generate signed LTI parameters."""
-        passport = ConsumerSiteLTIPassportFactory(consumer_site__domain="testserver")
-        lti_parameters = {
-            "roles": random.choice(["instructor", "administrator"]),
-            "content_item_return_url": "http://return.url/",
-            "content_items": "some content items",
-            "context_id": "unknown",
-        }
-        url = "http://testserver/lti/respond/"
-        client = oauth1.Client(
-            client_key=passport.oauth_consumer_key, client_secret=passport.shared_secret
-        )
-        # Compute Authorization header which looks like:
-        # Authorization: OAuth oauth_nonce="80966668944732164491378916897",
-        # oauth_timestamp="1378916897", oauth_version="1.0", oauth_signature_method="HMAC-SHA1",
-        # oauth_consumer_key="", oauth_signature="frVp4JuvT1mVXlxktiAUjQ7%2F1cw%3D"
-        _uri, headers, _body = client.sign(
-            url,
-            http_method="POST",
-            body=lti_parameters,
-            headers={"Content-Type": "application/x-www-form-urlencoded"},
-        )
-
-        # Parse headers to pass to template as part of context:
-        oauth_dict = dict(
-            param.strip().replace('"', "").split("=")
-            for param in headers["Authorization"].split(",")
-        )
-
-        signature = oauth_dict["oauth_signature"]
-        oauth_dict["oauth_signature"] = unquote(signature)
-        oauth_dict["oauth_nonce"] = oauth_dict.pop("OAuth oauth_nonce")
-
-        lti_parameters.update(oauth_dict)
-        return lti_parameters
-
     def test_views_lti_respond(self):
         """Validate the format of the response returned by the view for an instructor request."""
-        lti_parameters = self._get_signed_lti_parameters()
+        lti_parameters, _ = generate_passport_and_signed_lti_parameters(
+            url="http://testserver/lti/respond/",
+            lti_parameters={
+                "roles": random.choice(["instructor", "administrator"]),
+                "content_item_return_url": "http://return.url/",
+                "content_items": "some content items",
+                "context_id": "unknown",
+            },
+        )
         response = self.client.post(
             "/lti/respond/",
             lti_parameters,
@@ -98,7 +65,15 @@ class RespondLTIViewTestCase(TestCase):
 
     def test_views_lti_respond_verification_wrong_signature(self):
         """Wrong signature should raise a 403 error."""
-        lti_parameters = self._get_signed_lti_parameters()
+        lti_parameters, _ = generate_passport_and_signed_lti_parameters(
+            url="http://testserver/lti/respond/",
+            lti_parameters={
+                "roles": random.choice(["instructor", "administrator"]),
+                "content_item_return_url": "http://return.url/",
+                "content_items": "some content items",
+                "context_id": "unknown",
+            },
+        )
         lti_parameters["oauth_signature"] = "{:s}a".format(
             lti_parameters["oauth_signature"]
         )
@@ -112,7 +87,16 @@ class RespondLTIViewTestCase(TestCase):
 
     def test_views_lti_respond_verification_wrong_referer(self):
         """Wrong referer should raise a 403 error."""
-        lti_parameters = self._get_signed_lti_parameters()
+        lti_parameters, _ = generate_passport_and_signed_lti_parameters(
+            url="http://testserver/lti/respond/",
+            lti_parameters={
+                "roles": random.choice(["instructor", "administrator"]),
+                "content_item_return_url": "http://return.url/",
+                "content_items": "some content items",
+                "context_id": "unknown",
+            },
+        )
+
         response = self.client.post(
             "/lti/respond/",
             lti_parameters,

--- a/src/backend/marsha/core/tests/utils.py
+++ b/src/backend/marsha/core/tests/utils.py
@@ -1,0 +1,38 @@
+"""Test utils module."""
+
+from urllib.parse import unquote, urlparse
+
+from oauthlib import oauth1
+
+from marsha.core.factories import ConsumerSiteLTIPassportFactory
+
+
+def generate_passport_and_signed_lti_parameters(url, lti_parameters):
+    """Generate signed LTI parameters."""
+    url = urlparse(url)
+    passport = ConsumerSiteLTIPassportFactory(consumer_site__domain=url.hostname)
+    client = oauth1.Client(
+        client_key=passport.oauth_consumer_key, client_secret=passport.shared_secret
+    )
+    # Compute Authorization header which looks like:
+    # Authorization: OAuth oauth_nonce="80966668944732164491378916897",
+    # oauth_timestamp="1378916897", oauth_version="1.0", oauth_signature_method="HMAC-SHA1",
+    # oauth_consumer_key="", oauth_signature="frVp4JuvT1mVXlxktiAUjQ7%2F1cw%3D"
+    _uri, headers, _body = client.sign(
+        url.geturl(),
+        http_method="POST",
+        body=lti_parameters,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+
+    oauth_dict = dict(
+        param.strip().replace('"', "").split("=")
+        for param in headers["Authorization"].split(",")
+    )
+
+    signature = oauth_dict["oauth_signature"]
+    oauth_dict["oauth_signature"] = unquote(signature)
+    oauth_dict["oauth_nonce"] = oauth_dict.pop("OAuth oauth_nonce")
+
+    lti_parameters.update(oauth_dict)
+    return lti_parameters, passport


### PR DESCRIPTION
## Purpose

In our tests, we use 3 times the same code to generate signed LTI requests.

## Proposal

Factorize it into a new tests.utils module.
