### PR TITLE
✨(front) add confirmation before starting/stopping a live

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Add a confirmation before starting or stopping a live
+
 ## [3.21.0] - 2021-07-05
 
 ### Added

--- a/src/frontend/components/ConfirmationLayer/index.spec.tsx
+++ b/src/frontend/components/ConfirmationLayer/index.spec.tsx
@@ -1,0 +1,75 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { Grommet } from 'grommet';
+import { wrapInIntlProvider } from '../../utils/tests/intl';
+import { ConfirmationLayer } from '.';
+
+const props = {
+  confirmationLabel: <small>Are you sure ?</small>,
+  onConfirm: jest.fn(),
+  onCancel: jest.fn(),
+};
+
+describe('<ConfirmationLayer />', () => {
+  beforeEach(() => {
+    /*
+      make sure to remove all body children, grommet layer gets rendered twice, known issue
+      https://github.com/grommet/grommet/issues/5200
+    */
+    document.body.innerHTML = '';
+    document.body.appendChild(document.createElement('div'));
+  });
+
+  it('renders the component and expected elements are present', () => {
+    // wrap the component in a grommet provider to have a valid theme.
+    render(
+      wrapInIntlProvider(
+        <Grommet>
+          <ConfirmationLayer
+            confirmationLabel={props.confirmationLabel}
+            onConfirm={props.onConfirm}
+            onCancel={props.onCancel}
+          />
+        </Grommet>,
+      ),
+    );
+    screen.getByText(/are you sure \?/i);
+    screen.getByRole('button', { name: /ok/i });
+    screen.getByRole('button', { name: /cancel/i });
+  });
+
+  it('button actions get called', () => {
+    // wrap the component in a grommet provider to have a valid theme.
+    render(
+      wrapInIntlProvider(
+        <Grommet>
+          <ConfirmationLayer
+            confirmationLabel={props.confirmationLabel}
+            onConfirm={props.onConfirm}
+            onCancel={props.onCancel}
+          />
+        </Grommet>,
+      ),
+    );
+
+    const okButton = screen.getByRole('button', { name: /ok/i });
+    const cancelButton = screen.getByRole('button', { name: /cancel/i });
+
+    // Clicks on the ok button, onConfirm should be called
+    fireEvent.click(okButton);
+    expect(props.onConfirm).toHaveBeenCalled();
+
+    // If cancel button is clicked, onCancel should be called
+    fireEvent.click(cancelButton);
+    expect(props.onCancel).toHaveBeenCalled();
+
+    // Presses escape key, onCancel should be called
+    fireEvent.keyDown(cancelButton, {
+      key: 'Escape',
+      code: 'Escape',
+      keyCode: 27,
+      charCode: 27,
+    });
+    expect(props.onCancel).toBeCalledTimes(2);
+  });
+});

--- a/src/frontend/components/ConfirmationLayer/index.tsx
+++ b/src/frontend/components/ConfirmationLayer/index.tsx
@@ -1,0 +1,53 @@
+import React, { MouseEventHandler } from 'react';
+import { Box, Button, Layer, Text } from 'grommet';
+import { KeyboardEventHandler } from 'react-select';
+import { defineMessages, useIntl } from 'react-intl';
+
+const messages = defineMessages({
+  confirmation: {
+    defaultMessage: 'Ok',
+    description: 'Label for the confirmation button',
+    id: 'components.ConfirmationLayer.Confirmation',
+  },
+  cancel: {
+    defaultMessage: 'Cancel',
+    description: 'Label for the cancel button',
+    id: 'components.ConfirmationLayer.Cancel',
+  },
+});
+
+interface ConfirmationLayerProps {
+  confirmationLabel: JSX.Element;
+  onConfirm: MouseEventHandler;
+  onCancel: KeyboardEventHandler | MouseEventHandler;
+}
+
+export const ConfirmationLayer = ({
+  confirmationLabel,
+  onCancel,
+  onConfirm,
+}: ConfirmationLayerProps) => {
+  const intl = useIntl();
+  return (
+    <Layer
+      position="center"
+      onClickOutside={onCancel as MouseEventHandler}
+      onEsc={onCancel as KeyboardEventHandler}
+    >
+      <Box pad="large" gap="medium">
+        <Text>{confirmationLabel}</Text>
+        <Box align="center" direction="row" gap="medium">
+          <Button
+            label={intl.formatMessage(messages.confirmation)}
+            onClick={onConfirm}
+            primary={true}
+          />
+          <Button
+            label={intl.formatMessage(messages.cancel)}
+            onClick={onCancel as MouseEventHandler}
+          />
+        </Box>
+      </Box>
+    </Layer>
+  );
+};

--- a/src/frontend/components/DashboardConfirmButton/index.spec.tsx
+++ b/src/frontend/components/DashboardConfirmButton/index.spec.tsx
@@ -1,0 +1,129 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import fetchMock from 'fetch-mock';
+import { Grommet } from 'grommet';
+import { wrapInIntlProvider } from '../../utils/tests/intl';
+import { DashboardConfirmButton } from '.';
+
+const props = {
+  confirmationLabel: <small>Are you sure ?</small>,
+  label: <span>Start a live</span>,
+  onConfirm: jest.fn(),
+};
+
+jest.mock('../../data/appData', () => ({
+  appData: {
+    document: null,
+    jwt: 'cool_token_m8',
+  },
+}));
+
+describe('<DashboardConfirmButton />', () => {
+  afterEach(jest.resetAllMocks);
+  beforeEach(() => {
+    /*
+      make sure to remove all body children, grommet layer gets rendered twice, known issue
+      https://github.com/grommet/grommet/issues/5200
+    */
+    document.body.innerHTML = '';
+    document.body.appendChild(document.createElement('div'));
+  });
+
+  // render twice component why ? if I comment it second test is ok
+  it('renders the component and expected elements are present', () => {
+    render(
+      wrapInIntlProvider(
+        <DashboardConfirmButton
+          confirmationLabel={props.confirmationLabel}
+          label={props.label}
+          onConfirm={props.onConfirm}
+        />,
+      ),
+    );
+    screen.getByRole('button', { name: /start a live/i });
+  });
+
+  it('renders the confirmation box when the button is fired', () => {
+    // wrap the component in a grommet provider to have a valid theme.
+    render(
+      wrapInIntlProvider(
+        <Grommet>
+          <DashboardConfirmButton
+            confirmationLabel={props.confirmationLabel}
+            label={props.label}
+            onConfirm={props.onConfirm}
+          />
+        </Grommet>,
+      ),
+    );
+
+    const startButton = screen.getByRole('button', { name: /start a live/i });
+
+    // Clicks on ok start button, confirmation layer should show up
+    fireEvent.click(startButton);
+
+    screen.getByText(/are you sure \?/i);
+    screen.getByRole('button', { name: /ok/i });
+    screen.getByRole('button', { name: /cancel/i });
+
+    const okButton = screen.getByRole('button', { name: /ok/i });
+
+    fireEvent.click(okButton);
+    expect(props.onConfirm).toHaveBeenCalled();
+  });
+
+  it('renders the confirmation box when the button is fired and call onConfirm when ok is pressed', () => {
+    // wrap the component in a grommet provider to have a valid theme.
+    render(
+      wrapInIntlProvider(
+        <Grommet>
+          <DashboardConfirmButton
+            confirmationLabel={props.confirmationLabel}
+            label={props.label}
+            onConfirm={props.onConfirm}
+          />
+        </Grommet>,
+      ),
+    );
+
+    const startButton = screen.getByRole('button', { name: /start a live/i });
+
+    // Clicks on start button, confirmation layer should show up
+    fireEvent.click(startButton);
+
+    screen.getByText(/are you sure \?/i);
+    const okButton = screen.getByRole('button', { name: /ok/i });
+    screen.getByRole('button', { name: /cancel/i });
+
+    // Clicks on ok button, onConfirm should be called
+    fireEvent.click(okButton);
+    expect(props.onConfirm).toHaveBeenCalled();
+  });
+
+  it('renders the confirmation box when the button is fired and onConfirm is not called by clicking the cancel button ', () => {
+    // wrap the component in a grommet provider to have a valid theme.
+    render(
+      wrapInIntlProvider(
+        <Grommet>
+          <DashboardConfirmButton
+            confirmationLabel={props.confirmationLabel}
+            label={props.label}
+            onConfirm={props.onConfirm}
+          />
+        </Grommet>,
+      ),
+    );
+
+    const startButton = screen.getByRole('button', { name: /start a live/i });
+
+    // Clicks on start button, confirmation layer should show up
+    fireEvent.click(startButton);
+
+    screen.getByText(/are you sure \?/i);
+    const cancelButton = screen.getByRole('button', { name: /cancel/i });
+
+    // Clicks on cancel button, onConfirm should not be called
+    fireEvent.click(cancelButton);
+    expect(props.onConfirm).not.toHaveBeenCalled();
+  });
+});

--- a/src/frontend/components/DashboardConfirmButton/index.tsx
+++ b/src/frontend/components/DashboardConfirmButton/index.tsx
@@ -1,0 +1,43 @@
+import React, { MouseEventHandler, useState } from 'react';
+import { ConfirmationLayer } from '../ConfirmationLayer';
+import { DashboardButton } from '../DashboardPaneButtons';
+
+interface DashboardConfirmButtonProps {
+  label: JSX.Element;
+  confirmationLabel: JSX.Element;
+  onConfirm: MouseEventHandler;
+}
+
+export const DashboardConfirmButton = ({
+  label,
+  confirmationLabel,
+  onConfirm,
+}: DashboardConfirmButtonProps) => {
+  const [showConfirm, setShowConfirm] = useState(false);
+
+  const requireConfirmAction = () => {
+    setShowConfirm(true);
+  };
+
+  const onConfirmAction = (e: React.MouseEvent<Element, MouseEvent>) => {
+    setShowConfirm(false);
+    onConfirm(e);
+  };
+
+  return (
+    <React.Fragment>
+      <DashboardButton
+        label={label}
+        primary={true}
+        onClick={requireConfirmAction}
+      />
+      {showConfirm && (
+        <ConfirmationLayer
+          confirmationLabel={confirmationLabel}
+          onCancel={() => setShowConfirm(false)}
+          onConfirm={onConfirmAction}
+        />
+      )}
+    </React.Fragment>
+  );
+};

--- a/src/frontend/components/DashboardVideoLiveStartButton/index.tsx
+++ b/src/frontend/components/DashboardVideoLiveStartButton/index.tsx
@@ -6,7 +6,7 @@ import { startLive } from '../../data/sideEffects/startLive';
 import { useVideo } from '../../data/stores/useVideo';
 import { Video } from '../../types/tracks';
 import { Nullable } from '../../utils/types';
-import { DashboardButton } from '../DashboardPaneButtons';
+import { DashboardConfirmButton } from '../DashboardConfirmButton';
 import { FULL_SCREEN_ERROR_ROUTE } from '../ErrorComponents/route';
 import { Loader } from '../Loader';
 
@@ -15,6 +15,11 @@ const messages = defineMessages({
     defaultMessage: 'start streaming',
     description: 'Start a video streaming.',
     id: 'components.DashboardVideoLive.startLive',
+  },
+  confirmStartLive: {
+    defaultMessage: 'Are you sure you want to start a video streaming ?',
+    description: 'Confirmation to start a video streaming.',
+    id: 'components.DashboardVideoLive.confirmStartLive',
   },
 });
 
@@ -49,10 +54,10 @@ export const DashboardVideoLiveStartButton = ({
   return (
     <React.Fragment>
       {status === 'pending' && <Loader />}
-      <DashboardButton
+      <DashboardConfirmButton
         label={<FormattedMessage {...messages.startLive} />}
-        primary={true}
-        onClick={startLiveAction}
+        confirmationLabel={<FormattedMessage {...messages.confirmStartLive} />}
+        onConfirm={startLiveAction}
       />
     </React.Fragment>
   );

--- a/src/frontend/components/DashboardVideoLiveStopButton/index.spec.tsx
+++ b/src/frontend/components/DashboardVideoLiveStopButton/index.spec.tsx
@@ -1,10 +1,11 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import fetchMock from 'fetch-mock';
+import { Grommet } from 'grommet';
 import React from 'react';
 import { ImportMock } from 'ts-mock-imports';
 
 import * as useVideoModule from '../../data/stores/useVideo';
-import { uploadState, liveState } from '../../types/tracks';
+import { liveState } from '../../types/tracks';
 import { videoMockFactory } from '../../utils/tests/factories';
 import { wrapInIntlProvider } from '../../utils/tests/intl';
 import { wrapInRouter } from '../../utils/tests/router';
@@ -32,6 +33,14 @@ describe('components/DashboardVideoLiveStopButton', () => {
   });
 
   afterAll(useVideoStub.restore);
+  beforeEach(() => {
+    /*
+      make sure to remove all body children, grommet layer gets rendered twice, known issue
+      https://github.com/grommet/grommet/issues/5200
+    */
+    document.body.innerHTML = '';
+    document.body.appendChild(document.createElement('div'));
+  });
 
   const video = videoMockFactory();
 
@@ -60,12 +69,17 @@ describe('components/DashboardVideoLiveStopButton', () => {
 
     render(
       wrapInIntlProvider(
-        wrapInRouter(<DashboardVideoLiveStopButton video={video} />, [
-          {
-            path: FULL_SCREEN_ERROR_ROUTE('liveInit'),
-            render: () => <span>error</span>,
-          },
-        ]),
+        wrapInRouter(
+          <Grommet>
+            <DashboardVideoLiveStopButton video={video} />
+          </Grommet>,
+          [
+            {
+              path: FULL_SCREEN_ERROR_ROUTE('liveInit'),
+              render: () => <span>error</span>,
+            },
+          ],
+        ),
       ),
     );
 
@@ -76,6 +90,13 @@ describe('components/DashboardVideoLiveStopButton', () => {
       name: /stop streaming/i,
     });
     fireEvent.click(stopButton);
+
+    // Confirmation layer should show up
+    const confirmButton = screen.getByRole('button', { name: /ok/i });
+    screen.getByRole('button', { name: /cancel/i });
+
+    // Clicks on start button, confirmation layer should show up
+    fireEvent.click(confirmButton);
 
     // the state changes to pending, the loader is rendered
     screen.getByText('Loader');
@@ -100,7 +121,11 @@ describe('components/DashboardVideoLiveStopButton', () => {
 
     render(
       wrapInIntlProvider(
-        wrapInRouter(<DashboardVideoLiveStopButton video={video} />),
+        wrapInRouter(
+          <Grommet>
+            <DashboardVideoLiveStopButton video={video} />
+          </Grommet>,
+        ),
       ),
     );
 
@@ -111,6 +136,13 @@ describe('components/DashboardVideoLiveStopButton', () => {
       name: /stop streaming/i,
     });
     fireEvent.click(stopButton);
+
+    // Confirmation layer should show up
+    const confirmButton = screen.getByRole('button', { name: /ok/i });
+    screen.getByRole('button', { name: /cancel/i });
+
+    // Clicks on start button, confirmation layer should show up
+    fireEvent.click(confirmButton);
 
     // the state changes to pending, the loader is rendered
     screen.getByText('Loader');

--- a/src/frontend/components/DashboardVideoLiveStopButton/index.tsx
+++ b/src/frontend/components/DashboardVideoLiveStopButton/index.tsx
@@ -6,7 +6,7 @@ import { stopLive } from '../../data/sideEffects/stopLive';
 import { useVideo } from '../../data/stores/useVideo';
 import { Video } from '../../types/tracks';
 import { Nullable } from '../../utils/types';
-import { DashboardButton } from '../DashboardPaneButtons';
+import { DashboardConfirmButton } from '../DashboardConfirmButton';
 import { FULL_SCREEN_ERROR_ROUTE } from '../ErrorComponents/route';
 import { Loader } from '../Loader';
 
@@ -15,6 +15,11 @@ const messages = defineMessages({
     defaultMessage: 'stop streaming',
     description: 'Stop a video streaming.',
     id: 'components.DashboardVideoLiveStopButton.startLive',
+  },
+  confirmStopLive: {
+    defaultMessage: 'Are you sure you want to stop the video streaming ?',
+    description: 'Confirmation to stop the video streaming.',
+    id: 'components.DashboardVideoLiveStopButton.confirmStopLive',
   },
 });
 
@@ -51,10 +56,10 @@ export const DashboardVideoLiveStopButton = ({
   return (
     <React.Fragment>
       {status === 'pending' && <Loader />}
-      <DashboardButton
+      <DashboardConfirmButton
         label={<FormattedMessage {...messages.stopLive} />}
-        primary={true}
-        onClick={stopLiveAction}
+        confirmationLabel={<FormattedMessage {...messages.confirmStopLive} />}
+        onConfirm={stopLiveAction}
       />
     </React.Fragment>
   );


### PR DESCRIPTION
## Purpose

Starting or stopping a live had no confirmation. This is an action that can't be reversed.
To prevent users from making errors, it is now necessary to confirm both actions.

## Proposal

Add new components to confirm an action to stop and start video


https://user-images.githubusercontent.com/76939263/124787696-fbcbaa00-df48-11eb-847a-498c4db06e51.mp4

