### PR TITLE
🚨(front) remove warning fetch not found

### DIFF
--- a/src/frontend/Player/createVideojsPlayer.spec.tsx
+++ b/src/frontend/Player/createVideojsPlayer.spec.tsx
@@ -74,6 +74,13 @@ jest.mock('../index', () => ({
   },
 }));
 
+jest.mock('../data/stores/useTimedTextTrackLanguageChoices', () => ({
+  useTimedTextTrackLanguageChoices: () => ({
+    getChoices: jest.fn(),
+    choices: [],
+  }),
+}));
+
 describe('createVideoJsPlayer', () => {
   const XAPIStatementMocked = mocked(XAPIStatement);
   beforeEach(() => {


### PR DESCRIPTION
## Purpose

In createVideoJsPlayer tests we render a real Video component. In the
video component we fetch available timed text track languages in the
useEffet hook. As we are in a node context, fetch is not defined and a
warning was display. To resolve this issue we choose to mock the call to
getChoices.

## Proposal

- [x] remove warning fetch not found

