### PR TITLE
✨(front) create a component to manage a public video dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Add a parametrized cicrcleci job to run e2e tests on 3 browsers (chromium, firefox and webkit)
 - Move DevelopmentLTIView to a new development directory
 - Add a variable to set frontend video polling interval
+- Add a component responsible to manage public video dashboard
 
 ### Changed
 

--- a/src/frontend/Player/createVideojsPlayer.spec.tsx
+++ b/src/frontend/Player/createVideojsPlayer.spec.tsx
@@ -87,7 +87,11 @@ describe('createVideoJsPlayer', () => {
     mockIsMSESupported.mockReturnValue(true);
     const { container } = render(
       wrapInIntlProvider(
-        <VideoPlayer video={mockVideo} playerType={'videojs'} />,
+        <VideoPlayer
+          video={mockVideo}
+          playerType={'videojs'}
+          timedTextTracks={[]}
+        />,
       ),
     );
 
@@ -128,7 +132,11 @@ describe('createVideoJsPlayer', () => {
     mockIsMSESupported.mockReturnValue(false);
     const { container } = render(
       wrapInIntlProvider(
-        <VideoPlayer video={mockVideo} playerType={'videojs'} />,
+        <VideoPlayer
+          video={mockVideo}
+          playerType={'videojs'}
+          timedTextTracks={[]}
+        />,
       ),
     );
 
@@ -207,7 +215,13 @@ describe('createVideoJsPlayer', () => {
       live_state: liveState.RUNNING,
     });
     const { container } = render(
-      wrapInIntlProvider(<VideoPlayer video={video} playerType={'videojs'} />),
+      wrapInIntlProvider(
+        <VideoPlayer
+          video={video}
+          playerType={'videojs'}
+          timedTextTracks={[]}
+        />,
+      ),
     );
 
     const videoElement = container.querySelector('video');
@@ -229,7 +243,11 @@ describe('createVideoJsPlayer', () => {
   it('sends xapi events', () => {
     const { container } = render(
       wrapInIntlProvider(
-        <VideoPlayer video={mockVideo} playerType={'videojs'} />,
+        <VideoPlayer
+          video={mockVideo}
+          playerType={'videojs'}
+          timedTextTracks={[]}
+        />,
       ),
     );
 

--- a/src/frontend/components/Chat/index.tsx
+++ b/src/frontend/components/Chat/index.tsx
@@ -1,4 +1,4 @@
-import { Box } from 'grommet';
+import { Box, BoxExtendedProps } from 'grommet';
 import React, { useEffect } from 'react';
 
 import { useVideo } from '../../data/stores/useVideo';
@@ -7,24 +7,31 @@ import { converseMounter } from '../../utils/converse';
 
 interface ChatProps {
   video: Video;
+  standalone?: boolean;
 }
 
 const converseManager = converseMounter();
 
-export const Chat = ({ video: baseVideo }: ChatProps) => {
+export const Chat = ({ video: baseVideo, standalone }: ChatProps) => {
   const video = useVideo((state) => state.getVideo(baseVideo));
 
   useEffect(() => {
     converseManager('#converse-container', video.xmpp!);
   }, []);
 
+  const conditionalProps: Partial<BoxExtendedProps> = {};
+  if (standalone) {
+    conditionalProps.height = 'large';
+  } else {
+    conditionalProps.fill = true;
+  }
+
   return (
     <Box
       align="start"
       direction="row"
-      height="large"
-      pad={{ top: 'small' }}
       id="converse-container"
+      {...conditionalProps}
     />
   );
 };

--- a/src/frontend/components/LTIRoutes/index.tsx
+++ b/src/frontend/components/LTIRoutes/index.tsx
@@ -24,6 +24,7 @@ import { LTIUploadHandlers } from '../UploadManager/LTIUploadHandlers';
 const Dashboard = lazy(() => import('../Dashboard'));
 const DocumentPlayer = lazy(() => import('../DocumentPlayer'));
 const VideoPlayer = lazy(() => import('../VideoPlayer'));
+const PublicVideoDashboard = lazy(() => import('../PublicVideoDashboard'));
 
 const Wrappers = ({ children }: React.PropsWithChildren<{}>) => (
   <MemoryRouter>
@@ -45,7 +46,7 @@ export const Routes = () => (
             if (match.params.objectType === modelName.VIDEOS && appData.video) {
               return (
                 <InstructorWrapper resource={appData.video}>
-                  <VideoPlayer
+                  <PublicVideoDashboard
                     video={appData.video}
                     playerType={appData.player!}
                   />
@@ -88,7 +89,7 @@ export const Routes = () => (
             if (appData.modelName === modelName.VIDEOS && appData.video?.xmpp) {
               return (
                 <InstructorWrapper resource={appData.video}>
-                  <Chat video={appData.video} />
+                  <Chat video={appData.video} standalone={true} />
                 </InstructorWrapper>
               );
             }

--- a/src/frontend/components/PublicVideoDashboard/index.spec.tsx
+++ b/src/frontend/components/PublicVideoDashboard/index.spec.tsx
@@ -1,0 +1,281 @@
+import React from 'react';
+import fetchMock from 'fetch-mock';
+import { render, screen, waitFor } from '@testing-library/react';
+import { ImportMock } from 'ts-mock-imports';
+
+import * as useTimedTextTrackModule from '../../data/stores/useTimedTextTrack';
+import { liveState, timedTextMode } from '../../types/tracks';
+import { converseMounter } from '../../utils/converse';
+import {
+  timedTextMockFactory,
+  videoMockFactory,
+} from '../../utils/tests/factories';
+import { wrapInIntlProvider } from '../../utils/tests/intl';
+import { createPlayer } from '../../Player/createPlayer';
+import PublicVideoDashboard from '.';
+
+jest.mock('../../Player/createPlayer', () => ({
+  createPlayer: jest.fn(),
+}));
+
+const mockCreatePlayer = createPlayer as jest.MockedFunction<
+  typeof createPlayer
+>;
+
+const mockVideo = videoMockFactory();
+jest.mock('../../data/appData', () => ({
+  appData: {
+    video: mockVideo,
+  },
+}));
+
+const useTimedTextTrackStub = ImportMock.mockFunction(
+  useTimedTextTrackModule,
+  'useTimedTextTrack',
+);
+
+jest.mock('../../utils/converse', () => ({
+  converseMounter: jest.fn(() => jest.fn()),
+}));
+
+describe('PublicVideoDashboard', () => {
+  beforeEach(() => {
+    fetchMock.mock(
+      '/api/timedtexttracks/',
+      {
+        actions: {
+          POST: {
+            language: {
+              choices: [
+                { display_name: 'English', value: 'en' },
+                { display_name: 'French', value: 'fr' },
+              ],
+            },
+          },
+        },
+      },
+      { method: 'OPTIONS' },
+    );
+    mockCreatePlayer.mockResolvedValue({
+      destroy: jest.fn(),
+    });
+  });
+
+  afterEach(() => {
+    fetchMock.restore();
+    jest.clearAllMocks();
+  });
+  it('displays the video player alone', async () => {
+    useTimedTextTrackStub.returns([]);
+    const video = videoMockFactory({
+      urls: {
+        manifests: {
+          hls: 'https://example.com/hls.m3u8',
+        },
+        mp4: {
+          144: 'https://example.com/144p.mp4',
+          1080: 'https://example.com/1080p.mp4',
+        },
+        thumbnails: {
+          144: 'https://example.com/thumbnail/144p.jpg',
+          1080: 'https://example.com/thumbnail/1080p.jpg',
+        },
+      },
+    });
+
+    const { container } = render(
+      wrapInIntlProvider(
+        <PublicVideoDashboard video={video} playerType="videojs" />,
+      ),
+    );
+
+    await waitFor(() =>
+      // The player is created
+      expect(mockCreatePlayer).toHaveBeenCalledWith(
+        'videojs',
+        expect.any(Element),
+        expect.anything(),
+        video,
+      ),
+    );
+
+    expect(
+      container.querySelector('source[src="https://example.com/144p.mp4"]'),
+    ).not.toBeNull();
+    expect(
+      container.querySelector('source[src="https://example.com/1080p.mp4"]'),
+    ).not.toBeNull();
+    expect(container.querySelectorAll('source[type="video/mp4"]')).toHaveLength(
+      2,
+    );
+    const videoElement = container.querySelector('video')!;
+    expect(videoElement.tabIndex).toEqual(-1);
+    expect(videoElement.poster).toEqual(
+      'https://example.com/thumbnail/1080p.jpg',
+    );
+  });
+  it('displays the video player, the download link and transcripts', async () => {
+    const timedTextTracks = [
+      timedTextMockFactory({
+        is_ready_to_show: true,
+        mode: timedTextMode.TRANSCRIPT,
+      }),
+    ];
+    useTimedTextTrackStub.returns(timedTextTracks);
+    const video = videoMockFactory({
+      has_transcript: true,
+      show_download: true,
+      timed_text_tracks: timedTextTracks,
+      urls: {
+        manifests: {
+          hls: 'https://example.com/hls.m3u8',
+        },
+        mp4: {
+          144: 'https://example.com/144p.mp4',
+          1080: 'https://example.com/1080p.mp4',
+        },
+        thumbnails: {
+          144: 'https://example.com/thumbnail/144p.jpg',
+          1080: 'https://example.com/thumbnail/1080p.jpg',
+        },
+      },
+    });
+
+    const { container } = render(
+      wrapInIntlProvider(
+        <PublicVideoDashboard video={video} playerType="videojs" />,
+      ),
+    );
+
+    await waitFor(() =>
+      // The player is created
+      expect(mockCreatePlayer).toHaveBeenCalledWith(
+        'videojs',
+        expect.any(Element),
+        expect.anything(),
+        video,
+      ),
+    );
+
+    screen.getByText(/Download this video/i);
+    screen.getByText('Show a transcript');
+    expect(
+      container.querySelector('source[src="https://example.com/144p.mp4"]'),
+    ).not.toBeNull();
+    expect(
+      container.querySelector('source[src="https://example.com/1080p.mp4"]'),
+    ).not.toBeNull();
+    expect(container.querySelectorAll('source[type="video/mp4"]')).toHaveLength(
+      2,
+    );
+    const videoElement = container.querySelector('video')!;
+    expect(videoElement.tabIndex).toEqual(-1);
+    expect(videoElement.poster).toEqual(
+      'https://example.com/thumbnail/1080p.jpg',
+    );
+  });
+  it('uses subtitles as transcripts', async () => {
+    const timedTextTracks = [
+      timedTextMockFactory({
+        id: 'ttt-1',
+        is_ready_to_show: true,
+        mode: timedTextMode.SUBTITLE,
+      }),
+    ];
+    useTimedTextTrackStub.returns(timedTextTracks);
+    const video = videoMockFactory({
+      has_transcript: false,
+      show_download: true,
+      should_use_subtitle_as_transcript: true,
+      timed_text_tracks: timedTextTracks,
+      urls: {
+        manifests: {
+          hls: 'https://example.com/hls.m3u8',
+        },
+        mp4: {
+          144: 'https://example.com/144p.mp4',
+          1080: 'https://example.com/1080p.mp4',
+        },
+        thumbnails: {
+          144: 'https://example.com/thumbnail/144p.jpg',
+          1080: 'https://example.com/thumbnail/1080p.jpg',
+        },
+      },
+    });
+
+    const { container } = render(
+      wrapInIntlProvider(
+        <PublicVideoDashboard video={video} playerType="videojs" />,
+      ),
+    );
+
+    await waitFor(() =>
+      // The player is created
+      expect(mockCreatePlayer).toHaveBeenCalledWith(
+        'videojs',
+        expect.any(Element),
+        expect.anything(),
+        video,
+      ),
+    );
+
+    screen.getByText(/Download this video/i);
+    screen.getByText('Show a transcript');
+    expect(
+      container.querySelector('source[src="https://example.com/144p.mp4"]'),
+    ).not.toBeNull();
+    expect(
+      container.querySelector('source[src="https://example.com/1080p.mp4"]'),
+    ).not.toBeNull();
+    expect(container.querySelectorAll('source[type="video/mp4"]')).toHaveLength(
+      2,
+    );
+    const videoElement = container.querySelector('video')!;
+    expect(videoElement.tabIndex).toEqual(-1);
+    expect(videoElement.poster).toEqual(
+      'https://example.com/thumbnail/1080p.jpg',
+    );
+
+    expect(container.querySelector('option[value="ttt-1"]')).not.toBeNull();
+  });
+  it('displays the video player and the chat', async () => {
+    useTimedTextTrackStub.returns([]);
+    const video = videoMockFactory({
+      live_state: liveState.RUNNING,
+      urls: {
+        manifests: {
+          hls: 'https://example.com/hls.m3u8',
+        },
+        mp4: {},
+        thumbnails: {},
+      },
+      xmpp: {
+        bosh_url: 'https://xmpp-server.com/http-bind',
+        conference_url:
+          '870c467b-d66e-4949-8ee5-fcf460c72e88@conference.xmpp-server.com',
+        prebind_url: 'https://xmpp-server.com/http-pre-bind',
+        jid: 'xmpp-server.com',
+      },
+    });
+
+    const { container } = render(
+      wrapInIntlProvider(
+        <PublicVideoDashboard video={video} playerType="videojs" />,
+      ),
+    );
+
+    await waitFor(() =>
+      // The player is created
+      expect(mockCreatePlayer).toHaveBeenCalledWith(
+        'videojs',
+        expect.any(Element),
+        expect.anything(),
+        video,
+      ),
+    );
+
+    const videoElement = container.querySelector('video')!;
+    expect(videoElement.tabIndex).toEqual(-1);
+    expect(container.querySelector('#converse-container')).toBeInTheDocument();
+  });
+});

--- a/src/frontend/components/PublicVideoDashboard/index.tsx
+++ b/src/frontend/components/PublicVideoDashboard/index.tsx
@@ -1,0 +1,66 @@
+import { Box } from 'grommet';
+import React from 'react';
+
+import { Chat } from '../Chat';
+import { DownloadVideo } from '../DownloadVideo';
+import { Transcripts } from '../Transcripts';
+import VideoPlayer from '../VideoPlayer';
+import { useTimedTextTrack } from '../../data/stores/useTimedTextTrack';
+import { useVideo } from '../../data/stores/useVideo';
+import { timedTextMode, TimedTextTranscript, Video } from '../../types/tracks';
+
+interface PublicVideoDashboardProps {
+  video: Video;
+  playerType: string;
+}
+
+const PublicVideoDashboard = ({
+  video: baseVideo,
+  playerType,
+}: PublicVideoDashboardProps) => {
+  const video = useVideo((state) => state.getVideo(baseVideo));
+  const timedTextTracks = useTimedTextTrack((state) =>
+    state.getTimedTextTracks(),
+  );
+
+  if (video.live_state !== null && video.xmpp) {
+    return (
+      <Box direction="row">
+        <Box basis="xlarge">
+          <VideoPlayer
+            video={video}
+            playerType={playerType}
+            timedTextTracks={[]}
+          />
+        </Box>
+        <Box>
+          <Chat video={video} />
+        </Box>
+      </Box>
+    );
+  }
+
+  const transcripts = timedTextTracks
+    .filter((track) => track.is_ready_to_show)
+    .filter((track) =>
+      video.has_transcript === false && video.should_use_subtitle_as_transcript
+        ? timedTextMode.SUBTITLE === track.mode
+        : timedTextMode.TRANSCRIPT === track.mode,
+    );
+
+  return (
+    <Box>
+      <VideoPlayer
+        video={video}
+        playerType={playerType}
+        timedTextTracks={timedTextTracks}
+      />
+      {video.show_download && <DownloadVideo urls={video.urls!} />}
+      {transcripts.length > 0 && (
+        <Transcripts transcripts={transcripts as TimedTextTranscript[]} />
+      )}
+    </Box>
+  );
+};
+
+export default PublicVideoDashboard;


### PR DESCRIPTION
## Purpose

The VideoPlayer was the main component managing the video player but
also every feature linked to the video public part like the download
links, displaying transcripts and the chat. We decided to create a
component dedicated to manage a public video dashboard and depending the
video type it displays the needed components. Splitting it will allow us
to choose how to display the components independently of each other.

## Proposal

- [x] create a component to manage a public video dashboard

