### PR TITLE
jitsi streamed in marsha live

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Jitsi streamed in marsha live
+
 ## [3.18.0] - 2021-05-10
 
 ### Added

--- a/src/backend/marsha/core/defaults.py
+++ b/src/backend/marsha/core/defaults.py
@@ -50,6 +50,11 @@ LIVE_CHOICES = (
     (STOPPING, _("stopping")),
 )
 
+# LIVE TYPE
+(RAW, JITSI) = ("raw", "jitsi")
+
+LIVE_TYPE_CHOICES = ((RAW, _("raw")), (JITSI, _("jitsi")))
+
 # FLAGS
 VIDEO_LIVE = "video_live"
 SENTRY = "sentry"

--- a/src/backend/marsha/core/tests/test_views_lti_video.py
+++ b/src/backend/marsha/core/tests/test_views_lti_video.py
@@ -17,6 +17,7 @@ from ..defaults import (
     HARVESTED,
     IDLE,
     PENDING,
+    RAW,
     READY,
     RUNNING,
     SENTRY,
@@ -44,6 +45,7 @@ class VideoLTIViewTestCase(TestCase):
     @mock.patch.object(LTI, "get_consumer_site")
     @override_settings(SENTRY_DSN="https://sentry.dsn")
     @override_settings(RELEASE="1.2.3")
+    @override_settings(JITSI_ENABLED=True)
     @override_settings(VIDEO_PLAYER="videojs")
     @override_switch(VIDEO_LIVE, active=True)
     @override_switch(SENTRY, active=True)
@@ -124,7 +126,9 @@ class VideoLTIViewTestCase(TestCase):
         self.assertEqual(context.get("environment"), "test")
         self.assertEqual(context.get("release"), "1.2.3")
         self.assertEqual(context.get("player"), "videojs")
-        self.assertEqual(context.get("flags"), {"video_live": True, "sentry": True})
+        self.assertEqual(
+            context.get("flags"), {"video_live": True, "sentry": True, "jitsi": True}
+        )
         # Make sure we only go through LTI verification once as it is costly (getting passport +
         # signature)
         self.assertEqual(mock_verify.call_count, 1)
@@ -138,6 +142,135 @@ class VideoLTIViewTestCase(TestCase):
         self, mock_get_consumer_site, mock_verify
     ):
         """Validate the format of the response for a live video requested by an instructor."""
+        passport = ConsumerSiteLTIPassportFactory()
+        video = VideoFactory(
+            playlist__lti_id="course-v1:ufr+mathematics+00001",
+            playlist__title="foo bar",
+            playlist__consumer_site=passport.consumer_site,
+            live_state=IDLE,
+            live_info={
+                "medialive": {
+                    "input": {
+                        "id": "medialive_input_1",
+                        "endpoints": [
+                            "https://live_endpoint1",
+                            "https://live_endpoint2",
+                        ],
+                    },
+                    "channel": {"id": "medialive_channel_1"},
+                },
+                "mediapackage": {
+                    "id": "mediapackage_channel_1",
+                    "endpoints": {
+                        "hls": {
+                            "id": "endpoint1",
+                            "url": "https://channel_endpoint1/live.m3u8",
+                        },
+                    },
+                },
+                "type": RAW,
+            },
+            upload_state=PENDING,
+        )
+        data = {
+            "resource_link_id": video.lti_id,
+            "context_id": video.playlist.lti_id,
+            "roles": "instructor",
+            "oauth_consumer_key": passport.oauth_consumer_key,
+            "user_id": "56255f3807599c377bf0e5bf072359fd",
+            "launch_presentation_locale": "fr",
+        }
+
+        mock_get_consumer_site.return_value = passport.consumer_site
+        response = self.client.post("/lti/videos/{!s}".format(video.pk), data)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "<html>")
+        content = response.content.decode("utf-8")
+
+        match = re.search(
+            '<div id="marsha-frontend-data" data-context="(.*)">', content
+        )
+
+        context = json.loads(unescape(match.group(1)))
+        jwt_token = AccessToken(context.get("jwt"))
+        self.assertEqual(jwt_token.payload["resource_id"], str(video.id))
+        self.assertEqual(jwt_token.payload["user_id"], data["user_id"])
+        self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
+        self.assertEqual(jwt_token.payload["roles"], [data["roles"]])
+        self.assertEqual(jwt_token.payload["locale"], "fr_FR")
+        self.assertEqual(
+            jwt_token.payload["permissions"],
+            {"can_access_dashboard": True, "can_update": True},
+        )
+        self.assertDictEqual(
+            jwt_token.payload["course"],
+            {"school_name": "ufr", "course_name": "mathematics", "course_run": "00001"},
+        )
+
+        self.assertEqual(context.get("state"), "success")
+        self.assertEqual(
+            context.get("static"),
+            {"svg": {"icons": "/static/svg/icons.svg", "plyr": "/static/svg/plyr.svg"}},
+        )
+        self.assertEqual(
+            context.get("resource"),
+            {
+                "active_stamp": None,
+                "is_ready_to_show": False,
+                "show_download": True,
+                "description": video.description,
+                "id": str(video.id),
+                "upload_state": PENDING,
+                "timed_text_tracks": [],
+                "thumbnail": None,
+                "title": video.title,
+                "urls": {
+                    "manifests": {
+                        "hls": "https://channel_endpoint1/live.m3u8",
+                    },
+                    "mp4": {},
+                    "thumbnails": {},
+                },
+                "should_use_subtitle_as_transcript": False,
+                "has_transcript": False,
+                "playlist": {
+                    "title": "foo bar",
+                    "lti_id": "course-v1:ufr+mathematics+00001",
+                },
+                "live_state": IDLE,
+                "live_info": {
+                    "medialive": {
+                        "input": {
+                            "endpoints": [
+                                "https://live_endpoint1",
+                                "https://live_endpoint2",
+                            ],
+                        }
+                    },
+                    "type": RAW,
+                },
+                "xmpp": None,
+            },
+        )
+        self.assertEqual(context.get("modelName"), "videos")
+        self.assertEqual(context.get("sentry_dsn"), "https://sentry.dsn")
+        self.assertEqual(context.get("environment"), "test")
+        self.assertEqual(context.get("release"), "1.2.3")
+        self.assertEqual(context.get("player"), "videojs")
+        # Make sure we only go through LTI verification once as it is costly (getting passport +
+        # signature)
+        self.assertEqual(mock_verify.call_count, 1)
+
+    @mock.patch.object(LTI, "verify")
+    @mock.patch.object(LTI, "get_consumer_site")
+    @override_settings(SENTRY_DSN="https://sentry.dsn")
+    @override_settings(RELEASE="1.2.3")
+    @override_settings(VIDEO_PLAYER="videojs")
+    @override_settings(JITSI_ENABLED=True)
+    def test_views_lti_video_instructor_live_mode_on_no_type_specified(
+        self, mock_get_consumer_site, mock_verify
+    ):
+        """A live video with no type specified should fallback on raw type."""
         passport = ConsumerSiteLTIPassportFactory()
         video = VideoFactory(
             playlist__lti_id="course-v1:ufr+mathematics+00001",
@@ -241,7 +374,8 @@ class VideoLTIViewTestCase(TestCase):
                                 "https://live_endpoint2",
                             ],
                         }
-                    }
+                    },
+                    "type": RAW,
                 },
                 "xmpp": None,
             },
@@ -298,6 +432,7 @@ class VideoLTIViewTestCase(TestCase):
                         },
                     },
                 },
+                "type": RAW,
             },
             upload_state=PENDING,
         )
@@ -381,6 +516,7 @@ class VideoLTIViewTestCase(TestCase):
                             ],
                         }
                     },
+                    "type": RAW,
                 },
                 "xmpp": {
                     "bosh_url": "https://xmpp-server.com/http-bind?token=xmpp_jwt",

--- a/src/backend/marsha/core/views.py
+++ b/src/backend/marsha/core/views.py
@@ -29,7 +29,7 @@ from rest_framework_simplejwt.exceptions import TokenError
 from rest_framework_simplejwt.tokens import AccessToken
 from waffle import mixins, switch_is_active
 
-from .defaults import SENTRY, VIDEO_LIVE
+from .defaults import JITSI, SENTRY, VIDEO_LIVE
 from .lti import LTI
 from .lti.utils import (
     PortabilityError,
@@ -246,6 +246,7 @@ class BaseLTIView(ABC, TemplateResponseMixin, View):
                     "flags": {
                         VIDEO_LIVE: switch_is_active(VIDEO_LIVE),
                         SENTRY: switch_is_active(SENTRY),
+                        JITSI: settings.JITSI_ENABLED,
                     },
                     "resource": self.serializer_class(
                         resource,
@@ -263,6 +264,7 @@ class BaseLTIView(ABC, TemplateResponseMixin, View):
                     "player": settings.VIDEO_PLAYER,
                 }
             )
+
             if lti is None or lti.is_student:
                 cache.set(cache_key, app_data, settings.APP_DATA_CACHE_DURATION)
 

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -282,6 +282,13 @@ class Base(Configuration):
     LIVE_FRAMERATE_DENOMINATOR = values.PositiveIntegerValue(1000)
     LIVE_GOP_SIZE = values.FloatValue(4)
 
+    # JITSI SETTINGS
+    JITSI_ENABLED = values.BooleanValue(False)
+    JITSI_EXTERNAL_API_URL = values.Value("https://meet.jit.si/external_api.js")
+    JITSI_DOMAIN = values.Value("meet.jit.si")
+    JITSI_CONFIG_OVERWRITE = values.DictValue({})
+    JITSI_INTERFACE_CONFIG_OVERWRITE = values.DictValue({})
+
     # pylint: disable=invalid-name
     @property
     def AWS_SOURCE_BUCKET_NAME(self):

--- a/src/frontend/components/DashboardPaneButtons/index.spec.tsx
+++ b/src/frontend/components/DashboardPaneButtons/index.spec.tsx
@@ -72,6 +72,23 @@ describe('<DashboardPaneButtons />', () => {
     screen.getByRole('button', { name: 'Configure a live streaming' });
   });
 
+  it('displays the configure live and jitsi button', () => {
+    mockFlags = { [flags.VIDEO_LIVE]: true, [flags.JITSI]: true };
+    render(
+      wrapInIntlProvider(
+        wrapInRouter(
+          <DashboardPaneButtons
+            object={videoMockFactory({ id: 'vid1', upload_state: PENDING })}
+            objectType={modelName.VIDEOS}
+          />,
+        ),
+      ),
+    );
+
+    screen.getByRole('button', { name: 'Configure a live streaming' });
+    screen.getByRole('button', { name: 'Launch Jitsi LiveStream' });
+  });
+
   it('hides the configure live button when live state is not null', () => {
     mockFlags = { [flags.VIDEO_LIVE]: false };
     render(

--- a/src/frontend/components/DashboardPaneButtons/index.tsx
+++ b/src/frontend/components/DashboardPaneButtons/index.tsx
@@ -3,10 +3,11 @@ import React from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import styled from 'styled-components';
 
+import { appData } from '../../data/appData';
 import { Document } from '../../types/file';
 import { modelName } from '../../types/models';
 import { flags } from '../../types/AppData';
-import { uploadState, Video } from '../../types/tracks';
+import { uploadState, LiveModeType, Video } from '../../types/tracks';
 import { isFeatureEnabled } from '../../utils/isFeatureEnabled';
 import { DashboardVideoLiveConfigureButton } from '../DashboardVideoLiveConfigureButton';
 import { PLAYER_ROUTE } from '../routes';
@@ -100,7 +101,18 @@ export const DashboardPaneButtons = ({
       {objectType === modelName.VIDEOS &&
         object.upload_state === uploadState.PENDING &&
         isFeatureEnabled(flags.VIDEO_LIVE) && (
-          <DashboardVideoLiveConfigureButton video={object as Video} />
+          <React.Fragment>
+            <DashboardVideoLiveConfigureButton
+              video={object as Video}
+              type={LiveModeType.RAW}
+            />
+            {isFeatureEnabled(flags.JITSI) && (
+              <DashboardVideoLiveConfigureButton
+                video={object as Video}
+                type={LiveModeType.JITSI}
+              />
+            )}
+          </React.Fragment>
         )}
       <DashboardButtonWithLink
         label={

--- a/src/frontend/components/DashboardVideoLive/index.spec.tsx
+++ b/src/frontend/components/DashboardVideoLive/index.spec.tsx
@@ -1,11 +1,16 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import fetchMock from 'fetch-mock';
-import React from 'react';
+import React, { Suspense } from 'react';
 
 import { CHAT_ROUTE } from '../Chat/route';
 import { PLAYER_ROUTE } from '../routes';
 import { modelName } from '../../types/models';
-import { liveState, uploadState } from '../../types/tracks';
+import {
+  LiveModeType,
+  liveState,
+  uploadState,
+  Video,
+} from '../../types/tracks';
 import { videoMockFactory } from '../../utils/tests/factories';
 import { wrapInIntlProvider } from '../../utils/tests/intl';
 import { wrapInRouter } from '../../utils/tests/router';
@@ -15,6 +20,13 @@ jest.mock('jwt-decode', () => jest.fn());
 jest.mock('../../data/appData', () => ({
   appData: { jwt: 'cool_token_m8' },
 }));
+jest.mock('../DashboardVideoLiveRaw', () => (props: { video: Video }) => (
+  <span title={props.video.id} />
+));
+
+jest.mock('../DashboardVideoLiveJitsi', () => (props: { video: Video }) => (
+  <span title={props.video.id}>jitsi</span>
+));
 
 describe('components/DashboardVideoLive', () => {
   beforeEach(() => jest.useFakeTimers());
@@ -46,7 +58,6 @@ describe('components/DashboardVideoLive', () => {
       title: 'foo',
       lti_id: 'foo+context_id',
     },
-    live_state: liveState.IDLE,
     live_info: {
       medialive: {
         input: {
@@ -56,42 +67,35 @@ describe('components/DashboardVideoLive', () => {
           ],
         },
       },
+      type: LiveModeType.RAW,
     },
   });
 
-  it('displays streaming links', () => {
+  it('shows the start button when the status is IDLE', () => {
     render(
-      wrapInIntlProvider(wrapInRouter(<DashboardVideoLive video={video} />)),
+      wrapInIntlProvider(
+        wrapInRouter(
+          <Suspense fallback="loading...">
+            <DashboardVideoLive
+              video={{ ...video, live_state: liveState.IDLE }}
+            />
+          </Suspense>,
+        ),
+      ),
     );
 
-    screen.getByText('Streaming link');
-    screen.getByText('rtmp://1.2.3.4:1935');
-    screen.getByText('stream-key-primary');
-    screen.getByText('rtmp://4.3.2.1:1935');
-    screen.getByText('stream-key-secondary');
-
-    screen.getByRole('button', { name: 'copy url rtmp://1.2.3.4:1935' });
-    screen.getByRole('button', { name: 'copy key stream-key-primary' });
-
-    screen.getByRole('button', { name: 'copy url rtmp://4.3.2.1:1935' });
-    screen.getByRole('button', { name: 'copy key stream-key-secondary' });
-  });
-
-  it('shows the start button when the status id IDLE', () => {
-    render(
-      wrapInIntlProvider(wrapInRouter(<DashboardVideoLive video={video} />)),
-    );
-
-    screen.getByRole('button', { name: /start streaming/i });
+    screen.getByText('start streaming');
   });
 
   it('shows the live and stop button when the status is LIVE', () => {
     render(
       wrapInIntlProvider(
         wrapInRouter(
-          <DashboardVideoLive
-            video={{ ...video, live_state: liveState.RUNNING }}
-          />,
+          <Suspense fallback="loading...">
+            <DashboardVideoLive
+              video={{ ...video, live_state: liveState.RUNNING }}
+            />
+          </Suspense>,
         ),
       ),
     );
@@ -105,9 +109,11 @@ describe('components/DashboardVideoLive', () => {
     render(
       wrapInIntlProvider(
         wrapInRouter(
-          <DashboardVideoLive
-            video={{ ...video, live_state: liveState.RUNNING }}
-          />,
+          <Suspense fallback="loading...">
+            <DashboardVideoLive
+              video={{ ...video, live_state: liveState.RUNNING }}
+            />
+          </Suspense>,
           [
             {
               path: PLAYER_ROUTE(modelName.VIDEOS),
@@ -130,9 +136,11 @@ describe('components/DashboardVideoLive', () => {
     render(
       wrapInIntlProvider(
         wrapInRouter(
-          <DashboardVideoLive
-            video={{ ...video, live_state: liveState.RUNNING }}
-          />,
+          <Suspense fallback="loading...">
+            <DashboardVideoLive
+              video={{ ...video, live_state: liveState.RUNNING }}
+            />
+          </Suspense>,
           [
             {
               path: CHAT_ROUTE(),
@@ -162,9 +170,11 @@ describe('components/DashboardVideoLive', () => {
     const { rerender } = render(
       wrapInIntlProvider(
         wrapInRouter(
-          <DashboardVideoLive
-            video={{ ...video, live_state: liveState.STARTING }}
-          />,
+          <Suspense fallback="loading...">
+            <DashboardVideoLive
+              video={{ ...video, live_state: liveState.STARTING }}
+            />
+          </Suspense>,
         ),
       ),
     );
@@ -210,9 +220,11 @@ describe('components/DashboardVideoLive', () => {
     rerender(
       wrapInIntlProvider(
         wrapInRouter(
-          <DashboardVideoLive
-            video={{ ...video, live_state: liveState.RUNNING }}
-          />,
+          <Suspense fallback="loading...">
+            <DashboardVideoLive
+              video={{ ...video, live_state: liveState.RUNNING }}
+            />
+          </Suspense>,
         ),
       ),
     );

--- a/src/frontend/components/DashboardVideoLive/index.tsx
+++ b/src/frontend/components/DashboardVideoLive/index.tsx
@@ -1,15 +1,12 @@
-import ClipboardJS from 'clipboard';
 import { Box, Heading, Text } from 'grommet';
-import React, { useEffect } from 'react';
+import React, { lazy, useEffect } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
-import ReactTooltip from 'react-tooltip';
-import styled from 'styled-components';
 
 import { appData } from '../../data/appData';
 import { useVideo } from '../../data/stores/useVideo';
 import { API_ENDPOINT } from '../../settings';
 import { modelName } from '../../types/models';
-import { Video, liveState } from '../../types/tracks';
+import { Video, liveState, LiveModeType } from '../../types/tracks';
 import { report } from '../../utils/errors/report';
 import { CHAT_ROUTE } from '../Chat/route';
 import { PLAYER_ROUTE } from '../routes';
@@ -17,31 +14,26 @@ import { DashboardVideoLiveStartButton } from '../DashboardVideoLiveStartButton'
 import { DashboardVideoLiveStopButton } from '../DashboardVideoLiveStopButton';
 import { DashboardButtonWithLink } from '../DashboardPaneButtons';
 
+const DashboardVideoLiveRaw = lazy(() => import('../DashboardVideoLiveRaw'));
+const DashboardVideoLiveJitsi = lazy(
+  () => import('../DashboardVideoLiveJitsi'),
+);
+
 const messages = defineMessages({
-  copied: {
-    defaultMessage: 'Copied!',
-    description: 'Message displayed when endpoints info are copied.',
-    id: 'components.DashboardVideoLive.copied',
-  },
-  title: {
+  raw: {
     defaultMessage: 'Streaming link',
     description: 'DashboardVideoLive main title.',
-    id: 'components.DashboardVideoLive.title',
+    id: 'components.DashboardVideoLive.raw',
   },
-  streamLink: {
-    defaultMessage: 'Stream link',
-    description: 'link to use to stream a video.',
-    id: 'components.DashboardVideoLive.streamLink',
+  jitsi: {
+    defaultMessage: 'Jitsi Streaming',
+    description: 'DashboardVideoLive jitsi title.',
+    id: 'components.DashboardVideoLive.jitsi',
   },
   url: {
     defaultMessage: 'url',
     description: 'Video url streaming.',
     id: 'components.DashboardVideoLive.url',
-  },
-  streamKey: {
-    defaultMessage: 'stream key',
-    description: 'Video key streaming.',
-    id: 'components.DashboardVideoLive.streamKey',
   },
   showLive: {
     defaultMessage: 'show live',
@@ -80,15 +72,6 @@ const messages = defineMessages({
     id: 'components.DashboardVideoLive.liveStopping',
   },
 });
-
-const IconBox = styled.span`
-  font-size: 18px;
-`;
-
-const CopyButton = styled.button`
-  border: none;
-  cursor: pointer;
-`;
 
 interface DashboardVideoLiveProps {
   video: Video;
@@ -133,82 +116,17 @@ export const DashboardVideoLive = ({ video }: DashboardVideoLiveProps) => {
     }
   }, [video.live_state]);
 
-  useEffect(() => {
-    const clipboard = new ClipboardJS('.copy');
-    clipboard.on('success', (event) => {
-      setTimeout(() => ReactTooltip.hide(event.trigger), 1000);
-
-      event.clearSelection();
-    });
-
-    clipboard.on('error', (event) => {
-      ReactTooltip.hide(event.trigger);
-    });
-
-    return clipboard.destroy;
-  }, []);
-
-  const endpointIdentifier = /^(rtmp:\/\/.*)\/(.*)$/;
-  const endpoints = video.live_info.medialive!.input.endpoints.map(
-    (endpoint) => {
-      const matches = endpoint.match(endpointIdentifier);
-      if (matches) {
-        return (
-          <Box key={matches[2]}>
-            <Heading level={4}>
-              <FormattedMessage {...messages.streamLink} />
-            </Heading>
-            <ul>
-              <li>
-                <FormattedMessage {...messages.url} />
-                :&nbsp;
-                <span id={`url-${matches[2]}`}>{matches[1]}</span>
-                <CopyButton
-                  data-tip
-                  aria-label={`copy url ${matches[1]}`}
-                  className="copy"
-                  data-clipboard-target={`#url-${matches[2]}`}
-                >
-                  <IconBox className="icon-copy" />
-                </CopyButton>
-              </li>
-              <li>
-                <FormattedMessage {...messages.streamKey} />
-                :&nbsp;
-                <span id={`key-${matches[2]}`}>{matches[2]}</span>
-                <CopyButton
-                  data-tip
-                  aria-label={`copy key ${matches[2]}`}
-                  className="copy"
-                  data-clipboard-target={`#key-${matches[2]}`}
-                >
-                  <IconBox className="icon-copy" />
-                </CopyButton>
-              </li>
-            </ul>
-          </Box>
-        );
-      }
-    },
-  );
-
   return (
     <Box>
       <Heading level={2}>
-        <FormattedMessage {...messages.title} />
+        <FormattedMessage {...messages[video.live_info.type!]} />
       </Heading>
-      <Box>
-        {endpoints}
-        <ReactTooltip
-          effect="solid"
-          place="bottom"
-          type="success"
-          isCapture={true}
-          event="click"
-        >
-          <FormattedMessage {...messages.copied} />
-        </ReactTooltip>
-      </Box>
+      {video.live_info.type === LiveModeType.RAW && (
+        <DashboardVideoLiveRaw video={video} />
+      )}
+      {video.live_info.type === LiveModeType.JITSI && (
+        <DashboardVideoLiveJitsi video={video} />
+      )}
       <Box direction={'row'} justify={'center'} margin={'small'}>
         {video.live_state === liveState.CREATING && (
           <Text>
@@ -225,16 +143,20 @@ export const DashboardVideoLive = ({ video }: DashboardVideoLiveProps) => {
         )}
         {video.live_state === liveState.RUNNING && (
           <React.Fragment>
-            <DashboardButtonWithLink
-              label={<FormattedMessage {...messages.chatOnly} />}
-              primary={false}
-              to={CHAT_ROUTE()}
-            />
-            <DashboardButtonWithLink
-              label={<FormattedMessage {...messages.showLive} />}
-              primary={false}
-              to={PLAYER_ROUTE(modelName.VIDEOS)}
-            />
+            {video.live_info.type === LiveModeType.RAW && (
+              <React.Fragment>
+                <DashboardButtonWithLink
+                  label={<FormattedMessage {...messages.chatOnly} />}
+                  primary={false}
+                  to={CHAT_ROUTE()}
+                />
+                <DashboardButtonWithLink
+                  label={<FormattedMessage {...messages.showLive} />}
+                  primary={false}
+                  to={PLAYER_ROUTE(modelName.VIDEOS)}
+                />
+              </React.Fragment>
+            )}
             <DashboardVideoLiveStopButton video={video} />
           </React.Fragment>
         )}

--- a/src/frontend/components/DashboardVideoLiveConfigureButton/index.spec.tsx
+++ b/src/frontend/components/DashboardVideoLiveConfigureButton/index.spec.tsx
@@ -3,6 +3,7 @@ import fetchMock from 'fetch-mock';
 import React from 'react';
 
 import { appData } from '../../data/appData';
+import { LiveModeType } from '../../types/tracks';
 import { wrapInIntlProvider } from '../../utils/tests/intl';
 import { wrapInRouter } from '../../utils/tests/router';
 import { DASHBOARD_ROUTE } from '../Dashboard/route';
@@ -55,7 +56,10 @@ describe('components/DashboardVideoLiveConfigureButton', () => {
     render(
       wrapInIntlProvider(
         wrapInRouter(
-          <DashboardVideoLiveConfigureButton video={appData.video!} />,
+          <DashboardVideoLiveConfigureButton
+            video={appData.video!}
+            type={LiveModeType.RAW}
+          />,
         ),
       ),
     );
@@ -84,7 +88,10 @@ describe('components/DashboardVideoLiveConfigureButton', () => {
     render(
       wrapInIntlProvider(
         wrapInRouter(
-          <DashboardVideoLiveConfigureButton video={appData.video!} />,
+          <DashboardVideoLiveConfigureButton
+            video={appData.video!}
+            type={LiveModeType.RAW}
+          />,
           [
             {
               path: DASHBOARD_ROUTE(),
@@ -117,7 +124,10 @@ describe('components/DashboardVideoLiveConfigureButton', () => {
     render(
       wrapInIntlProvider(
         wrapInRouter(
-          <DashboardVideoLiveConfigureButton video={appData.video!} />,
+          <DashboardVideoLiveConfigureButton
+            video={appData.video!}
+            type={LiveModeType.RAW}
+          />,
           [
             {
               path: FULL_SCREEN_ERROR_ROUTE('liveInit'),

--- a/src/frontend/components/DashboardVideoLiveConfigureButton/index.tsx
+++ b/src/frontend/components/DashboardVideoLiveConfigureButton/index.tsx
@@ -5,7 +5,7 @@ import { Redirect } from 'react-router-dom';
 import { initiateLive } from '../../data/sideEffects/initiateLive';
 import { useVideo } from '../../data/stores/useVideo';
 import { modelName } from '../../types/models';
-import { Video } from '../../types/tracks';
+import { LiveModeType, Video } from '../../types/tracks';
 import { Nullable } from '../../utils/types';
 import { DASHBOARD_ROUTE } from '../Dashboard/route';
 import { DashboardButton } from '../DashboardPaneButtons';
@@ -13,10 +13,15 @@ import { FULL_SCREEN_ERROR_ROUTE } from '../ErrorComponents/route';
 import { Loader } from '../Loader';
 
 const messages = defineMessages({
-  btnConfigureLive: {
+  raw: {
     defaultMessage: 'Configure a live streaming',
     description: 'Dashboard button to configure a live streaming',
-    id: 'components.Dashboard.DashboardPaneButtons.videos.btnStartLive',
+    id: 'components.Dashboard.DashboardPaneButtons.videos.raw',
+  },
+  jitsi: {
+    defaultMessage: 'Launch Jitsi LiveStream',
+    description: 'Dashboard button to launch jitsi livestream',
+    id: 'components.Dashboard.DashboardPaneButtons.videos.jitsi',
   },
 });
 
@@ -25,10 +30,12 @@ type configureLiveStatus = 'pending' | 'success' | 'error';
 /** Props shape for the DashboardVideoLiveConfigureButton component. */
 export interface DashboardVideoLiveConfigureButtonProps {
   video: Video;
+  type: LiveModeType;
 }
 
 export const DashboardVideoLiveConfigureButton = ({
   video,
+  type,
 }: DashboardVideoLiveConfigureButtonProps) => {
   const [status, setStatus] = useState<Nullable<configureLiveStatus>>(null);
   const { updateVideo } = useVideo((state) => ({
@@ -38,7 +45,7 @@ export const DashboardVideoLiveConfigureButton = ({
   const configureLive = async () => {
     setStatus('pending');
     try {
-      const updatedVideo = await initiateLive(video);
+      const updatedVideo = await initiateLive(video, type);
       updateVideo(updatedVideo);
       setStatus('success');
     } catch (error) {
@@ -60,7 +67,7 @@ export const DashboardVideoLiveConfigureButton = ({
 
       <DashboardButton
         onClick={configureLive}
-        label={<FormattedMessage {...messages.btnConfigureLive} />}
+        label={<FormattedMessage {...messages[type]} />}
       />
     </React.Fragment>
   );

--- a/src/frontend/components/DashboardVideoLiveJitsi/index.spec.tsx
+++ b/src/frontend/components/DashboardVideoLiveJitsi/index.spec.tsx
@@ -1,0 +1,124 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+
+import { LiveModeType, liveState } from '../../types/tracks';
+import { videoMockFactory } from '../../utils/tests/factories';
+import DashboardVideoLiveJitsi from '.';
+
+const mockExecuteCommand = jest.fn();
+const mockJitsi = jest.fn().mockImplementation(() => ({
+  executeCommand: mockExecuteCommand,
+}));
+
+describe('<DashboardVideoLiveJitsi />', () => {
+  it('configures jitsi', () => {
+    const video = videoMockFactory({
+      live_info: {
+        medialive: {
+          input: {
+            endpoints: [
+              'rtmp://1.2.3.4:1935/stream-key-primary',
+              'rtmp://4.3.2.1:1935/stream-key-secondary',
+            ],
+          },
+        },
+        type: LiveModeType.JITSI,
+        jitsi: {
+          domain: 'meet.jit.si',
+          external_api_url: 'https://meet.jit.si/external_api.js',
+          config_overwrite: {},
+          interface_config_overwrite: {},
+        },
+      },
+      live_state: liveState.CREATING,
+    });
+    global.JitsiMeetExternalAPI = mockJitsi;
+
+    const { rerender } = render(<DashboardVideoLiveJitsi video={video} />);
+    const toolbarButtons = [
+      'microphone',
+      'camera',
+      'closedcaptions',
+      'desktop',
+      'embedmeeting',
+      'fullscreen',
+      'fodeviceselection',
+      'hangup',
+      'profile',
+      'chat',
+      'etherpad',
+      'shareaudio',
+      'settings',
+      'raisehand',
+      'videoquality',
+      'filmstrip',
+      'invite',
+      'feedback',
+      'stats',
+      'shortcuts',
+      'tileview',
+      'select-background',
+      'help',
+      'mute-everyone',
+      'mute-video-everyone',
+      'security',
+    ];
+    expect(mockJitsi).toHaveBeenCalledWith('meet.jit.si', {
+      configOverwrite: {
+        constraints: {
+          video: {
+            height: {
+              ideal: 720,
+              max: 720,
+              min: 240,
+            },
+          },
+        },
+        resolution: 720,
+        toolbarButtons,
+      },
+      interfaceConfigOverwrite: {
+        HIDE_INVITE_MORE_HEADER: true,
+        TOOLBAR_BUTTONS: toolbarButtons,
+      },
+      parentNode: expect.any(HTMLElement),
+      roomName: video.id,
+    });
+
+    expect(mockExecuteCommand).not.toHaveBeenCalledWith(
+      'startRecording',
+      expect.any({}),
+    );
+    expect(mockExecuteCommand).not.toHaveBeenCalledWith(
+      'stopRecording',
+      expect.any(String),
+    );
+
+    // state switch to running, recording must start
+    rerender(
+      <DashboardVideoLiveJitsi
+        video={{ ...video, live_state: liveState.RUNNING }}
+      />,
+    );
+
+    expect(mockExecuteCommand).toHaveBeenCalledWith('startRecording', {
+      mode: 'stream',
+      rtmpStreamKey: 'rtmp://1.2.3.4:1935/marsha/stream-key-primary',
+    });
+    expect(mockExecuteCommand).not.toHaveBeenCalledWith(
+      'stopRecording',
+      expect.any(String),
+    );
+
+    // state switch to stopping, recording must stop
+    rerender(
+      <DashboardVideoLiveJitsi
+        video={{ ...video, live_state: liveState.STOPPING }}
+      />,
+    );
+
+    expect(mockExecuteCommand).toHaveBeenCalledWith('stopRecording', 'stream');
+
+    expect(mockExecuteCommand).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/frontend/components/DashboardVideoLiveJitsi/index.tsx
+++ b/src/frontend/components/DashboardVideoLiveJitsi/index.tsx
@@ -1,0 +1,122 @@
+import { Box } from 'grommet';
+import React, { useEffect, useRef, useState } from 'react';
+
+import { Video, liveState } from '../../types/tracks';
+
+interface DashboardVideoLiveJitsiProps {
+  video: Video;
+}
+
+const DashboardVideoLiveJitsi = ({ video }: DashboardVideoLiveJitsiProps) => {
+  const jitsiNode = useRef(null);
+  const [jitsi, setJitsi] = useState<JitsiMeetExternalAPI>();
+
+  const loadJitsiScript = () =>
+    new Promise((resolve) => {
+      const script = document.createElement('script');
+      script.src = video.live_info.jitsi!.external_api_url!;
+      script.async = true;
+      script.onload = resolve;
+      document.body.appendChild(script);
+    });
+
+  const initialiseJitsi = async () => {
+    if (!window.JitsiMeetExternalAPI) {
+      await loadJitsiScript();
+    }
+
+    // toolbar config must be set in both configOverwrite and interfaceConfigOverwrite. This settings
+    // has moved from interfaceConfigOverwrite to configOverwrite and depending the jitsi version used
+    // we don't know which one to use. Settings both does not raise an error, there is no check on
+    // extra settings.
+    const toolbarButtons = [
+      'microphone',
+      'camera',
+      'closedcaptions',
+      'desktop',
+      'embedmeeting',
+      'fullscreen',
+      'fodeviceselection',
+      'hangup',
+      'profile',
+      'chat',
+      'etherpad',
+      'shareaudio',
+      'settings',
+      'raisehand',
+      'videoquality',
+      'filmstrip',
+      'invite',
+      'feedback',
+      'stats',
+      'shortcuts',
+      'tileview',
+      'select-background',
+      'help',
+      'mute-everyone',
+      'mute-video-everyone',
+      'security',
+    ];
+
+    const _jitsi = new window.JitsiMeetExternalAPI(
+      video.live_info.jitsi!.domain!,
+      {
+        configOverwrite: {
+          constraints: {
+            video: {
+              height: {
+                ideal: 720,
+                max: 720,
+                min: 240,
+              },
+            },
+          },
+          resolution: 720,
+          toolbarButtons,
+          ...video.live_info.jitsi!.config_overwrite,
+        },
+        interfaceConfigOverwrite: {
+          HIDE_INVITE_MORE_HEADER: true,
+          TOOLBAR_BUTTONS: toolbarButtons,
+          ...video.live_info.jitsi!.interface_config_overwrite,
+        },
+        parentNode: jitsiNode.current!,
+        roomName: video.id,
+      },
+    );
+
+    setJitsi(_jitsi);
+  };
+
+  useEffect(() => {
+    initialiseJitsi();
+
+    return () => jitsi?.dispose();
+  }, []);
+
+  useEffect(() => {
+    if (jitsi && video.live_state === liveState.RUNNING) {
+      const endpointIdentifier = /^(rtmp:\/\/.*)\/(.*)$/;
+      const endpoints = video.live_info.medialive!.input.endpoints.map(
+        (endpoint) => {
+          const matches = endpoint.match(endpointIdentifier);
+          if (matches) {
+            return `${matches[1]}/marsha/${matches[2]}`;
+          }
+        },
+      );
+      jitsi?.executeCommand('startRecording', {
+        mode: 'stream',
+        rtmpStreamKey: endpoints[0]!,
+      });
+    }
+
+    if (jitsi && video.live_state === liveState.STOPPING) {
+      jitsi.executeCommand('stopRecording', 'stream');
+    }
+  }, [video.live_state]);
+
+  return <Box height={'large'} ref={jitsiNode} />;
+};
+
+export default DashboardVideoLiveJitsi;

--- a/src/frontend/components/DashboardVideoLiveRaw/index.spec.tsx
+++ b/src/frontend/components/DashboardVideoLiveRaw/index.spec.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { videoMockFactory } from '../../utils/tests/factories';
+import { wrapInIntlProvider } from '../../utils/tests/intl';
+import { LiveModeType } from '../../types/tracks';
+import DashboardVideoLiveRaw from '.';
+
+jest.mock('clipboard');
+
+const video = videoMockFactory({
+  live_info: {
+    medialive: {
+      input: {
+        endpoints: [
+          'rtmp://1.2.3.4:1935/stream-key-primary',
+          'rtmp://4.3.2.1:1935/stream-key-secondary',
+        ],
+      },
+    },
+    type: LiveModeType.RAW,
+  },
+});
+
+describe('<DashboardVideoLiveRaw>', () => {
+  it('displays streaming links', () => {
+    render(wrapInIntlProvider(<DashboardVideoLiveRaw video={video} />));
+
+    screen.getByText('rtmp://1.2.3.4:1935');
+    screen.getByText('stream-key-primary');
+    screen.getByText('rtmp://4.3.2.1:1935');
+    screen.getByText('stream-key-secondary');
+
+    screen.getByRole('button', { name: 'copy url rtmp://1.2.3.4:1935' });
+    screen.getByRole('button', { name: 'copy key stream-key-primary' });
+
+    screen.getByRole('button', { name: 'copy url rtmp://4.3.2.1:1935' });
+    screen.getByRole('button', { name: 'copy key stream-key-secondary' });
+  });
+});

--- a/src/frontend/components/DashboardVideoLiveRaw/index.tsx
+++ b/src/frontend/components/DashboardVideoLiveRaw/index.tsx
@@ -1,0 +1,122 @@
+import ClipboardJS from 'clipboard';
+import { Box, Heading } from 'grommet';
+import React, { useEffect } from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+import ReactTooltip from 'react-tooltip';
+import styled from 'styled-components';
+
+import { Video } from '../../types/tracks';
+
+const messages = defineMessages({
+  copied: {
+    defaultMessage: 'Copied!',
+    description: 'Message displayed when endpoints info are copied.',
+    id: 'components.DashboardVideoLiveRaw.copied',
+  },
+  streamLink: {
+    defaultMessage: 'Stream link',
+    description: 'link to use to stream a video.',
+    id: 'components.DashboardVideoLiveRaw.streamLink',
+  },
+  url: {
+    defaultMessage: 'url',
+    description: 'Video url streaming.',
+    id: 'components.DashboardVideoLiveRaw.url',
+  },
+  streamKey: {
+    defaultMessage: 'stream key',
+    description: 'Video key streaming.',
+    id: 'components.DashboardVideoLiveRaw.streamKey',
+  },
+});
+
+const IconBox = styled.span`
+  font-size: 18px;
+`;
+
+const CopyButton = styled.button`
+  border: none;
+  cursor: pointer;
+`;
+
+export interface DashboardVideoLiveRawProps {
+  video: Video;
+}
+
+const DashboardVideoLiveRaw = ({ video }: DashboardVideoLiveRawProps) => {
+  useEffect(() => {
+    const clipboard = new ClipboardJS('.copy');
+    clipboard.on('success', (event) => {
+      setTimeout(() => ReactTooltip.hide(event.trigger), 1000);
+
+      event.clearSelection();
+    });
+
+    clipboard.on('error', (event) => {
+      ReactTooltip.hide(event.trigger);
+    });
+
+    return clipboard.destroy;
+  }, []);
+
+  const endpointIdentifier = /^(rtmp:\/\/.*)\/(.*)$/;
+  const endpoints = video.live_info.medialive!.input.endpoints.map(
+    (endpoint) => {
+      const matches = endpoint.match(endpointIdentifier);
+      if (matches) {
+        return (
+          <Box key={matches[2]}>
+            <Heading level={4}>
+              <FormattedMessage {...messages.streamLink} />
+            </Heading>
+            <ul>
+              <li>
+                <FormattedMessage {...messages.url} />
+                :&nbsp;
+                <span id={`url-${matches[2]}`}>{matches[1]}</span>
+                <CopyButton
+                  data-tip
+                  aria-label={`copy url ${matches[1]}`}
+                  className="copy"
+                  data-clipboard-target={`#url-${matches[2]}`}
+                >
+                  <IconBox className="icon-copy" />
+                </CopyButton>
+              </li>
+              <li>
+                <FormattedMessage {...messages.streamKey} />
+                :&nbsp;
+                <span id={`key-${matches[2]}`}>{matches[2]}</span>
+                <CopyButton
+                  data-tip
+                  aria-label={`copy key ${matches[2]}`}
+                  className="copy"
+                  data-clipboard-target={`#key-${matches[2]}`}
+                >
+                  <IconBox className="icon-copy" />
+                </CopyButton>
+              </li>
+            </ul>
+          </Box>
+        );
+      }
+    },
+  );
+
+  return (
+    <Box>
+      {endpoints}
+      <ReactTooltip
+        effect="solid"
+        place="bottom"
+        type="success"
+        isCapture={true}
+        event="click"
+      >
+        <FormattedMessage {...messages.copied} />
+      </ReactTooltip>
+    </Box>
+  );
+};
+
+export default DashboardVideoLiveRaw;

--- a/src/frontend/components/DashboardVideoLiveStopButton/index.tsx
+++ b/src/frontend/components/DashboardVideoLiveStopButton/index.tsx
@@ -22,9 +22,11 @@ type stopLiveStatus = 'pending' | 'error';
 
 interface DashboardVideoLiveStartButtonProps {
   video: Video;
+  jitsi?: JitsiMeetExternalAPI;
 }
 
 export const DashboardVideoLiveStopButton = ({
+  jitsi,
   video,
 }: DashboardVideoLiveStartButtonProps) => {
   const [status, setStatus] = useState<Nullable<stopLiveStatus>>(null);

--- a/src/frontend/components/DashboardVideoPane/index.spec.tsx
+++ b/src/frontend/components/DashboardVideoPane/index.spec.tsx
@@ -1,9 +1,9 @@
 import { cleanup, render, screen, act } from '@testing-library/react';
 import fetchMock from 'fetch-mock';
-import React from 'react';
+import React, { Suspense } from 'react';
 
 import { modelName } from '../../types/models';
-import { liveState, uploadState } from '../../types/tracks';
+import { LiveModeType, liveState, uploadState } from '../../types/tracks';
 import { report } from '../../utils/errors/report';
 import { Deferred } from '../../utils/tests/Deferred';
 import { videoMockFactory } from '../../utils/tests/factories';
@@ -340,23 +340,26 @@ describe('<DashboardVideoPane />', () => {
       const { getByText, queryByText } = render(
         wrapInIntlProvider(
           wrapInRouter(
-            <DashboardVideoPane
-              video={videoMockFactory({
-                is_ready_to_show: false,
-                upload_state: state,
-                live_state: liveState.IDLE,
-                live_info: {
-                  medialive: {
-                    input: {
-                      endpoints: [
-                        'https://live_endpoint1',
-                        'https://live_endpoint2',
-                      ],
+            <Suspense fallback="loading...">
+              <DashboardVideoPane
+                video={videoMockFactory({
+                  is_ready_to_show: false,
+                  upload_state: state,
+                  live_state: liveState.IDLE,
+                  live_info: {
+                    medialive: {
+                      input: {
+                        endpoints: [
+                          'https://live_endpoint1',
+                          'https://live_endpoint2',
+                        ],
+                      },
                     },
+                    type: LiveModeType.RAW,
                   },
-                },
-              })}
-            />,
+                })}
+              />
+            </Suspense>,
           ),
         ),
       );

--- a/src/frontend/components/DashboardVideoPane/index.tsx
+++ b/src/frontend/components/DashboardVideoPane/index.tsx
@@ -8,7 +8,7 @@ import { appData } from '../../data/appData';
 import { useVideo } from '../../data/stores/useVideo';
 import { API_ENDPOINT } from '../../settings';
 import { modelName } from '../../types/models';
-import { uploadState, Video } from '../../types/tracks';
+import { uploadState, LiveModeType, Video } from '../../types/tracks';
 import { report } from '../../utils/errors/report';
 import { DashboardInternalHeading } from '../Dashboard/DashboardInternalHeading';
 import { DashboardObjectProgress } from '../DashboardObjectProgress';
@@ -177,7 +177,11 @@ export const DashboardVideoPane = ({ video }: DashboardVideoPaneProps) => {
       if (video.live_state !== null) {
         return (
           <DashboardVideoPaneInnerContainer>
-            <Box direction={'row'}>
+            <Box
+              direction={
+                video.live_info.type === LiveModeType.RAW ? 'row' : 'column'
+              }
+            >
               <Box basis={'1/2'} margin={'small'}>
                 <CommonStatusLine video={video} />
               </Box>

--- a/src/frontend/data/sideEffects/initiateLive/index.ts
+++ b/src/frontend/data/sideEffects/initiateLive/index.ts
@@ -1,5 +1,5 @@
 import { API_ENDPOINT } from '../../../settings';
-import { Video } from '../../../types/tracks';
+import { LiveModeType, Video } from '../../../types/tracks';
 import { appData } from '../../appData';
 
 /**
@@ -7,7 +7,10 @@ import { appData } from '../../appData';
  * Returns the updated video
  * @param video initiate a live mode on this video
  */
-export const initiateLive = async (video: Video): Promise<Video> => {
+export const initiateLive = async (
+  video: Video,
+  type: LiveModeType,
+): Promise<Video> => {
   const response = await fetch(
     `${API_ENDPOINT}/videos/${video.id}/initiate-live/`,
     {
@@ -16,6 +19,9 @@ export const initiateLive = async (video: Video): Promise<Video> => {
         'Content-Type': 'application/json',
       },
       method: 'POST',
+      body: JSON.stringify({
+        type,
+      }),
     },
   );
 

--- a/src/frontend/tsconfig.json
+++ b/src/frontend/tsconfig.json
@@ -20,7 +20,8 @@
     "paths": {
       "intl-pluralrules": ["types/libs/intl-pluralrules"],
       "plyr": ["types/libs/plyr"],
-      "vtt.js": ["types/libs/vtt.js"]
+      "vtt.js": ["types/libs/vtt.js"],
+      "JitsiMeetExternalAPI": ["types/libs/JitsiMeetExternalAPI"]
     },
     "resolveJsonModule": true,
     "skipLibCheck": true,

--- a/src/frontend/types/AppData.ts
+++ b/src/frontend/types/AppData.ts
@@ -11,6 +11,7 @@ export enum appState {
 export enum flags {
   VIDEO_LIVE = 'video_live',
   SENTRY = 'sentry',
+  JITSI = 'jitsi',
 }
 
 export interface AppData {

--- a/src/frontend/types/libs/JitsiMeetExternalAPI/index.d.ts
+++ b/src/frontend/types/libs/JitsiMeetExternalAPI/index.d.ts
@@ -1,0 +1,51 @@
+export as namespace JitsiMeetExternalAPI;
+export = JitsiMeetExternalAPI;
+
+declare class JitsiMeetExternalAPI {
+  constructor(
+    domain: string,
+    options?: {
+      configOverwrite?: JitsiMeetExternalAPI.ConfigOverwriteOptions;
+      interfaceConfigOverwrite?: JitsiMeetExternalAPI.InterfaceConfigOverwrtieOptions;
+      parentNode?: HTMLElement;
+      roomName?: string;
+    },
+  );
+
+  getLivestreamUrl: () => Promise<any>;
+  executeCommand: (
+    command: JitsiMeetExternalAPI.Command,
+    options:
+      | JitsiMeetExternalAPI.RecordingMode
+      | JitsiMeetExternalAPI.RecordingOptions,
+  ) => void;
+
+  dispose: () => void;
+}
+
+// tslint:disable-next-line:no-namespace
+declare namespace JitsiMeetExternalAPI {
+  export type Command = 'startRecording' | 'stopRecording';
+  export type RecordingMode = 'stream' | 'file';
+  export type RecordingOptions = {
+    mode: RecordingMode;
+    rtmpStreamKey: string;
+  };
+  export type ConfigOverwriteOptions = {
+    constraints?: {
+      video: {
+        height: {
+          ideal: number;
+          max: number;
+          min: number;
+        };
+      };
+    };
+    resolution?: number;
+    toolbarButtons?: string[];
+  };
+  export type InterfaceConfigOverwrtieOptions = {
+    HIDE_INVITE_MORE_HEADER?: boolean;
+    TOOLBAR_BUTTONS?: string[];
+  };
+}

--- a/src/frontend/types/libs/window.d.ts
+++ b/src/frontend/types/libs/window.d.ts
@@ -7,5 +7,6 @@ declare global {
       insertInto: (container: HTMLElement) => void;
       initialize: (options: any) => void;
     };
+    JitsiMeetExternalAPI: JitsiMeetExternalAPI;
   }
 }

--- a/src/frontend/types/tracks.ts
+++ b/src/frontend/types/tracks.ts
@@ -104,6 +104,11 @@ export interface VideoUrls {
   thumbnails: Partial<urls>;
 }
 
+export enum LiveModeType {
+  RAW = 'raw',
+  JITSI = 'jitsi',
+}
+
 /** A Video record as it exists on the backend. */
 export interface Video extends Resource {
   description: string;
@@ -125,6 +130,7 @@ export interface Video extends Resource {
         endpoints: string[];
       };
     };
+    type?: LiveModeType;
   };
   xmpp: Nullable<XMPP>;
 }

--- a/src/frontend/types/tracks.ts
+++ b/src/frontend/types/tracks.ts
@@ -131,6 +131,12 @@ export interface Video extends Resource {
       };
     };
     type?: LiveModeType;
+    jitsi?: {
+      external_api_url?: string;
+      domain?: string;
+      config_overwrite: JitsiMeetExternalAPI.ConfigOverwriteOptions;
+      interface_config_overwrite: JitsiMeetExternalAPI.InterfaceConfigOverwrtieOptions;
+    };
   };
   xmpp: Nullable<XMPP>;
 }


### PR DESCRIPTION
## Purpose

We want to stream jitsi in marsha live as an alternative to tools like OBS Studio. Jitsi is fully integrated in marsha using its [IFrame API](https://jitsi.github.io/handbook/docs/dev-guide/dev-guide-iframe). An instructor will start a live with jitsi, jitsi is added like an iframe the configured to use medialive RTMP settings.

## Proposal

- [x] Manage jitsi info in backend
- [x] create jitsi iframe API types
- [x] integrate jitsi in marsha

