### PR TITLE
Fix storybook build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -404,6 +404,23 @@ jobs:
           name: Run tests
           command: yarn test -w 1
 
+  test-storybook-build:
+    docker:
+      - image: circleci/node:14
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
+    working_directory: ~/marsha/src/frontend
+    steps:
+      - checkout:
+          path: ~/marsha
+      - restore_cache:
+          keys:
+            - v4-front-dependencies-{{ checksum "yarn.lock" }}
+      - run:
+          name: Ensure storybook builds
+          command: yarn build-storybook
+
   test-e2e:
     docker:
       - image: mcr.microsoft.com/playwright:focal
@@ -996,6 +1013,12 @@ workflows:
             tags:
               only: /.*/
       - test-front:
+          requires:
+            - build-front
+          filters:
+            tags:
+              only: /.*/
+      - test-storybook-build:
           requires:
             - build-front
           filters:

--- a/src/frontend/.storybook/main.js
+++ b/src/frontend/.storybook/main.js
@@ -1,4 +1,11 @@
 module.exports = {
   stories: ['../components/**/*.stories.@(js|jsx|ts|tsx)'],
   addons: ['@storybook/addon-a11y', '@storybook/addon-essentials'],
+
+  // workaround for https://github.com/storybookjs/storybook/issues/15067
+  // storybook 6.3 should fix it
+  typescript: {
+    // also valid 'react-docgen-typescript' | false
+    reactDocgen: 'react-docgen',
+  },
 };


### PR DESCRIPTION
## Purpose

A [recent commit](https://github.com/openfun/marsha/commit/bbfe50a6201c605cf4242e4ba0cedb986a05ed1c#diff-12ee508ecc1901fe1a1d71ed459dba8454f3160983ee18b2c51b76ade45235d3) from Renovate Bot broke storybook build.

Related issue: https://github.com/storybookjs/storybook/issues/15067

## Proposal

Thanks to @jbpenrath, who find a solution, a config is added to storybook as a workaround until version 6.3.
Also, to prevent future similar issues, a job has been added to Circle CI for running a storybook build.

- [X] Add a temborary fix to storybook config
- [X] Add a job to Circle CI to prevent future breaks

