### PR TITLE
♻️(front) rewrite pollForTrack tests

### DIFF
--- a/src/frontend/data/sideEffects/pollForTrack/index.spec.tsx
+++ b/src/frontend/data/sideEffects/pollForTrack/index.spec.tsx
@@ -1,10 +1,15 @@
-import { wait, waitFor } from '@testing-library/react';
+import { waitFor } from '@testing-library/react';
 import fetchMock from 'fetch-mock';
 
 import { pollForTrack } from '.';
 import { requestStatus } from '../../../types/api';
 import { modelName } from '../../../types/models';
 import { report } from '../../../utils/errors/report';
+import {
+  documentMockFactory,
+  timedTextMockFactory,
+  videoMockFactory,
+} from '../../../utils/tests/factories';
 
 jest.mock('../../../utils/errors/report', () => ({ report: jest.fn() }));
 jest.mock('../../appData', () => ({
@@ -14,148 +19,170 @@ jest.mock('../../appData', () => ({
 }));
 
 describe('sideEffects/pollForTrack', () => {
-  jest.useFakeTimers();
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers('modern');
+  });
 
-  afterEach(() => fetchMock.restore());
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    fetchMock.restore();
+  });
 
   it('polls the track, backing off until it is ready and resolves with a success', async () => {
     fetchMock.mock(
-      '/api/videos/42/',
-      JSON.stringify({ is_ready_to_show: false }),
+      '/api/timedtexttracks/c43f0c8f-4d3b-4219-86c3-86367b2b88cc/',
+      JSON.stringify(
+        timedTextMockFactory({
+          id: 'c43f0c8f-4d3b-4219-86c3-86367b2b88cc',
+          is_ready_to_show: false,
+        }),
+      ),
       { method: 'GET' },
     );
-    const promise = pollForTrack(modelName.VIDEOS, '42', 15);
 
-    expect(
-      fetchMock.calls('/api/videos/42/', { method: 'GET' }).length,
-    ).toEqual(1);
-
-    jest.advanceTimersByTime(2 * 15 * 1000 + 200);
-
-    await waitFor(() => {
-      expect(
-        fetchMock.calls('/api/videos/42/', { method: 'GET' }).length,
-      ).toEqual(2);
-    });
-
-    jest.advanceTimersByTime(2 * 3 * 15 * 1000 + 200);
-
-    await waitFor(() => {
-      expect(
-        fetchMock.calls('/api/videos/42/', { method: 'GET' }).length,
-      ).toEqual(3);
-    });
-
-    fetchMock.mock(
-      '/api/videos/42/',
-      JSON.stringify({ is_ready_to_show: true }),
-      { method: 'GET', overwriteRoutes: true },
+    const promise = pollForTrack(
+      modelName.TIMEDTEXTTRACKS,
+      'c43f0c8f-4d3b-4219-86c3-86367b2b88cc',
     );
 
-    jest.advanceTimersByTime(2 * 3 * 4 * 15 * 1000 + 200);
-
     await waitFor(() => {
       expect(
-        fetchMock.calls('/api/videos/42/', { method: 'GET' }).length,
-      ).toEqual(4);
-    });
-
-    expect(await promise).toEqual(requestStatus.SUCCESS);
-
-    jest.advanceTimersByTime(2 * 3 * 4 * 5 * 15 * 1000 + 200);
-
-    await waitFor(() => {
-      // No new calls have been issued
-      expect(
-        fetchMock.calls('/api/videos/42/', { method: 'GET' }).length,
-      ).toEqual(4);
-    });
-  });
-
-  it('polls a document, backing off until it is ready and resolves with a success', async () => {
-    fetchMock.mock(
-      '/api/documents/42/',
-      JSON.stringify({ is_ready_to_show: false }),
-      { method: 'GET' },
-    );
-    const promise = pollForTrack(modelName.DOCUMENTS, '42', 15);
-
-    expect(
-      fetchMock.calls('/api/documents/42/', { method: 'GET' }).length,
-    ).toEqual(1);
-
-    jest.advanceTimersByTime(2 * 15 * 1000 + 200);
-
-    await waitFor(() => {
-      expect(
-        fetchMock.calls('/api/documents/42/', { method: 'GET' }).length,
-      ).toEqual(2);
-    });
-
-    jest.advanceTimersByTime(2 * 3 * 15 * 1000 + 200);
-
-    await waitFor(() => {
-      expect(
-        fetchMock.calls('/api/documents/42/', { method: 'GET' }).length,
-      ).toEqual(3);
+        fetchMock.calls(
+          '/api/timedtexttracks/c43f0c8f-4d3b-4219-86c3-86367b2b88cc/',
+          {
+            method: 'GET',
+          },
+        ),
+      ).toHaveLength(1);
     });
 
     fetchMock.mock(
-      '/api/documents/42/',
-      JSON.stringify({ is_ready_to_show: true }),
-      { method: 'GET', overwriteRoutes: true },
-    );
-
-    jest.advanceTimersByTime(2 * 3 * 4 * 15 * 1000 + 200);
-
-    await waitFor(() => {
-      expect(
-        fetchMock.calls('/api/documents/42/', { method: 'GET' }).length,
-      ).toEqual(4);
-    });
-
-    expect(await promise).toEqual(requestStatus.SUCCESS);
-
-    jest.advanceTimersByTime(2 * 3 * 4 * 5 * 15 * 1000 + 200);
-
-    // No new calls have been issued
-    await waitFor(() => {
-      expect(
-        fetchMock.calls('/api/documents/42/', { method: 'GET' }).length,
-      ).toEqual(4);
-    });
-  });
-
-  it('resolves with a failure and reports it when it fails to poll the track', async () => {
-    fetchMock.mock(
-      '/api/videos/42/',
-      JSON.stringify({ is_ready_to_show: false }),
-      { method: 'GET' },
-    );
-    const promise = pollForTrack(modelName.VIDEOS, '42', 15);
-
-    // The first call was successful
-    expect(
-      fetchMock.calls('/api/videos/42/', { method: 'GET' }).length,
-    ).toEqual(1);
-
-    fetchMock.mock(
-      '/api/videos/42/',
-      { throws: new Error('Failed to get the track') },
+      '/api/timedtexttracks/c43f0c8f-4d3b-4219-86c3-86367b2b88cc/',
+      JSON.stringify(
+        timedTextMockFactory({
+          id: 'c43f0c8f-4d3b-4219-86c3-86367b2b88cc',
+          is_ready_to_show: true,
+        }),
+      ),
       {
         method: 'GET',
         overwriteRoutes: true,
       },
     );
 
-    jest.advanceTimersByTime(2 * 15 * 1000 + 200);
+    jest.runOnlyPendingTimers();
 
     await waitFor(() => {
       expect(
-        fetchMock.calls('/api/videos/42/', { method: 'GET' }).length,
-      ).toEqual(2);
+        fetchMock.calls(
+          '/api/timedtexttracks/c43f0c8f-4d3b-4219-86c3-86367b2b88cc/',
+          {
+            method: 'GET',
+          },
+        ),
+      ).toHaveLength(2);
     });
+
+    expect(await promise).toEqual(requestStatus.SUCCESS);
+  });
+
+  it('polls a document, backing off until it is ready and resolves with a success', async () => {
+    fetchMock.mock(
+      '/api/documents/5704165a-89ee-4378-a2ee-85b8f643ad07/',
+      JSON.stringify(
+        documentMockFactory({
+          id: 'c43f0c8f-4d3b-4219-86c3-86367b2b88cc',
+          is_ready_to_show: false,
+        }),
+      ),
+      { method: 'GET' },
+    );
+
+    const promise = pollForTrack(
+      modelName.DOCUMENTS,
+      '5704165a-89ee-4378-a2ee-85b8f643ad07',
+    );
+
+    await waitFor(() => {
+      expect(
+        fetchMock.calls(
+          '/api/documents/5704165a-89ee-4378-a2ee-85b8f643ad07/',
+          {
+            method: 'GET',
+          },
+        ),
+      ).toHaveLength(1);
+    });
+
+    fetchMock.mock(
+      '/api/documents/5704165a-89ee-4378-a2ee-85b8f643ad07/',
+      JSON.stringify(
+        documentMockFactory({
+          id: '5704165a-89ee-4378-a2ee-85b8f643ad07',
+          is_ready_to_show: true,
+        }),
+      ),
+      {
+        method: 'GET',
+        overwriteRoutes: true,
+      },
+    );
+
+    jest.runOnlyPendingTimers();
+
+    await waitFor(() => {
+      expect(
+        fetchMock.calls(
+          '/api/documents/5704165a-89ee-4378-a2ee-85b8f643ad07/',
+          {
+            method: 'GET',
+          },
+        ),
+      ).toHaveLength(2);
+    });
+
+    expect(await promise).toEqual(requestStatus.SUCCESS);
+  });
+
+  it('resolves with a failure and reports it when it fails to poll the track', async () => {
+    fetchMock.mock(
+      '/api/videos/15cf570a-5dc6-421a-9856-59e1b008a6fb/',
+      JSON.stringify(
+        videoMockFactory({
+          id: 'c43f0c8f-4d3b-4219-86c3-86367b2b88cc',
+          is_ready_to_show: false,
+        }),
+      ),
+      { method: 'GET' },
+    );
+
+    const promise = pollForTrack(
+      modelName.VIDEOS,
+      '15cf570a-5dc6-421a-9856-59e1b008a6fb',
+    );
+
+    await waitFor(() => {
+      expect(
+        fetchMock.calls('/api/videos/15cf570a-5dc6-421a-9856-59e1b008a6fb/', {
+          method: 'GET',
+        }),
+      ).toHaveLength(1);
+    });
+
+    fetchMock.mock(
+      '/api/videos/15cf570a-5dc6-421a-9856-59e1b008a6fb/',
+      Promise.reject(new Error('Failed to get the track')),
+      {
+        method: 'GET',
+        overwriteRoutes: true,
+      },
+    );
+
+    jest.runOnlyPendingTimers();
+
     expect(await promise).toEqual(requestStatus.FAILURE);
-    expect(report).toHaveBeenCalledWith(new Error('Failed to get the track'));
+    expect(report).toHaveBeenCalledWith(Error('Failed to get the track'));
   });
 });

--- a/src/frontend/data/sideEffects/pollForTrack/index.tsx
+++ b/src/frontend/data/sideEffects/pollForTrack/index.tsx
@@ -1,5 +1,3 @@
-import { Dispatch } from 'redux';
-
 import { API_ENDPOINT } from '../../../settings';
 import { requestStatus } from '../../../types/api';
 import { Document } from '../../../types/file';


### PR DESCRIPTION
## Purpose

The pollForTrack tests were failing time to time, only in local, not on
the CI. With jest 27 this test is always failing. We rewrite them using
the modern fake timer implementation and changing how jest timer is used.

## Proposal

- [x] rewrite pollForTrack tests

