### PR TITLE
🐛(lti-select) fix public path on lti select view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Frontend video type now allows Nullable urls.
+- Fix js public path on LTI select view.
 
 ## [3.17.1] - 2021-03-26
 

--- a/src/backend/marsha/core/views.py
+++ b/src/backend/marsha/core/views.py
@@ -507,7 +507,7 @@ class LTISelectView(TemplateResponseMixin, View):
 
         return {
             "app_data": json.dumps(app_data),
-            "static_base_url": f"{settings.STATIC_URL}js/",
+            "static_base_url": f"{settings.STATIC_URL}js/build/",
         }
 
     def _get_app_data(self, lti):


### PR DESCRIPTION
## Purpose

With a recent commit which builds frontend js on a static subdirectory, public path needs an update.

## Proposal

Update static_base_url in LTISelectView.