### PR TITLE
✨(front) display a waiting message while live is not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Display chat in dashboard during a jitsi live
 - Use chat when a live is publicly available
 - Set chat nickname when user is connected
+- Display a waiting message while live is not available
 
 ### Changed
 

--- a/src/frontend/Player/createPlayer.spec.ts
+++ b/src/frontend/Player/createPlayer.spec.ts
@@ -1,6 +1,10 @@
+import { waitFor } from '@testing-library/react';
+import fetchMock from 'fetch-mock';
+
 import { videoMockFactory } from '../utils/tests/factories';
 import { createPlayer } from './createPlayer';
 import { createVideojsPlayer } from './createVideojsPlayer';
+import { liveState } from '../types/tracks';
 import { report } from '../utils/errors/report';
 
 jest.mock('jwt-decode', () => {
@@ -23,6 +27,13 @@ jest.mock('../utils/errors/report');
 describe('createPlayer', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.useFakeTimers('modern');
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    fetchMock.restore();
   });
 
   it('creates a videojs instance when type player is videojs', () => {
@@ -49,6 +60,60 @@ describe('createPlayer', () => {
 
     expect(report).toHaveBeenCalledWith(
       Error('player unknown not implemented'),
+    );
+  });
+
+  it('polls the hls link while it does not exists when in live mode', async () => {
+    fetchMock.mock('https://marsha.education/live.m3u8', 404);
+    const video = videoMockFactory({
+      live_state: liveState.RUNNING,
+      urls: {
+        manifests: {
+          hls: 'https://marsha.education/live.m3u8',
+        },
+        mp4: {},
+        thumbnails: {},
+      },
+    });
+    const ref = document.createElement('video');
+    const dispatchPlayerTimeUpdate = jest.fn();
+
+    const promise = createPlayer(
+      'videojs',
+      ref,
+      dispatchPlayerTimeUpdate,
+      video,
+    );
+
+    await waitFor(() => {
+      expect(
+        fetchMock.calls('https://marsha.education/live.m3u8', {
+          method: 'GET',
+        }),
+      ).toHaveLength(1);
+    });
+
+    fetchMock.mock('https://marsha.education/live.m3u8', 200, {
+      overwriteRoutes: true,
+    });
+
+    jest.advanceTimersToNextTimer();
+
+    await waitFor(() => {
+      expect(
+        fetchMock.calls('https://marsha.education/live.m3u8', {
+          method: 'GET',
+        }),
+      ).toHaveLength(2);
+    });
+
+    await promise;
+
+    expect(createVideojsPlayer).toHaveBeenCalledWith(
+      ref,
+      dispatchPlayerTimeUpdate,
+      video.urls!,
+      video.live_state,
     );
   });
 });

--- a/src/frontend/Player/createPlayer.ts
+++ b/src/frontend/Player/createPlayer.ts
@@ -1,13 +1,34 @@
 import { VideoPlayerCreator } from '../types/VideoPlayer';
 import { createVideojsPlayer } from './createVideojsPlayer';
 import { report } from '../utils/errors/report';
+import { VideoUrls } from '../types/tracks';
 
-export const createPlayer: VideoPlayerCreator = (
+const pollForLive = async (urls: VideoUrls): Promise<null> => {
+  try {
+    const response = await fetch(urls.manifests.hls);
+    if (response.status === 404) {
+      throw new Error('missing manifest');
+    }
+  } catch (error) {
+    await new Promise((resolve) => window.setTimeout(resolve, 1000));
+    return await pollForLive(urls);
+  }
+
+  return null;
+};
+
+export const createPlayer: VideoPlayerCreator = async (
   type,
   ref,
   dispatchPlayerTimeUpdate,
   video,
 ) => {
+  if (video.live_state) {
+    ref.classList.add('offscreen');
+    await pollForLive(video.urls!);
+    ref.classList.remove('offscreen');
+  }
+
   switch (type) {
     case 'videojs':
       const player = createVideojsPlayer(

--- a/src/frontend/scss/_main.scss
+++ b/src/frontend/scss/_main.scss
@@ -1,3 +1,6 @@
 
 // Icomoon font
 @import './vendor/icomoon';
+
+// Generic stuff
+@import './generic/accessibility';

--- a/src/frontend/scss/generic/accessibility.scss
+++ b/src/frontend/scss/generic/accessibility.scss
@@ -1,0 +1,6 @@
+// Helper class to hide elements from sighted users and have accessibility devices still read them
+// to users that need it.
+.offscreen {
+    position: absolute;
+    left: -9999rem;
+  }

--- a/src/frontend/types/VideoPlayer.ts
+++ b/src/frontend/types/VideoPlayer.ts
@@ -11,4 +11,4 @@ export type VideoPlayerCreator = (
   ref: HTMLVideoElement,
   dispatchPlayerTimeUpdate: (time: number) => void,
   video: Video,
-) => Maybe<VideoPlayerInterface>;
+) => Promise<Maybe<VideoPlayerInterface>>;


### PR DESCRIPTION
## Purpose

When a live begins, you have to wait a few seconds before the hls
manifest is created and available. If the player starts fetching this
missing manifest, it fails and never restart. We choose to poll the
manifest while it returns a 200 status code and then the player is
created. A waiting message is display during this period.

## Proposal

- [x] poll manifest while available
- [x] display a wiating message in the same time.

