### PR TITLE
Connect to xmpp server using a websocket

### DIFF
--- a/docker/files/etc/nginx/conf.d/default.conf
+++ b/docker/files/etc/nginx/conf.d/default.conf
@@ -11,4 +11,17 @@ server {
         proxy_buffering off;
         tcp_nodelay on;
 	}
+
+    # https://prosody.im/doc/websocket
+    location /xmpp-websocket {
+        proxy_pass  http://prosody:5280/xmpp-websocket;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "Upgrade";
+        proxy_set_header Upgrade $http_upgrade;
+
+        proxy_set_header Host prosody;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 900s;
+    }
 }

--- a/docker/files/etc/prosody/prosody.cfg.lua
+++ b/docker/files/etc/prosody/prosody.cfg.lua
@@ -39,7 +39,9 @@ use_libevent = true
 
 
 cross_domain_bosh = true
+cross_domain_websocket = true
 consider_bosh_secure = true
+consider_websocket_secure = true
 
 -- This is the list of modules Prosody will load on startup.
 -- It looks for mod_modulename.lua in the plugins folder, so make sure that exists too.
@@ -172,6 +174,7 @@ VirtualHost "prosody"
     allow_empty_token = false;  
     modules_enabled = {
         "bosh";
+        "websocket";
     }
     c2s_require_encryption = false
 

--- a/src/backend/marsha/core/serializers/video.py
+++ b/src/backend/marsha/core/serializers/video.py
@@ -1,6 +1,6 @@
 """Structure of Video related models API responses with Django Rest Framework serializers."""
 from datetime import timedelta
-from urllib.parse import parse_qs, quote_plus, urlencode, urlparse, urlunparse
+from urllib.parse import quote_plus
 
 from django.conf import settings
 from django.urls import reverse
@@ -501,13 +501,14 @@ class VideoSerializer(VideoBaseSerializer):
                 "owner" if is_admin or is_instructor else "member",
                 timezone.now() + timedelta(days=1),
             )
-            bosh_url = list(urlparse(settings.XMPP_BOSH_URL))
-            bosh_query_string = dict(parse_qs(bosh_url[4]))
-            bosh_query_string.update({"token": token})
-            bosh_url[4] = urlencode(bosh_query_string)
 
             return {
-                "bosh_url": urlunparse(bosh_url),
+                "bosh_url": xmpp_utils.add_jwt_token_to_url(
+                    settings.XMPP_BOSH_URL, token
+                ),
+                "websocket_url": xmpp_utils.add_jwt_token_to_url(
+                    settings.XMPP_WEBSOCKET_URL, token
+                ),
                 "conference_url": f"{obj.id}@{settings.XMPP_CONFERENCE_DOMAIN}",
                 "jid": settings.XMPP_DOMAIN,
             }

--- a/src/backend/marsha/core/tests/test_api_video.py
+++ b/src/backend/marsha/core/tests/test_api_video.py
@@ -2889,6 +2889,7 @@ class VideoAPITest(TestCase):
                 "live_type": RAW,
                 "xmpp": {
                     "bosh_url": "https://xmpp-server.com/http-bind?token=xmpp_jwt",
+                    "websocket_url": None,
                     "conference_url": f"{video.id}@conference.xmpp-server.com",
                     "jid": "xmpp-server.com",
                 },

--- a/src/backend/marsha/core/tests/test_utils_xmpp_utils.py
+++ b/src/backend/marsha/core/tests/test_utils_xmpp_utils.py
@@ -34,3 +34,10 @@ class XmppUtilsTestCase(TestCase):
                 },
                 "thisIsASecret",
             )
+
+    def test_add_jwt_token_to_url(self):
+        """Test adding a token to a XMPP url."""
+        self.assertEqual(
+            xmpp_utils.add_jwt_token_to_url("https://xmpp-server.com", "my-token"),
+            "https://xmpp-server.com?token=my-token",
+        )

--- a/src/backend/marsha/core/tests/test_views_lti_video.py
+++ b/src/backend/marsha/core/tests/test_views_lti_video.py
@@ -411,6 +411,7 @@ class VideoLTIViewTestCase(TestCase):
                 "live_type": RAW,
                 "xmpp": {
                     "bosh_url": "https://xmpp-server.com/http-bind?token=xmpp_jwt",
+                    "websocket_url": None,
                     "conference_url": f"{video.id}@conference.xmpp-server.com",
                     "jid": "conference.xmpp-server.com",
                 },

--- a/src/backend/marsha/core/tests/test_views_public_video.py
+++ b/src/backend/marsha/core/tests/test_views_public_video.py
@@ -167,7 +167,7 @@ class VideoPublicViewTestCase(TestCase):
         self.assertEqual(context.get("modelName"), "videos")
 
     @override_settings(LIVE_CHAT_ENABLED=True)
-    @override_settings(XMPP_BOSH_URL="https://xmpp-server.com/http-bind")
+    @override_settings(XMPP_WEBSOCKET_URL="ws://xmpp-server.com/xmpp-websocket")
     @override_settings(XMPP_CONFERENCE_DOMAIN="conference.xmpp-server.com")
     @override_settings(XMPP_DOMAIN="conference.xmpp-server.com")
     @override_settings(XMPP_JWT_SHARED_SECRET="xmpp_shared_secret")
@@ -256,7 +256,8 @@ class VideoPublicViewTestCase(TestCase):
                 "live_info": {},
                 "live_type": RAW,
                 "xmpp": {
-                    "bosh_url": "https://xmpp-server.com/http-bind?token=xmpp_jwt",
+                    "bosh_url": None,
+                    "websocket_url": "ws://xmpp-server.com/xmpp-websocket?token=xmpp_jwt",
                     "conference_url": f"{video.id}@conference.xmpp-server.com",
                     "jid": "conference.xmpp-server.com",
                 },

--- a/src/backend/marsha/core/utils/xmpp_utils.py
+++ b/src/backend/marsha/core/utils/xmpp_utils.py
@@ -1,4 +1,6 @@
 """Utils for XMPP server."""
+from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
+
 from django.conf import settings
 
 import jwt
@@ -170,3 +172,16 @@ def generate_jwt(room_name, user_id, affiliation, expires_at):
         },
         settings.XMPP_JWT_SHARED_SECRET,
     )
+
+
+def add_jwt_token_to_url(url, token):
+    """Add a JWT token to a XMPP url."""
+    if url is None:
+        return None
+
+    generated_url = list(urlparse(url))
+    generated_query_string = dict(parse_qs(generated_url[4]))
+    generated_query_string.update({"token": token})
+    generated_url[4] = urlencode(generated_query_string)
+
+    return urlunparse(generated_url)

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -266,6 +266,7 @@ class Base(Configuration):
     # XMPP Settings
     LIVE_CHAT_ENABLED = values.BooleanValue(False)
     XMPP_BOSH_URL = values.Value(None)
+    XMPP_WEBSOCKET_URL = values.Value(None)
     XMPP_CONFERENCE_DOMAIN = values.Value(None)
     XMPP_PRIVATE_ADMIN_JID = values.Value(None)
     XMPP_PRIVATE_SERVER_PORT = values.Value(5222)

--- a/src/frontend/components/Chat/index.spec.tsx
+++ b/src/frontend/components/Chat/index.spec.tsx
@@ -11,6 +11,7 @@ const mockVideo = videoMockFactory({
   live_state: liveState.RUNNING,
   xmpp: {
     bosh_url: 'https://xmpp-server.com/http-bind',
+    websocket_url: null,
     conference_url:
       '870c467b-d66e-4949-8ee5-fcf460c72e88@conference.xmpp-server.com',
     prebind_url: 'https://xmpp-server.com/http-pre-bind',

--- a/src/frontend/components/PublicVideoDashboard/index.spec.tsx
+++ b/src/frontend/components/PublicVideoDashboard/index.spec.tsx
@@ -258,6 +258,7 @@ describe('PublicVideoDashboard', () => {
       },
       xmpp: {
         bosh_url: 'https://xmpp-server.com/http-bind',
+        websocket_url: null,
         conference_url:
           '870c467b-d66e-4949-8ee5-fcf460c72e88@conference.xmpp-server.com',
         prebind_url: 'https://xmpp-server.com/http-pre-bind',

--- a/src/frontend/types/tracks.ts
+++ b/src/frontend/types/tracks.ts
@@ -68,7 +68,8 @@ export interface Playlist {
 
 /* XMPP representation */
 export interface XMPP {
-  bosh_url: string;
+  bosh_url: Nullable<string>;
+  websocket_url: Nullable<string>;
   conference_url: string;
   prebind_url: string;
   jid: string;

--- a/src/frontend/utils/converse.spec.ts
+++ b/src/frontend/utils/converse.spec.ts
@@ -30,6 +30,7 @@ describe('converseMounter', () => {
 
     const xmpp = {
       bosh_url: 'https://xmpp-server.com/http-bind',
+      websocket_url: null,
       conference_url:
         '870c467b-d66e-4949-8ee5-fcf460c72e88@conference.xmpp-server.com',
       prebind_url: 'https://xmpp-server.com/http-pre-bind',
@@ -78,6 +79,7 @@ describe('converseMounter', () => {
         spoiler: false,
         toggle_occupants: false,
       },
+      websocket_url: null,
       whitelisted_plugins: ['marsha'],
     });
     expect(mockWindow.converse.plugins.add).toHaveBeenCalledTimes(1);

--- a/src/frontend/utils/converse.ts
+++ b/src/frontend/utils/converse.ts
@@ -52,6 +52,7 @@ export const converseMounter = () => {
           spoiler: false,
           toggle_occupants: false,
         },
+        websocket_url: xmpp.websocket_url,
         whitelisted_plugins: ['marsha'],
       });
       hasBeenInitialized = true;


### PR DESCRIPTION
## Purpose

We want to connect to a xmpp server using a websocket instead of using a bosh connection. Websockets provide a more modern and effective two-way communication protocol between the browser and a server, effectively emulating TCP at the application layer and therefore overcoming many of the problems with existing long-polling techniques for bidirectional HTTP (such as BOSH).

## Proposal

- [x] configure prosody server in our docker-compose stack to accept websocket connection
- [x] expose websocket url in the video object, along bosh url
- [x] use websocket url when converse is initialized

