### PR TITLE
♻️(make) stop ngrok before running a new ngrok-apply

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,7 @@ run: ## start the development server using Docker
 
 ngrok: ## start the development server using Docker through ngrok
 ngrok: run
+	@$(COMPOSE) stop ngrok
 	@$(COMPOSE) up -d ngrok
 	@echo
 	@echo "$(BOLD)App running at:$(RESET)"


### PR DESCRIPTION
## Purpose

Once ngrok session expired, you have to stop ngrok and then restart it.
Running make ngrok-apply does not do it for us. This commit stop ngrok
before running again ngrok.

## Proposal

- [x] stop ngrok before running a new ngrok-apply

Closes #1055 