### PR TITLE
🐛(CI) change docker layer caching version in hub job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -729,6 +729,7 @@ jobs:
       # Activate docker-in-docker (with layers caching enabled)
       - setup_remote_docker:
           docker_layer_caching: true
+          version: 19.03.13
       - *docker_login
       - run:
           name: Build production image (using cached layers)


### PR DESCRIPTION
## Purpose

In order to build the docker image, we need to change the docker layer
caching version like we did in the build-docker job.

## Proposal

- [x] change docker layer caching version in hub job
