### PR TITLE
Live xapi

### DIFF
--- a/src/backend/marsha/core/xapi.py
+++ b/src/backend/marsha/core/xapi.py
@@ -52,6 +52,12 @@ class XAPIStatement:
 
         homepage = video.playlist.consumer_site.domain
 
+        activity_type = "https://w3id.org/xapi/video/activity-type/video"
+
+        # When the video is a live we change the activity to webinar
+        if video.live_state is not None:
+            activity_type = "http://id.tincanapi.com/activitytype/webinar"
+
         if re.match(r"^http(s?):\/\/.*", homepage) is None:
             homepage = f"http://{homepage}"
 
@@ -70,7 +76,7 @@ class XAPIStatement:
 
         statement["object"] = {
             "definition": {
-                "type": "https://w3id.org/xapi/video/activity-type/video",
+                "type": activity_type,
                 "name": {
                     to_locale(settings.LANGUAGE_CODE).replace("_", "-"): video.title
                 },

--- a/src/frontend/Player/createPlayer.spec.ts
+++ b/src/frontend/Player/createPlayer.spec.ts
@@ -46,8 +46,7 @@ describe('createPlayer', () => {
     expect(createVideojsPlayer).toHaveBeenCalledWith(
       ref,
       dispatchPlayerTimeUpdate,
-      video.urls!,
-      video.live_state,
+      video,
     );
   });
 
@@ -112,8 +111,7 @@ describe('createPlayer', () => {
     expect(createVideojsPlayer).toHaveBeenCalledWith(
       ref,
       dispatchPlayerTimeUpdate,
-      video.urls!,
-      video.live_state,
+      video,
     );
   });
 });

--- a/src/frontend/Player/createPlayer.ts
+++ b/src/frontend/Player/createPlayer.ts
@@ -17,12 +17,7 @@ export const createPlayer: VideoPlayerCreator = async (
 
   switch (type) {
     case 'videojs':
-      const player = createVideojsPlayer(
-        ref,
-        dispatchPlayerTimeUpdate,
-        video.urls!,
-        video.live_state,
-      );
+      const player = createVideojsPlayer(ref, dispatchPlayerTimeUpdate, video);
       return {
         destroy: () => player.dispose(),
       };

--- a/src/frontend/XAPI/LiveXapiStatement.spec.ts
+++ b/src/frontend/XAPI/LiveXapiStatement.spec.ts
@@ -1,0 +1,261 @@
+import fetchMock from 'fetch-mock';
+
+import { XAPI_ENDPOINT } from '../settings';
+import { VerbDefinition } from '../types/XAPI';
+import { truncateDecimalDigits } from '../utils/truncateDecimalDigits';
+import { LiveXAPIStatement } from './LiveXapiStatement';
+
+describe('LiveXapiStatement', () => {
+  afterEach(() => fetchMock.reset());
+
+  it('post an initialized statement with all extensions', () => {
+    fetchMock.mock(`${XAPI_ENDPOINT}/`, 204, {
+      overwriteRoutes: true,
+    });
+    const xapiStatement = new LiveXAPIStatement('jwt', 'abcd');
+    xapiStatement.initialized({
+      ccSubtitleEnabled: true,
+      ccSubtitleLanguage: 'en-US',
+      frameRate: 29.97,
+      fullScreen: false,
+      length: 1,
+      quality: '480',
+      screenSize: '1080x960',
+      speed: '1x',
+      track: 'foo',
+      userAgent: 'Mozilla/5.0',
+      videoPlaybackSize: '1080x960',
+      volume: 1,
+    });
+    const lastCall = fetchMock.lastCall(`${XAPI_ENDPOINT}/`);
+
+    const requestParameters = lastCall![1]!;
+
+    expect(requestParameters.headers).toEqual({
+      Authorization: 'Bearer jwt',
+      'Content-Type': 'application/json',
+    });
+
+    const body = JSON.parse(requestParameters.body as string);
+
+    expect(body.verb.id).toEqual(VerbDefinition.initialized);
+    expect(body.verb.display).toEqual({
+      'en-US': 'initialized',
+    });
+    expect(body.context.extensions).toEqual({
+      'https://w3id.org/xapi/video/extensions/cc-subtitle-enabled': true,
+      'https://w3id.org/xapi/video/extensions/cc-subtitle-lang': 'en-US',
+      'https://w3id.org/xapi/video/extensions/frame-rate': 29.97,
+      'https://w3id.org/xapi/video/extensions/full-screen': false,
+      'https://w3id.org/xapi/video/extensions/quality': '480',
+      'https://w3id.org/xapi/video/extensions/screen-size': '1080x960',
+      'https://w3id.org/xapi/video/extensions/session-id': 'abcd',
+      'https://w3id.org/xapi/video/extensions/speed': '1x',
+      'https://w3id.org/xapi/video/extensions/track': 'foo',
+      'https://w3id.org/xapi/video/extensions/user-agent': 'Mozilla/5.0',
+      'https://w3id.org/xapi/video/extensions/video-playback-size': '1080x960',
+      'https://w3id.org/xapi/video/extensions/volume': 1,
+    });
+    expect(body).toHaveProperty('id');
+  });
+
+  it('sends a play statement', () => {
+    fetchMock.mock(`${XAPI_ENDPOINT}/`, 204, {
+      overwriteRoutes: true,
+    });
+    const xapiStatement = new LiveXAPIStatement('jwt', 'abcd');
+    xapiStatement.played({
+      time: 42.321,
+    });
+    const lastCall = fetchMock.lastCall(`${XAPI_ENDPOINT}/`);
+
+    const requestParameters = lastCall![1]!;
+
+    expect(requestParameters.headers).toEqual({
+      Authorization: 'Bearer jwt',
+      'Content-Type': 'application/json',
+    });
+
+    const body = JSON.parse(requestParameters.body as string);
+
+    expect(body.verb.id).toEqual(VerbDefinition.played);
+    expect(body.verb.display).toEqual({
+      'en-US': 'played',
+    });
+    expect(body.context.extensions).toEqual({
+      'https://w3id.org/xapi/video/extensions/session-id': 'abcd',
+    });
+    expect(body.result.extensions).toEqual({
+      'https://w3id.org/xapi/video/extensions/time': 42.321,
+    });
+    expect(body).toHaveProperty('id');
+  });
+
+  it('sends a pause statement', () => {
+    fetchMock.mock(`${XAPI_ENDPOINT}/`, 204, {
+      overwriteRoutes: true,
+    });
+    const xapiStatement = new LiveXAPIStatement('jwt', 'abcd');
+    xapiStatement.played({ time: 0 });
+    xapiStatement.paused({ time: 10 });
+
+    const lastCall = fetchMock.lastCall(`${XAPI_ENDPOINT}/`);
+
+    const requestParameters = lastCall![1]!;
+
+    expect(requestParameters.headers).toEqual({
+      Authorization: 'Bearer jwt',
+      'Content-Type': 'application/json',
+    });
+
+    const body = JSON.parse(requestParameters.body as string);
+
+    expect(body.verb.id).toEqual(VerbDefinition.paused);
+    expect(body.verb.display).toEqual({
+      'en-US': 'paused',
+    });
+    expect(body.context.extensions).toEqual({
+      'https://w3id.org/xapi/video/extensions/session-id': 'abcd',
+    });
+    expect(body.result.extensions).toEqual({
+      'https://w3id.org/xapi/video/extensions/played-segments': '0[.]10',
+      'https://w3id.org/xapi/video/extensions/time': 10,
+    });
+    expect(body).toHaveProperty('id');
+  });
+
+  it('sends terminated statement', () => {
+    fetchMock.mock(`${XAPI_ENDPOINT}/`, 204, {
+      overwriteRoutes: true,
+    });
+    const xapiStatement = new LiveXAPIStatement('jwt', 'abcd');
+    xapiStatement.terminated({
+      time: 50,
+    });
+
+    const lastCall = fetchMock.lastCall(`${XAPI_ENDPOINT}/`);
+
+    const requestParameters = lastCall![1]!;
+
+    expect(requestParameters.headers).toEqual({
+      Authorization: 'Bearer jwt',
+      'Content-Type': 'application/json',
+    });
+
+    const body = JSON.parse(requestParameters.body as string);
+
+    expect(body.verb.id).toEqual(VerbDefinition.terminated);
+    expect(body.verb.display).toEqual({
+      'en-US': 'terminated',
+    });
+    expect(body.context.extensions).toEqual({
+      'https://w3id.org/xapi/video/extensions/session-id': 'abcd',
+    });
+    expect(body.result.extensions).toEqual({
+      'https://w3id.org/xapi/video/extensions/played-segments': '',
+      'https://w3id.org/xapi/video/extensions/time': 50,
+    });
+    expect(body).toHaveProperty('id');
+  });
+
+  it('sends a terminated statement with a segment started and not closed', () => {
+    fetchMock.mock(`${XAPI_ENDPOINT}/`, 204, {
+      overwriteRoutes: true,
+    });
+    const xapiStatement = new LiveXAPIStatement('jwt', 'abcd');
+    xapiStatement.played({ time: 0 });
+    xapiStatement.terminated({
+      time: 50,
+    });
+
+    const calls = fetchMock.calls(`${XAPI_ENDPOINT}/`);
+
+    const pausedCall = calls[1];
+
+    const pausedRequestParameters = pausedCall![1]!;
+
+    const pausedBody = JSON.parse(pausedRequestParameters.body as string);
+
+    expect(pausedBody.verb.id).toEqual(VerbDefinition.paused);
+    expect(pausedBody.verb.display).toEqual({
+      'en-US': 'paused',
+    });
+
+    const terminatedCall = calls[2];
+    const requestParameters = terminatedCall![1]!;
+    expect(requestParameters.headers).toEqual({
+      Authorization: 'Bearer jwt',
+      'Content-Type': 'application/json',
+    });
+
+    const body = JSON.parse(requestParameters.body as string);
+
+    expect(body.verb.id).toEqual(VerbDefinition.terminated);
+    expect(body.verb.display).toEqual({
+      'en-US': 'terminated',
+    });
+    expect(body.context.extensions).toEqual({
+      'https://w3id.org/xapi/video/extensions/session-id': 'abcd',
+    });
+    expect(body.result.extensions).toEqual({
+      'https://w3id.org/xapi/video/extensions/played-segments': '0[.]50',
+      'https://w3id.org/xapi/video/extensions/time': 50,
+    });
+    expect(body).toHaveProperty('id');
+  });
+
+  it('sends an interacted event with all context entensions', () => {
+    fetchMock.mock(`${XAPI_ENDPOINT}/`, 204, {
+      overwriteRoutes: true,
+    });
+    const xapiStatement = new LiveXAPIStatement('jwt', 'abcd');
+    xapiStatement.interacted(
+      {
+        time: 50,
+      },
+      {
+        ccSubtitleEnabled: true,
+        ccSubtitleLanguage: 'en',
+        frameRate: 29.97,
+        fullScreen: true,
+        quality: '480',
+        speed: '1x',
+        track: 'foo',
+        videoPlaybackSize: '640x480',
+        volume: 1,
+      },
+    );
+
+    const lastCall = fetchMock.lastCall(`${XAPI_ENDPOINT}/`);
+
+    const requestParameters = lastCall![1]!;
+
+    expect(requestParameters.headers).toEqual({
+      Authorization: 'Bearer jwt',
+      'Content-Type': 'application/json',
+    });
+
+    const body = JSON.parse(requestParameters.body as string);
+
+    expect(body.verb.id).toEqual(VerbDefinition.interacted);
+    expect(body.verb.display).toEqual({
+      'en-US': 'interacted',
+    });
+    expect(body.context.extensions).toEqual({
+      'https://w3id.org/xapi/video/extensions/cc-subtitle-enabled': true,
+      'https://w3id.org/xapi/video/extensions/cc-subtitle-lang': 'en',
+      'https://w3id.org/xapi/video/extensions/frame-rate': 29.97,
+      'https://w3id.org/xapi/video/extensions/full-screen': true,
+      'https://w3id.org/xapi/video/extensions/quality': '480',
+      'https://w3id.org/xapi/video/extensions/session-id': 'abcd',
+      'https://w3id.org/xapi/video/extensions/speed': '1x',
+      'https://w3id.org/xapi/video/extensions/track': 'foo',
+      'https://w3id.org/xapi/video/extensions/video-playback-size': '640x480',
+      'https://w3id.org/xapi/video/extensions/volume': 1,
+    });
+    expect(body.result.extensions).toEqual({
+      'https://w3id.org/xapi/video/extensions/time': 50,
+    });
+    expect(body).toHaveProperty('id');
+  });
+});

--- a/src/frontend/XAPI/LiveXapiStatement.ts
+++ b/src/frontend/XAPI/LiveXapiStatement.ts
@@ -1,0 +1,206 @@
+import {
+  ContextExtensionsDefinition,
+  DataPayload,
+  InitializedContextExtensions,
+  InteractedContextExtensions,
+  InteractedResultExtensions,
+  PausedResultExtensions,
+  PlayedResultExtensions,
+  ResultExtensionsDefinition,
+  SeekedResultExtensions,
+  TerminatedResultExtensions,
+  VerbDefinition,
+} from '../types/XAPI';
+import { truncateDecimalDigits } from '../utils/truncateDecimalDigits';
+import { Nullable } from '../utils/types';
+import { sendXAPIStatement, VideoXAPIStatementInterface } from '.';
+
+export class LiveXAPIStatement implements VideoXAPIStatementInterface {
+  private playedSegments: string = '';
+  private startSegment: Nullable<number> = null;
+
+  constructor(private jwt: string, private sessionId: string) {}
+
+  getPlayedSegment(): string {
+    if (this.startSegment !== null) {
+      if (this.playedSegments.length === 0) {
+        return `${this.startSegment}`;
+      }
+      return `${this.playedSegments}[,]${this.startSegment}`;
+    }
+
+    return this.playedSegments;
+  }
+
+  initialized(contextExtensions: InitializedContextExtensions): void {
+    const extensions: {
+      [key: string]: string | boolean | number | undefined;
+    } = {
+      [ContextExtensionsDefinition.sessionId]: this.sessionId,
+    };
+    for (const key of Object.keys(contextExtensions)) {
+      // ignore length
+      if (key === 'length') continue;
+      extensions[
+        ContextExtensionsDefinition[key as keyof InitializedContextExtensions]
+      ] = contextExtensions[key as keyof InitializedContextExtensions];
+    }
+
+    const data: DataPayload = {
+      context: {
+        extensions,
+      },
+      verb: {
+        display: {
+          'en-US': 'initialized',
+        },
+        id: VerbDefinition.initialized,
+      },
+    };
+
+    this.send(data);
+  }
+
+  played(resultExtensions: PlayedResultExtensions): void {
+    const time: number = truncateDecimalDigits(resultExtensions.time);
+    this.addStartSegment(time);
+    const data: DataPayload = {
+      context: {
+        extensions: {
+          [ContextExtensionsDefinition.sessionId]: this.sessionId,
+        },
+      },
+      result: {
+        extensions: {
+          [ResultExtensionsDefinition.time]: time,
+        },
+      },
+      verb: {
+        display: {
+          'en-US': 'played',
+        },
+        id: VerbDefinition.played,
+      },
+    };
+
+    this.send(data);
+  }
+
+  paused(resultExtensions: PausedResultExtensions): void {
+    const time: number = truncateDecimalDigits(resultExtensions.time);
+    this.addEndSegment(time);
+    const data: DataPayload = {
+      context: {
+        extensions: {
+          [ContextExtensionsDefinition.sessionId]: this.sessionId,
+        },
+      },
+      result: {
+        extensions: {
+          [ResultExtensionsDefinition.time]: time,
+          [ResultExtensionsDefinition.playedSegment]: this.getPlayedSegment(),
+        },
+      },
+      verb: {
+        display: {
+          'en-US': 'paused',
+        },
+        id: VerbDefinition.paused,
+      },
+    };
+
+    this.send(data);
+  }
+
+  seeked(resultExtensions: SeekedResultExtensions): void {}
+
+  completed(time: number): void {}
+
+  terminated(resultExtensions: TerminatedResultExtensions): void {
+    if (this.startSegment !== null) {
+      this.paused({ time: resultExtensions.time });
+    }
+
+    const time = truncateDecimalDigits(resultExtensions.time);
+
+    const data: DataPayload = {
+      context: {
+        extensions: {
+          [ContextExtensionsDefinition.sessionId]: this.sessionId,
+        },
+      },
+      result: {
+        extensions: {
+          [ResultExtensionsDefinition.time]: time,
+          [ResultExtensionsDefinition.playedSegment]: this.getPlayedSegment(),
+        },
+      },
+      verb: {
+        display: {
+          'en-US': 'terminated',
+        },
+        id: VerbDefinition.terminated,
+      },
+    };
+
+    this.send(data);
+  }
+
+  interacted(
+    resultExtensions: InteractedResultExtensions,
+    contextExtensions: InteractedContextExtensions,
+  ): void {
+    // find a way to remove this undefined type. There is no undefined value
+    const extensions: {
+      [key: string]: string | boolean | number | undefined;
+    } = {
+      [ContextExtensionsDefinition.sessionId]: this.sessionId,
+    };
+    for (const key of Object.keys(contextExtensions)) {
+      extensions[
+        ContextExtensionsDefinition[key as keyof InteractedContextExtensions]
+      ] = contextExtensions[key as keyof InteractedContextExtensions];
+    }
+
+    const data: DataPayload = {
+      context: {
+        extensions,
+      },
+      result: {
+        extensions: {
+          [ResultExtensionsDefinition.time]: truncateDecimalDigits(
+            resultExtensions.time,
+          ),
+        },
+      },
+      verb: {
+        display: {
+          'en-US': 'interacted',
+        },
+        id: VerbDefinition.interacted,
+      },
+    };
+
+    this.send(data);
+  }
+
+  private send(data: DataPayload) {
+    sendXAPIStatement(data, this.jwt);
+  }
+
+  private addStartSegment(time: number) {
+    this.startSegment = time;
+  }
+
+  private addEndSegment(time: number) {
+    if (this.startSegment === null) {
+      return;
+    }
+
+    const playedSegments =
+      this.playedSegments.length === 0 ? [] : this.playedSegments.split('[,]');
+    playedSegments.push(`${this.startSegment}[.]${time}`);
+    this.playedSegments = playedSegments.join('[,]');
+    this.startSegment = null;
+  }
+}

--- a/src/frontend/XAPI/VideoXAPIStatement.spec.ts
+++ b/src/frontend/XAPI/VideoXAPIStatement.spec.ts
@@ -3,14 +3,14 @@ import fetchMock from 'fetch-mock';
 import { XAPI_ENDPOINT } from '../settings';
 import { VerbDefinition } from '../types/XAPI';
 import { truncateDecimalDigits } from '../utils/truncateDecimalDigits';
-import { XAPIStatement } from './XAPIStatement';
+import { VideoXAPIStatement } from './VideoXAPIStatement';
 
-describe('XAPIStatement', () => {
+describe('VideoXAPIStatement', () => {
   afterEach(() => fetchMock.reset());
 
-  describe('XAPIStatement.setDuration', () => {
+  describe('VideoXAPIStatement.setDuration', () => {
     it('does not accept negative or 0 value', () => {
-      const xapiStatement = new XAPIStatement('jwt', 'abcd');
+      const xapiStatement = new VideoXAPIStatement('jwt', 'abcd');
 
       expect(() => {
         xapiStatement.setDuration(-1);
@@ -22,7 +22,7 @@ describe('XAPIStatement', () => {
     });
 
     it('accept only one modification', () => {
-      const xapiStatement = new XAPIStatement('jwt', 'abcd');
+      const xapiStatement = new VideoXAPIStatement('jwt', 'abcd');
       xapiStatement.setDuration(20);
 
       expect(() => {
@@ -31,10 +31,10 @@ describe('XAPIStatement', () => {
     });
   });
 
-  describe('XAPIStatement.initialized', () => {
+  describe('VideoXAPIStatement.initialized', () => {
     it('post an initialized statement with only required extensions', () => {
       fetchMock.mock(`${XAPI_ENDPOINT}/`, 204);
-      const xapiStatement = new XAPIStatement('jwt', 'abcd');
+      const xapiStatement = new VideoXAPIStatement('jwt', 'abcd');
       xapiStatement.initialized({
         length: 1,
       });
@@ -66,7 +66,7 @@ describe('XAPIStatement', () => {
       fetchMock.mock(`${XAPI_ENDPOINT}/`, 204, {
         overwriteRoutes: true,
       });
-      const xapiStatement = new XAPIStatement('jwt', 'abcd');
+      const xapiStatement = new VideoXAPIStatement('jwt', 'abcd');
       xapiStatement.initialized({
         ccSubtitleEnabled: true,
         ccSubtitleLanguage: 'en-US',
@@ -123,7 +123,7 @@ describe('XAPIStatement', () => {
       fetchMock.mock(`${XAPI_ENDPOINT}/`, 204, {
         overwriteRoutes: true,
       });
-      const xapiStatement = new XAPIStatement('jwt', 'abcd');
+      const xapiStatement = new VideoXAPIStatement('jwt', 'abcd');
       xapiStatement.setDuration(1);
       xapiStatement.played({
         time: 42.321,
@@ -153,12 +153,12 @@ describe('XAPIStatement', () => {
     });
   });
 
-  describe('XAPIStatement.paused', () => {
+  describe('VideoXAPIStatement.paused', () => {
     it('sends a paused statement without completion threshold', () => {
       fetchMock.mock(`${XAPI_ENDPOINT}/`, 204, {
         overwriteRoutes: true,
       });
-      const xapiStatement = new XAPIStatement('jwt', 'abcd');
+      const xapiStatement = new VideoXAPIStatement('jwt', 'abcd');
       xapiStatement.setDuration(100);
       xapiStatement.played({ time: 0 });
       xapiStatement.paused({ time: 10 });
@@ -198,7 +198,7 @@ describe('XAPIStatement', () => {
       fetchMock.mock(`${XAPI_ENDPOINT}/`, 204, {
         overwriteRoutes: true,
       });
-      const xapiStatement = new XAPIStatement('jwt', 'abcd');
+      const xapiStatement = new VideoXAPIStatement('jwt', 'abcd');
       xapiStatement.setDuration(100);
       xapiStatement.seeked({
         timeFrom: 0,
@@ -239,7 +239,7 @@ describe('XAPIStatement', () => {
       fetchMock.mock(`${XAPI_ENDPOINT}/`, 204, {
         overwriteRoutes: true,
       });
-      const xapiStatement = new XAPIStatement('jwt', 'abcd');
+      const xapiStatement = new VideoXAPIStatement('jwt', 'abcd');
       xapiStatement.initialized({ length: 100 });
       xapiStatement.played({ time: 0 });
       xapiStatement.paused({ time: 100 });
@@ -288,7 +288,7 @@ describe('XAPIStatement', () => {
       fetchMock.mock(`${XAPI_ENDPOINT}/`, 204, {
         overwriteRoutes: true,
       });
-      const xapiStatement = new XAPIStatement('jwt', 'abcd');
+      const xapiStatement = new VideoXAPIStatement('jwt', 'abcd');
       xapiStatement.initialized({ length: 74.582 });
       xapiStatement.played({ time: 0 });
       xapiStatement.paused({ time: 74.608 });
@@ -330,7 +330,7 @@ describe('XAPIStatement', () => {
       fetchMock.mock(`${XAPI_ENDPOINT}/`, 204, {
         overwriteRoutes: true,
       });
-      const xapiStatement = new XAPIStatement('jwt', 'abcd');
+      const xapiStatement = new VideoXAPIStatement('jwt', 'abcd');
       xapiStatement.setDuration(100);
       xapiStatement.terminated({
         time: 50,
@@ -369,7 +369,7 @@ describe('XAPIStatement', () => {
       fetchMock.mock(`${XAPI_ENDPOINT}/`, 204, {
         overwriteRoutes: true,
       });
-      const xapiStatement = new XAPIStatement('jwt', 'abcd');
+      const xapiStatement = new VideoXAPIStatement('jwt', 'abcd');
       xapiStatement.setDuration(100);
       xapiStatement.played({ time: 0 });
       xapiStatement.terminated({
@@ -421,7 +421,7 @@ describe('XAPIStatement', () => {
       fetchMock.mock(`${XAPI_ENDPOINT}/`, 204, {
         overwriteRoutes: true,
       });
-      const xapiStatement = new XAPIStatement('jwt', 'abcd');
+      const xapiStatement = new VideoXAPIStatement('jwt', 'abcd');
       xapiStatement.setDuration(1);
       xapiStatement.interacted(
         {
@@ -473,12 +473,12 @@ describe('XAPIStatement', () => {
       expect(body).toHaveProperty('id');
     });
   });
-  describe('XAPIStatement played segment', () => {
+  describe('VideoXAPIStatement played segment', () => {
     it('computes played segment', () => {
       fetchMock.mock(`${XAPI_ENDPOINT}/`, 204, {
         overwriteRoutes: true,
       });
-      const xapiStatement = new XAPIStatement('jwt', 'abcd');
+      const xapiStatement = new VideoXAPIStatement('jwt', 'abcd');
       xapiStatement.initialized({
         length: 100,
       });
@@ -520,12 +520,12 @@ describe('XAPIStatement', () => {
     });
   });
 
-  describe('XAPIStatement.getProgress', () => {
+  describe('VideoXAPIStatement.getProgress', () => {
     it('compute progress at random time', () => {
       fetchMock.mock(`${XAPI_ENDPOINT}/`, 204, {
         overwriteRoutes: true,
       });
-      const xapiStatement = new XAPIStatement('jwt', 'abcd');
+      const xapiStatement = new VideoXAPIStatement('jwt', 'abcd');
       xapiStatement.initialized({
         length: 100,
       });
@@ -560,7 +560,7 @@ describe('XAPIStatement', () => {
       fetchMock.mock(`${XAPI_ENDPOINT}/`, 204, {
         overwriteRoutes: true,
       });
-      const xapiStatement = new XAPIStatement('jwt', 'abcd');
+      const xapiStatement = new VideoXAPIStatement('jwt', 'abcd');
       xapiStatement.initialized({
         length: 100,
       });
@@ -571,7 +571,7 @@ describe('XAPIStatement', () => {
       fetchMock.mock(`${XAPI_ENDPOINT}/`, 204, {
         overwriteRoutes: true,
       });
-      const xapiStatement = new XAPIStatement('jwt', 'abcd');
+      const xapiStatement = new VideoXAPIStatement('jwt', 'abcd');
       xapiStatement.initialized({
         length: 100,
       });
@@ -588,21 +588,21 @@ describe('XAPIStatement', () => {
     });
   });
 
-  describe('XAPIStatement.computeThreshold', () => {
+  describe('VideoXAPIStatement.computeThreshold', () => {
     it('return a completion thresold equal to 0.95 when time is 600', () => {
-      const xapiStatement = new XAPIStatement('jwt', 'abcd');
+      const xapiStatement = new VideoXAPIStatement('jwt', 'abcd');
       xapiStatement.setDuration(600);
       xapiStatement.computeCompletionThreshold();
       expect(xapiStatement.getCompletionThreshold()).toEqual(0.95);
     });
     it('return a completion threshold equal to 0.95 when duration is higher than 600', () => {
-      const xapiStatement = new XAPIStatement('jwt', 'abcd');
+      const xapiStatement = new VideoXAPIStatement('jwt', 'abcd');
       xapiStatement.setDuration(600 * (Math.random() + 1));
       xapiStatement.computeCompletionThreshold();
       expect(xapiStatement.getCompletionThreshold()).toEqual(0.95);
     });
     it('return a completion closed to 0.70 when duration is less than 1 minute', () => {
-      const xapiStatement = new XAPIStatement('jwt', 'abcd');
+      const xapiStatement = new VideoXAPIStatement('jwt', 'abcd');
       xapiStatement.setDuration(1);
       xapiStatement.computeCompletionThreshold();
       expect(xapiStatement.getCompletionThreshold()).toBeCloseTo(0.7, 3);

--- a/src/frontend/XAPI/VideoXAPIStatement.ts
+++ b/src/frontend/XAPI/VideoXAPIStatement.ts
@@ -1,8 +1,5 @@
 // https://liveaspankaj.gitbooks.io/xapi-video-profile/content/statement_data_model.html
 import { DateTime, Interval } from 'luxon';
-import { v4 as uuidv4 } from 'uuid';
-
-import { XAPI_ENDPOINT } from '../settings';
 import {
   CompletedDataPlayload,
   ContextExtensionsDefinition,
@@ -19,8 +16,9 @@ import {
 } from '../types/XAPI';
 import { truncateDecimalDigits } from '../utils/truncateDecimalDigits';
 import { Nullable } from '../utils/types';
+import { sendXAPIStatement, VideoXAPIStatementInterface } from '.';
 
-export class XAPIStatement {
+export class VideoXAPIStatement implements VideoXAPIStatementInterface {
   private playedSegments: string = '';
   private startSegment: Nullable<number> = null;
   private duration: number = 0;
@@ -376,17 +374,7 @@ export class XAPIStatement {
       return;
     }
 
-    fetch(`${XAPI_ENDPOINT}/`, {
-      body: JSON.stringify({
-        ...data,
-        id: uuidv4(),
-      }),
-      headers: {
-        Authorization: `Bearer ${this.jwt}`,
-        'Content-Type': 'application/json',
-      },
-      method: 'POST',
-    });
+    sendXAPIStatement(data, this.jwt);
   }
 
   private addStartSegment(time: number) {

--- a/src/frontend/XAPI/index.spec.ts
+++ b/src/frontend/XAPI/index.spec.ts
@@ -1,0 +1,25 @@
+import { liveState } from '../types/tracks';
+import { videoMockFactory } from '../utils/tests/factories';
+import { LiveXAPIStatement } from './LiveXapiStatement';
+import { VideoXAPIStatement } from './VideoXAPIStatement';
+import { XAPIStatement } from './index';
+
+describe('XAPIStatement', () => {
+  it('returns a LiveXapiStatement instance when video is live', () => {
+    const video = videoMockFactory({
+      live_state: liveState.RUNNING,
+    });
+
+    const xapiStatement = XAPIStatement('jwt', 'sessionId', video);
+
+    expect(xapiStatement).toBeInstanceOf(LiveXAPIStatement);
+  });
+
+  it('returns a VideoXAPIStatement instance when video is not live', () => {
+    const video = videoMockFactory();
+
+    const xapiStatement = XAPIStatement('jwt', 'sessionId', video);
+
+    expect(xapiStatement).toBeInstanceOf(VideoXAPIStatement);
+  });
+});

--- a/src/frontend/XAPI/index.tsx
+++ b/src/frontend/XAPI/index.tsx
@@ -1,0 +1,55 @@
+// https://liveaspankaj.gitbooks.io/xapi-video-profile/content/statement_data_model.html
+import { Video } from '../types/tracks';
+import { v4 as uuidv4 } from 'uuid';
+import { XAPI_ENDPOINT } from '../settings';
+import {
+  DataPayload,
+  InitializedContextExtensions,
+  InteractedContextExtensions,
+  InteractedResultExtensions,
+  PausedResultExtensions,
+  PlayedResultExtensions,
+  SeekedResultExtensions,
+  TerminatedResultExtensions,
+} from '../types/XAPI';
+import { VideoXAPIStatement } from './VideoXAPIStatement';
+import { LiveXAPIStatement } from './LiveXapiStatement';
+
+export interface VideoXAPIStatementInterface {
+  initialized(contextExtensions: InitializedContextExtensions): void;
+  played(resultExtensions: PlayedResultExtensions): void;
+  paused(resultExtensions: PausedResultExtensions): void;
+  seeked(resultExtensions: SeekedResultExtensions): void;
+  completed(time: number): void;
+  terminated(resultExtensions: TerminatedResultExtensions): void;
+  interacted(
+    resultExtensions: InteractedResultExtensions,
+    contextExtensions: InteractedContextExtensions,
+  ): void;
+}
+
+export const sendXAPIStatement = (data: DataPayload, jwt: string) => {
+  fetch(`${XAPI_ENDPOINT}/`, {
+    body: JSON.stringify({
+      ...data,
+      id: uuidv4(),
+    }),
+    headers: {
+      Authorization: `Bearer ${jwt}`,
+      'Content-Type': 'application/json',
+    },
+    method: 'POST',
+  });
+};
+
+export const XAPIStatement = (
+  jwt: string,
+  sessionId: string,
+  video: Video,
+): VideoXAPIStatementInterface => {
+  if (video.live_state) {
+    return new LiveXAPIStatement(jwt, sessionId);
+  }
+
+  return new VideoXAPIStatement(jwt, sessionId);
+};


### PR DESCRIPTION
## Purpose

Live and VOD video can not send the same XAPI statements. We decided to
create a class by type of video and then a factory is responsible to
instantiate the good one based on the video object used.

## Proposal

- [x] Change the activity type to `http://id.tincanapi.com/activitytype/webinar` when it's a live
- [x] Create a class dedicated to live xapi statements
- [x] Create a factory responsible to instantiate the good class depending on the video object passed as argument. 

resolves #1053 
