### PR TITLE
🔥(front) remove jestMockOf utility

### DIFF
--- a/src/frontend/Player/createPlyrPlayer.spec.ts
+++ b/src/frontend/Player/createPlyrPlayer.spec.ts
@@ -1,6 +1,5 @@
 import { timedTextMode, uploadState } from '../types/tracks';
 import { videoMockFactory } from '../utils/tests/factories';
-import { jestMockOf } from '../utils/types';
 import { createHlsPlayer } from './createHlsPlayer';
 import { createPlyrPlayer } from './createPlyrPlayer';
 
@@ -8,7 +7,7 @@ jest.mock('./createHlsPlayer', () => ({
   createHlsPlayer: jest.fn(),
 }));
 
-const mockCreateHlsPlayer = createHlsPlayer as jestMockOf<
+const mockCreateHlsPlayer = createHlsPlayer as jest.MockedFunction<
   typeof createHlsPlayer
 >;
 

--- a/src/frontend/Player/createVideojsPlayer.spec.tsx
+++ b/src/frontend/Player/createVideojsPlayer.spec.tsx
@@ -7,7 +7,6 @@ import VideoPlayer from '../components/VideoPlayer';
 import { createVideojsPlayer } from './createVideojsPlayer';
 import { liveState, timedTextMode, uploadState } from '../types/tracks';
 import { isMSESupported } from '../utils/isMSESupported';
-import { jestMockOf } from '../utils/types';
 import { videoMockFactory } from '../utils/tests/factories';
 import { wrapInIntlProvider } from '../utils/tests/intl';
 import { XAPIStatement } from '../XAPI/XAPIStatement';
@@ -21,7 +20,9 @@ jest.mock('../utils/isMSESupported', () => ({
   isMSESupported: jest.fn(),
 }));
 
-const mockIsMSESupported = isMSESupported as jestMockOf<typeof isMSESupported>;
+const mockIsMSESupported = isMSESupported as jest.MockedFunction<
+  typeof isMSESupported
+>;
 
 const mockVideo = videoMockFactory({
   id: 'video-test-videojs-instance',

--- a/src/frontend/components/UploadForm/index.spec.tsx
+++ b/src/frontend/components/UploadForm/index.spec.tsx
@@ -9,7 +9,6 @@ import { timedTextMode, uploadState } from '../../types/tracks';
 import { videoMockFactory } from '../../utils/tests/factories';
 import { wrapInIntlProvider } from '../../utils/tests/intl';
 import { wrapInRouter } from '../../utils/tests/router';
-import { jestMockOf } from '../../utils/types';
 import { DASHBOARD_ROUTE } from '../Dashboard/route';
 import { FULL_SCREEN_ERROR_ROUTE } from '../ErrorComponents/route';
 import { UploadManager } from '../UploadManager';
@@ -30,8 +29,10 @@ jest.mock('../../data/stores/generics', () => ({
   getResource: jest.fn(),
 }));
 
-const mockUploadFile: jestMockOf<typeof uploadFile> = uploadFile as any;
-const mockGetResource = getResource as jestMockOf<typeof getResource>;
+const mockUploadFile: jest.MockedFunction<
+  typeof uploadFile
+> = uploadFile as any;
+const mockGetResource = getResource as jest.MockedFunction<typeof getResource>;
 
 describe('UploadForm', () => {
   const object = videoMockFactory({

--- a/src/frontend/components/UploadManager/LTIUploadHandlers.spec.tsx
+++ b/src/frontend/components/UploadManager/LTIUploadHandlers.spec.tsx
@@ -6,7 +6,6 @@ import { updateResource } from '../../data/sideEffects/updateResource';
 import { addResource, getResource } from '../../data/stores/generics';
 import { modelName } from '../../types/models';
 import { Thumbnail, Video } from '../../types/tracks';
-import { jestMockOf } from '../../utils/types';
 import { LTIUploadHandlers } from './LTIUploadHandlers';
 import { UploadManagerContext, UploadManagerStatus } from '.';
 
@@ -19,9 +18,11 @@ jest.mock('../../data/stores/generics', () => ({
   getResource: jest.fn(),
 }));
 
-const mockAddResource = addResource as jestMockOf<typeof addResource>;
-const mockGetResource = getResource as jestMockOf<typeof getResource>;
-const mockUpdateResource = updateResource as jestMockOf<typeof updateResource>;
+const mockAddResource = addResource as jest.MockedFunction<typeof addResource>;
+const mockGetResource = getResource as jest.MockedFunction<typeof getResource>;
+const mockUpdateResource = updateResource as jest.MockedFunction<
+  typeof updateResource
+>;
 
 describe('<LTIUploadHandlers />', () => {
   const file = new File(['(⌐□_□)'], 'course.mp4', { type: 'video/mp4' });

--- a/src/frontend/components/VideoPlayer/index.spec.tsx
+++ b/src/frontend/components/VideoPlayer/index.spec.tsx
@@ -8,7 +8,6 @@ import { createPlayer } from '../../Player/createPlayer';
 import { uploadState } from '../../types/tracks';
 import { videoMockFactory } from '../../utils/tests/factories';
 import { wrapInIntlProvider } from '../../utils/tests/intl';
-import { jestMockOf } from '../../utils/types';
 import VideoPlayer from './index';
 
 jest.mock('jwt-decode', () => jest.fn());
@@ -17,7 +16,9 @@ jest.mock('../../Player/createPlayer', () => ({
   createPlayer: jest.fn(),
 }));
 
-const mockCreatePlayer = createPlayer as jestMockOf<typeof createPlayer>;
+const mockCreatePlayer = createPlayer as jest.MockedFunction<
+  typeof createPlayer
+>;
 
 const useTimedTextTrackStub = ImportMock.mockFunction(
   useTimedTextTrackModule,

--- a/src/frontend/data/sideEffects/getResourceList/index.spec.tsx
+++ b/src/frontend/data/sideEffects/getResourceList/index.spec.tsx
@@ -5,7 +5,6 @@ import { modelName } from '../../../types/models';
 import { uploadState, Video } from '../../../types/tracks';
 import { report } from '../../../utils/errors/report';
 import { videoMockFactory } from '../../../utils/tests/factories';
-import { jestMockOf } from '../../../utils/types';
 import { addMultipleResources } from '../../stores/generics';
 import { getResourceList } from './';
 
@@ -23,7 +22,7 @@ jest.mock('../../../utils/errors/report', () => ({
   report: jest.fn(),
 }));
 
-const mockAddMultipleResources = addMultipleResources as jestMockOf<
+const mockAddMultipleResources = addMultipleResources as jest.MockedFunction<
   typeof addMultipleResources
 >;
 

--- a/src/frontend/utils/types.ts
+++ b/src/frontend/utils/types.ts
@@ -1,8 +1,3 @@
-export type jestMockOf<T extends (...args: any[]) => any> = jest.Mock<
-  ReturnType<T>,
-  Parameters<T>
->;
-
 export type Maybe<T> = T | undefined;
 
 export type Nullable<T> = T | null;


### PR DESCRIPTION
## Purpose

the type jestMockOf exists now in jest library. We can remove this
helper and use jest.MockedFunction instead.

## Proposal

- [x] remove jestMockOf utility

