### PR TITLE
🐛(front) manage jitsi recording interruption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Prevent to display a deleted video
 - Disable video speed menu for live video
+- Manage jitsi recording interruption
 
 ### Removed
 

--- a/src/frontend/components/DashboardVideoLiveJitsi/index.spec.tsx
+++ b/src/frontend/components/DashboardVideoLiveJitsi/index.spec.tsx
@@ -1,16 +1,36 @@
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import React from 'react';
 
 import { LiveModeType, liveState } from '../../types/tracks';
 import { videoMockFactory } from '../../utils/tests/factories';
 import DashboardVideoLiveJitsi from '.';
 
+let events: any = {};
+const dispatch = (eventName: string, eventObject: any) => {
+  events[eventName](eventObject);
+};
+
 const mockExecuteCommand = jest.fn();
 const mockJitsi = jest.fn().mockImplementation(() => ({
   executeCommand: mockExecuteCommand,
+  addListener: (eventName: string, callback: (event: any) => void) => {
+    events[eventName] = callback;
+  },
 }));
+jest.mock('../../utils/errors/report', () => ({ report: jest.fn() }));
 
 describe('<DashboardVideoLiveJitsi />', () => {
+  beforeEach(() => {
+    events = {};
+    jest.clearAllMocks();
+    jest.useFakeTimers('modern');
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
   it('configures jitsi', () => {
     const video = videoMockFactory({
       live_info: {
@@ -93,6 +113,7 @@ describe('<DashboardVideoLiveJitsi />', () => {
       'stopRecording',
       expect.any(String),
     );
+    expect(events.recordingStatusChanged).toBeDefined();
 
     // state switch to running, recording must start
     rerender(
@@ -120,5 +141,64 @@ describe('<DashboardVideoLiveJitsi />', () => {
     expect(mockExecuteCommand).toHaveBeenCalledWith('stopRecording', 'stream');
 
     expect(mockExecuteCommand).toHaveBeenCalledTimes(2);
+  });
+
+  it('manages recording interruption', async () => {
+    const video = videoMockFactory({
+      live_info: {
+        medialive: {
+          input: {
+            endpoints: [
+              'rtmp://1.2.3.4:1935/stream-key-primary',
+              'rtmp://4.3.2.1:1935/stream-key-secondary',
+            ],
+          },
+        },
+        jitsi: {
+          domain: 'meet.jit.si',
+          external_api_url: 'https://meet.jit.si/external_api.js',
+          config_overwrite: {},
+          interface_config_overwrite: {},
+        },
+      },
+      live_state: liveState.RUNNING,
+      live_type: LiveModeType.JITSI,
+    });
+    global.JitsiMeetExternalAPI = mockJitsi;
+
+    render(<DashboardVideoLiveJitsi video={video} />);
+
+    expect(events.recordingStatusChanged).toBeDefined();
+
+    expect(mockExecuteCommand).toHaveBeenCalledWith('startRecording', {
+      mode: 'stream',
+      rtmpStreamKey: 'rtmp://1.2.3.4:1935/marsha/stream-key-primary',
+    });
+    expect(mockExecuteCommand).not.toHaveBeenCalledWith(
+      'stopRecording',
+      expect.any(String),
+    );
+    expect(mockExecuteCommand).toHaveBeenCalledTimes(1);
+
+    // simulates recording interruption
+    dispatch('recordingStatusChanged', {
+      on: false,
+      mode: 'stream',
+      error: 'service unavailable',
+    });
+
+    jest.advanceTimersToNextTimer();
+
+    await waitFor(() => {
+      expect(mockExecuteCommand).toHaveBeenCalledTimes(2);
+    });
+    expect(mockExecuteCommand).toHaveBeenCalledWith('startRecording', {
+      mode: 'stream',
+      rtmpStreamKey: 'rtmp://1.2.3.4:1935/marsha/stream-key-primary',
+    });
+    expect(mockExecuteCommand).not.toHaveBeenCalledWith(
+      'stopRecording',
+      expect.any(String),
+    );
   });
 });

--- a/src/frontend/types/libs/JitsiMeetExternalAPI/index.d.ts
+++ b/src/frontend/types/libs/JitsiMeetExternalAPI/index.d.ts
@@ -19,6 +19,7 @@ declare class JitsiMeetExternalAPI {
       | JitsiMeetExternalAPI.RecordingMode
       | JitsiMeetExternalAPI.RecordingOptions,
   ) => void;
+  addListener: (eventName: string, callback: (event: any) => void) => void;
 
   dispose: () => void;
 }


### PR DESCRIPTION
## Purpose

Jitsi recording can be stopped. If it's a failure, an event is emitted
we can listen. In this event we wait 1 sec before stating again the
record. While the record is not started the same event is emitted again
and again.

## Proposal

- [x] manage jitsi recording interruption

