### PR TITLE
🐛(back) prevent to display a deleted video

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Display chat in dashboard during a jitsi live
 - Use chat when a live is publicly available
 
+### Fixed
+
+- Prevent to display a deleted video
+
 ## [3.19.0] - 2021-05-10
 
 ### Added

--- a/src/backend/marsha/core/models/video.py
+++ b/src/backend/marsha/core/models/video.py
@@ -5,7 +5,7 @@ from django.db import models
 from django.utils.functional import lazy
 from django.utils.translation import gettext_lazy as _
 
-from ..defaults import HARVESTED, LIVE_CHOICES, RUNNING
+from ..defaults import DELETED, HARVESTED, LIVE_CHOICES, RUNNING
 from ..utils.time_utils import to_timestamp
 from .base import BaseModel
 from .file import AbstractImage, BaseFile, UploadableFileMixin
@@ -121,7 +121,8 @@ class Video(BaseFile):
         `uploaded_on` field but it is necessary for conveniency and clarity in the client.
         """
         return (
-            self.uploaded_on is not None and self.upload_state != HARVESTED
+            self.uploaded_on is not None
+            and self.upload_state not in [HARVESTED, DELETED]
         ) or self.live_state == RUNNING
 
     @staticmethod

--- a/src/backend/marsha/core/tests/test_views_lti_video.py
+++ b/src/backend/marsha/core/tests/test_views_lti_video.py
@@ -14,6 +14,7 @@ from rest_framework_simplejwt.tokens import AccessToken
 from waffle.testutils import override_switch
 
 from ..defaults import (
+    DELETED,
     HARVESTED,
     IDLE,
     PENDING,
@@ -768,7 +769,7 @@ class VideoLTIViewTestCase(TestCase):
             playlist__title="playlist-003",
             playlist__lti_id="course-v1:ufr+mathematics+00001",
             upload_state=random.choice(
-                [s[0] for s in STATE_CHOICES if s[0] != HARVESTED]
+                [s[0] for s in STATE_CHOICES if s[0] not in [DELETED, HARVESTED]]
             ),
             uploaded_on="2019-09-24 07:24:40+00",
             resolutions=[144, 240, 480, 720, 1080],
@@ -877,7 +878,7 @@ class VideoLTIViewTestCase(TestCase):
             playlist__consumer_site=passport.consumer_site,
             playlist__title="playlist-002",
             upload_state=random.choice(
-                [s[0] for s in STATE_CHOICES if s[0] != HARVESTED]
+                [s[0] for s in STATE_CHOICES if s[0] not in [DELETED, HARVESTED]]
             ),
             uploaded_on="2019-09-24 07:24:40+00",
             resolutions=[144, 240, 480],
@@ -1093,7 +1094,7 @@ class VideoLTIViewTestCase(TestCase):
             playlist__consumer_site=passport.consumer_site,
             playlist__title="playlist-002",
             upload_state=random.choice(
-                [s[0] for s in STATE_CHOICES if s[0] != HARVESTED]
+                [s[0] for s in STATE_CHOICES if s[0] not in [DELETED, HARVESTED]]
             ),
             uploaded_on="2019-09-24 07:24:40+00",
             resolutions=[144, 240, 480, 720, 1080],

--- a/src/backend/marsha/core/tests/test_views_public_video.py
+++ b/src/backend/marsha/core/tests/test_views_public_video.py
@@ -10,7 +10,7 @@ from django.test import TestCase, override_settings
 
 from rest_framework_simplejwt.tokens import AccessToken
 
-from ..defaults import HARVESTED, PENDING, RAW, RUNNING, STATE_CHOICES
+from ..defaults import DELETED, HARVESTED, PENDING, RAW, RUNNING, STATE_CHOICES
 from ..factories import VideoFactory
 
 
@@ -32,7 +32,7 @@ class VideoPublicViewTestCase(TestCase):
             is_public=True,
             resolutions=[144, 240, 480, 720, 1080],
             upload_state=random.choice(
-                [s[0] for s in STATE_CHOICES if s[0] != HARVESTED]
+                [s[0] for s in STATE_CHOICES if s[0] not in [DELETED, HARVESTED]]
             ),
             uploaded_on="2019-09-24 07:24:40+00",
         )


### PR DESCRIPTION
## Purpose

When the uploaded_state switch to DELETED, `is_ready_to_show` property
on the video object must be false, there is nothing to show.

## Proposal

- [x] prevent to display a deleted video

