### PR TITLE
🐛(front) redirect instructor to the dashboard when live is stopped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Redirect instructor to the dashboard when live is stopped
+
 ## [3.20.0] - 2021-06-18
 
 ### Added

--- a/src/frontend/components/ErrorComponents/index.tsx
+++ b/src/frontend/components/ErrorComponents/index.tsx
@@ -15,7 +15,8 @@ export interface ErrorComponentsProps {
     | 'upload'
     | 'liveIncompatible'
     | 'liveInit'
-    | 'liveToVod';
+    | 'liveToVod'
+    | 'liveStopped';
 }
 
 const FullScreenErrorStyled = styled(LayoutMainArea)`
@@ -139,6 +140,21 @@ const messages = {
         'We could not publish this video as a VOD. Please retry later',
       description: 'Error message when publish a live to VOD fails.',
       id: 'components.ErrorComponents.liveToVod.text',
+    },
+  },
+  liveStopped: {
+    text: {
+      defaultMessage:
+        'This live has now ended. If the host decides to publish the recording, the video will be available here in a while.',
+      description:
+        'Text explaining that a live has ended and that the VOD may be available soon.',
+      id: 'components.ErrorComponents.liveStopped.text',
+    },
+    title: {
+      defaultMessage: 'This live has ended',
+      description:
+        'Title for a user without update permission when a live is stopped or stopping',
+      id: 'components.ErrorComponents.liveStopped.title',
     },
   },
 };

--- a/src/frontend/components/PublicVideoDashboard/index.tsx
+++ b/src/frontend/components/PublicVideoDashboard/index.tsx
@@ -3,13 +3,16 @@ import React from 'react';
 import { Redirect } from 'react-router-dom';
 
 import { Chat } from '../Chat';
+import { DASHBOARD_ROUTE } from '../Dashboard/route';
 import { DownloadVideo } from '../DownloadVideo';
 import { FULL_SCREEN_ERROR_ROUTE } from '../ErrorComponents/route';
 import { Transcripts } from '../Transcripts';
 import VideoPlayer from '../VideoPlayer';
 import { WaitingLiveVideo } from '../WaitingLiveVideo';
+import { getDecodedJwt } from '../../data/appData';
 import { useTimedTextTrack } from '../../data/stores/useTimedTextTrack';
 import { useVideo } from '../../data/stores/useVideo';
+import { modelName } from '../../types/models';
 import {
   liveState,
   timedTextMode,
@@ -52,8 +55,13 @@ const PublicVideoDashboard = ({
         );
       case liveState.STOPPED:
       case liveState.STOPPING:
-        // nothing to show
-        return <Redirect push to={FULL_SCREEN_ERROR_ROUTE('notFound')} />;
+        // user has update permission, we redirect him to the dashboard
+        if (getDecodedJwt().permissions.can_update) {
+          return <Redirect push to={DASHBOARD_ROUTE(modelName.VIDEOS)} />;
+        }
+
+        // otherwise the user can only see a message
+        return <Redirect push to={FULL_SCREEN_ERROR_ROUTE('liveStopped')} />;
       default:
         // waiting message
         return <WaitingLiveVideo video={video} />;


### PR DESCRIPTION
## Purpose

When a live is stopped, an instructor show the page saying the video is
not found. We should redirect him to the dashboard when the live is
stopped or stopping and he has update permission.

## Proposal

- [x] redirect instructor to the dashboard when live is stopped
