### PR TITLE
✨(back) use chat when a live is publicly available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Display chat in dashboard during a jitsi live
+- Use chat when a live is publicly available
 
 ## [3.19.0] - 2021-05-10
 

--- a/src/backend/marsha/core/api.py
+++ b/src/backend/marsha/core/api.py
@@ -278,8 +278,7 @@ class VideoViewSet(ObjectPkMixin, viewsets.ModelViewSet):
 
         user = self.request.user
         if isinstance(user, TokenUser):
-            context["roles"] = user.token.payload.get("roles", [])
-            context["user_id"] = user.token.payload.get("user_id", None)
+            context.update(user.token.payload)
 
         return context
 

--- a/src/backend/marsha/core/serializers/video.py
+++ b/src/backend/marsha/core/serializers/video.py
@@ -486,17 +486,14 @@ class VideoSerializer(VideoBaseSerializer):
         Dictionnary
             A dictionary containing all info needed to manage a connection to a xmpp server.
         """
-        if (
-            settings.LIVE_CHAT_ENABLED
-            and obj.live_state is not None
-            and self.context.get("user_id", False)
-        ):
+        user_id = self.context.get("user_id") or self.context.get("session_id")
+        if settings.LIVE_CHAT_ENABLED and user_id and obj.live_state is not None:
             roles = self.context.get("roles", [])
             is_admin = bool(LTI_ROLES[ADMINISTRATOR] & set(roles))
             is_instructor = bool(LTI_ROLES[INSTRUCTOR] & set(roles))
             token = xmpp_utils.generate_jwt(
                 str(obj.id),
-                self.context["user_id"],
+                user_id,
                 "owner" if is_admin or is_instructor else "member",
                 timezone.now() + timedelta(days=1),
             )

--- a/src/backend/marsha/core/views.py
+++ b/src/backend/marsha/core/views.py
@@ -227,6 +227,7 @@ class BaseLTIView(ABC, TemplateResponseMixin, View):
         permissions = {"can_access_dashboard": False, "can_update": False}
 
         user_id = getattr(lti, "user_id", None) if lti else None
+        session_id = str(uuid.uuid4())
 
         if app_data is None:
             resource = (
@@ -256,6 +257,7 @@ class BaseLTIView(ABC, TemplateResponseMixin, View):
                             else False,
                             "roles": lti.roles if lti else [],
                             "user_id": user_id,
+                            "session_id": session_id,
                         },
                     ).data
                     if resource
@@ -282,7 +284,7 @@ class BaseLTIView(ABC, TemplateResponseMixin, View):
             jwt_token = AccessToken()
             jwt_token.payload.update(
                 {
-                    "session_id": str(uuid.uuid4()),
+                    "session_id": session_id,
                     "context_id": lti.context_id
                     if lti
                     else app_data["resource"]["playlist"]["lti_id"],


### PR DESCRIPTION
## Purpose

A live can be set a public. But the chat is never display because the
`user_id` is used to configure the prosody JWT token. To allow the chat
usage with a public live, we can use the `session_id` instead of the
`user_id`.

## Proposal

- [x] Use chat when a live is publicly available

