### PR TITLE
Improve chat session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Display chat in dashboard during a jitsi live
 - Use chat when a live is publicly available
+- Set chat nickname when user is connected
 
 ### Changed
 

--- a/src/frontend/types/libs/window.d.ts
+++ b/src/frontend/types/libs/window.d.ts
@@ -6,6 +6,9 @@ declare global {
     converse: {
       insertInto: (container: HTMLElement) => void;
       initialize: (options: any) => void;
+      plugins: {
+        add: (name: string, plugin: any) => void;
+      };
     };
     JitsiMeetExternalAPI: JitsiMeetExternalAPI;
   }

--- a/src/frontend/utils/converse.spec.ts
+++ b/src/frontend/utils/converse.spec.ts
@@ -7,6 +7,10 @@ jest.mock('./window', () => ({
     insertInto: jest.fn(),
   },
 }));
+let mockDecodedJwtToken = {};
+jest.mock('../data/appData', () => ({
+  getDecodedJwt: () => mockDecodedJwtToken,
+}));
 
 describe('converseMounter', () => {
   afterEach(() => {
@@ -14,6 +18,11 @@ describe('converseMounter', () => {
   });
 
   it('initializes once converse.js', () => {
+    mockDecodedJwtToken = {
+      user: {
+        username: 'jane_doe',
+      },
+    };
     document.body.innerHTML = '<div id="converse-container"></div>';
 
     const xmpp = {
@@ -53,6 +62,7 @@ describe('converseMounter', () => {
       jid: 'xmpp-server.com',
       modtools_disable_assign: true,
       muc_instant_rooms: false,
+      nickname: 'jane_doe',
       root: expect.any(HTMLDivElement),
       show_client_info: false,
       singleton: true,

--- a/src/frontend/utils/converse.spec.ts
+++ b/src/frontend/utils/converse.spec.ts
@@ -5,6 +5,9 @@ jest.mock('./window', () => ({
   converse: {
     initialize: jest.fn(),
     insertInto: jest.fn(),
+    plugins: {
+      add: jest.fn(),
+    },
   },
 }));
 let mockDecodedJwtToken = {};
@@ -38,6 +41,7 @@ describe('converseMounter', () => {
     // The converse mounter is initialized and converse has not been initialized nor inserted.
     expect(mockWindow.converse.initialize).not.toHaveBeenCalled();
     expect(mockWindow.converse.insertInto).not.toHaveBeenCalled();
+    expect(mockWindow.converse.plugins.add).not.toHaveBeenCalled();
 
     // first call, converse is initialized
     converseManager('#converse-container', xmpp);
@@ -74,6 +78,11 @@ describe('converseMounter', () => {
         spoiler: false,
         toggle_occupants: false,
       },
+      whitelisted_plugins: ['marsha'],
+    });
+    expect(mockWindow.converse.plugins.add).toHaveBeenCalledTimes(1);
+    expect(mockWindow.converse.plugins.add).toHaveBeenCalledWith('marsha', {
+      initialize: expect.any(Function),
     });
     expect(mockWindow.converse.insertInto).not.toHaveBeenCalled();
 
@@ -82,5 +91,6 @@ describe('converseMounter', () => {
 
     expect(mockWindow.converse.initialize).toHaveBeenCalledTimes(1);
     expect(mockWindow.converse.insertInto).toHaveBeenCalledTimes(1);
+    expect(mockWindow.converse.plugins.add).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/frontend/utils/converse.ts
+++ b/src/frontend/utils/converse.ts
@@ -4,6 +4,7 @@ import 'converse.js/dist/emojis.js';
 import 'converse.js/dist/icons.js';
 
 import { converse } from './window';
+import { getDecodedJwt } from '../data/appData';
 import { XMPP } from '../types/tracks';
 
 export const converseMounter = () => {
@@ -30,6 +31,7 @@ export const converseMounter = () => {
         jid: xmpp.jid,
         modtools_disable_assign: true,
         muc_instant_rooms: false,
+        nickname: getDecodedJwt().user?.username,
         root: document.querySelector(containerName),
         show_client_info: false,
         singleton: true,

--- a/src/frontend/utils/converse.ts
+++ b/src/frontend/utils/converse.ts
@@ -14,6 +14,15 @@ export const converseMounter = () => {
     if (hasBeenInitialized) {
       converse.insertInto(document.querySelector(containerName)!);
     } else {
+      converse.plugins.add('marsha', {
+        initialize() {
+          const _converse = this._converse;
+
+          window.addEventListener('beforeunload', () => {
+            _converse.api.user.logout();
+          });
+        },
+      });
       converse.initialize({
         allow_contact_requests: false,
         allow_logout: false,
@@ -43,6 +52,7 @@ export const converseMounter = () => {
           spoiler: false,
           toggle_occupants: false,
         },
+        whitelisted_plugins: ['marsha'],
       });
       hasBeenInitialized = true;
     }


### PR DESCRIPTION
## Purpose

When a user is connected on Marsha we can know the username set in the LTI request. We decided to use this username as chat nickname. Also we log out the chat user when the window is closed to prevent non restorable session when marsha will be used later.

## Proposal

- [x] set chack nickname when username is available
- [x] log chat user when window is closed

