### PR TITLE
✨(api) open video endpoints for playlist & organization admins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - The `lti_id` field is optional on Videos and Documents.
+- Open Video related API endpoints to playlist and org admins.
 - Clean built frontend files before each build
 - Variabilize live conf related to latency
 - Upgrade node to version 14, the current LTS

--- a/src/backend/marsha/core/api.py
+++ b/src/backend/marsha/core/api.py
@@ -245,6 +245,8 @@ class VideoViewSet(ObjectPkMixin, viewsets.ModelViewSet):
             permission_classes = [
                 permissions.IsTokenResourceRouteObject & permissions.IsTokenInstructor
                 | permissions.IsTokenResourceRouteObject & permissions.IsTokenAdmin
+                | permissions.IsVideoPlaylistAdmin
+                | permissions.IsVideoOrganizationAdmin
             ]
         elif self.action in ["list"]:
             permission_classes = [IsAuthenticated]
@@ -327,6 +329,8 @@ class VideoViewSet(ObjectPkMixin, viewsets.ModelViewSet):
         permission_classes=[
             permissions.IsTokenResourceRouteObject & permissions.IsTokenInstructor
             | permissions.IsTokenResourceRouteObject & permissions.IsTokenAdmin
+            | permissions.IsVideoPlaylistAdmin
+            | permissions.IsVideoOrganizationAdmin
         ],
     )
     # pylint: disable=unused-argument


### PR DESCRIPTION
## Purpose

In the new marsha site, administrators for playlists as well as organizations need to be able to create videos, upload files for
them and generally manage them.

## Proposal

To let them do this, we need to open the relevant API endpoints to them, using user-level authentication (in addition to the existing resource-based permissions).

