### PR TITLE
🔧(renovate) use configuration from renovate-configuration repo

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,19 +1,5 @@
 {
-  "commitMessageAction": "update",
-  "commitMessagePrefix": "⬆️(dependencies)",
-  "commitMessageTopic": "{{depName}}",
-  "enabledManagers": ["npm"],
-  "extends": ["config:base"],
-  "packageRules": [{
-    "groupName": "npm dependencies",
-    "schedule": ["before 7am on monday"],
-    "matchPackagePatterns": ["*"]
-  }],
-  "prConcurrentLimit": 2,
-  "prHourlyLimit": 1,
-  "prCreation": "not-pending",
-  "semanticCommits": "disabled",
-  "separateMajorMinor": false,
-  "updateNotScheduled": true,
-  "rebaseWhen": "behind-base-branch"
+  "extends": [
+    "github>openfun/renovate-configuration"
+  ]
 }


### PR DESCRIPTION
## Purpose

We mutualized renovate configuration in the github repo
openfun/renovate-configuration. We can use it without any modification
in marsha.

## Proposal

- [x] Use configuration from renovate-configuration repo

