### PR TITLE
🐛(front) force to display chat in standalone on jitsi dashboard

### DIFF
--- a/src/frontend/components/DashboardVideoLiveRunning/index.spec.tsx
+++ b/src/frontend/components/DashboardVideoLiveRunning/index.spec.tsx
@@ -15,8 +15,11 @@ jest.mock('../../data/appData', () => ({
 }));
 
 jest.mock('../Chat', () => ({
-  Chat: (props: { video: Video }) => (
-    <span title={props.video.id}>chat component</span>
+  Chat: (props: { video: Video; standalone?: boolean }) => (
+    <div>
+      <span title={props.video.id}>chat component</span>
+      <span>standalone: {props.standalone ? 'true' : 'false'}</span>
+    </div>
   ),
 }));
 
@@ -89,6 +92,7 @@ describe('<DashboardVideoLiveRunning />  displays "show live" and "show chat onl
     fireEvent.click(showChatButton);
 
     screen.getByText('chat component');
+    screen.getByText('standalone: true');
 
     const hideChatButton = screen.getByRole('button', { name: /hide chat/ });
 

--- a/src/frontend/components/DashboardVideoLiveRunning/index.tsx
+++ b/src/frontend/components/DashboardVideoLiveRunning/index.tsx
@@ -72,7 +72,7 @@ export const DashboardVideoLiveRunning = ({
         )}
         <DashboardVideoLiveStopButton video={video} />
       </Box>
-      {displayChat && <Chat video={video} />}
+      {displayChat && <Chat video={video} standalone={true} />}
     </Box>
   );
 };


### PR DESCRIPTION
## Purpose

In the dashboard, when the live is streamed by jitsi the chat must be
used in standalone mode otherwise we don't see it on the screen.

## Proposal

Description...

- [x] force to display chat in standlone on jitsi dashboard

