### PR TITLE
Remove live switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Add a beta label on live configuration buttons
+
 ### Removed
 
 - VIDEO_LIVE Waffle switch
@@ -451,7 +455,6 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Add document management
 - Cache database queries and serialization in LTI views for students
-- Add a beta label on live configuration buttons
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Removed
+
+- VIDEO_LIVE Waffle switch
+
 ## [3.20.1] - 2021-06-23
 
 ### Fixed

--- a/src/backend/marsha/core/defaults.py
+++ b/src/backend/marsha/core/defaults.py
@@ -56,5 +56,4 @@ LIVE_CHOICES = (
 LIVE_TYPE_CHOICES = ((RAW, _("raw")), (JITSI, _("jitsi")))
 
 # FLAGS
-VIDEO_LIVE = "video_live"
 SENTRY = "sentry"

--- a/src/backend/marsha/core/tests/test_views_lti_cache.py
+++ b/src/backend/marsha/core/tests/test_views_lti_cache.py
@@ -10,7 +10,7 @@ from django.test import TestCase
 
 from waffle.testutils import override_switch
 
-from ..defaults import SENTRY, STATE_CHOICES, VIDEO_LIVE
+from ..defaults import SENTRY, STATE_CHOICES
 from ..factories import ConsumerSiteFactory, VideoFactory
 from ..lti import LTI
 
@@ -37,7 +37,6 @@ class CacheLTIViewTestCase(TestCase):
 
     @mock.patch.object(LTI, "verify")
     @mock.patch.object(LTI, "get_consumer_site")
-    @override_switch(VIDEO_LIVE, active=True)
     @override_switch(SENTRY, active=True)
     def test_views_lti_cache_student(self, mock_get_consumer_site, mock_verify):
         """Validate that responses are cached for students."""
@@ -61,7 +60,7 @@ class CacheLTIViewTestCase(TestCase):
             "lis_person_sourcedid": "jane_doe",
         }
 
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(5):
             elapsed, resource_origin = self._fetch_lti_request(url, data)
         self.assertEqual(resource_origin["id"], str(video1.id))
         self.assertTrue(elapsed < 0.1)
@@ -120,7 +119,6 @@ class CacheLTIViewTestCase(TestCase):
 
     @mock.patch.object(LTI, "verify")
     @mock.patch.object(LTI, "get_consumer_site")
-    @override_switch(VIDEO_LIVE, active=True)
     @override_switch(SENTRY, active=True)
     def test_views_lti_cache_instructor(self, mock_get_consumer_site, mock_verify):
         """Validate that responses are not cached for instructors."""
@@ -141,7 +139,7 @@ class CacheLTIViewTestCase(TestCase):
             "lis_person_sourcedid": "jane_doe",
         }
 
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(5):
             elapsed, resource_origin = self._fetch_lti_request(url, data)
         self.assertEqual(resource_origin["id"], str(video.id))
         self.assertTrue(elapsed < 0.1)
@@ -153,7 +151,6 @@ class CacheLTIViewTestCase(TestCase):
         self.assertEqual(resource, resource_origin)
         self.assertTrue(elapsed < 0.1)
 
-    @override_switch(VIDEO_LIVE, active=True)
     @override_switch(SENTRY, active=True)
     def test_views_public_resource(self):
         """Validate that response for public resources are cached."""
@@ -165,7 +162,7 @@ class CacheLTIViewTestCase(TestCase):
         )
         url = "/videos/{!s}".format(video.pk)
 
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(5):
             elapsed, resource_origin = self._fetch_lti_request(url)
         self.assertEqual(resource_origin["id"], str(video.id))
         self.assertTrue(elapsed < 0.1)

--- a/src/backend/marsha/core/tests/test_views_lti_video.py
+++ b/src/backend/marsha/core/tests/test_views_lti_video.py
@@ -23,7 +23,6 @@ from ..defaults import (
     RUNNING,
     SENTRY,
     STATE_CHOICES,
-    VIDEO_LIVE,
 )
 from ..factories import (
     ConsumerSiteLTIPassportFactory,
@@ -48,7 +47,6 @@ class VideoLTIViewTestCase(TestCase):
     @override_settings(RELEASE="1.2.3")
     @override_settings(JITSI_ENABLED=True)
     @override_settings(VIDEO_PLAYER="videojs")
-    @override_switch(VIDEO_LIVE, active=True)
     @override_switch(SENTRY, active=True)
     def test_views_lti_video_post_instructor(self, mock_get_consumer_site, mock_verify):
         """Validate the format of the response returned by the view for an instructor request."""
@@ -135,9 +133,7 @@ class VideoLTIViewTestCase(TestCase):
         self.assertEqual(context.get("environment"), "test")
         self.assertEqual(context.get("release"), "1.2.3")
         self.assertEqual(context.get("player"), "videojs")
-        self.assertEqual(
-            context.get("flags"), {"video_live": True, "sentry": True, "jitsi": True}
-        )
+        self.assertEqual(context.get("flags"), {"sentry": True, "jitsi": True})
         # Make sure we only go through LTI verification once as it is costly (getting passport +
         # signature)
         self.assertEqual(mock_verify.call_count, 1)

--- a/src/backend/marsha/core/views.py
+++ b/src/backend/marsha/core/views.py
@@ -29,7 +29,7 @@ from rest_framework_simplejwt.exceptions import TokenError
 from rest_framework_simplejwt.tokens import AccessToken
 from waffle import mixins, switch_is_active
 
-from .defaults import JITSI, SENTRY, VIDEO_LIVE
+from .defaults import JITSI, SENTRY
 from .lti import LTI
 from .lti.utils import (
     PortabilityError,
@@ -244,7 +244,6 @@ class BaseLTIView(ABC, TemplateResponseMixin, View):
             app_data.update(
                 {
                     "flags": {
-                        VIDEO_LIVE: switch_is_active(VIDEO_LIVE),
                         SENTRY: switch_is_active(SENTRY),
                         JITSI: settings.JITSI_ENABLED,
                     },

--- a/src/frontend/components/DashboardPaneButtons/index.spec.tsx
+++ b/src/frontend/components/DashboardPaneButtons/index.spec.tsx
@@ -57,7 +57,6 @@ describe('<DashboardPaneButtons />', () => {
   });
 
   it('displays the configure live button', () => {
-    mockFlags = { [flags.VIDEO_LIVE]: true };
     render(
       wrapInIntlProvider(
         wrapInRouter(
@@ -73,7 +72,7 @@ describe('<DashboardPaneButtons />', () => {
   });
 
   it('displays the configure live and jitsi button', () => {
-    mockFlags = { [flags.VIDEO_LIVE]: true, [flags.JITSI]: true };
+    mockFlags = { [flags.JITSI]: true };
     render(
       wrapInIntlProvider(
         wrapInRouter(
@@ -90,7 +89,6 @@ describe('<DashboardPaneButtons />', () => {
   });
 
   it('hides the configure live button when live state is not null', () => {
-    mockFlags = { [flags.VIDEO_LIVE]: false };
     render(
       wrapInIntlProvider(
         wrapInRouter(
@@ -100,24 +98,6 @@ describe('<DashboardPaneButtons />', () => {
               upload_state: PENDING,
               live_state: liveState.IDLE,
             })}
-            objectType={modelName.VIDEOS}
-          />,
-        ),
-      ),
-    );
-
-    expect(
-      screen.queryByRole('button', { name: 'Configure a live streaming' }),
-    ).toBeNull();
-  });
-
-  it('hides the configure live button when the flag is disabled', () => {
-    mockFlags = { [flags.VIDEO_LIVE]: false };
-    render(
-      wrapInIntlProvider(
-        wrapInRouter(
-          <DashboardPaneButtons
-            object={videoMockFactory({ id: 'vid1', upload_state: PENDING })}
             objectType={modelName.VIDEOS}
           />,
         ),

--- a/src/frontend/components/DashboardPaneButtons/index.tsx
+++ b/src/frontend/components/DashboardPaneButtons/index.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import styled from 'styled-components';
 
-import { appData } from '../../data/appData';
 import { Document } from '../../types/file';
 import { modelName } from '../../types/models';
 import { flags } from '../../types/AppData';
@@ -112,7 +111,7 @@ export const DashboardPaneButtons = ({
     >
       {objectType === modelName.VIDEOS &&
         object.upload_state === uploadState.PENDING &&
-        isFeatureEnabled(flags.VIDEO_LIVE) && (
+        !(object as Video).live_state && (
           <React.Fragment>
             <DashboardVideoLiveConfigureButton
               video={object as Video}

--- a/src/frontend/types/AppData.ts
+++ b/src/frontend/types/AppData.ts
@@ -9,7 +9,6 @@ export enum appState {
 }
 
 export enum flags {
-  VIDEO_LIVE = 'video_live',
   SENTRY = 'sentry',
   JITSI = 'jitsi',
 }

--- a/src/frontend/utils/isFeatureEnabled.spec.ts
+++ b/src/frontend/utils/isFeatureEnabled.spec.ts
@@ -12,30 +12,30 @@ describe('isFeatureEnabled', () => {
   it('returns true is flag is enabled', () => {
     mockAppData = {
       flags: {
-        [flags.VIDEO_LIVE]: true,
+        [flags.JITSI]: true,
       },
     };
-    expect(isFeatureEnabled(flags.VIDEO_LIVE)).toBe(true);
+    expect(isFeatureEnabled(flags.JITSI)).toBe(true);
   });
 
   it('returns false if flag is disabled', () => {
     mockAppData = {
       flags: {
-        [flags.VIDEO_LIVE]: false,
+        [flags.JITSI]: false,
       },
     };
-    expect(isFeatureEnabled(flags.VIDEO_LIVE)).toBe(false);
+    expect(isFeatureEnabled(flags.JITSI)).toBe(false);
   });
 
   it('returns false when the wanted flag is undefined', () => {
     mockAppData = {
       flags: {},
     };
-    expect(isFeatureEnabled(flags.VIDEO_LIVE)).toBe(false);
+    expect(isFeatureEnabled(flags.JITSI)).toBe(false);
   });
 
   it('returns false when flag is undefined', () => {
     mockAppData = {};
-    expect(isFeatureEnabled(flags.VIDEO_LIVE)).toBe(false);
+    expect(isFeatureEnabled(flags.JITSI)).toBe(false);
   });
 });


### PR DESCRIPTION
## Purpose

VIDEO_LIVE switch is enabled, we will not use it anymore. We can
remove it to not make unnecessary sql queries.

## Proposal

- [x] remove VIDEO_LIVE switch in the back application
- [x] remove VIDEO_LIVE flag in the front application

