### PR TITLE
♻️(front) Use conversejs concord theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Switch from classic to jitsi live when a classic is created
+- Use conversejs concord theme
 
 ### Fixed
 

--- a/src/frontend/utils/converse.spec.ts
+++ b/src/frontend/utils/converse.spec.ts
@@ -52,8 +52,11 @@ describe('converseMounter', () => {
       hide_muc_participants: true,
       jid: 'xmpp-server.com',
       modtools_disable_assign: true,
+      muc_instant_rooms: false,
       root: expect.any(HTMLDivElement),
+      show_client_info: false,
       singleton: true,
+      theme: 'concord',
       view_mode: 'embedded',
       visible_toolbar_buttons: {
         call: false,

--- a/src/frontend/utils/converse.ts
+++ b/src/frontend/utils/converse.ts
@@ -29,8 +29,11 @@ export const converseMounter = () => {
         hide_muc_participants: true,
         jid: xmpp.jid,
         modtools_disable_assign: true,
+        muc_instant_rooms: false,
         root: document.querySelector(containerName),
+        show_client_info: false,
         singleton: true,
+        theme: 'concord',
         view_mode: 'embedded',
         visible_toolbar_buttons: {
           call: false,


### PR DESCRIPTION
## Purpose

The default conversejs theme is flashy with orange/red colors which can
remind a "danger" zone in a web context. The concord theme is a light
theme without any color.
Also `muc_instant_rooms` is disabled to inform conversejs that the xmpp server
only accepts registered rooms and `show_client_info` is disabled to hide
the info icon displaying info about conversejs configuration.


## Proposal

- [x] use conversejs concord theme
![Screenshot from 2021-06-03 14-30-32](https://user-images.githubusercontent.com/767834/120645185-6be19e80-c478-11eb-854b-c56a630cf429.png)

