### PR TITLE
✨(front) display Chat in Dashboard during a jitsi live

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Display chat in dashboard during a jitsi live
+
 ## [3.19.0] - 2021-05-10
 
 ### Added

--- a/src/frontend/components/DashboardVideoLive/index.spec.tsx
+++ b/src/frontend/components/DashboardVideoLive/index.spec.tsx
@@ -105,62 +105,6 @@ describe('components/DashboardVideoLive', () => {
     screen.getByRole('button', { name: /stop streaming/i });
   });
 
-  it('clicks on show live and redirects to the video player', () => {
-    render(
-      wrapInIntlProvider(
-        wrapInRouter(
-          <Suspense fallback="loading...">
-            <DashboardVideoLive
-              video={{ ...video, live_state: liveState.RUNNING }}
-            />
-          </Suspense>,
-          [
-            {
-              path: PLAYER_ROUTE(modelName.VIDEOS),
-              render: () => <span>video player</span>,
-            },
-          ],
-        ),
-      ),
-    );
-
-    const showLiveButton = screen.getByRole('button', { name: /show live/i });
-    expect(screen.queryByText('video player')).not.toBeInTheDocument();
-
-    fireEvent.click(showLiveButton);
-
-    screen.getByText('video player');
-  });
-
-  it('clicks on show chat only and redirects to the chat component', () => {
-    render(
-      wrapInIntlProvider(
-        wrapInRouter(
-          <Suspense fallback="loading...">
-            <DashboardVideoLive
-              video={{ ...video, live_state: liveState.RUNNING }}
-            />
-          </Suspense>,
-          [
-            {
-              path: CHAT_ROUTE(),
-              render: () => <span>chat component</span>,
-            },
-          ],
-        ),
-      ),
-    );
-
-    const showChatOnlyButton = screen.getByRole('button', {
-      name: /show chat only/i,
-    });
-    expect(screen.queryByText('chat component')).not.toBeInTheDocument();
-
-    fireEvent.click(showChatOnlyButton);
-
-    screen.getByText('chat component');
-  });
-
   it('polls the video when live state is STARTING', async () => {
     fetchMock.mock(
       '/api/videos/9e02ae7d-6c18-40ce-95e8-f87bbeae31c5/',

--- a/src/frontend/components/DashboardVideoLive/index.tsx
+++ b/src/frontend/components/DashboardVideoLive/index.tsx
@@ -12,6 +12,7 @@ import { CHAT_ROUTE } from '../Chat/route';
 import { PLAYER_ROUTE } from '../routes';
 import { DashboardVideoLiveStartButton } from '../DashboardVideoLiveStartButton';
 import { DashboardVideoLiveStopButton } from '../DashboardVideoLiveStopButton';
+import { DashboardVideoLiveRunning } from '../DashboardVideoLiveRunning';
 import { DashboardButtonWithLink } from '../DashboardPaneButtons';
 
 const DashboardVideoLiveRaw = lazy(() => import('../DashboardVideoLiveRaw'));
@@ -34,16 +35,6 @@ const messages = defineMessages({
     defaultMessage: 'url',
     description: 'Video url streaming.',
     id: 'components.DashboardVideoLive.url',
-  },
-  showLive: {
-    defaultMessage: 'show live',
-    description: 'button to redirect use to video player.',
-    id: 'components.DashboardVideoLive.showLive',
-  },
-  chatOnly: {
-    defaultMessage: 'show chat only',
-    description: 'button to redirect to the chat only view.',
-    id: 'components.DashboardVideoLive.chatOnly',
   },
   liveCreating: {
     defaultMessage:
@@ -142,23 +133,7 @@ export const DashboardVideoLive = ({ video }: DashboardVideoLiveProps) => {
           </Text>
         )}
         {video.live_state === liveState.RUNNING && (
-          <React.Fragment>
-            {video.live_info.type === LiveModeType.RAW && (
-              <React.Fragment>
-                <DashboardButtonWithLink
-                  label={<FormattedMessage {...messages.chatOnly} />}
-                  primary={false}
-                  to={CHAT_ROUTE()}
-                />
-                <DashboardButtonWithLink
-                  label={<FormattedMessage {...messages.showLive} />}
-                  primary={false}
-                  to={PLAYER_ROUTE(modelName.VIDEOS)}
-                />
-              </React.Fragment>
-            )}
-            <DashboardVideoLiveStopButton video={video} />
-          </React.Fragment>
+          <DashboardVideoLiveRunning video={video} />
         )}
         {video.live_state === liveState.STOPPED && (
           <Text>

--- a/src/frontend/components/DashboardVideoLiveRunning/index.spec.tsx
+++ b/src/frontend/components/DashboardVideoLiveRunning/index.spec.tsx
@@ -1,0 +1,106 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { CHAT_ROUTE } from '../Chat/route';
+import { PLAYER_ROUTE } from '../routes';
+import { modelName } from '../../types/models';
+import { LiveModeType, Video } from '../../types/tracks';
+import { videoMockFactory } from '../../utils/tests/factories';
+import { wrapInIntlProvider } from '../../utils/tests/intl';
+import { wrapInRouter } from '../../utils/tests/router';
+import { DashboardVideoLiveRunning } from '.';
+
+jest.mock('../../data/appData', () => ({
+  appData: { jwt: 'cool_token_m8' },
+}));
+
+jest.mock('../Chat', () => ({
+  Chat: (props: { video: Video }) => (
+    <span title={props.video.id}>chat component</span>
+  ),
+}));
+
+describe('<DashboardVideoLiveRunning />  displays "show live" and "show chat only" buttons', () => {
+  it('shows live', () => {
+    const video = videoMockFactory({
+      live_info: {
+        type: LiveModeType.RAW,
+      },
+    });
+
+    render(
+      wrapInIntlProvider(
+        wrapInRouter(<DashboardVideoLiveRunning video={video} />, [
+          {
+            path: PLAYER_ROUTE(modelName.VIDEOS),
+            render: () => <span>video player</span>,
+          },
+        ]),
+      ),
+    );
+
+    const showLiveButton = screen.getByRole('button', { name: /show live/ });
+    screen.getByRole('button', { name: /show chat only/ });
+
+    fireEvent.click(showLiveButton);
+
+    screen.getByText('video player');
+  });
+
+  it('shows chat only', () => {
+    const video = videoMockFactory({
+      live_info: {
+        type: LiveModeType.RAW,
+      },
+    });
+
+    render(
+      wrapInIntlProvider(
+        wrapInRouter(<DashboardVideoLiveRunning video={video} />, [
+          {
+            path: CHAT_ROUTE(),
+            render: () => <span>chat component</span>,
+          },
+        ]),
+      ),
+    );
+
+    screen.getByRole('button', { name: /show live/ });
+    const showChatOnlyButton = screen.getByRole('button', {
+      name: /show chat only/i,
+    });
+
+    fireEvent.click(showChatOnlyButton);
+
+    screen.getByText('chat component');
+  });
+
+  it('shows and hides the chat during a jitsi live.', () => {
+    const video = videoMockFactory({
+      live_info: {
+        type: LiveModeType.JITSI,
+      },
+    });
+
+    const { debug } = render(
+      wrapInIntlProvider(
+        wrapInRouter(<DashboardVideoLiveRunning video={video} />),
+      ),
+    );
+
+    const showChatButton = screen.getByRole('button', { name: /show chat/ });
+    expect(screen.queryByText('chat component')).not.toBeInTheDocument();
+
+    // show chat
+    fireEvent.click(showChatButton);
+
+    screen.getByText('chat component');
+
+    const hideChatButton = screen.getByRole('button', { name: /hide chat/ });
+
+    // hide chat
+    fireEvent.click(hideChatButton);
+
+    expect(screen.queryByText('chat component')).not.toBeInTheDocument();
+  });
+});

--- a/src/frontend/components/DashboardVideoLiveRunning/index.tsx
+++ b/src/frontend/components/DashboardVideoLiveRunning/index.tsx
@@ -1,0 +1,78 @@
+import { Box } from 'grommet';
+import React, { useState } from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+
+import { DashboardVideoLiveStopButton } from '../DashboardVideoLiveStopButton';
+import {
+  DashboardButton,
+  DashboardButtonWithLink,
+} from '../DashboardPaneButtons';
+import { Chat } from '../Chat';
+import { CHAT_ROUTE } from '../Chat/route';
+import { PLAYER_ROUTE } from '../routes';
+import { modelName } from '../../types/models';
+import { LiveModeType, Video } from '../../types/tracks';
+
+const messages = defineMessages({
+  showLive: {
+    defaultMessage: 'show live',
+    description: 'button to redirect use to video player.',
+    id: 'components.DashboardVideoLiveRunning.showLive',
+  },
+  chatOnly: {
+    defaultMessage: 'show chat only',
+    description: 'button to redirect to the chat only view.',
+    id: 'components.DashboardVideoLiveRunning.chatOnly',
+  },
+  showChat: {
+    defaultMessage: 'show chat',
+    description: 'button to show the chat during a jitsi live.',
+    id: 'components.DashboardVideoLiveRunning.showChat',
+  },
+  hideChat: {
+    defaultMessage: 'hide chat',
+    description: 'button to hide the chat during a jitsi live.',
+    id: 'components.DashboardVideoLiveRunning.hideChat',
+  },
+});
+
+interface DashboardVideoLiveRunningProps {
+  video: Video;
+}
+
+export const DashboardVideoLiveRunning = ({
+  video,
+}: DashboardVideoLiveRunningProps) => {
+  const [displayChat, setDisplayChat] = useState(false);
+  const displayChatMessage = displayChat
+    ? messages.hideChat
+    : messages.showChat;
+  return (
+    <Box direction="column" fill={true}>
+      <Box direction="row">
+        {video.live_info.type === LiveModeType.RAW && (
+          <React.Fragment>
+            <DashboardButtonWithLink
+              label={<FormattedMessage {...messages.chatOnly} />}
+              primary={false}
+              to={CHAT_ROUTE()}
+            />
+            <DashboardButtonWithLink
+              label={<FormattedMessage {...messages.showLive} />}
+              primary={false}
+              to={PLAYER_ROUTE(modelName.VIDEOS)}
+            />
+          </React.Fragment>
+        )}
+        {video.live_info.type === LiveModeType.JITSI && (
+          <DashboardButton
+            label={<FormattedMessage {...displayChatMessage} />}
+            onClick={() => setDisplayChat(!displayChat)}
+          />
+        )}
+        <DashboardVideoLiveStopButton video={video} />
+      </Box>
+      {displayChat && <Chat video={video} />}
+    </Box>
+  );
+};


### PR DESCRIPTION
## Purpose

During a jitsi live, we want to show/hide the Chat component below the
jitsi client.

## Proposal

- [x] create a component `DashboadVideoLiveRunning` to manage buttons depending on live type.

