### PR TITLE
🐛(lti-select) fix content urls when placed behind a TLS termination proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Frontend video type now allows Nullable urls.
 - Fix js public path on LTI select view.
 - Replace LTI verification in lti/respond view by JWT verification
+- Fix URLs schemes returned by LTI select view
 
 ## [3.17.1] - 2021-03-26
 

--- a/src/backend/marsha/core/lti/__init__.py
+++ b/src/backend/marsha/core/lti/__init__.py
@@ -11,6 +11,7 @@ from pylti.common import LTIException, verify_request_common
 
 from ..models import ConsumerSite
 from ..models.account import ADMINISTRATOR, INSTRUCTOR, LTI_ROLES, STUDENT, LTIPassport
+from ..utils.url_utils import build_absolute_uri_behind_proxy
 
 
 class LTI:
@@ -86,9 +87,7 @@ class LTI:
         # calculated by our LTI consumer.
         # Note that this is normally done in pylti's "verify_request_common" method but it does
         # not support WSGI normalized headers so let's do it ourselves.
-        url = self.request.build_absolute_uri()
-        if self.request.META.get("HTTP_X_FORWARDED_PROTO", "http") == "https":
-            url = url.replace("http:", "https:", 1)
+        url = build_absolute_uri_behind_proxy(self.request)
 
         # A call to the verification function should raise an LTIException but
         # we can further check that it returns True.

--- a/src/backend/marsha/core/serializers/file.py
+++ b/src/backend/marsha/core/serializers/file.py
@@ -13,6 +13,7 @@ from rest_framework import serializers
 
 from ..models import Document
 from ..utils import cloudfront_utils, time_utils
+from ..utils.url_utils import build_absolute_uri_behind_proxy
 from .base import EXTENSION_REGEX, TimestampField
 from .playlist import PlaylistLiteSerializer
 
@@ -198,8 +199,9 @@ class DocumentSelectLTISerializer(serializers.ModelSerializer):
             the LTI url to be used by LTI consumers
 
         """
-        return self.context["request"].build_absolute_uri(
-            reverse("document_lti_view", args=[obj.id])
+        return build_absolute_uri_behind_proxy(
+            self.context["request"],
+            reverse("document_lti_view", args=[obj.id]),
         )
 
 

--- a/src/backend/marsha/core/serializers/video.py
+++ b/src/backend/marsha/core/serializers/video.py
@@ -15,6 +15,7 @@ from ..defaults import IDLE, LIVE_CHOICES, RUNNING, STOPPED
 from ..models import Thumbnail, TimedTextTrack, Video
 from ..models.account import ADMINISTRATOR, INSTRUCTOR, LTI_ROLES
 from ..utils import cloudfront_utils, time_utils, xmpp_utils
+from ..utils.url_utils import build_absolute_uri_behind_proxy
 from .base import TimestampField
 from .playlist import PlaylistLiteSerializer
 
@@ -582,6 +583,7 @@ class VideoSelectLTISerializer(VideoBaseSerializer):
             the LTI url to be used by LTI consumers
 
         """
-        return self.context["request"].build_absolute_uri(
-            reverse("video_lti_view", args=[obj.id])
+        return build_absolute_uri_behind_proxy(
+            self.context["request"],
+            reverse("video_lti_view", args=[obj.id]),
         )

--- a/src/backend/marsha/core/tests/test_utils_url_utils.py
+++ b/src/backend/marsha/core/tests/test_utils_url_utils.py
@@ -1,0 +1,116 @@
+"""Test the url utils of the Marsha core app."""
+from django.test import RequestFactory, TestCase
+
+from ..utils.url_utils import build_absolute_uri_behind_proxy, uri_scheme_behind_proxy
+
+
+class URLUtilsTestCase(TestCase):
+    """Test our time utils."""
+
+    def test_uri_scheme_behind_proxy(self):
+        """Test fix uris behind proxy."""
+        factory = RequestFactory()
+        request_url = "/request/url/"
+        request = factory.get(
+            request_url,
+        )
+        http_proxy_request = factory.get(
+            request_url,
+            HTTP_X_FORWARDED_PROTO="http",
+        )
+        https_proxy_request = factory.get(
+            request_url,
+            HTTP_X_FORWARDED_PROTO="https",
+        )
+
+        def _test_without_proxy(expected_url, url):
+            self.assertEqual(expected_url, uri_scheme_behind_proxy(request, url))
+
+        def _test_with_http_proxy(expected_url, url):
+            self.assertEqual(
+                expected_url, uri_scheme_behind_proxy(http_proxy_request, url)
+            )
+
+        def _test_with_https_proxy(expected_url, url):
+            self.assertEqual(
+                expected_url, uri_scheme_behind_proxy(https_proxy_request, url)
+            )
+
+        _test_without_proxy(
+            "http://testserver/some/url/", "http://testserver/some/url/"
+        )
+        _test_without_proxy(
+            "https://testserver/some/url/", "https://testserver/some/url/"
+        )
+
+        _test_with_http_proxy(
+            "http://testserver/some/url/", "http://testserver/some/url/"
+        )
+        _test_with_http_proxy(
+            "https://testserver/some/url/", "https://testserver/some/url/"
+        )
+
+        _test_with_https_proxy(
+            "https://testserver/some/url/", "http://testserver/some/url/"
+        )
+        _test_with_https_proxy(
+            "https://testserver/some/url/", "https://testserver/some/url/"
+        )
+
+    def test_build_absolute_uri_behind_proxy(self):
+        """Test absolute uris behind proxy."""
+        factory = RequestFactory()
+        request_url = "/request/url/"
+        request = factory.get(
+            request_url,
+        )
+        http_proxy_request = factory.get(
+            request_url,
+            HTTP_X_FORWARDED_PROTO="http",
+        )
+        https_proxy_request = factory.get(
+            request_url,
+            HTTP_X_FORWARDED_PROTO="https",
+        )
+
+        def _test_without_proxy(expected_url, url):
+            self.assertEqual(
+                expected_url, build_absolute_uri_behind_proxy(request, url)
+            )
+
+        def _test_with_http_proxy(expected_url, url):
+            self.assertEqual(
+                expected_url, build_absolute_uri_behind_proxy(http_proxy_request, url)
+            )
+
+        def _test_with_https_proxy(expected_url, url):
+            self.assertEqual(
+                expected_url, build_absolute_uri_behind_proxy(https_proxy_request, url)
+            )
+
+        _test_without_proxy(
+            "http://testserver/some/url/", "http://testserver/some/url/"
+        )
+        _test_without_proxy(
+            "https://testserver/some/url/", "https://testserver/some/url/"
+        )
+        _test_without_proxy("http://testserver/request/url/", None)
+        _test_without_proxy("http://testserver/request/url/", "")
+
+        _test_with_http_proxy(
+            "http://testserver/some/url/", "http://testserver/some/url/"
+        )
+        _test_with_http_proxy(
+            "https://testserver/some/url/", "https://testserver/some/url/"
+        )
+        _test_with_http_proxy("http://testserver/request/url/", None)
+        _test_with_http_proxy("http://testserver/request/url/", "")
+
+        _test_with_https_proxy(
+            "https://testserver/some/url/", "http://testserver/some/url/"
+        )
+        _test_with_https_proxy(
+            "https://testserver/some/url/", "https://testserver/some/url/"
+        )
+        _test_with_https_proxy("https://testserver/request/url/", None)
+        _test_with_https_proxy("https://testserver/request/url/", "")

--- a/src/backend/marsha/core/utils/url_utils.py
+++ b/src/backend/marsha/core/utils/url_utils.py
@@ -1,0 +1,18 @@
+"""Utils related to urls."""
+
+
+def uri_scheme_behind_proxy(request, url):
+    """
+    Fix uris with forwarded protocol.
+
+    When behind a proxy, django is reached in http, so generated urls are
+    using http too.
+    """
+    if request.META.get("HTTP_X_FORWARDED_PROTO", "http") == "https":
+        url = url.replace("http:", "https:", 1)
+    return url
+
+
+def build_absolute_uri_behind_proxy(request, url=None):
+    """build_absolute_uri behind a proxy."""
+    return uri_scheme_behind_proxy(request, request.build_absolute_uri(url))

--- a/src/backend/marsha/core/views.py
+++ b/src/backend/marsha/core/views.py
@@ -45,6 +45,7 @@ from .serializers import (
     VideoSerializer,
 )
 from .utils.react_locales_utils import react_locale
+from .utils.url_utils import build_absolute_uri_behind_proxy
 
 
 logger = getLogger(__name__)
@@ -504,17 +505,23 @@ class LTISelectView(TemplateResponseMixin, View):
         jwt_token = AccessToken()
         jwt_token.payload["lti_select_form_data"] = lti_select_form_data
 
+        new_document_url = build_absolute_uri_behind_proxy(
+            self.request,
+            reverse("document_lti_view", args=[new_uuid]),
+        )
+
+        new_video_url = build_absolute_uri_behind_proxy(
+            self.request,
+            reverse("video_lti_view", args=[new_uuid]),
+        )
+
         app_data.update(
             {
                 "frontend": "LTI",
                 "lti_select_form_action_url": reverse("respond_lti_view"),
                 "lti_select_form_data": {"jwt": str(jwt_token)},
-                "new_document_url": self.request.build_absolute_uri(
-                    reverse("document_lti_view", args=[new_uuid])
-                ),
-                "new_video_url": self.request.build_absolute_uri(
-                    reverse("video_lti_view", args=[new_uuid])
-                ),
+                "new_document_url": new_document_url,
+                "new_video_url": new_video_url,
                 "documents": documents,
                 "videos": videos,
             }


### PR DESCRIPTION
## Purpose

URLs returned by LTI Deep linking faces the same problem fixed by this commit fd11cd0259c211aefcaaae3c46ad15254eac5976
   
When behind a proxy, djjango is reached in http, so generated urls are using http too.

## Proposal

Apply the same process found in fd11cd0259c211aefcaaae3c46ad15254eac5976
