### PR TITLE
✨(front) only jitsi moderators can start a live

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Add a confirmation before starting or stopping a live
 - Use a tabbed navigation on LTI resource views
+- Only jitsi moderators can start a live
 
 ## [3.21.0] - 2021-07-05
 

--- a/src/frontend/components/ConfirmationLayer/index.tsx
+++ b/src/frontend/components/ConfirmationLayer/index.tsx
@@ -17,7 +17,7 @@ const messages = defineMessages({
 });
 
 interface ConfirmationLayerProps {
-  confirmationLabel: JSX.Element;
+  confirmationLabel: JSX.Element | string;
   onConfirm: MouseEventHandler;
   onCancel: KeyboardEventHandler | MouseEventHandler;
 }

--- a/src/frontend/components/DashboardConfirmButton/index.spec.tsx
+++ b/src/frontend/components/DashboardConfirmButton/index.spec.tsx
@@ -1,6 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
-import fetchMock from 'fetch-mock';
 import { Grommet } from 'grommet';
 import { wrapInIntlProvider } from '../../utils/tests/intl';
 import { DashboardConfirmButton } from '.';
@@ -12,10 +11,7 @@ const props = {
 };
 
 jest.mock('../../data/appData', () => ({
-  appData: {
-    document: null,
-    jwt: 'cool_token_m8',
-  },
+  appData: {},
 }));
 
 describe('<DashboardConfirmButton />', () => {
@@ -29,7 +25,6 @@ describe('<DashboardConfirmButton />', () => {
     document.body.appendChild(document.createElement('div'));
   });
 
-  // render twice component why ? if I comment it second test is ok
   it('renders the component and expected elements are present', () => {
     render(
       wrapInIntlProvider(
@@ -40,7 +35,27 @@ describe('<DashboardConfirmButton />', () => {
         />,
       ),
     );
-    screen.getByRole('button', { name: /start a live/i });
+    const button = screen.getByRole('button', {
+      name: /start a live/i,
+    }) as HTMLButtonElement;
+    expect(button.disabled).toBe(false);
+  });
+
+  it('renders the component and expected elements are present and the button is disabled', () => {
+    render(
+      wrapInIntlProvider(
+        <DashboardConfirmButton
+          confirmationLabel={props.confirmationLabel}
+          disabled={true}
+          label={props.label}
+          onConfirm={props.onConfirm}
+        />,
+      ),
+    );
+    const button = screen.getByRole('button', {
+      name: /start a live/i,
+    }) as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
   });
 
   it('renders the confirmation box when the button is fired', () => {

--- a/src/frontend/components/DashboardConfirmButton/index.tsx
+++ b/src/frontend/components/DashboardConfirmButton/index.tsx
@@ -4,7 +4,7 @@ import { ConfirmationLayer } from '../ConfirmationLayer';
 import { DashboardButton } from '../DashboardPaneButtons';
 
 interface DashboardConfirmButtonProps extends ButtonProps {
-  confirmationLabel: JSX.Element;
+  confirmationLabel: JSX.Element | string;
   onConfirm: MouseEventHandler;
 }
 

--- a/src/frontend/components/DashboardConfirmButton/index.tsx
+++ b/src/frontend/components/DashboardConfirmButton/index.tsx
@@ -1,17 +1,17 @@
+import { ButtonProps } from 'grommet';
 import React, { MouseEventHandler, useState } from 'react';
 import { ConfirmationLayer } from '../ConfirmationLayer';
 import { DashboardButton } from '../DashboardPaneButtons';
 
-interface DashboardConfirmButtonProps {
-  label: JSX.Element;
+interface DashboardConfirmButtonProps extends ButtonProps {
   confirmationLabel: JSX.Element;
   onConfirm: MouseEventHandler;
 }
 
 export const DashboardConfirmButton = ({
-  label,
   confirmationLabel,
   onConfirm,
+  ...buttonProps
 }: DashboardConfirmButtonProps) => {
   const [showConfirm, setShowConfirm] = useState(false);
 
@@ -27,9 +27,9 @@ export const DashboardConfirmButton = ({
   return (
     <React.Fragment>
       <DashboardButton
-        label={label}
         primary={true}
         onClick={requireConfirmAction}
+        {...buttonProps}
       />
       {showConfirm && (
         <ConfirmationLayer

--- a/src/frontend/components/DashboardVideoLive/index.tsx
+++ b/src/frontend/components/DashboardVideoLive/index.tsx
@@ -1,5 +1,5 @@
 import { Box, Heading, Text } from 'grommet';
-import React, { lazy, useEffect } from 'react';
+import React, { lazy, useEffect, useState } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 
 import { appData } from '../../data/appData';
@@ -68,6 +68,8 @@ export const DashboardVideoLive = ({ video }: DashboardVideoLiveProps) => {
   const { updateVideo } = useVideo((state) => ({
     updateVideo: state.addResource,
   }));
+  const [canStartLive, setCanStartLive] = useState(false);
+  const [canShowStartButton, setCanShowStartButton] = useState(false);
   const pollForVideo = async () => {
     try {
       const response = await fetch(`${API_ENDPOINT}/videos/${video.id}/`, {
@@ -103,6 +105,13 @@ export const DashboardVideoLive = ({ video }: DashboardVideoLiveProps) => {
     }
   }, [video.live_state]);
 
+  useEffect(() => {
+    if (video.live_type === LiveModeType.RAW) {
+      setCanStartLive(true);
+      setCanShowStartButton(true);
+    }
+  }, []);
+
   return (
     <Box>
       <Heading level={2}>
@@ -112,7 +121,11 @@ export const DashboardVideoLive = ({ video }: DashboardVideoLiveProps) => {
         <DashboardVideoLiveRaw video={video} />
       )}
       {video.live_type === LiveModeType.JITSI && (
-        <DashboardVideoLiveJitsi video={video} />
+        <DashboardVideoLiveJitsi
+          video={video}
+          setCanShowStartButton={setCanShowStartButton}
+          setCanStartLive={setCanStartLive}
+        />
       )}
       <Box direction={'row'} justify={'center'} margin={'small'}>
         {video.live_state === liveState.CREATING && (
@@ -128,7 +141,12 @@ export const DashboardVideoLive = ({ video }: DashboardVideoLiveProps) => {
                 type={LiveModeType.JITSI}
               />
             )}
-            <DashboardVideoLiveStartButton video={video} />
+            {canShowStartButton && (
+              <DashboardVideoLiveStartButton
+                video={video}
+                canStartLive={canStartLive}
+              />
+            )}
           </React.Fragment>
         )}
         {video.live_state === liveState.STARTING && (

--- a/src/frontend/components/DashboardVideoLiveJitsi/index.tsx
+++ b/src/frontend/components/DashboardVideoLiveJitsi/index.tsx
@@ -5,10 +5,16 @@ import { Video, liveState } from '../../types/tracks';
 import { report } from '../../utils/errors/report';
 
 interface DashboardVideoLiveJitsiProps {
+  setCanStartLive: (canStartLive: boolean) => void;
+  setCanShowStartButton: (canShowStartButton: boolean) => void;
   video: Video;
 }
 
-const DashboardVideoLiveJitsi = ({ video }: DashboardVideoLiveJitsiProps) => {
+const DashboardVideoLiveJitsi = ({
+  setCanStartLive,
+  setCanShowStartButton,
+  video,
+}: DashboardVideoLiveJitsiProps) => {
   const jitsiNode = useRef(null);
   const [jitsi, setJitsi] = useState<JitsiMeetExternalAPI>();
   const jitsiIsRecording = useRef(false);
@@ -120,6 +126,23 @@ const DashboardVideoLiveJitsi = ({ video }: DashboardVideoLiveJitsiProps) => {
       if (event.on) {
         retryStartRecordingDelay.current = retryDelayStep;
       }
+    });
+
+    _jitsi.addListener('participantRoleChanged', (event) => {
+      if (event.role === 'moderator') {
+        setCanStartLive(true);
+      } else {
+        setCanStartLive(false);
+      }
+    });
+
+    _jitsi.addListener('videoConferenceJoined', () => {
+      setCanShowStartButton(true);
+    });
+
+    _jitsi.addListener('videoConferenceLeft', () => {
+      setCanStartLive(false);
+      setCanShowStartButton(false);
     });
 
     if (video.live_state === liveState.RUNNING) {

--- a/src/frontend/components/DashboardVideoLiveStartButton/index.spec.tsx
+++ b/src/frontend/components/DashboardVideoLiveStartButton/index.spec.tsx
@@ -40,11 +40,16 @@ describe('components/DashboardVideoLiveStartButton', () => {
   it('renders the start button', () => {
     render(
       wrapInIntlProvider(
-        wrapInRouter(<DashboardVideoLiveStartButton video={video} />),
+        wrapInRouter(
+          <DashboardVideoLiveStartButton video={video} canStartLive={true} />,
+        ),
       ),
     );
 
-    screen.getByRole('button', { name: /start streaming/i });
+    const button = screen.getByRole('button', {
+      name: /start streaming/i,
+    }) as HTMLButtonElement;
+    expect(button.disabled).toBe(false);
   });
 
   it('clicks on start live button and fails.', async () => {
@@ -56,7 +61,7 @@ describe('components/DashboardVideoLiveStartButton', () => {
       wrapInIntlProvider(
         wrapInRouter(
           <Grommet>
-            <DashboardVideoLiveStartButton video={video} />
+            <DashboardVideoLiveStartButton video={video} canStartLive={true} />
           </Grommet>,
           [
             {
@@ -105,7 +110,7 @@ describe('components/DashboardVideoLiveStartButton', () => {
       wrapInIntlProvider(
         wrapInRouter(
           <Grommet>
-            <DashboardVideoLiveStartButton video={video} />
+            <DashboardVideoLiveStartButton video={video} canStartLive={true} />
           </Grommet>,
         ),
       ),
@@ -135,5 +140,20 @@ describe('components/DashboardVideoLiveStartButton', () => {
       ...video,
       live_state: liveState.STARTING,
     });
+  });
+
+  it('disables the start button when canStartLive is false', () => {
+    render(
+      wrapInIntlProvider(
+        wrapInRouter(
+          <DashboardVideoLiveStartButton video={video} canStartLive={false} />,
+        ),
+      ),
+    );
+
+    const button = screen.getByRole('button', {
+      name: /Only moderators can start a live/i,
+    }) as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
   });
 });

--- a/src/frontend/components/DashboardVideoLiveStartButton/index.tsx
+++ b/src/frontend/components/DashboardVideoLiveStartButton/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useState } from 'react';
-import { defineMessages, FormattedMessage } from 'react-intl';
+import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 import { Redirect } from 'react-router-dom';
 
 import { startLive } from '../../data/sideEffects/startLive';
@@ -14,28 +14,37 @@ const messages = defineMessages({
   startLive: {
     defaultMessage: 'start streaming',
     description: 'Start a video streaming.',
-    id: 'components.DashboardVideoLive.startLive',
+    id: 'components.DashboardVideoLiveStartButton.startLive',
   },
   confirmStartLive: {
     defaultMessage: 'Are you sure you want to start a video streaming ?',
     description: 'Confirmation to start a video streaming.',
-    id: 'components.DashboardVideoLive.confirmStartLive',
+    id: 'components.DashboardVideoLiveStartButton.confirmStartLive',
+  },
+  startLiveHelper: {
+    defaultMessage: 'Only moderators can start a live',
+    description:
+      'Helper message explaining why the start live button is disabled',
+    id: 'components.DashboardVideoLiveStartButton.startLiveHelper',
   },
 });
 
 type startLiveStatus = 'pending' | 'error';
 
 interface DashboardVideoLiveStartButtonProps {
+  canStartLive: boolean;
   video: Video;
 }
 
 export const DashboardVideoLiveStartButton = ({
+  canStartLive,
   video,
 }: DashboardVideoLiveStartButtonProps) => {
   const [status, setStatus] = useState<Nullable<startLiveStatus>>(null);
   const { updateVideo } = useVideo((state) => ({
     updateVideo: state.addResource,
   }));
+  const intl = useIntl();
 
   const startLiveAction = useCallback(async () => {
     setStatus('pending');
@@ -55,8 +64,13 @@ export const DashboardVideoLiveStartButton = ({
     <React.Fragment>
       {status === 'pending' && <Loader />}
       <DashboardConfirmButton
-        label={<FormattedMessage {...messages.startLive} />}
-        confirmationLabel={<FormattedMessage {...messages.confirmStartLive} />}
+        disabled={!canStartLive}
+        label={
+          canStartLive
+            ? intl.formatMessage(messages.startLive)
+            : intl.formatMessage(messages.startLiveHelper)
+        }
+        confirmationLabel={intl.formatMessage(messages.confirmStartLive)}
         onConfirm={startLiveAction}
       />
     </React.Fragment>


### PR DESCRIPTION
## Purpose

When a live is starting by a non moderator in a jitsi live, the live is
started on AWS but never in jitsi. Now only moderators can start a jitsi
live.

## Proposal

- [x] only jitsi moderators can start a live

Closes #1041 

