### PR TITLE
Wait while a live is ready to be played

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Move DevelopmentLTIView to a new development directory
 - Add a variable to set frontend video polling interval
 - Add a component responsible to manage public video dashboard
+- Add a waiting workflow while a live is not ready
 
 ### Changed
 

--- a/src/backend/marsha/core/api.py
+++ b/src/backend/marsha/core/api.py
@@ -241,10 +241,16 @@ class VideoViewSet(ObjectPkMixin, viewsets.ModelViewSet):
         Default to the actions' self defined permissions if applicable or
         to the ViewSet's default permissions.
         """
-        if self.action in ["retrieve", "partial_update", "update"]:
+        if self.action in ["partial_update", "update"]:
             permission_classes = [
                 permissions.IsTokenResourceRouteObject & permissions.IsTokenInstructor
                 | permissions.IsTokenResourceRouteObject & permissions.IsTokenAdmin
+                | permissions.IsVideoPlaylistAdmin
+                | permissions.IsVideoOrganizationAdmin
+            ]
+        elif self.action in ["retrieve"]:
+            permission_classes = [
+                permissions.IsTokenResourceRouteObject
                 | permissions.IsVideoPlaylistAdmin
                 | permissions.IsVideoOrganizationAdmin
             ]

--- a/src/backend/marsha/core/models/video.py
+++ b/src/backend/marsha/core/models/video.py
@@ -5,7 +5,7 @@ from django.db import models
 from django.utils.functional import lazy
 from django.utils.translation import gettext_lazy as _
 
-from ..defaults import DELETED, HARVESTED, LIVE_CHOICES, LIVE_TYPE_CHOICES, RUNNING
+from ..defaults import DELETED, HARVESTED, LIVE_CHOICES, LIVE_TYPE_CHOICES
 from ..utils.time_utils import to_timestamp
 from .base import BaseModel
 from .file import AbstractImage, BaseFile, UploadableFileMixin
@@ -140,7 +140,7 @@ class Video(BaseFile):
         return (
             self.uploaded_on is not None
             and self.upload_state not in [HARVESTED, DELETED]
-        ) or self.live_state == RUNNING
+        ) or self.live_state is not None
 
     @staticmethod
     def get_ready_clause():
@@ -155,7 +155,7 @@ class Video(BaseFile):
             A condition added to a QuerySet
         """
         return models.Q(uploaded_on__isnull=False, live_state__isnull=True) | models.Q(
-            live_state="running"
+            live_state__isnull=False
         )
 
 

--- a/src/backend/marsha/core/tests/test_api_video.py
+++ b/src/backend/marsha/core/tests/test_api_video.py
@@ -233,7 +233,7 @@ class VideoAPITest(TestCase):
         )
 
     def test_api_video_read_detail_as_instructor_in_read_only(self):
-        """An instructor with read_only set to True should not be able to read the video."""
+        """An instructor with read_only can read the video."""
         video = factories.VideoFactory(upload_state="ready")
 
         jwt_token = AccessToken()
@@ -246,7 +246,7 @@ class VideoAPITest(TestCase):
             "/api/videos/{!s}/".format(video.id),
             HTTP_AUTHORIZATION="Bearer {!s}".format(jwt_token),
         )
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 200)
 
     @override_settings(CLOUDFRONT_SIGNED_URLS_ACTIVE=False)
     def test_api_video_read_detail_token_user_no_active_stamp(self):
@@ -2553,7 +2553,7 @@ class VideoAPITest(TestCase):
                 "id": str(video.id),
                 "title": video.title,
                 "active_stamp": None,
-                "is_ready_to_show": False,
+                "is_ready_to_show": True,
                 "show_download": True,
                 "upload_state": "pending",
                 "thumbnail": None,
@@ -2639,7 +2639,7 @@ class VideoAPITest(TestCase):
                 "id": str(video.id),
                 "title": video.title,
                 "active_stamp": None,
-                "is_ready_to_show": False,
+                "is_ready_to_show": True,
                 "show_download": True,
                 "upload_state": "pending",
                 "thumbnail": None,
@@ -2846,7 +2846,7 @@ class VideoAPITest(TestCase):
                 "id": str(video.id),
                 "title": video.title,
                 "active_stamp": None,
-                "is_ready_to_show": False,
+                "is_ready_to_show": True,
                 "show_download": True,
                 "upload_state": "pending",
                 "thumbnail": None,
@@ -3034,7 +3034,7 @@ class VideoAPITest(TestCase):
                 "id": str(video.id),
                 "title": video.title,
                 "active_stamp": None,
-                "is_ready_to_show": False,
+                "is_ready_to_show": True,
                 "show_download": True,
                 "upload_state": PENDING,
                 "thumbnail": None,

--- a/src/backend/marsha/core/tests/test_lti_utils.py
+++ b/src/backend/marsha/core/tests/test_lti_utils.py
@@ -241,7 +241,10 @@ class PortabilityLTITestCase(TestCase):
         self._test_lti_get_resource_same_playlist_same_site_student_ready_to_show(
             factories.VideoFactory,
             models.Video,
-            {"live_state": "running", "live_type": RAW},
+            {
+                "live_state": random.choice([lc[0] for lc in LIVE_CHOICES]),
+                "live_type": RAW,
+            },
         )
 
     @mock.patch.object(LTIOAuthServer, "verify_request", return_value=True)
@@ -308,26 +311,6 @@ class PortabilityLTITestCase(TestCase):
                 "upload_state": random.choice(
                     [s[0] for s in STATE_CHOICES if s[0] != "ready"]
                 )
-            },
-        )
-
-    @mock.patch.object(LTIOAuthServer, "verify_request", return_value=True)
-    def test_lti_get_video_live_same_playlist_same_site_student_not_ready_to_show(
-        self, mock_verify
-    ):
-        """Above case 1-1-2 live state not running.
-
-        A video live that exists for the requested playlist and consumer site should not be
-        returned to a student if it is not running.
-        """
-        self._test_lti_get_resource_same_playlist_same_site_student_not_ready_to_show(
-            factories.VideoFactory,
-            models.Video,
-            {
-                "live_state": random.choice(
-                    [lc[0] for lc in LIVE_CHOICES if lc[0] != "running"]
-                ),
-                "live_type": RAW,
             },
         )
 
@@ -415,7 +398,10 @@ class PortabilityLTITestCase(TestCase):
         self._test_lti_get_resource_other_site_playlist_portable_ready_to_show(
             factories.VideoFactory,
             models.Video,
-            {"live_state": "running", "live_type": RAW},
+            {
+                "live_state": random.choice([lc[0] for lc in LIVE_CHOICES]),
+                "live_type": RAW,
+            },
         )
 
     @mock.patch.object(LTIOAuthServer, "verify_request", return_value=True)
@@ -499,27 +485,6 @@ class PortabilityLTITestCase(TestCase):
         )
 
     @mock.patch.object(LTIOAuthServer, "verify_request", return_value=True)
-    def test_lti_get_video_live_other_site_playlist_portable_not_ready_to_show_instructor(
-        self, mock_verify
-    ):
-        """Above case 1-2-1-2-1.
-
-        An LTI Exception should be raised if an instructor tries to retrieve a video live that is
-        already existing for a consumer site but not running, even if it is portable to another
-        consumer site.
-        """
-        self._test_lti_get_resource_other_site_playlist_portable_not_ready_to_show_instructor(
-            factories.VideoFactory,
-            models.Video,
-            {
-                "live_state": random.choice(
-                    [lc[0] for lc in LIVE_CHOICES if lc[0] != "running"]
-                ),
-                "live_type": RAW,
-            },
-        )
-
-    @mock.patch.object(LTIOAuthServer, "verify_request", return_value=True)
     def test_lti_get_document_other_site_playlist_portable_not_ready_to_show_instructor(
         self, mock_verify
     ):
@@ -585,27 +550,6 @@ class PortabilityLTITestCase(TestCase):
                 "upload_state": random.choice(
                     [s[0] for s in STATE_CHOICES if s[0] != "ready"]
                 ),
-            },
-        )
-
-    @mock.patch.object(LTIOAuthServer, "verify_request", return_value=True)
-    def test_lti_get_video_live_other_site_playlist_portable_not_ready_to_show_student(
-        self, mock_verify
-    ):
-        """Above case 1-2-1-2-2.
-
-        No video live is returned to a student trying to access a video that is existing
-        for another consumer site but not running, even if it is portable to another consumer
-        site.
-        """
-        self._test_lti_get_resource_other_site_playlist_portable_not_ready_to_show_student(
-            factories.VideoFactory,
-            models.Video,
-            {
-                "live_state": random.choice(
-                    [lc[0] for lc in LIVE_CHOICES if lc[0] != "running"]
-                ),
-                "live_type": RAW,
             },
         )
 
@@ -692,7 +636,10 @@ class PortabilityLTITestCase(TestCase):
         self._test_lti_get_resource_other_site_auto_portable_ready_to_show(
             factories.VideoFactory,
             models.Video,
-            {"live_state": "running", "live_type": RAW},
+            {
+                "live_state": random.choice([lc[0] for lc in LIVE_CHOICES]),
+                "live_type": RAW,
+            },
         )
 
     @mock.patch.object(LTIOAuthServer, "verify_request", return_value=True)
@@ -774,26 +721,6 @@ class PortabilityLTITestCase(TestCase):
         )
 
     @mock.patch.object(LTIOAuthServer, "verify_request", return_value=True)
-    def test_lti_get_video_live_other_site_auto_portable_not_ready_to_show_instructor(
-        self, mock_verify
-    ):
-        """Above case 1-2-2-2-1.
-
-        Same as 1-2-1-2-1 but portability is automatic from the site of the video to the site
-        of the passport.
-        """
-        self._test_lti_get_resource_other_site_auto_portable_not_ready_to_show_instructor(
-            factories.VideoFactory,
-            models.Video,
-            {
-                "live_state": random.choice(
-                    [lc[0] for lc in LIVE_CHOICES if lc[0] != "running"]
-                ),
-                "live_type": RAW,
-            },
-        )
-
-    @mock.patch.object(LTIOAuthServer, "verify_request", return_value=True)
     def test_lti_get_document_other_site_auto_portable_not_ready_to_show_instructor(
         self, mock_verify
     ):
@@ -863,26 +790,6 @@ class PortabilityLTITestCase(TestCase):
                 "upload_state": random.choice(
                     [s[0] for s in STATE_CHOICES if s[0] != "ready"]
                 ),
-            },
-        )
-
-    @mock.patch.object(LTIOAuthServer, "verify_request", return_value=True)
-    def test_lti_get_video_live_other_site_auto_portable_not_ready_to_show_student(
-        self, mock_verify
-    ):
-        """Above case 1-2-2-2-2.
-
-        Same as 1-2-1-2-2 but portability is automatic from the site of the video live to the site
-        of the passport.
-        """
-        self._test_lti_get_resource_other_site_auto_portable_not_ready_to_show_student(
-            factories.VideoFactory,
-            models.Video,
-            {
-                "live_state": random.choice(
-                    [lc[0] for lc in LIVE_CHOICES if lc[0] != "running"]
-                ),
-                "live_type": RAW,
             },
         )
 
@@ -1301,7 +1208,10 @@ class PortabilityLTITestCase(TestCase):
         self._test_lti_get_resource_other_playlist_portable_ready_to_show(
             factories.VideoFactory,
             models.Video,
-            {"live_state": "running", "live_type": RAW},
+            {
+                "live_state": random.choice([lc[0] for lc in LIVE_CHOICES]),
+                "live_type": RAW,
+            },
         )
 
     @mock.patch.object(LTIOAuthServer, "verify_request", return_value=True)
@@ -1381,27 +1291,6 @@ class PortabilityLTITestCase(TestCase):
         )
 
     @mock.patch.object(LTIOAuthServer, "verify_request", return_value=True)
-    def test_lti_get_video_live_other_pl_portable_not_ready_to_show_instructor(
-        self, mock_verify
-    ):
-        """Above case 1-3-1-2-1 for video live.
-
-        A PortabilityError should be raised if an instructor tries to retrieve a video that
-        is already existing in a playlist but not running, even if it is portable to another
-        playlist.
-        """
-        self._test_lti_get_resource_other_pl_portable_not_ready_to_show_instructor(
-            factories.VideoFactory,
-            models.Video,
-            {
-                "live_state": random.choice(
-                    [lc[0] for lc in LIVE_CHOICES if lc[0] != "running"]
-                ),
-                "live_type": RAW,
-            },
-        )
-
-    @mock.patch.object(LTIOAuthServer, "verify_request", return_value=True)
     def test_lti_get_document_other_pl_portable_not_ready_to_show_instructor(
         self, mock_verify
     ):
@@ -1468,26 +1357,6 @@ class PortabilityLTITestCase(TestCase):
                 "upload_state": random.choice(
                     [s[0] for s in STATE_CHOICES if s[0] != "ready"]
                 ),
-            },
-        )
-
-    @mock.patch.object(LTIOAuthServer, "verify_request", return_value=True)
-    def test_lti_get_video_live_other_playlist_portable_not_ready_to_show_student(
-        self, mock_verify
-    ):
-        """Above case 1-3-1-2-2 for video live.
-
-        No video is returned to a student trying to access a video that is existing in another
-        playlist but not running, even if it is portable to another playlist.
-        """
-        self._test_lti_get_resource_other_playlist_portable_not_ready_to_show_student(
-            factories.VideoFactory,
-            models.Video,
-            {
-                "live_state": random.choice(
-                    [lc[0] for lc in LIVE_CHOICES if lc[0] != "running"]
-                ),
-                "live_type": RAW,
             },
         )
 
@@ -1740,7 +1609,10 @@ class PortabilityLTITestCase(TestCase):
         self._test_lti_get_resource_other_pl_site_portable_ready_to_show(
             factories.VideoFactory,
             models.Video,
-            {"live_state": "running", "live_type": RAW},
+            {
+                "live_state": random.choice([lc[0] for lc in LIVE_CHOICES]),
+                "live_type": RAW,
+            },
         )
 
     @mock.patch.object(LTIOAuthServer, "verify_request", return_value=True)
@@ -1823,27 +1695,6 @@ class PortabilityLTITestCase(TestCase):
         )
 
     @mock.patch.object(LTIOAuthServer, "verify_request", return_value=True)
-    def test_lti_get_video_live_other_pl_site_portable_not_ready_to_show_instructor(
-        self, mock_verify
-    ):
-        """Above case 1-4-1-1-2-1 for video live.
-
-        A PortabilityError should be raised if an instructor tries to retrieve a video that is
-        already existing in a playlist on another consumer site but not running, even if it is
-        portable to another playlist AND to another consumer site.
-        """
-        self._test_lti_get_resource_other_pl_site_portable_not_ready_to_show_instructor(
-            factories.VideoFactory,
-            models.Video,
-            {
-                "live_state": random.choice(
-                    [lc[0] for lc in LIVE_CHOICES if lc[0] != "running"]
-                ),
-                "live_type": RAW,
-            },
-        )
-
-    @mock.patch.object(LTIOAuthServer, "verify_request", return_value=True)
     def test_lti_get_document_other_pl_site_portable_not_ready_to_show_instructor(
         self, mock_verify
     ):
@@ -1912,27 +1763,6 @@ class PortabilityLTITestCase(TestCase):
                 "upload_state": random.choice(
                     [s[0] for s in STATE_CHOICES if s[0] != "ready"]
                 ),
-            },
-        )
-
-    @mock.patch.object(LTIOAuthServer, "verify_request", return_value=True)
-    def test_lti_get_video_live_other_pl_site_portable_not_ready_to_show_student(
-        self, mock_verify
-    ):
-        """Above case 1-4-1-1-2-2 for video live.
-
-        No video is returned to a student trying to access a video that is existing in another
-        playlist for another consumer site but not running, even if it is portable to another
-        playlist AND to another consumer site.
-        """
-        self._test_lti_get_resource_other_pl_site_portable_not_ready_to_show_student(
-            factories.VideoFactory,
-            models.Video,
-            {
-                "live_state": random.choice(
-                    [lc[0] for lc in LIVE_CHOICES if lc[0] != "running"]
-                ),
-                "live_type": RAW,
             },
         )
 
@@ -2021,7 +1851,10 @@ class PortabilityLTITestCase(TestCase):
         self._test_lti_get_resource_other_pl_site_auto_portable_ready_to_show(
             factories.VideoFactory,
             models.Video,
-            {"live_state": "running", "live_type": RAW},
+            {
+                "live_state": random.choice([lc[0] for lc in LIVE_CHOICES]),
+                "live_type": RAW,
+            },
         )
 
     @mock.patch.object(LTIOAuthServer, "verify_request", return_value=True)
@@ -2109,26 +1942,6 @@ class PortabilityLTITestCase(TestCase):
         )
 
     @mock.patch.object(LTIOAuthServer, "verify_request", return_value=True)
-    def test_lti_get_video_live_other_pl_site_auto_portable_not_ready_to_show_instructor(
-        self, mock_verify
-    ):
-        """Above case 1-4-1-2-2-1 for Video.
-
-        Same as 1-4-1-1-2-1 but portability is automatic from the site of the video to the site
-        of the passport.
-        """
-        self._test_lti_get_resource_other_pl_site_auto_portable_not_ready_to_show_instructor(
-            factories.VideoFactory,
-            models.Video,
-            {
-                "live_state": random.choice(
-                    [lc[0] for lc in LIVE_CHOICES if lc[0] != "running"]
-                ),
-                "live_type": RAW,
-            },
-        )
-
-    @mock.patch.object(LTIOAuthServer, "verify_request", return_value=True)
     def test_lti_get_document_other_pl_site_auto_portable_not_ready_to_show_instructor(
         self, mock_verify
     ):
@@ -2197,26 +2010,6 @@ class PortabilityLTITestCase(TestCase):
                 "upload_state": random.choice(
                     [s[0] for s in STATE_CHOICES if s[0] != "ready"]
                 ),
-            },
-        )
-
-    @mock.patch.object(LTIOAuthServer, "verify_request", return_value=True)
-    def test_lti_get_video_live_other_pl_site_auto_portable_not_ready_to_show_student(
-        self, mock_verify
-    ):
-        """Above case 1-4-1-2-2-2 for Video.
-
-        Same as 1-4-1-1-2-2 but portability is automatic from the site of the video to the site
-        of the passport.
-        """
-        self._test_lti_get_resource_other_pl_site_auto_portable_not_ready_to_show_student(
-            factories.VideoFactory,
-            models.Video,
-            {
-                "live_state": random.choice(
-                    [lc[0] for lc in LIVE_CHOICES if lc[0] != "running"]
-                ),
-                "live_type": RAW,
             },
         )
 
@@ -2307,7 +2100,7 @@ class PortabilityLTITestCase(TestCase):
             factories.VideoFactory,
             models.Video,
             {
-                "live_state": "running",
+                "live_state": random.choice([lc[0] for lc in LIVE_CHOICES]),
                 "live_type": RAW,
             },
         )
@@ -2398,26 +2191,6 @@ class PortabilityLTITestCase(TestCase):
         )
 
     @mock.patch.object(LTIOAuthServer, "verify_request", return_value=True)
-    def test_lti_get_video_live_other_pl_pl_auto_portable_not_ready_to_show_instructor(
-        self, mock_verify
-    ):
-        """Above case 1-4-1-3-2-1 for Video.
-
-        Same as 1-4-1-1-2-1 but portability is automatic from the site of the video to the site
-        of the passport.
-        """
-        self._test_lti_get_resource_other_pl_pl_auto_portable_not_ready_to_show_instructor(
-            factories.VideoFactory,
-            models.Video,
-            {
-                "live_state": random.choice(
-                    [lc[0] for lc in LIVE_CHOICES if lc[0] != "running"]
-                ),
-                "live_type": RAW,
-            },
-        )
-
-    @mock.patch.object(LTIOAuthServer, "verify_request", return_value=True)
     def test_lti_get_document_other_pl_pl_auto_portable_not_ready_to_show_instructor(
         self, mock_verify
     ):
@@ -2489,26 +2262,6 @@ class PortabilityLTITestCase(TestCase):
                 "upload_state": random.choice(
                     [s[0] for s in STATE_CHOICES if s[0] != "ready"]
                 ),
-            },
-        )
-
-    @mock.patch.object(LTIOAuthServer, "verify_request", return_value=True)
-    def test_lti_get_video_live_other_pl_pl_auto_portable_not_ready_to_show_student(
-        self, mock_verify
-    ):
-        """Above case 1-4-1-3-2-2 for Video.
-
-        Same as 1-4-1-1-2-2 but portability is automatic from the site of the video to the site
-        of the passport.
-        """
-        self._test_lti_get_resource_other_pl_pl_auto_portable_not_ready_to_show_student(
-            factories.VideoFactory,
-            models.Video,
-            {
-                "live_state": random.choice(
-                    [lc[0] for lc in LIVE_CHOICES if lc[0] != "running"]
-                ),
-                "live_type": RAW,
             },
         )
 

--- a/src/backend/marsha/core/tests/test_models_video.py
+++ b/src/backend/marsha/core/tests/test_models_video.py
@@ -15,7 +15,6 @@ from ..defaults import (
     LIVE_CHOICES,
     LIVE_TYPE_CHOICES,
     RAW,
-    RUNNING,
     STATE_CHOICES,
 )
 from ..factories import VideoFactory
@@ -89,8 +88,8 @@ class VideoModelsTestCase(TestCase):
 
             self.assertEqual(video.is_ready_to_show, False)
 
-        # Only when live is running, the video is ready to show
+        # The video is ready to show when live_state is not null
         for live_choice in LIVE_CHOICES:
             video = VideoFactory(live_state=live_choice[0], live_type=RAW)
 
-            self.assertEqual(video.is_ready_to_show, live_choice[0] == RUNNING)
+            self.assertEqual(video.is_ready_to_show, True)

--- a/src/backend/marsha/core/tests/test_views_lti_video.py
+++ b/src/backend/marsha/core/tests/test_views_lti_video.py
@@ -232,7 +232,7 @@ class VideoLTIViewTestCase(TestCase):
             context.get("resource"),
             {
                 "active_stamp": None,
-                "is_ready_to_show": False,
+                "is_ready_to_show": True,
                 "show_download": True,
                 "description": video.description,
                 "id": str(video.id),
@@ -287,7 +287,7 @@ class VideoLTIViewTestCase(TestCase):
     @override_settings(XMPP_CONFERENCE_DOMAIN="conference.xmpp-server.com")
     @override_settings(XMPP_DOMAIN="conference.xmpp-server.com")
     @override_settings(XMPP_JWT_SHARED_SECRET="xmpp_shared_secret")
-    def test_views_lti_video_instructor_live_mode_an_chat_on(
+    def test_views_lti_video_instructor_live_mode_and_chat_on(
         self, mock_get_consumer_site, mock_verify
     ):
         """Validate the format of the response for a live video.
@@ -380,7 +380,7 @@ class VideoLTIViewTestCase(TestCase):
             context.get("resource"),
             {
                 "active_stamp": None,
-                "is_ready_to_show": False,
+                "is_ready_to_show": True,
                 "show_download": True,
                 "description": video.description,
                 "id": str(video.id),

--- a/src/frontend/Player/createPlayer.ts
+++ b/src/frontend/Player/createPlayer.ts
@@ -1,21 +1,7 @@
+import { pollForLive } from '../data/sideEffects/pollForLive';
 import { VideoPlayerCreator } from '../types/VideoPlayer';
 import { createVideojsPlayer } from './createVideojsPlayer';
 import { report } from '../utils/errors/report';
-import { VideoUrls } from '../types/tracks';
-
-const pollForLive = async (urls: VideoUrls): Promise<null> => {
-  try {
-    const response = await fetch(urls.manifests.hls);
-    if (response.status === 404) {
-      throw new Error('missing manifest');
-    }
-  } catch (error) {
-    await new Promise((resolve) => window.setTimeout(resolve, 1000));
-    return await pollForLive(urls);
-  }
-
-  return null;
-};
 
 export const createPlayer: VideoPlayerCreator = async (
   type,

--- a/src/frontend/Player/createVideojsPlayer.spec.tsx
+++ b/src/frontend/Player/createVideojsPlayer.spec.tsx
@@ -111,6 +111,7 @@ describe('createVideoJsPlayer', () => {
     expect(player.options_.playbackRates).toEqual([
       0.5, 0.75, 1, 1.25, 1.5, 1.75, 2, 4,
     ]);
+    expect(player.options_.autoplay).toBe(false);
     expect(player.options_.controls).toBe(true);
     expect(player.options_.debug).toBe(false);
     expect(player.options_.fluid).toBe(true);
@@ -236,6 +237,7 @@ describe('createVideoJsPlayer', () => {
     expect(player.currentSources()).toEqual([
       { type: 'application/x-mpegURL', src: 'https://example.com/hls' },
     ]);
+    expect(player.options_.autoplay).toBe(true);
     expect(player.options_.liveui).toBe(true);
     expect(player.options_.playbackRates).toEqual([]);
   });

--- a/src/frontend/Player/createVideojsPlayer.ts
+++ b/src/frontend/Player/createVideojsPlayer.ts
@@ -60,6 +60,7 @@ export const createVideojsPlayer = (
   }
 
   const options: VideoJsPlayerOptions = {
+    autoplay: !!live,
     controls: true,
     debug: false,
     fluid: true,

--- a/src/frontend/components/LTIRoutes/index.tsx
+++ b/src/frontend/components/LTIRoutes/index.tsx
@@ -23,7 +23,6 @@ import { LTIUploadHandlers } from '../UploadManager/LTIUploadHandlers';
 
 const Dashboard = lazy(() => import('../Dashboard'));
 const DocumentPlayer = lazy(() => import('../DocumentPlayer'));
-const VideoPlayer = lazy(() => import('../VideoPlayer'));
 const PublicVideoDashboard = lazy(() => import('../PublicVideoDashboard'));
 
 const Wrappers = ({ children }: React.PropsWithChildren<{}>) => (

--- a/src/frontend/components/PublicVideoDashboard/index.tsx
+++ b/src/frontend/components/PublicVideoDashboard/index.tsx
@@ -1,13 +1,21 @@
 import { Box } from 'grommet';
 import React from 'react';
+import { Redirect } from 'react-router-dom';
 
 import { Chat } from '../Chat';
 import { DownloadVideo } from '../DownloadVideo';
+import { FULL_SCREEN_ERROR_ROUTE } from '../ErrorComponents/route';
 import { Transcripts } from '../Transcripts';
 import VideoPlayer from '../VideoPlayer';
+import { WaitingLiveVideo } from '../WaitingLiveVideo';
 import { useTimedTextTrack } from '../../data/stores/useTimedTextTrack';
 import { useVideo } from '../../data/stores/useVideo';
-import { timedTextMode, TimedTextTranscript, Video } from '../../types/tracks';
+import {
+  liveState,
+  timedTextMode,
+  TimedTextTranscript,
+  Video,
+} from '../../types/tracks';
 
 interface PublicVideoDashboardProps {
   video: Video;
@@ -23,21 +31,33 @@ const PublicVideoDashboard = ({
     state.getTimedTextTracks(),
   );
 
-  if (video.live_state !== null && video.xmpp) {
-    return (
-      <Box direction="row">
-        <Box basis="xlarge">
-          <VideoPlayer
-            video={video}
-            playerType={playerType}
-            timedTextTracks={[]}
-          />
-        </Box>
-        <Box>
-          <Chat video={video} />
-        </Box>
-      </Box>
-    );
+  if (video.live_state !== null) {
+    switch (video.live_state) {
+      case liveState.RUNNING:
+        return (
+          <Box direction="row">
+            <Box basis={video.xmpp ? 'xlarge' : 'auto'}>
+              <VideoPlayer
+                video={video}
+                playerType={playerType}
+                timedTextTracks={[]}
+              />
+            </Box>
+            {video.xmpp && (
+              <Box>
+                <Chat video={video} />
+              </Box>
+            )}
+          </Box>
+        );
+      case liveState.STOPPED:
+      case liveState.STOPPING:
+        // nothing to show
+        return <Redirect push to={FULL_SCREEN_ERROR_ROUTE('notFound')} />;
+      default:
+        // waiting message
+        return <WaitingLiveVideo video={video} />;
+    }
   }
 
   const transcripts = timedTextTracks

--- a/src/frontend/components/RedirectOnLoad/index.spec.tsx
+++ b/src/frontend/components/RedirectOnLoad/index.spec.tsx
@@ -1,5 +1,5 @@
 import { cleanup, render } from '@testing-library/react';
-import * as React from 'react';
+import React from 'react';
 
 import { appState } from '../../types/AppData';
 import { modelName } from '../../types/models';
@@ -8,7 +8,6 @@ import { wrapInRouter } from '../../utils/tests/router';
 import { DASHBOARD_ROUTE } from '../Dashboard/route';
 import { FULL_SCREEN_ERROR_ROUTE } from '../ErrorComponents/route';
 import { PLAYER_ROUTE } from '../routes';
-import { UPLOAD_FORM_ROUTE } from '../UploadForm/route';
 import { RedirectOnLoad } from './index';
 import { SELECT_CONTENT_ROUTE } from '../SelectContent/route';
 

--- a/src/frontend/components/RedirectOnLoad/index.tsx
+++ b/src/frontend/components/RedirectOnLoad/index.tsx
@@ -3,7 +3,6 @@ import { Redirect } from 'react-router-dom';
 
 import { appData, getDecodedJwt } from '../../data/appData';
 import { appState } from '../../types/AppData';
-import { uploadState } from '../../types/tracks';
 import { DASHBOARD_ROUTE } from '../Dashboard/route';
 import { FULL_SCREEN_ERROR_ROUTE } from '../ErrorComponents/route';
 import { PLAYER_ROUTE } from '../routes';

--- a/src/frontend/components/VideoPlayer/index.spec.tsx
+++ b/src/frontend/components/VideoPlayer/index.spec.tsx
@@ -11,8 +11,8 @@ import {
   timedTextMockFactory,
   videoMockFactory,
 } from '../../utils/tests/factories';
-import { wrapInIntlProvider } from '../../utils/tests/intl';
 import { Deferred } from '../../utils/tests/Deferred';
+import { wrapInIntlProvider } from '../../utils/tests/intl';
 import VideoPlayer from './index';
 
 jest.mock('jwt-decode', () => jest.fn());
@@ -125,13 +125,11 @@ describe('VideoPlayer', () => {
     ];
 
     const { container } = render(
-      wrapInIntlProvider(
-        <VideoPlayer
-          video={mockVideo}
-          playerType={'videojs'}
-          timedTextTracks={timedTextTracks}
-        />,
-      ),
+      <VideoPlayer
+        video={mockVideo}
+        playerType={'videojs'}
+        timedTextTracks={timedTextTracks}
+      />,
     );
     await waitFor(() =>
       // The player is created and initialized with DashJS for adaptive bitrate
@@ -178,7 +176,10 @@ describe('VideoPlayer', () => {
       ),
     );
 
-    screen.getByText('Live is starting and will be displayed soon.');
+    screen.getByText('Live will begin soon');
+    screen.getByText(
+      'The live is going to start. You can wait here, the player will start once the live is ready.',
+    );
 
     await act(async () =>
       deferred.resolve({
@@ -193,8 +194,13 @@ describe('VideoPlayer', () => {
       video,
     ),
       expect(
-        screen.queryByText('Live is starting and will be displayed soon.'),
+        screen.queryByText('Live will begin soon'),
       ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        'The live is going to start. You can wait here, the player will start once the live is ready.',
+      ),
+    ).not.toBeInTheDocument();
 
     const videoElement = container.querySelector('video')!;
     expect(videoElement.tabIndex).toEqual(-1);

--- a/src/frontend/components/VideoPlayer/index.tsx
+++ b/src/frontend/components/VideoPlayer/index.tsx
@@ -1,8 +1,8 @@
-import { Box, Text } from 'grommet';
+import { Box } from 'grommet';
 import React, { useRef, useState } from 'react';
-import { defineMessages, useIntl } from 'react-intl';
 import { Redirect } from 'react-router';
 
+import { WaitingLiveVideo } from '../WaitingLiveVideo';
 import { useThumbnail } from '../../data/stores/useThumbnail';
 import { useTimedTextTrackLanguageChoices } from '../../data/stores/useTimedTextTrackLanguageChoices';
 import { useVideoProgress } from '../../data/stores/useVideoProgress';
@@ -10,16 +10,8 @@ import { createPlayer } from '../../Player/createPlayer';
 import { TimedText, timedTextMode, Video, videoSize } from '../../types/tracks';
 import { VideoPlayerInterface } from '../../types/VideoPlayer';
 import { useAsyncEffect } from '../../utils/useAsyncEffect';
-import { Maybe, Nullable } from '../../utils/types';
+import { Nullable } from '../../utils/types';
 import { FULL_SCREEN_ERROR_ROUTE } from '../ErrorComponents/route';
-
-const messages = defineMessages({
-  liveOnGoing: {
-    defaultMessage: 'Live is starting and will be displayed soon.',
-    description: 'Waiting message when a live is starting',
-    id: 'components.VideoPlayer.LiveOnDoing',
-  },
-});
 
 const trackTextKind: { [key in timedTextMode]?: string } = {
   [timedTextMode.CLOSED_CAPTIONING]: 'captions',
@@ -37,10 +29,7 @@ const VideoPlayer = ({
   playerType,
   timedTextTracks,
 }: BaseVideoPlayerProps) => {
-  const intl = useIntl();
-  const [player, setPlayer] = useState(
-    undefined as Maybe<VideoPlayerInterface>,
-  );
+  const [player, setPlayer] = useState<VideoPlayerInterface>();
   const videoNodeRef = useRef(null as Nullable<HTMLVideoElement>);
 
   const { choices, getChoices } = useTimedTextTrackLanguageChoices(
@@ -146,11 +135,7 @@ const VideoPlayer = ({
             />
           ))}
       </video>
-      {!player && video.live_state && (
-        <Text size="large" textAlign="center">
-          {intl.formatMessage(messages.liveOnGoing)}
-        </Text>
-      )}
+      {!player && video.live_state && <WaitingLiveVideo />}
     </Box>
   );
 };

--- a/src/frontend/components/WaitingLiveVideo/index.spec.tsx
+++ b/src/frontend/components/WaitingLiveVideo/index.spec.tsx
@@ -1,0 +1,70 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+
+import { getResource } from '../../data/sideEffects/getResource';
+import { pollForLive } from '../../data/sideEffects/pollForLive';
+import { requestStatus } from '../../types/api';
+import { modelName } from '../../types/models';
+import { videoMockFactory } from '../../utils/tests/factories';
+import { wrapInIntlProvider } from '../../utils/tests/intl';
+import { WaitingLiveVideo } from '.';
+
+jest.mock('../../data/appData', () => ({
+  appData: {},
+}));
+
+jest.mock('../../data/sideEffects/getResource', () => ({
+  getResource: jest.fn(),
+}));
+jest.mock('../../data/sideEffects/pollForLive', () => ({
+  pollForLive: jest.fn(),
+}));
+const mockGetResource = getResource as jest.MockedFunction<typeof getResource>;
+const mockPollForLive = pollForLive as jest.MockedFunction<typeof pollForLive>;
+
+describe('WaitingLiveVideo', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('renders the component without polling the hls manifest', () => {
+    render(wrapInIntlProvider(<WaitingLiveVideo />));
+
+    screen.getByText('Live will begin soon');
+    screen.getByText(
+      'The live is going to start. You can wait here, the player will start once the live is ready.',
+    );
+
+    expect(mockGetResource).not.toHaveBeenCalled();
+    expect(mockPollForLive).not.toHaveBeenCalled();
+  });
+
+  it('renders the component and poll the hls manifest', async () => {
+    const video = videoMockFactory({
+      urls: {
+        manifests: {
+          hls: 'https://marsha.education/live.m3u8',
+        },
+        mp4: {},
+        thumbnails: {},
+      },
+    });
+
+    mockPollForLive.mockResolvedValue(null);
+    mockGetResource.mockResolvedValue(requestStatus.SUCCESS);
+
+    render(wrapInIntlProvider(<WaitingLiveVideo video={video} />));
+
+    screen.getByText('Live will begin soon');
+    screen.getByText(
+      'The live is going to start. You can wait here, the player will start once the live is ready.',
+    );
+
+    await waitFor(() => {
+      expect(mockGetResource).toHaveBeenCalled();
+    });
+
+    expect(mockGetResource).toHaveBeenCalledWith(modelName.VIDEOS, video.id);
+    expect(mockPollForLive).toHaveBeenCalledWith(video.urls);
+  });
+});

--- a/src/frontend/components/WaitingLiveVideo/index.tsx
+++ b/src/frontend/components/WaitingLiveVideo/index.tsx
@@ -1,0 +1,69 @@
+import { Paragraph } from 'grommet';
+import React from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+import styled from 'styled-components';
+
+import { H2 } from '../Headings';
+import { LayoutMainArea } from '../LayoutMainArea';
+import { getResource } from '../../data/sideEffects/getResource';
+import { pollForLive } from '../../data/sideEffects/pollForLive';
+import { Video } from '../../types/tracks';
+import { useAsyncEffect } from '../../utils/useAsyncEffect';
+import { modelName } from '../../types/models';
+
+const messages = defineMessages({
+  title: {
+    defaultMessage: 'Live will begin soon',
+    description: 'Title for the waiting live video component',
+    id: 'components.WaitingLiveVideo.title',
+  },
+  text: {
+    defaultMessage:
+      'The live is going to start. You can wait here, the player will start once the live is ready.',
+    description: 'Message for the waiting live video component',
+    id: 'components.WaitingLiveVideo.message',
+  },
+});
+
+const WaitingLiveVideoStyled = styled(LayoutMainArea)`
+  display: flex;
+  flex-direction: column;
+  padding: 0 2rem;
+`;
+
+const WaitingLiveVideoContentStyled = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-evenly;
+  align-items: center;
+  flex-grow: 1;
+  padding-top: 4rem;
+  padding-bottom: 6rem;
+  text-align: center;
+`;
+
+interface WaitingLiveVideoProps {
+  video?: Video;
+}
+
+export const WaitingLiveVideo = ({ video }: WaitingLiveVideoProps) => {
+  useAsyncEffect(async () => {
+    if (video) {
+      await pollForLive(video.urls!);
+      await getResource(modelName.VIDEOS, video.id);
+    }
+  }, []);
+
+  return (
+    <WaitingLiveVideoStyled>
+      <WaitingLiveVideoContentStyled>
+        <H2>
+          <FormattedMessage {...messages.title} />
+        </H2>
+        <Paragraph>
+          <FormattedMessage {...messages.text} />
+        </Paragraph>
+      </WaitingLiveVideoContentStyled>
+    </WaitingLiveVideoStyled>
+  );
+};

--- a/src/frontend/data/sideEffects/pollForLive/index.spec.tsx
+++ b/src/frontend/data/sideEffects/pollForLive/index.spec.tsx
@@ -1,0 +1,55 @@
+import { waitFor } from '@testing-library/react';
+import fetchMock from 'fetch-mock';
+
+import { videoMockFactory } from '../../../utils/tests/factories';
+import { pollForLive } from '.';
+
+describe('createPlayer', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers('modern');
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    fetchMock.restore();
+  });
+
+  it('polls while the manifest is not available', async () => {
+    fetchMock.mock('https://marsha.education/live.m3u8', 404);
+    const video = videoMockFactory({
+      urls: {
+        manifests: {
+          hls: 'https://marsha.education/live.m3u8',
+        },
+        mp4: {},
+        thumbnails: {},
+      },
+    });
+
+    pollForLive(video.urls!);
+
+    await waitFor(() => {
+      expect(
+        fetchMock.calls('https://marsha.education/live.m3u8', {
+          method: 'GET',
+        }),
+      ).toHaveLength(1);
+    });
+
+    fetchMock.mock('https://marsha.education/live.m3u8', 200, {
+      overwriteRoutes: true,
+    });
+
+    jest.advanceTimersToNextTimer();
+
+    await waitFor(() => {
+      expect(
+        fetchMock.calls('https://marsha.education/live.m3u8', {
+          method: 'GET',
+        }),
+      ).toHaveLength(2);
+    });
+  });
+});

--- a/src/frontend/data/sideEffects/pollForLive/index.tsx
+++ b/src/frontend/data/sideEffects/pollForLive/index.tsx
@@ -1,0 +1,18 @@
+import { VideoUrls } from '../../../types/tracks';
+
+export const pollForLive = async (
+  urls: VideoUrls,
+  timeout: number = 2000,
+): Promise<null> => {
+  try {
+    const response = await fetch(urls.manifests.hls);
+    if (response.status === 404) {
+      throw new Error('missing manifest');
+    }
+  } catch (error) {
+    await new Promise((resolve) => window.setTimeout(resolve, timeout));
+    return await pollForLive(urls);
+  }
+
+  return null;
+};


### PR DESCRIPTION
## Purpose

We want to display a waiting message while a live is not ready to be played. For this a component `<WaitingLiveVideo />` is created and this component can poll the hls urls while not created and update the video resource in the store once avaiable. At this time the player is created and the video automatically played.

## Proposal

- [x] a video `is_ready_to_show` when `live_state` is not null
- [x] The read video API is open to student having a valid AccessToken
- [x]  extract `pollForLive` function in a dedicated module
- [x] create `WaitingLiveVideo` component
- [x] manage video live states in `<PublicVideoDashboard />`
- [x] autoplay a video live

