### PR TITLE
🐛(front) disable speed menu for live video

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Prevent to display a deleted video
+- Disable video speed menu for live video
 
 ### Removed
 

--- a/src/frontend/Player/createVideojsPlayer.spec.tsx
+++ b/src/frontend/Player/createVideojsPlayer.spec.tsx
@@ -223,6 +223,7 @@ describe('createVideoJsPlayer', () => {
       { type: 'application/x-mpegURL', src: 'https://example.com/hls' },
     ]);
     expect(player.options_.liveui).toBe(true);
+    expect(player.options_.playbackRates).toEqual([]);
   });
 
   it('sends xapi events', () => {

--- a/src/frontend/Player/createVideojsPlayer.ts
+++ b/src/frontend/Player/createVideojsPlayer.ts
@@ -80,7 +80,7 @@ export const createVideojsPlayer = (
     },
     language: intl.locale,
     liveui: live !== null,
-    playbackRates: [0.5, 0.75, 1, 1.25, 1.5, 1.75, 2, 4],
+    playbackRates: live ? [] : [0.5, 0.75, 1, 1.25, 1.5, 1.75, 2, 4],
     plugins,
     responsive: true,
     sources,


### PR DESCRIPTION
## Purpose

For a live video we must disable the speed menu, it's not possible to
read the video faster or slower.

## Proposal

Description...

- [x] disable speed menu for live video

