### PR TITLE
use username value if present in the LTI request

### DIFF
--- a/src/backend/marsha/core/factories.py
+++ b/src/backend/marsha/core/factories.py
@@ -34,7 +34,8 @@ class UserFactory(DjangoModelFactory):
         model = models.User
 
     username = factory.Faker("user_name")
-    password = make_password(u"password")
+    password = make_password("password")
+    email = factory.LazyAttribute(lambda o: f"{o.username}@example.org")
 
 
 class ConsumerSiteFactory(DjangoModelFactory):

--- a/src/backend/marsha/core/lti/__init__.py
+++ b/src/backend/marsha/core/lti/__init__.py
@@ -313,6 +313,19 @@ class LTI:
         """
         return self.request.POST.get("launch_presentation_locale", "en")
 
+    @property
+    def username(self):
+        """Username of the authenticated user.
+
+        Returns
+        -------
+        string
+            The username of the authenticated user.
+        """
+        return self.request.POST.get("lis_person_sourcedid") or self.request.POST.get(
+            "ext_user_username"
+        )
+
 
 class LTIUser:
     """

--- a/src/backend/marsha/core/lti/__init__.py
+++ b/src/backend/marsha/core/lti/__init__.py
@@ -326,6 +326,11 @@ class LTI:
             "ext_user_username"
         )
 
+    @property
+    def email(self):
+        """Email of the authenticated user."""
+        return self.request.POST.get("lis_person_contact_email_primary")
+
 
 class LTIUser:
     """

--- a/src/backend/marsha/core/serializers/video.py
+++ b/src/backend/marsha/core/serializers/video.py
@@ -479,7 +479,9 @@ class VideoSerializer(VideoBaseSerializer):
         Dictionnary
             A dictionary containing all info needed to manage a connection to a xmpp server.
         """
-        user_id = self.context.get("user_id") or self.context.get("session_id")
+        user_id = self.context.get("user", {}).get("id") or self.context.get(
+            "session_id"
+        )
         if settings.LIVE_CHAT_ENABLED and user_id and obj.live_state is not None:
             roles = self.context.get("roles", [])
             is_admin = bool(LTI_ROLES[ADMINISTRATOR] & set(roles))

--- a/src/backend/marsha/core/tests/test_api_organization.py
+++ b/src/backend/marsha/core/tests/test_api_organization.py
@@ -24,7 +24,10 @@ class OrganizationAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         response = self.client.post(
             "/api/organizations/",
@@ -48,7 +51,10 @@ class OrganizationAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         response = self.client.get(
             f"/api/organizations/{organization.id}/",
@@ -67,7 +73,10 @@ class OrganizationAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         response = self.client.get(
             f"/api/organizations/{organization.id}/",
@@ -86,7 +95,10 @@ class OrganizationAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": str(user.username),
+        }
 
         response = self.client.get(
             f"/api/organizations/{organization.id}/",
@@ -119,7 +131,10 @@ class OrganizationAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         response = self.client.get(
             "/api/organizations/",
@@ -137,7 +152,10 @@ class OrganizationAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         response = self.client.get(
             "/api/organizations/",
@@ -162,7 +180,10 @@ class OrganizationAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         response = self.client.delete(
             f"/api/organizations/{organization.id}/",
@@ -182,7 +203,10 @@ class OrganizationAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         response = self.client.delete(
             f"/api/organizations/{organization.id}/",
@@ -209,7 +233,10 @@ class OrganizationAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         response = self.client.put(
             f"/api/organizations/{organization.id}/",
@@ -231,7 +258,10 @@ class OrganizationAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         response = self.client.put(
             f"/api/organizations/{organization.id}/",

--- a/src/backend/marsha/core/tests/test_api_playlist.py
+++ b/src/backend/marsha/core/tests/test_api_playlist.py
@@ -38,7 +38,10 @@ class PlaylistAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         response = self.client.post(
             "/api/playlists/",
@@ -67,7 +70,10 @@ class PlaylistAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         response = self.client.post(
             "/api/playlists/",
@@ -92,7 +98,10 @@ class PlaylistAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         response = self.client.post(
             "/api/playlists/",
@@ -117,7 +126,10 @@ class PlaylistAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         self.assertEqual(models.Playlist.objects.count(), 0)
 
@@ -166,7 +178,10 @@ class PlaylistAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         response = self.client.get(
             f"/api/playlists/{playlist.id}/",
@@ -185,7 +200,10 @@ class PlaylistAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         response = self.client.get(
             f"/api/playlists/{playlist.id}/",
@@ -204,7 +222,10 @@ class PlaylistAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         response = self.client.get(
             f"/api/playlists/{playlist.id}/",
@@ -241,7 +262,10 @@ class PlaylistAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         response = self.client.get(
             f"/api/playlists/{playlist.id}/",
@@ -284,7 +308,10 @@ class PlaylistAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         response = self.client.get(
             "/api/playlists/",
@@ -317,7 +344,10 @@ class PlaylistAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         response = self.client.get(
             "/api/playlists/",
@@ -388,7 +418,10 @@ class PlaylistAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         response = self.client.get(
             f"/api/playlists/?organization={str(org_1.id)}",
@@ -435,7 +468,10 @@ class PlaylistAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         response = self.client.delete(
             f"/api/playlists/{playlist.id}/",
@@ -455,7 +491,10 @@ class PlaylistAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         response = self.client.delete(
             f"/api/playlists/{playlist.id}/",
@@ -483,7 +522,10 @@ class PlaylistAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         response = self.client.delete(
             f"/api/playlists/{playlist.id}/",
@@ -504,7 +546,10 @@ class PlaylistAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         response = self.client.delete(
             f"/api/playlists/{playlist.id}/",

--- a/src/backend/marsha/core/tests/test_api_user.py
+++ b/src/backend/marsha/core/tests/test_api_user.py
@@ -39,7 +39,11 @@ class UserAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": str(user.username),
+        }
+        print(jwt_token.payload["user"])
 
         with self.assertNumQueries(3):
             response = self.client.get(

--- a/src/backend/marsha/core/tests/test_api_video.py
+++ b/src/backend/marsha/core/tests/test_api_video.py
@@ -420,7 +420,10 @@ class VideoAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         response = self.client.get(
             f"/api/videos/{video.id}/",
@@ -441,7 +444,10 @@ class VideoAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         response = self.client.get(
             f"/api/videos/{video.id}/",
@@ -483,7 +489,10 @@ class VideoAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         response = self.client.get(
             f"/api/videos/{video.id}/",
@@ -503,7 +512,10 @@ class VideoAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         response = self.client.get(
             f"/api/videos/{video.id}/",
@@ -578,7 +590,10 @@ class VideoAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         response = self.client.get(
             "/api/videos/", HTTP_AUTHORIZATION=f"Bearer {jwt_token}"
@@ -611,7 +626,10 @@ class VideoAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         response = self.client.get(
             "/api/videos/", HTTP_AUTHORIZATION=f"Bearer {jwt_token}"
@@ -682,7 +700,10 @@ class VideoAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         response = self.client.get(
             "/api/videos/", HTTP_AUTHORIZATION=f"Bearer {jwt_token}"
@@ -757,7 +778,10 @@ class VideoAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         response = self.client.get(
             f"/api/videos/?playlist={playlist.id}",
@@ -785,7 +809,10 @@ class VideoAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         response = self.client.get(
             f"/api/videos/?playlist={first_playlist.id}",
@@ -845,7 +872,10 @@ class VideoAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         response = self.client.get(
             f"/api/videos/?playlist={first_playlist.id}",
@@ -900,8 +930,10 @@ class VideoAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
-
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
         response = self.client.get(
             f"/api/videos/?organization={organization.id}",
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
@@ -932,7 +964,10 @@ class VideoAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         response = self.client.get(
             f"/api/videos/?organization={organization.id}",
@@ -991,7 +1026,10 @@ class VideoAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         response = self.client.get(
             f"/api/videos/?organization={organization.id}",
@@ -1166,7 +1204,10 @@ class VideoAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         self.assertEqual(models.Video.objects.count(), 0)
 
@@ -1216,8 +1257,10 @@ class VideoAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
-
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
         self.assertEqual(models.Video.objects.count(), 0)
 
         response = self.client.post(
@@ -1244,7 +1287,10 @@ class VideoAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         self.assertEqual(models.Video.objects.count(), 0)
 
@@ -1276,7 +1322,10 @@ class VideoAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         self.assertEqual(models.Video.objects.count(), 0)
 
@@ -1309,7 +1358,10 @@ class VideoAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         self.assertEqual(models.Video.objects.count(), 0)
 
@@ -1364,7 +1416,10 @@ class VideoAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         self.assertEqual(models.Video.objects.count(), 0)
 
@@ -1628,7 +1683,10 @@ class VideoAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         response = self.client.patch(
             f"/api/videos/{video.id}/",
@@ -1653,7 +1711,10 @@ class VideoAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         response = self.client.patch(
             f"/api/videos/{video.id}/",
@@ -1677,7 +1738,10 @@ class VideoAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         response = self.client.patch(
             f"/api/videos/{video.id}/",
@@ -1701,7 +1765,10 @@ class VideoAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         response = self.client.patch(
             f"/api/videos/{video.id}/",
@@ -1726,7 +1793,10 @@ class VideoAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         response = self.client.put(
             f"/api/videos/{video.id}/",
@@ -1751,7 +1821,10 @@ class VideoAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         response = self.client.put(
             f"/api/videos/{video.id}/",
@@ -1775,7 +1848,10 @@ class VideoAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         response = self.client.put(
             f"/api/videos/{video.id}/",
@@ -1799,7 +1875,10 @@ class VideoAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         response = self.client.put(
             f"/api/videos/{video.id}/",
@@ -1870,7 +1949,10 @@ class VideoAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         self.assertEqual(models.Video.objects.count(), 1)
 
@@ -1897,7 +1979,10 @@ class VideoAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         self.assertEqual(models.Video.objects.count(), 1)
 
@@ -1926,7 +2011,10 @@ class VideoAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         self.assertEqual(models.Video.objects.count(), 1)
 
@@ -1955,7 +2043,10 @@ class VideoAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         self.assertEqual(models.Video.objects.count(), 1)
 
@@ -2151,7 +2242,10 @@ class VideoAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         # Get the upload policy for this video
         # It should generate a key file with the Unix timestamp of the present time
@@ -2190,7 +2284,10 @@ class VideoAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         # Get the upload policy for this video
         # It should generate a key file with the Unix timestamp of the present time
@@ -2254,7 +2351,10 @@ class VideoAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
 
         # Get the upload policy for this video
         # It should generate a key file with the Unix timestamp of the present time
@@ -2292,8 +2392,10 @@ class VideoAPITest(TestCase):
 
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user_id"] = str(user.id)
-
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+            "username": user.username,
+        }
         # Get the upload policy for this video
         # It should generate a key file with the Unix timestamp of the present time
         now = datetime(2018, 8, 8, tzinfo=pytz.utc)
@@ -2720,7 +2822,7 @@ class VideoAPITest(TestCase):
         jwt_token.payload["resource_id"] = str(video.id)
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
         jwt_token.payload["permissions"] = {"can_update": True}
-        jwt_token.payload["user_id"] = "56255f3807599c377bf0e5bf072359fd"
+        jwt_token.payload["user"] = {"id": "56255f3807599c377bf0e5bf072359fd"}
 
         # start a live video,
         with mock.patch.object(api, "start_live_channel"), mock.patch.object(

--- a/src/backend/marsha/core/tests/test_api_xapi_statement.py
+++ b/src/backend/marsha/core/tests/test_api_xapi_statement.py
@@ -34,7 +34,10 @@ class XAPIStatementApiTest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(video.id)
         jwt_token.payload["roles"] = ["student"]
-        jwt_token.payload["user_id"] = "John Doe"
+        jwt_token.payload["user"] = {
+            "id": "John Doe",
+            "username": "john_doe",
+        }
         jwt_token.payload["course"] = {
             "school_name": None,
             "course_name": None,
@@ -132,7 +135,10 @@ class XAPIStatementApiTest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(video.id)
         jwt_token.payload["roles"] = ["student"]
-        jwt_token.payload["user_id"] = "John Doe"
+        jwt_token.payload["user"] = {
+            "id": "John Doe",
+            "username": "john_doe",
+        }
         jwt_token.payload["course"] = {
             "school_name": None,
             "course_name": None,
@@ -180,7 +186,10 @@ class XAPIStatementApiTest(TestCase):
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(video.id)
         jwt_token.payload["roles"] = ["student"]
-        jwt_token.payload["user_id"] = "John Doe"
+        jwt_token.payload["user"] = {
+            "id": "John Doe",
+            "username": "john_doe",
+        }
         jwt_token.payload["course"] = {
             "school_name": None,
             "course_name": None,
@@ -210,8 +219,8 @@ class XAPIStatementApiTest(TestCase):
         self.assertEqual(response.status_code, 204)
 
     @mock.patch("marsha.core.api.Video.objects.get")
-    def test_xapi_statement_with_missing_user_id(self, video_model_mock):
-        """Missing user_id parameter in JWT will fail request to LRS."""
+    def test_xapi_statement_with_missing_user(self, video_model_mock):
+        """Missing user parameter in JWT will fail request to LRS."""
         video = VideoFactory(
             playlist__consumer_site__lrs_url="http://lrs.com/data/xAPI",
             playlist__consumer_site__lrs_auth_token="Basic ThisIsABasicAuth",

--- a/src/backend/marsha/core/tests/test_lti.py
+++ b/src/backend/marsha/core/tests/test_lti.py
@@ -609,7 +609,7 @@ class LTITestCase(TestCase):
         self.assertIsNone(lti.username)
 
     def test_lti_email(self):
-        """Email value is return when present."""
+        """Email value is returned when present."""
         ConsumerSiteLTIPassportFactory(
             oauth_consumer_key="ABC123", consumer_site__domain="testserver"
         )
@@ -633,7 +633,7 @@ class LTITestCase(TestCase):
         self.assertEqual(lti.email, "jane@doe.me")
 
     def test_lti_email_no_email(self):
-        """When email is missing None is return."""
+        """When email is missing None is returned."""
         ConsumerSiteLTIPassportFactory(
             oauth_consumer_key="ABC123", consumer_site__domain="testserver"
         )

--- a/src/backend/marsha/core/tests/test_lti.py
+++ b/src/backend/marsha/core/tests/test_lti.py
@@ -536,3 +536,121 @@ class LTITestCase(TestCase):
         lti = LTI(request, uuid.uuid4())
         self.assertTrue(lti.verify())
         self.assertEqual(lti.get_consumer_site(), passport.consumer_site)
+
+    def test_lti_username_edx_format(self):
+        """Return username for edx request."""
+        ConsumerSiteLTIPassportFactory(
+            oauth_consumer_key="ABC123", consumer_site__domain="testserver"
+        )
+        data = {
+            "resource_link_id": "df7",
+            "context_id": "13245",
+            "roles": "Student",
+            "oauth_consumer_key": "ABC123",
+            "tool_consumer_instance_name": "ufr",
+            "context_title": "mathematics",
+            "lis_person_sourcedid": "jane_doe",
+        }
+        resource_id = uuid.uuid4()
+        request = self.factory.post(
+            "/lti/videos/{!s}".format(resource_id),
+            data,
+            HTTP_X_FORWARDED_PROTO="https",
+            HTTP_REFERER="http://testserver/lti-video/",
+        )
+        lti = LTI(request, resource_id)
+        self.assertEqual(lti.username, "jane_doe")
+
+    def test_lti_username_moodle_format(self):
+        """Return username for moodle request."""
+        ConsumerSiteLTIPassportFactory(
+            oauth_consumer_key="ABC123", consumer_site__domain="testserver"
+        )
+        data = {
+            "resource_link_id": "df7",
+            "context_id": "13245",
+            "roles": "Student",
+            "oauth_consumer_key": "ABC123",
+            "tool_consumer_instance_name": "ufr",
+            "context_title": "mathematics",
+            "ext_user_username": "jane_doe",
+        }
+        resource_id = uuid.uuid4()
+        request = self.factory.post(
+            "/lti/videos/{!s}".format(resource_id),
+            data,
+            HTTP_X_FORWARDED_PROTO="https",
+            HTTP_REFERER="http://testserver/lti-video/",
+        )
+        lti = LTI(request, resource_id)
+        self.assertEqual(lti.username, "jane_doe")
+
+    def test_lti_username_no_username(self):
+        """When there is no username None should be returned."""
+        ConsumerSiteLTIPassportFactory(
+            oauth_consumer_key="ABC123", consumer_site__domain="testserver"
+        )
+        data = {
+            "resource_link_id": "df7",
+            "context_id": "13245",
+            "roles": "Student",
+            "oauth_consumer_key": "ABC123",
+            "tool_consumer_instance_name": "ufr",
+            "context_title": "mathematics",
+        }
+        resource_id = uuid.uuid4()
+        request = self.factory.post(
+            "/lti/videos/{!s}".format(resource_id),
+            data,
+            HTTP_X_FORWARDED_PROTO="https",
+            HTTP_REFERER="http://testserver/lti-video/",
+        )
+        lti = LTI(request, resource_id)
+        self.assertIsNone(lti.username)
+
+    def test_lti_email(self):
+        """Email value is return when present."""
+        ConsumerSiteLTIPassportFactory(
+            oauth_consumer_key="ABC123", consumer_site__domain="testserver"
+        )
+        data = {
+            "resource_link_id": "df7",
+            "context_id": "13245",
+            "roles": "Student",
+            "oauth_consumer_key": "ABC123",
+            "tool_consumer_instance_name": "ufr",
+            "context_title": "mathematics",
+            "lis_person_contact_email_primary": "jane@doe.me",
+        }
+        resource_id = uuid.uuid4()
+        request = self.factory.post(
+            "/lti/videos/{!s}".format(resource_id),
+            data,
+            HTTP_X_FORWARDED_PROTO="https",
+            HTTP_REFERER="http://testserver/lti-video/",
+        )
+        lti = LTI(request, resource_id)
+        self.assertEqual(lti.email, "jane@doe.me")
+
+    def test_lti_email_no_email(self):
+        """When email is missing None is return."""
+        ConsumerSiteLTIPassportFactory(
+            oauth_consumer_key="ABC123", consumer_site__domain="testserver"
+        )
+        data = {
+            "resource_link_id": "df7",
+            "context_id": "13245",
+            "roles": "Student",
+            "oauth_consumer_key": "ABC123",
+            "tool_consumer_instance_name": "ufr",
+            "context_title": "mathematics",
+        }
+        resource_id = uuid.uuid4()
+        request = self.factory.post(
+            "/lti/videos/{!s}".format(resource_id),
+            data,
+            HTTP_X_FORWARDED_PROTO="https",
+            HTTP_REFERER="http://testserver/lti-video/",
+        )
+        lti = LTI(request, resource_id)
+        self.assertIsNone(lti.email)

--- a/src/backend/marsha/core/tests/test_views_lti_cache.py
+++ b/src/backend/marsha/core/tests/test_views_lti_cache.py
@@ -58,6 +58,7 @@ class CacheLTIViewTestCase(TestCase):
             "context_id": video1.playlist.lti_id,
             "roles": "student",
             "user_id": "111",
+            "lis_person_sourcedid": "jane_doe",
         }
 
         with self.assertNumQueries(6):
@@ -137,6 +138,7 @@ class CacheLTIViewTestCase(TestCase):
             "context_id": video.playlist.lti_id,
             "roles": "instructor",
             "user_id": "111",
+            "lis_person_sourcedid": "jane_doe",
         }
 
         with self.assertNumQueries(6):

--- a/src/backend/marsha/core/tests/test_views_lti_development.py
+++ b/src/backend/marsha/core/tests/test_views_lti_development.py
@@ -50,6 +50,7 @@ class DevelopmentLTIViewTestCase(TestCase):
             "tool_consumer_instance_name": "ufr",
             "tool_consumer_instance_guid": "example.com",
             "user_id": "56255f3807599c377bf0e5bf072359fd",
+            "lis_person_sourcedid": "jane_doe",
             "launch_presentation_locale": "fr",
         }
         response = self.client.post(
@@ -68,7 +69,13 @@ class DevelopmentLTIViewTestCase(TestCase):
         context = json.loads(unescape(match.group(1)))
         jwt_token = AccessToken(context.get("jwt"))
         self.assertEqual(jwt_token.payload["resource_id"], str(video.id))
-        self.assertEqual(jwt_token.payload["user_id"], data["user_id"])
+        self.assertEqual(
+            jwt_token.payload["user"],
+            {
+                "username": "jane_doe",
+                "id": "56255f3807599c377bf0e5bf072359fd",
+            },
+        )
         self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
         self.assertEqual(jwt_token.payload["roles"], [data["roles"]])
         self.assertEqual(jwt_token.payload["locale"], "fr_FR")
@@ -118,7 +125,13 @@ class DevelopmentLTIViewTestCase(TestCase):
         context = json.loads(unescape(match.group(1)))
         jwt_token = AccessToken(context.get("jwt"))
         self.assertEqual(jwt_token.payload["resource_id"], str(video.id))
-        self.assertEqual(jwt_token.payload["user_id"], data["user_id"])
+        self.assertEqual(
+            jwt_token.payload["user"],
+            {
+                "username": None,
+                "id": "56255f3807599c377bf0e5bf072359fd",
+            },
+        )
         self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
         self.assertEqual(jwt_token.payload["roles"], [data["roles"]])
         self.assertEqual(jwt_token.payload["locale"], "en_US")
@@ -168,6 +181,7 @@ class DevelopmentLTIViewTestCase(TestCase):
             "roles": "instructor",
             "tool_consumer_instance_guid": "example.com",
             "user_id": "56255f3807599c377bf0e5bf072359fd",
+            "lis_person_sourcedid": "jane_doe",
         }
         response = self.client.post(
             "/lti/videos/{!s}".format(uuid.uuid4()),
@@ -185,7 +199,13 @@ class DevelopmentLTIViewTestCase(TestCase):
         jwt_token = AccessToken(context.get("jwt"))
         video = Video.objects.get()
         self.assertEqual(jwt_token.payload["resource_id"], str(video.id))
-        self.assertEqual(jwt_token.payload["user_id"], data["user_id"])
+        self.assertEqual(
+            jwt_token.payload["user"],
+            {
+                "username": "jane_doe",
+                "id": "56255f3807599c377bf0e5bf072359fd",
+            },
+        )
         self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
         self.assertEqual(jwt_token.payload["roles"], [data["roles"]])
         self.assertEqual(jwt_token.payload["locale"], "en_US")
@@ -234,6 +254,7 @@ class DevelopmentLTIViewTestCase(TestCase):
             "roles": role,
             "context_id": video.playlist.lti_id,
             "user_id": "56255f3807599c377bf0e5bf072359fd",
+            "lis_person_sourcedid": "jane_doe",
         }
 
         with self.assertRaises(ImproperlyConfigured):
@@ -255,6 +276,7 @@ class DevelopmentLTIViewTestCase(TestCase):
             "tool_consumer_instance_name": "ufr",
             "tool_consumer_instance_guid": "example.com",
             "user_id": "56255f3807599c377bf0e5bf072359fd",
+            "lis_person_sourcedid": "jane_doe",
             "launch_presentation_locale": "fr",
         }
         response = self.client.post("/lti/videos/{!s}".format(video.pk), data)

--- a/src/backend/marsha/core/tests/test_views_lti_document.py
+++ b/src/backend/marsha/core/tests/test_views_lti_document.py
@@ -43,6 +43,7 @@ class DocumentLTIViewTestCase(TestCase):
             "roles": random.choice(["instructor", "administrator"]),
             "oauth_consumer_key": passport.oauth_consumer_key,
             "user_id": "56255f3807599c377bf0e5bf072359fd",
+            "lis_person_sourcedid": "jane_doe",
             "launch_presentation_locale": "fr",
         }
 
@@ -59,7 +60,13 @@ class DocumentLTIViewTestCase(TestCase):
         context = json.loads(html.unescape(match.group(1)))
         jwt_token = AccessToken(context.get("jwt"))
         self.assertEqual(jwt_token.payload["resource_id"], str(document.id))
-        self.assertEqual(jwt_token.payload["user_id"], data["user_id"])
+        self.assertEqual(
+            jwt_token.payload["user"],
+            {
+                "username": "jane_doe",
+                "id": "56255f3807599c377bf0e5bf072359fd",
+            },
+        )
         self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
         self.assertEqual(jwt_token.payload["roles"], [data["roles"]])
         self.assertEqual(jwt_token.payload["locale"], "fr_FR")
@@ -102,6 +109,7 @@ class DocumentLTIViewTestCase(TestCase):
             "roles": random.choice(["instructor", "administrator"]),
             "oauth_consumer_key": passport.oauth_consumer_key,
             "user_id": "56255f3807599c377bf0e5bf072359fd",
+            "lis_person_sourcedid": "jane_doe",
             "launch_presentation_locale": "fr",
         }
 
@@ -118,7 +126,13 @@ class DocumentLTIViewTestCase(TestCase):
         context = json.loads(html.unescape(match.group(1)))
         jwt_token = AccessToken(context.get("jwt"))
         self.assertEqual(jwt_token.payload["resource_id"], str(document.id))
-        self.assertEqual(jwt_token.payload["user_id"], data["user_id"])
+        self.assertEqual(
+            jwt_token.payload["user"],
+            {
+                "username": "jane_doe",
+                "id": "56255f3807599c377bf0e5bf072359fd",
+            },
+        )
         self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
         self.assertEqual(jwt_token.payload["roles"], [data["roles"]])
         self.assertEqual(jwt_token.payload["locale"], "fr_FR")
@@ -157,6 +171,7 @@ class DocumentLTIViewTestCase(TestCase):
             "roles": "student",
             "oauth_consumer_key": passport.oauth_consumer_key,
             "user_id": "56255f3807599c377bf0e5bf072359fd",
+            "lis_person_sourcedid": "jane_doe",
             "launch_presentation_locale": "fr",
         }
 
@@ -173,7 +188,13 @@ class DocumentLTIViewTestCase(TestCase):
         context = json.loads(html.unescape(match.group(1)))
         jwt_token = AccessToken(context.get("jwt"))
         self.assertEqual(jwt_token.payload["resource_id"], str(document.id))
-        self.assertEqual(jwt_token.payload["user_id"], data["user_id"])
+        self.assertEqual(
+            jwt_token.payload["user"],
+            {
+                "username": "jane_doe",
+                "id": "56255f3807599c377bf0e5bf072359fd",
+            },
+        )
         self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
         self.assertEqual(jwt_token.payload["roles"], [data["roles"]])
         self.assertEqual(jwt_token.payload["locale"], "fr_FR")
@@ -206,6 +227,7 @@ class DocumentLTIViewTestCase(TestCase):
             "roles": "student",
             "oauth_consumer_key": passport.oauth_consumer_key,
             "user_id": "56255f3807599c377bf0e5bf072359fd",
+            "lis_person_sourcedid": "jane_doe",
         }
         mock_get_consumer_site.return_value = passport.consumer_site
 
@@ -240,6 +262,7 @@ class DocumentLTIViewTestCase(TestCase):
             "roles": "instructor",
             "oauth_consumer_key": passport.oauth_consumer_key,
             "user_id": "56255f3807599c377bf0e5bf072359fd",
+            "lis_person_sourcedid": "jane_doe",
         }
         mock_get_consumer_site.return_value = passport.consumer_site
 

--- a/src/backend/marsha/core/tests/test_views_lti_video.py
+++ b/src/backend/marsha/core/tests/test_views_lti_video.py
@@ -65,6 +65,7 @@ class VideoLTIViewTestCase(TestCase):
             "oauth_consumer_key": passport.oauth_consumer_key,
             "user_id": "56255f3807599c377bf0e5bf072359fd",
             "launch_presentation_locale": "fr",
+            "lis_person_sourcedid": "jane_doe",
         }
 
         mock_get_consumer_site.return_value = passport.consumer_site
@@ -80,7 +81,6 @@ class VideoLTIViewTestCase(TestCase):
         context = json.loads(unescape(match.group(1)))
         jwt_token = AccessToken(context.get("jwt"))
         self.assertEqual(jwt_token.payload["resource_id"], str(video.id))
-        self.assertEqual(jwt_token.payload["user_id"], data["user_id"])
         self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
         self.assertEqual(jwt_token.payload["roles"], [data["roles"]])
         self.assertEqual(jwt_token.payload["locale"], "fr_FR")
@@ -91,6 +91,13 @@ class VideoLTIViewTestCase(TestCase):
         self.assertDictEqual(
             jwt_token.payload["course"],
             {"school_name": "ufr", "course_name": "mathematics", "course_run": "00001"},
+        )
+        self.assertDictEqual(
+            jwt_token.payload["user"],
+            {
+                "username": "jane_doe",
+                "id": "56255f3807599c377bf0e5bf072359fd",
+            },
         )
 
         self.assertEqual(context.get("state"), "success")
@@ -180,6 +187,7 @@ class VideoLTIViewTestCase(TestCase):
             "roles": "instructor",
             "oauth_consumer_key": passport.oauth_consumer_key,
             "user_id": "56255f3807599c377bf0e5bf072359fd",
+            "lis_person_sourcedid": "jane_doe",
             "launch_presentation_locale": "fr",
         }
 
@@ -196,7 +204,13 @@ class VideoLTIViewTestCase(TestCase):
         context = json.loads(unescape(match.group(1)))
         jwt_token = AccessToken(context.get("jwt"))
         self.assertEqual(jwt_token.payload["resource_id"], str(video.id))
-        self.assertEqual(jwt_token.payload["user_id"], data["user_id"])
+        self.assertEqual(
+            jwt_token.payload["user"],
+            {
+                "username": "jane_doe",
+                "id": "56255f3807599c377bf0e5bf072359fd",
+            },
+        )
         self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
         self.assertEqual(jwt_token.payload["roles"], [data["roles"]])
         self.assertEqual(jwt_token.payload["locale"], "fr_FR")
@@ -316,6 +330,7 @@ class VideoLTIViewTestCase(TestCase):
             "roles": "instructor",
             "oauth_consumer_key": passport.oauth_consumer_key,
             "user_id": "56255f3807599c377bf0e5bf072359fd",
+            "lis_person_sourcedid": "jane_doe",
             "launch_presentation_locale": "fr",
         }
 
@@ -337,7 +352,13 @@ class VideoLTIViewTestCase(TestCase):
         context = json.loads(unescape(match.group(1)))
         jwt_token = AccessToken(context.get("jwt"))
         self.assertEqual(jwt_token.payload["resource_id"], str(video.id))
-        self.assertEqual(jwt_token.payload["user_id"], data["user_id"])
+        self.assertEqual(
+            jwt_token.payload["user"],
+            {
+                "username": "jane_doe",
+                "id": "56255f3807599c377bf0e5bf072359fd",
+            },
+        )
         self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
         self.assertEqual(jwt_token.payload["roles"], [data["roles"]])
         self.assertEqual(jwt_token.payload["locale"], "fr_FR")
@@ -452,6 +473,7 @@ class VideoLTIViewTestCase(TestCase):
             "roles": "student",
             "oauth_consumer_key": passport.oauth_consumer_key,
             "user_id": "56255f3807599c377bf0e5bf072359fd",
+            "lis_person_sourcedid": "jane_doe",
             "launch_presentation_locale": "fr",
         }
 
@@ -468,7 +490,13 @@ class VideoLTIViewTestCase(TestCase):
         context = json.loads(unescape(match.group(1)))
         jwt_token = AccessToken(context.get("jwt"))
         self.assertEqual(jwt_token.payload["resource_id"], str(video.id))
-        self.assertEqual(jwt_token.payload["user_id"], data["user_id"])
+        self.assertEqual(
+            jwt_token.payload["user"],
+            {
+                "username": "jane_doe",
+                "id": "56255f3807599c377bf0e5bf072359fd",
+            },
+        )
         self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
         self.assertEqual(jwt_token.payload["roles"], [data["roles"]])
         self.assertEqual(jwt_token.payload["locale"], "fr_FR")
@@ -543,6 +571,7 @@ class VideoLTIViewTestCase(TestCase):
             "roles": "administrator",
             "oauth_consumer_key": passport.oauth_consumer_key,
             "user_id": "56255f3807599c377bf0e5bf072359fd",
+            "lis_person_sourcedid": "jane_doe",
             "launch_presentation_locale": "fr",
         }
 
@@ -570,6 +599,7 @@ class VideoLTIViewTestCase(TestCase):
             "roles": "administrator",
             "oauth_consumer_key": passport.oauth_consumer_key,
             "user_id": "56255f3807599c377bf0e5bf072359fd",
+            "lis_person_sourcedid": "jane_doe",
             "launch_presentation_locale": "fr",
         }
 
@@ -586,7 +616,13 @@ class VideoLTIViewTestCase(TestCase):
         context = json.loads(unescape(match.group(1)))
         jwt_token = AccessToken(context.get("jwt"))
         self.assertEqual(jwt_token.payload["resource_id"], str(video.id))
-        self.assertEqual(jwt_token.payload["user_id"], data["user_id"])
+        self.assertEqual(
+            jwt_token.payload["user"],
+            {
+                "username": "jane_doe",
+                "id": "56255f3807599c377bf0e5bf072359fd",
+            },
+        )
         self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
         self.assertEqual(jwt_token.payload["roles"], [data["roles"]])
         self.assertEqual(jwt_token.payload["locale"], "fr_FR")
@@ -656,6 +692,7 @@ class VideoLTIViewTestCase(TestCase):
             "roles": "instructor",
             "oauth_consumer_key": passport.oauth_consumer_key,
             "user_id": "56255f3807599c377bf0e5bf072359fd",
+            "lis_person_sourcedid": "jane_doe",
             "launch_presentation_locale": "fr",
         }
 
@@ -766,6 +803,7 @@ class VideoLTIViewTestCase(TestCase):
             "roles": "student",
             "oauth_consumer_key": passport.oauth_consumer_key,
             "user_id": "56255f3807599c377bf0e5bf072359fd",
+            "lis_person_sourcedid": "jane_doe",
         }
         mock_get_consumer_site.return_value = passport.consumer_site
 
@@ -781,7 +819,13 @@ class VideoLTIViewTestCase(TestCase):
         context = json.loads(unescape(match.group(1)))
         jwt_token = AccessToken(context.get("jwt"))
         self.assertEqual(jwt_token.payload["resource_id"], str(video.id))
-        self.assertEqual(jwt_token.payload["user_id"], data["user_id"])
+        self.assertEqual(
+            jwt_token.payload["user"],
+            {
+                "username": "jane_doe",
+                "id": "56255f3807599c377bf0e5bf072359fd",
+            },
+        )
         self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
         self.assertEqual(jwt_token.payload["roles"], [data["roles"]])
         self.assertEqual(jwt_token.payload["locale"], "en_US")
@@ -874,6 +918,7 @@ class VideoLTIViewTestCase(TestCase):
             "roles": "student",
             "oauth_consumer_key": passport.oauth_consumer_key,
             "user_id": "56255f3807599c377bf0e5bf072359fd",
+            "lis_person_sourcedid": "jane_doe",
         }
         mock_get_consumer_site.return_value = passport.consumer_site
 
@@ -889,7 +934,13 @@ class VideoLTIViewTestCase(TestCase):
         context = json.loads(unescape(match.group(1)))
         jwt_token = AccessToken(context.get("jwt"))
         self.assertEqual(jwt_token.payload["resource_id"], str(video.id))
-        self.assertEqual(jwt_token.payload["user_id"], data["user_id"])
+        self.assertEqual(
+            jwt_token.payload["user"],
+            {
+                "username": "jane_doe",
+                "id": "56255f3807599c377bf0e5bf072359fd",
+            },
+        )
         self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
         self.assertEqual(jwt_token.payload["roles"], [data["roles"]])
         self.assertEqual(jwt_token.payload["locale"], "en_US")
@@ -984,6 +1035,7 @@ class VideoLTIViewTestCase(TestCase):
             "roles": "student",
             "oauth_consumer_key": passport.oauth_consumer_key,
             "user_id": "56255f3807599c377bf0e5bf072359fd",
+            "lis_person_sourcedid": "jane_doe",
         }
         mock_get_consumer_site.return_value = passport.consumer_site
 
@@ -999,7 +1051,13 @@ class VideoLTIViewTestCase(TestCase):
         context = json.loads(unescape(match.group(1)))
         jwt_token = AccessToken(context.get("jwt"))
         self.assertEqual(jwt_token.payload["resource_id"], str(video.id))
-        self.assertEqual(jwt_token.payload["user_id"], data["user_id"])
+        self.assertEqual(
+            jwt_token.payload["user"],
+            {
+                "username": "jane_doe",
+                "id": "56255f3807599c377bf0e5bf072359fd",
+            },
+        )
         self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
         self.assertEqual(jwt_token.payload["roles"], [data["roles"]])
         self.assertEqual(jwt_token.payload["locale"], "en_US")
@@ -1144,6 +1202,7 @@ class VideoLTIViewTestCase(TestCase):
             "roles": "student",
             "oauth_consumer_key": passport.oauth_consumer_key,
             "user_id": "56255f3807599c377bf0e5bf072359fd",
+            "lis_person_sourcedid": "jane_doe",
         }
         mock_get_consumer_site.return_value = passport.consumer_site
 
@@ -1231,6 +1290,7 @@ class VideoLTIViewTestCase(TestCase):
             "roles": "instructor",
             "oauth_consumer_key": passport.oauth_consumer_key,
             "user_id": "56255f3807599c377bf0e5bf072359fd",
+            "lis_person_sourcedid": "jane_doe",
         }
         mock_get_consumer_site.return_value = passport.consumer_site
 
@@ -1266,6 +1326,7 @@ class VideoLTIViewTestCase(TestCase):
             "roles": "instructor",
             "oauth_consumer_key": passport.oauth_consumer_key,
             "user_id": "56255f3807599c377bf0e5bf072359fd",
+            "lis_person_sourcedid": "jane_doe",
             "launch_presentation_locale": "fr",
         }
         mock_get_consumer_site.return_value = passport.consumer_site
@@ -1302,6 +1363,7 @@ class VideoLTIViewTestCase(TestCase):
             "roles": "instructor",
             "oauth_consumer_key": passport.oauth_consumer_key,
             "user_id": "56255f3807599c377bf0e5bf072359fd",
+            "lis_person_sourcedid": "jane_doe",
             "launch_presentation_locale": "fr",
         }
 
@@ -1387,6 +1449,7 @@ class VideoLTIViewTestCase(TestCase):
             "roles": "instructor",
             "oauth_consumer_key": passport.oauth_consumer_key,
             "user_id": "56255f3807599c377bf0e5bf072359fd",
+            "lis_person_sourcedid": "jane_doe",
             "launch_presentation_locale": "fr",
         }
 

--- a/src/backend/marsha/core/tests/test_views_public_video.py
+++ b/src/backend/marsha/core/tests/test_views_public_video.py
@@ -54,6 +54,7 @@ class VideoPublicViewTestCase(TestCase):
             jwt_token.payload["permissions"],
             {"can_access_dashboard": False, "can_update": False},
         )
+        self.assertNotIn("user", jwt_token.payload)
 
         self.assertEqual(
             context.get("resource"),

--- a/src/backend/marsha/core/tests/test_views_site.py
+++ b/src/backend/marsha/core/tests/test_views_site.py
@@ -40,7 +40,9 @@ class SiteViewTestCase(TestCase):
         context = json.loads(unescape(match.group(1)))
         jwt_token = AccessToken(context.get("jwt"))
         self.assertEqual(jwt_token.payload["resource_id"], str(user.id))
-        self.assertEqual(jwt_token.payload["user_id"], str(user.id))
+        jwt_token.payload["user"] = {
+            "id": str(user.id),
+        }
 
         self.assertEqual(context.get("sentry_dsn"), "https://sentry.dsn")
         self.assertEqual(context.get("environment"), "test")

--- a/src/backend/marsha/core/tests/test_xapi.py
+++ b/src/backend/marsha/core/tests/test_xapi.py
@@ -15,8 +15,8 @@ class MockLtiUser:
 class XAPIStatmentTest(TestCase):
     """Test the XAPIStatement class."""
 
-    def test_xapi_statement_missing_user_id(self):
-        """Missing lti user_id should fallback on session_id."""
+    def test_xapi_statement_missing_user(self):
+        """Missing lti user should fallback on session_id."""
         video = VideoFactory(
             id="68333c45-4b8c-4018-a195-5d5e1706b838",
             playlist__consumer_site__domain="example.com",
@@ -106,7 +106,9 @@ class XAPIStatmentTest(TestCase):
         mock_token = mock.MagicMock()
         type(mock_token).payload = mock.PropertyMock(
             return_value={
-                "user_id": "foo",
+                "user": {
+                    "id": "foo",
+                },
                 "course": {
                     "school_name": "ufr",
                     "course_name": "mathematics",

--- a/src/backend/marsha/core/views.py
+++ b/src/backend/marsha/core/views.py
@@ -104,7 +104,7 @@ class SiteView(mixins.WaffleSwitchMixin, TemplateView):
         """Build the context necessary to run the frontend app for the site."""
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(self.request.user.id)
-        jwt_token.payload["user_id"] = str(self.request.user.id)
+        jwt_token.payload["user"] = {"id": str(self.request.user.id)}
 
         app_data = _get_base_app_data()
         app_data.update(
@@ -300,7 +300,10 @@ class BaseLTIView(ABC, TemplateResponseMixin, View):
             )
 
             if user_id:
-                jwt_token.payload["user_id"] = user_id
+                jwt_token.payload["user"] = {
+                    "username": lti.username,
+                    "id": user_id,
+                }
 
             app_data["jwt"] = str(jwt_token)
 

--- a/src/backend/marsha/core/xapi.py
+++ b/src/backend/marsha/core/xapi.py
@@ -46,7 +46,7 @@ class XAPIStatement:
 
         """
         try:
-            user_id = lti_user.user_id
+            user_id = lti_user.user.get("id")
         except AttributeError:
             user_id = lti_user.session_id
 

--- a/src/frontend/types/jwt.ts
+++ b/src/frontend/types/jwt.ts
@@ -1,9 +1,10 @@
+import { Nullable } from '../utils/types';
+
 export interface DecodedJwt {
   context_id: string;
   email: string;
   roles: string[];
   session_id: string;
-  user_id: string;
   resource_id: string;
   locale: string;
   permissions: {
@@ -11,4 +12,8 @@ export interface DecodedJwt {
     can_update: boolean;
   };
   maintenance: boolean;
+  user?: {
+    id: string;
+    username: Nullable<string>;
+  };
 }


### PR DESCRIPTION
## Purpose

The LTI request can send the user username and/or email. We want to use them in the application and in the future match LTI user and site user to authenticate them easily.

## Proposal

The username can be set in two different LTI property, we need to handle this case. Also the JWT token `user_id` property is moved in the newly created `user` property. This property is a dict with user info.

- [x] retrieve username in the LTI request
- [x] retrieve email in the LTI request 
- [x] revamp JWT token removing `user_id` and adding `user` property
- [x] change typescript JWT definition

