### PR TITLE
🐛(back) move oauthlib from dev to prod requirement

### DIFF
--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -43,6 +43,7 @@ install_requires =
     dockerflow==2020.10.0
     gunicorn==20.1.0
     logging-ldp==0.0.6
+    oauthlib==3.1.0
     psycopg2-binary==2.8.6
     PyLTI==0.7.0
     python-dateutil==2.8.1
@@ -79,7 +80,6 @@ dev =
     flake8-pep3101==1.3.0
     ipython==7.22.0
     isort==5.8.0
-    oauthlib==3.1.0
     pycodestyle==2.7.0
     pylint==2.7.4
     pylint-django==2.4.3


### PR DESCRIPTION
## Purpose

Before implementing the LTI select view, oauthlib was used only in our
tests and was in the dev section in the setup.cfg file. We must move it
in the prod requirement, we are using it in the LTI module.

## Proposal

- [x] move oauthlib from dev to prod requirement

