### PR TITLE
💄(frontend) Add a beta label on live configuration buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -447,6 +447,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Add document management
 - Cache database queries and serialization in LTI views for students
+- Add a beta label on live configuration buttons
 
 ### Changed
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -11,6 +11,7 @@
 - [Manuel Raynaud](https://github.com/lunika) <manu@raynaud.io>
 - [Matthieu Huguet](https://github.com/madmatah) <matthieu.huguet@fun-mooc.fr>
 - [Florian Pereira](https://github.com/flo-pereira) <pereira.florian@gmail.com>
+- [Caroline Cramoisan](https://github.com/carofun) <caroline.cramoisan@fun-mooc.fr>
 
 - [Renovate Bot](https://renovatebot.com) <bot@renovateapp.com>
 - [Pyup Bot](https://pyup.io) <github-bot@pyup.io>

--- a/src/frontend/components/DashboardPaneButtons/index.tsx
+++ b/src/frontend/components/DashboardPaneButtons/index.tsx
@@ -62,6 +62,7 @@ export const DashboardButton = styled(Button)`
   flex-grow: 1;
   flex-basis: 8rem;
   max-width: 50%;
+  position: relative;
 
   :first-child {
     margin-right: 1rem;
@@ -71,6 +72,17 @@ export const DashboardButton = styled(Button)`
     margin-left: 1rem;
   }
 `;
+
+export const DashboardButtonBeta = styled(DashboardButton)`
+  :after {
+    color: #ff6a00;
+    content: '(BETA)';
+    font-size: 0.5em;
+    position: absolute;
+    top: -0.4em;
+  }
+`;
+
 export const DashboardButtonWithLink = withLink(DashboardButton);
 
 /** Props shape for the DashboardVideoPaneButtons component. */

--- a/src/frontend/components/DashboardVideoLiveConfigureButton/index.tsx
+++ b/src/frontend/components/DashboardVideoLiveConfigureButton/index.tsx
@@ -9,7 +9,7 @@ import { modelName } from '../../types/models';
 import { LiveModeType, Video } from '../../types/tracks';
 import { Nullable } from '../../utils/types';
 import { DASHBOARD_ROUTE } from '../Dashboard/route';
-import { DashboardButton } from '../DashboardPaneButtons';
+import { DashboardButtonBeta } from '../DashboardPaneButtons';
 import { FULL_SCREEN_ERROR_ROUTE } from '../ErrorComponents/route';
 import { Loader } from '../Loader';
 
@@ -75,7 +75,7 @@ export const DashboardVideoLiveConfigureButton = ({
     <React.Fragment>
       {status === 'pending' && <Loader />}
 
-      <DashboardButton
+      <DashboardButtonBeta
         onClick={configureLive}
         label={<FormattedMessage {...messages[type]} />}
       />


### PR DESCRIPTION

## Purpose

The feature to start a live is still on a beta version. We want to alert users
about this point. We add a temporary beta label on the two buttons.

## Proposal

No test for this proposal as jest-dom doesn't detect the added CSS. It's a temporary label added, WDYT ?

![Capture d’écran 2021-07-02 à 16 17 26](https://user-images.githubusercontent.com/76939263/124296604-71570500-db5a-11eb-8b29-4716da4e6a75.png)


