### PR TITLE
🚧(aws) implement harvest job failure strategy

### DIFF
--- a/src/aws/lambda-mediapackage/index.spec.js
+++ b/src/aws/lambda-mediapackage/index.spec.js
@@ -60,8 +60,7 @@ describe('lambda mediapackage', () => {
       detail: {
         harvest_job: {
           id: 'harvest_job_id',
-          arn:
-            'arn:aws:mediapackage-vod:us-east-1:aws_account_id:harvest_jobs/harvest_job_id',
+          arn: 'arn:aws:mediapackage-vod:us-east-1:aws_account_id:harvest_jobs/harvest_job_id',
           status: 'SUCCEEDED',
           origin_endpoint_id: 'endpoint_id',
           start_time: '2019-06-26T20:30:00-08:00',

--- a/src/aws/lambda-mediapackage/src/check.spec.js
+++ b/src/aws/lambda-mediapackage/src/check.spec.js
@@ -66,8 +66,7 @@ describe('check', () => {
 
     expect(mockHeadObject).toHaveBeenCalledWith({
       Bucket: 'test-marsha-destination',
-      Key:
-        'a3e213a7-9c56-4bd3-b71c-fe567b0cfe19/mp4/a3e213a7-9c56-4bd3-b71c-fe567b0cfe19_540.mp4',
+      Key: 'a3e213a7-9c56-4bd3-b71c-fe567b0cfe19/mp4/a3e213a7-9c56-4bd3-b71c-fe567b0cfe19_540.mp4',
     });
 
     expect(mockUpdateState).not.toHaveBeenCalled();
@@ -113,23 +112,19 @@ describe('check', () => {
 
     expect(mockHeadObject).toHaveBeenCalledWith({
       Bucket: 'test-marsha-destination',
-      Key:
-        'a3e213a7-9c56-4bd3-b71c-fe567b0cfe19/mp4/a3e213a7-9c56-4bd3-b71c-fe567b0cfe19_540.mp4',
+      Key: 'a3e213a7-9c56-4bd3-b71c-fe567b0cfe19/mp4/a3e213a7-9c56-4bd3-b71c-fe567b0cfe19_540.mp4',
     });
     expect(mockHeadObject).toHaveBeenCalledWith({
       Bucket: 'test-marsha-destination',
-      Key:
-        'a3e213a7-9c56-4bd3-b71c-fe567b0cfe19/thumbnails/a3e213a7-9c56-4bd3-b71c-fe567b0cfe19_540.0000000.jpg',
+      Key: 'a3e213a7-9c56-4bd3-b71c-fe567b0cfe19/thumbnails/a3e213a7-9c56-4bd3-b71c-fe567b0cfe19_540.0000000.jpg',
     });
     expect(mockHeadObject).toHaveBeenCalledWith({
       Bucket: 'test-marsha-destination',
-      Key:
-        'a3e213a7-9c56-4bd3-b71c-fe567b0cfe19/mp4/a3e213a7-9c56-4bd3-b71c-fe567b0cfe19_720.mp4',
+      Key: 'a3e213a7-9c56-4bd3-b71c-fe567b0cfe19/mp4/a3e213a7-9c56-4bd3-b71c-fe567b0cfe19_720.mp4',
     });
     expect(mockHeadObject).toHaveBeenCalledWith({
       Bucket: 'test-marsha-destination',
-      Key:
-        'a3e213a7-9c56-4bd3-b71c-fe567b0cfe19/thumbnails/a3e213a7-9c56-4bd3-b71c-fe567b0cfe19_720.0000000.jpg',
+      Key: 'a3e213a7-9c56-4bd3-b71c-fe567b0cfe19/thumbnails/a3e213a7-9c56-4bd3-b71c-fe567b0cfe19_720.0000000.jpg',
     });
 
     expect(mockUpdateState).toHaveBeenCalledWith(

--- a/src/aws/lambda-mediapackage/src/harvest.js
+++ b/src/aws/lambda-mediapackage/src/harvest.js
@@ -44,7 +44,7 @@ const harvestJobSucceeded = async (harvestJob, lambdaFunctionName) => {
     .promise();
 
   // The harvest id has this pattern : {environment}_{pk}_{stamp}
-  // splitting it give us the information we need
+  // splitting it gives us the information we need
   const [environment, pk, stamp] = harvestJob.id.split('_');
   // build the hls manifest url
   const manifestUrl = `https://${CLOUDFRONT_ENDPOINT}/${harvestJob.s3_destination.manifest_key}`;
@@ -175,7 +175,7 @@ const harvestJobFailed = async (harvestJob) => {
 
   if (existingHarvestJobs.HarvestJobs.length === 3) {
     console.log(
-      `harvesjob for channel ${harvestJob.channel_id} failed 3 times. Change video state to DELETED`,
+      `harves job for channel ${harvestJob.channel_id} failed 3 times. Video state changed to DELETED`,
     );
     // update state
     return updateState(`${pk}/video/${pk}/${stamp}`, 'deleted');

--- a/src/aws/lambda-mediapackage/src/harvest.spec.js
+++ b/src/aws/lambda-mediapackage/src/harvest.spec.js
@@ -58,8 +58,7 @@ describe('harvest', () => {
       detail: {
         harvest_job: {
           id: 'harvest_job_id',
-          arn:
-            'arn:aws:mediapackage-vod:eu-west-1:aws_account_id:harvest_jobs/harvest_job_id',
+          arn: 'arn:aws:mediapackage-vod:eu-west-1:aws_account_id:harvest_jobs/harvest_job_id',
           status: 'STARTING',
           origin_endpoint_id: 'endpoint_id',
           start_time: '2019-06-26T20:30:00-08:00',
@@ -93,8 +92,7 @@ describe('harvest', () => {
       detail: {
         harvest_job: {
           id: 'test_a3e213a7-9c56-4bd3-b71c-fe567b0cfe22_1610546271',
-          arn:
-            'arn:aws:mediapackage-vod:eu-west-1:aws_account_id:harvest_jobs/test_a3e213a7-9c56-4bd3-b71c-fe567b0cfe22_1610546271',
+          arn: 'arn:aws:mediapackage-vod:eu-west-1:aws_account_id:harvest_jobs/test_a3e213a7-9c56-4bd3-b71c-fe567b0cfe22_1610546271',
           status: 'SUCCEEDED',
           origin_endpoint_id:
             'test_a3e213a7-9c56-4bd3-b71c-fe567b0cfe22_1610546271_hls',

--- a/src/aws/roles.tf
+++ b/src/aws/roles.tf
@@ -556,7 +556,9 @@ resource "aws_iam_policy" "lambda_mediapackage_access_policy" {
       "Action": [
         "mediapackage:DeleteChannel",
         "mediapackage:DeleteOriginEndpoint",
-        "mediapackage:DescribeOriginEndpoint"
+        "mediapackage:DescribeOriginEndpoint",
+        "mediapackage:listHarvestJobs",
+        "mediapackage:createHarvestJob"
       ],
       "Resource": "*"
     }

--- a/src/backend/marsha/core/serializers/base.py
+++ b/src/backend/marsha/core/serializers/base.py
@@ -5,7 +5,7 @@ from django.core.exceptions import ValidationError
 
 from rest_framework import serializers
 
-from ..defaults import ERROR, HARVESTED, PROCESSING, READY, STATE_CHOICES
+from ..defaults import DELETED, ERROR, HARVESTED, PROCESSING, READY, STATE_CHOICES
 from ..models import TimedTextTrack
 from ..utils import time_utils
 
@@ -75,7 +75,7 @@ class UpdateStateSerializer(serializers.Serializer):
 
     key = serializers.RegexField(KEY_REGEX)
     state = serializers.ChoiceField(
-        tuple(c for c in STATE_CHOICES if c[0] in (PROCESSING, READY, ERROR, HARVESTED))
+        tuple(c for c in STATE_CHOICES if c[0] in (PROCESSING, READY, ERROR, HARVESTED, DELETED))
     )
     extraParameters = serializers.DictField()
 


### PR DESCRIPTION
## Purpose

When an harvest jobs fails nothing is done since now. The idea is to
retry 3 times the same harvest job and then delete the corresponding
mediapackage channel if it still fails.

## Proposal

To Do

resolves #1046 

