### PR TITLE
🔖(minor) bump release to 3.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.20.0] - 2021-06-18
+
 ### Added
 
 - Display chat in dashboard during a jitsi live
@@ -785,7 +787,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Minor fixes and improvements on features and tests
 
-[unreleased]: https://github.com/openfun/marsha/compare/v3.19.0...master
+[unreleased]: https://github.com/openfun/marsha/compare/v3.20.0...master
+[3.20.0]: https://github.com/openfun/marsha/compare/v3.19.0...v3.20.0
 [3.19.0]: https://github.com/openfun/marsha/compare/v3.18.0...v3.19.0
 [3.18.0]: https://github.com/openfun/marsha/compare/v3.17.1...v3.18.0
 [3.17.1]: https://github.com/openfun/marsha/compare/v3.17.0...v3.17.1

--- a/src/aws/lambda-complete/package.json
+++ b/src/aws/lambda-complete/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-complete",
-  "version": "3.19.0",
+  "version": "3.20.0",
   "engines": {
     "node": "14"
   },

--- a/src/aws/lambda-configure/package.json
+++ b/src/aws/lambda-configure/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-configure",
-  "version": "3.19.0",
+  "version": "3.20.0",
   "engines": {
     "node": "14"
   },

--- a/src/aws/lambda-elemental-routing/package.json
+++ b/src/aws/lambda-elemental-routing/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-elemental-routing",
-  "version": "3.19.0",
+  "version": "3.20.0",
   "engines": {
     "node": "14"
   },

--- a/src/aws/lambda-encode/package.json
+++ b/src/aws/lambda-encode/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-convert",
-  "version": "3.19.0",
+  "version": "3.20.0",
   "engines": {
     "node": "14"
   },

--- a/src/aws/lambda-medialive/package.json
+++ b/src/aws/lambda-medialive/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-medialive",
-  "version": "3.19.0",
+  "version": "3.20.0",
   "engines": {
     "node": "14"
   },

--- a/src/aws/lambda-mediapackage/package.json
+++ b/src/aws/lambda-mediapackage/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-mediapackage",
-  "version": "3.19.0",
+  "version": "3.20.0",
   "engines": {
     "node": "14"
   },

--- a/src/aws/lambda-migrate/package.json
+++ b/src/aws/lambda-migrate/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-migrate",
-  "version": "3.19.0",
+  "version": "3.20.0",
   "engines": {
     "node": "14"
   },

--- a/src/aws/utils/update-state/package.json
+++ b/src/aws/utils/update-state/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-update-state",
-  "version": "3.19.0",
+  "version": "3.20.0",
   "engines": {
     "node": "14"
   },

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = marsha
 description = A FUN video provider for Open edX
-version = 3.19.0
+version = 3.20.0
 author = Open FUN (France Universite Numerique)
 author_email = fun.dev@fun-mooc.fr
 license = MIT

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marsha",
-  "version": "3.19.0",
+  "version": "3.20.0",
   "description": "🐠 a FUN LTI video provider",
   "main": "front/index.tsx",
   "scripts": {


### PR DESCRIPTION
### Added

- Display chat in dashboard during a jitsi live
- Use chat when a live is publicly available
- Set chat nickname when user is connected
- Display a waiting message while live is not available
- Add Playrwright testing (with basic cloud storage mocking)
- Update circleci config to version 2.1
- Add a parametrized cicrcleci job to run e2e tests on 3 browsers
  (chromium, firefox and webkit)
- Move DevelopmentLTIView to a new development directory
- Add a variable to set frontend video polling interval
- Add a component responsible to manage public video dashboard
- Add a waiting workflow while a live is not ready
- Allow to play a youtube video in jitsi

### Changed

- Switch from classic to jitsi live when a classic is created
- Use conversejs concord theme

### Fixed

- Prevent to display a deleted video
- Disable video speed menu for live video
- Manage jitsi recording interruption

### Removed

- Remove plyr player
