### PR TITLE
♻️(front) use video object from state in Chat component

### DIFF
--- a/src/frontend/components/Chat/index.spec.tsx
+++ b/src/frontend/components/Chat/index.spec.tsx
@@ -1,9 +1,27 @@
 import { render } from '@testing-library/react';
 import React from 'react';
 
+import { liveState } from '../../types/tracks';
 import { converseMounter } from '../../utils/converse';
 import { videoMockFactory } from '../../utils/tests/factories';
 import { Chat } from '.';
+
+const mockVideo = videoMockFactory({
+  id: '5cffe85a-1829-4000-a6ca-a45d4647dc0d',
+  live_state: liveState.RUNNING,
+  xmpp: {
+    bosh_url: 'https://xmpp-server.com/http-bind',
+    conference_url:
+      '870c467b-d66e-4949-8ee5-fcf460c72e88@conference.xmpp-server.com',
+    prebind_url: 'https://xmpp-server.com/http-pre-bind',
+    jid: 'xmpp-server.com',
+  },
+});
+jest.mock('../../data/appData', () => ({
+  appData: {
+    video: mockVideo,
+  },
+}));
 
 jest.mock('../../utils/converse', () => ({
   converseMounter: jest.fn(() => jest.fn()),
@@ -19,25 +37,14 @@ describe('<Chat />', () => {
   });
 
   it('renders the Chat component', () => {
-    const video = videoMockFactory({
-      id: '870c467b-d66e-4949-8ee5-fcf460c72e88',
-      xmpp: {
-        bosh_url: 'https://xmpp-server.com/http-bind',
-        conference_url:
-          '870c467b-d66e-4949-8ee5-fcf460c72e88@conference.xmpp-server.com',
-        prebind_url: 'https://xmpp-server.com/http-pre-bind',
-        jid: 'xmpp-server.com',
-      },
-    });
-
     expect(mockConverseMounter).toHaveBeenCalled();
-    render(<Chat xmpp={video.xmpp!} />);
+    render(<Chat video={mockVideo} />);
 
     // mockConverseMounter returns itself a mock. We want to inspect this mock to be sure that
     // is was called with the container name and the xmpp object
     expect(mockConverseMounter.mock.results[0].value).toHaveBeenCalledWith(
       '#converse-container',
-      video.xmpp,
+      mockVideo.xmpp,
     );
   });
 });

--- a/src/frontend/components/Chat/index.tsx
+++ b/src/frontend/components/Chat/index.tsx
@@ -1,18 +1,21 @@
 import { Box } from 'grommet';
 import React, { useEffect } from 'react';
 
-import { XMPP } from '../../types/tracks';
+import { useVideo } from '../../data/stores/useVideo';
+import { Video } from '../../types/tracks';
 import { converseMounter } from '../../utils/converse';
 
 interface ChatProps {
-  xmpp: XMPP;
+  video: Video;
 }
 
 const converseManager = converseMounter();
 
-export const Chat = ({ xmpp }: ChatProps) => {
+export const Chat = ({ video: baseVideo }: ChatProps) => {
+  const video = useVideo((state) => state.getVideo(baseVideo));
+
   useEffect(() => {
-    converseManager('#converse-container', xmpp);
+    converseManager('#converse-container', video.xmpp!);
   }, []);
 
   return (

--- a/src/frontend/components/LTIRoutes/index.tsx
+++ b/src/frontend/components/LTIRoutes/index.tsx
@@ -88,7 +88,7 @@ export const Routes = () => (
             if (appData.modelName === modelName.VIDEOS && appData.video?.xmpp) {
               return (
                 <InstructorWrapper resource={appData.video}>
-                  <Chat xmpp={appData.video.xmpp} />
+                  <Chat video={appData.video} />
                 </InstructorWrapper>
               );
             }

--- a/src/frontend/components/VideoPlayer/index.tsx
+++ b/src/frontend/components/VideoPlayer/index.tsx
@@ -161,7 +161,7 @@ const VideoPlayer = ({
       {transcripts.length > 0 && (
         <Transcripts transcripts={transcripts as TimedTextTranscript[]} />
       )}
-      {video.live_state !== null && video.xmpp && <Chat xmpp={video.xmpp} />}
+      {video.live_state !== null && video.xmpp && <Chat video={video} />}
     </Box>
   );
 };


### PR DESCRIPTION
## Purpose

Since now the xmpp info injected in the chat component where retrieved
in the video object and it works fine like this if the component is
mounted in the VideoPlayer component. But if we mounted directly using
the chat only feature, the data used come from the appData and can be
outdated. We must retrieve the video from the state to be sure to have
up to date data.

## Proposal

- [x] use video object from state in Chat component

