### PR TITLE
Fix issues with new upload process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Jitsi streamed in marsha live
 
+### Fixed
+
+- Fetch fresh resource data after initiate-upload endpoint called
+
 ## [3.18.0] - 2021-05-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Fetch fresh resource data after initiate-upload endpoint called
+- Reset upload manager state before starting a new upload
 
 ## [3.18.0] - 2021-05-10
 

--- a/src/frontend/components/DashboardThumbnail/index.spec.tsx
+++ b/src/frontend/components/DashboardThumbnail/index.spec.tsx
@@ -228,6 +228,70 @@ describe('<DashboardThumbnail />', () => {
     useThumbnailStub.reset();
   });
 
+  it('displays an explanatory message when a thumbnail is pending but upload state is success', () => {
+    const file = new File(['(⌐□_□)'], 'thumb.png');
+    const videoWithLoadingThumbnail = videoMockFactory({
+      id: '43',
+      is_ready_to_show: true,
+      show_download: true,
+      thumbnail: {
+        active_stamp: 128748302847,
+        id: '42',
+        is_ready_to_show: true,
+        upload_state: uploadState.PENDING,
+        urls: {
+          144: 'https://example.com/thumbnail/144',
+          240: 'https://example.com/thumbnail/240',
+          480: 'https://example.com/thumbnail/480',
+          720: 'https://example.com/thumbnail/720',
+          1080: 'https://example.com/thumbnail/1080',
+        },
+        video: '43',
+      },
+      upload_state: uploadState.READY,
+    });
+
+    useThumbnailStub.returns({
+      addThumbnail: mockAddThumbnail,
+      thumbnail: videoWithLoadingThumbnail.thumbnail,
+    });
+
+    render(
+      <UploadManagerContext.Provider
+        value={{
+          setUploadState: jest.fn(),
+          uploadManagerState: {
+            42: {
+              file,
+              objectId: '42',
+              objectType: modelName.THUMBNAILS,
+              progress: 0,
+              status: UploadManagerStatus.SUCCESS,
+            },
+          },
+        }}
+      >
+        {wrapInIntlProvider(
+          <DashboardThumbnail video={videoWithLoadingThumbnail} />,
+        )}
+      </UploadManagerContext.Provider>,
+    );
+
+    // The thumbnail image, error message and progress indicator are not shown
+    expect(screen.queryByAltText('Video thumbnail preview image.')).toEqual(
+      null,
+    );
+    expect(
+      screen.queryByText('There was an error during thumbnail creation.'),
+    ).toEqual(null);
+    expect(screen.queryByText('0%')).toEqual(null);
+    // The processing message is shown
+    screen.getByText(
+      'Your thumbnail is currently processing. This may take several minutes. It will appear here once done.',
+    );
+    useThumbnailStub.reset();
+  });
+
   it('displays an error message when there is an issue with a thumbnail', () => {
     const videoWithErroredThumbnail = videoMockFactory({
       id: '43',

--- a/src/frontend/components/TimedTextListItem/index.tsx
+++ b/src/frontend/components/TimedTextListItem/index.tsx
@@ -92,7 +92,7 @@ export const TimedTextListItem = ({ track }: TimedTextListItemProps) => {
         }
       }, 1000 * 10);
     }
-  }, []);
+  }, [track.upload_state]);
 
   if (error) {
     return <Redirect push to={FULL_SCREEN_ERROR_ROUTE('notFound')} />;

--- a/src/frontend/components/UploadForm/index.spec.tsx
+++ b/src/frontend/components/UploadForm/index.spec.tsx
@@ -25,7 +25,6 @@ jest.mock('../../data/sideEffects/uploadFile', () => ({
   uploadFile: jest.fn(),
 }));
 jest.mock('../../data/stores/generics', () => ({
-  addResource: jest.fn(),
   getResource: jest.fn(),
 }));
 

--- a/src/frontend/components/UploadForm/index.tsx
+++ b/src/frontend/components/UploadForm/index.tsx
@@ -96,7 +96,7 @@ export interface UploadFormProps {
 }
 
 export const UploadForm = ({ objectId, objectType }: UploadFormProps) => {
-  const { uploadManagerState } = useUploadManager();
+  const { uploadManagerState, resetUpload } = useUploadManager();
   const objectStatus = uploadManagerState[objectId]?.status;
 
   const [object, setObject] = useState(undefined as Maybe<UploadableObject>);
@@ -112,6 +112,7 @@ export const UploadForm = ({ objectId, objectType }: UploadFormProps) => {
   };
 
   useEffect(() => {
+    if (uploadManagerState[objectId]) resetUpload(objectId);
     window.addEventListener('beforeunload', beforeUnload);
     return () => window.removeEventListener('beforeunload', beforeUnload);
   }, []);

--- a/src/frontend/components/UploadManager/LTIUploadHandlers.tsx
+++ b/src/frontend/components/UploadManager/LTIUploadHandlers.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { getResource as fetchResource } from '../../data/sideEffects/getResource';
 import { updateResource } from '../../data/sideEffects/updateResource';
 import { addResource, getResource } from '../../data/stores/generics';
 import { useAsyncEffect } from '../../utils/useAsyncEffect';
@@ -31,6 +32,11 @@ const UploadSuccessHandler = ({
           objectType,
         );
       }
+    }
+
+    if (objectState.status === UploadManagerStatus.UPLOADING) {
+      const { objectId, objectType } = objectState;
+      await fetchResource(objectType, objectId);
     }
   }, [objectState.status]);
 

--- a/src/frontend/components/UploadManager/index.tsx
+++ b/src/frontend/components/UploadManager/index.tsx
@@ -148,5 +148,16 @@ export const useUploadManager = () => {
     }));
   };
 
-  return { addUpload, uploadManagerState };
+  const resetUpload = (objectId: string) => {
+    setUploadState((state) =>
+      Object.keys(state)
+        .filter((resourceId) => resourceId !== objectId)
+        .reduce(
+          (acc, resourceId) => ({ ...acc, [resourceId]: state[resourceId] }),
+          {},
+        ),
+    );
+  };
+
+  return { addUpload, resetUpload, uploadManagerState };
 };

--- a/src/frontend/data/sideEffects/getResource/index.spec.tsx
+++ b/src/frontend/data/sideEffects/getResource/index.spec.tsx
@@ -1,0 +1,80 @@
+import fetchMock from 'fetch-mock';
+
+import { requestStatus } from '../../../types/api';
+import { modelName } from '../../../types/models';
+import { report } from '../../../utils/errors/report';
+import { videoMockFactory } from '../../../utils/tests/factories';
+import { addResource } from '../../stores/generics';
+import { getResource } from './';
+
+jest.mock('../../appData', () => ({
+  appData: {
+    jwt: 'some token',
+  },
+}));
+
+jest.mock('../../stores/generics', () => ({
+  addResource: jest.fn(),
+}));
+
+jest.mock('../../../utils/errors/report', () => ({
+  report: jest.fn(),
+}));
+
+const mockAddResource = addResource as jest.MockedFunction<typeof addResource>;
+
+describe('sideEffects/getResource', () => {
+  afterEach(() => fetchMock.restore());
+  afterEach(jest.resetAllMocks);
+
+  it('requests the resource, handles the response and resolves with a success', async () => {
+    const video = videoMockFactory({
+      id: '022d356b-171e-4bd3-9ba8-26ce21be8647',
+    });
+
+    fetchMock.mock(
+      `/api/videos/${video.id}/`,
+      JSON.stringify({
+        ...video,
+        title: 'updated title',
+      }),
+    );
+
+    const status = await getResource(modelName.VIDEOS, video.id);
+
+    expect(status).toEqual(requestStatus.SUCCESS);
+    expect(mockAddResource).toHaveBeenCalledWith(modelName.VIDEOS, {
+      ...video,
+      title: 'updated title',
+    });
+  });
+
+  it('resolves with a failure and handles it when it fails to get the resource (local)', async () => {
+    const id = '9ab04b2c-96af-437e-809e-0eb7a965df4b';
+    fetchMock.mock(
+      `/api/videos/${id}/`,
+      Promise.reject(new Error('Failed to perform the request')),
+    );
+
+    const status = await getResource(modelName.VIDEOS, id);
+
+    expect(status).toEqual(requestStatus.FAILURE);
+    expect(report).toHaveBeenCalledWith(
+      new Error('Failed to perform the request'),
+    );
+    expect(mockAddResource).not.toHaveBeenCalled();
+  });
+
+  it('returns an error response when it fails to get the resource (api)', async () => {
+    const id = '9ab04b2c-96af-437e-809e-0eb7a965df4c';
+    fetchMock.mock(`/api/videos/${id}/`, 404);
+
+    const status = await getResource(modelName.VIDEOS, id);
+
+    expect(status).toEqual(requestStatus.FAILURE);
+    expect(report).toHaveBeenCalledWith(
+      new Error(`Failed to fetch resource videos with id ${id}`),
+    );
+    expect(mockAddResource).not.toHaveBeenCalled();
+  });
+});

--- a/src/frontend/data/sideEffects/getResource/index.tsx
+++ b/src/frontend/data/sideEffects/getResource/index.tsx
@@ -1,0 +1,40 @@
+import { requestStatus } from '../../../types/api';
+import { API_ENDPOINT } from '../../../settings';
+import { modelName } from '../../../types/models';
+import { appData } from '../../appData';
+import { addResource } from '../../stores/generics';
+import { report } from '../../../utils/errors/report';
+
+/**
+ * Fetch a resource to update its state in our store.
+ * @param resourceName The model name for the resource .
+ * @param resourceId The resource id to fetch
+ * @returns a promise for a request status, so the side effect caller can simply wait for it if needed.
+ */
+export async function getResource(
+  resourceName: modelName,
+  resourceId: string,
+): Promise<requestStatus> {
+  const endpoint = `${API_ENDPOINT}/${resourceName}/${resourceId}/`;
+
+  try {
+    const response = await fetch(endpoint, {
+      headers: {
+        Authorization: `Bearer ${appData.jwt}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `Failed to fetch resource ${resourceName} with id ${resourceId}`,
+      );
+    }
+
+    await addResource(resourceName, await response.json());
+    return requestStatus.SUCCESS;
+  } catch (error) {
+    report(error);
+    return requestStatus.FAILURE;
+  }
+}


### PR DESCRIPTION
## Purpose

In #897 a new upload manager was created and we faced multiple bugs with release v3.18.0:
- The object involved in the upload process is never updated if it already exists because its `upload_state` is always `ready`. So the dashboard never display the progress bar and the processing message
- The thumbnail dashboard was failing once you click on `replace this thumbnail`
- Impossible to chain multiple time the same upload process. If you uploaded a wrong thumbnail you can not replace unless you refresh the browser

## Proposal

- [x] Create a new side effect `getResource` to fetch a resource given its id
- [x] Fetch fresh resource data after `initiate-upload` endpoint called
- [x] Adapt thumbnail dashboard with new upload workflow
- [x] Reset upload manager state before starting a new upload. 

