### PR TITLE
Allow a participant to join a jitsi conference 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Playlist portability management through LTI (resource sharing between courses)
 - Command to clean all development environments having a living stack on AWS medialive
   and mediapackage
+- Allow a participant to join a Jitsi conference
 
 ## [3.23.0] - 2021-08-23
 

--- a/src/frontend/__mocks__/zustand.js
+++ b/src/frontend/__mocks__/zustand.js
@@ -9,7 +9,16 @@ const storeResetFns = new Set();
 const create = (createState) => {
   const store = actualCreate(createState);
   const initialState = store.getState();
-  storeResetFns.add(() => store.setState(initialState, true));
+  storeResetFns.add(() => {
+    if (initialState) {
+      Object.keys(initialState).forEach((key) => {
+        if (Array.isArray(initialState[key])) {
+          initialState[key] = [];
+        }
+      });
+    }
+    store.setState(initialState, true);
+  });
   return store;
 };
 

--- a/src/frontend/components/DashboardConfirmButton/index.tsx
+++ b/src/frontend/components/DashboardConfirmButton/index.tsx
@@ -1,7 +1,7 @@
 import { ButtonProps } from 'grommet';
 import React, { MouseEventHandler, useState } from 'react';
 import { ConfirmationLayer } from '../ConfirmationLayer';
-import { DashboardButton } from '../DashboardPaneButtons';
+import { DashboardButton } from '../DashboardPaneButtons/DashboardButtons';
 
 interface DashboardConfirmButtonProps extends ButtonProps {
   confirmationLabel: JSX.Element | string;

--- a/src/frontend/components/DashboardJoinDiscussion/index.spec.tsx
+++ b/src/frontend/components/DashboardJoinDiscussion/index.spec.tsx
@@ -38,6 +38,10 @@ describe('<DashboardJoinDiscussion />', () => {
 
     // reject the request
     fireEvent.click(rejectJohnDoe);
+    act(() => {
+      // remove participant 1 from the waiting list
+      useJoinParticipant.getState().removeParticipantAskingToJoin(participant1);
+    });
 
     // nobody is in the waiting list
     expect(screen.queryByTestId('ask-participant1')).not.toBeInTheDocument();
@@ -61,6 +65,10 @@ describe('<DashboardJoinDiscussion />', () => {
 
     // accept the participant 2
     fireEvent.click(acceptParticipant2);
+    act(() => {
+      // add participant 2 to the waiting list
+      useJoinParticipant.getState().moveParticipantToDiscussion(participant2);
+    });
 
     // participant 2 is in the discussion
     const inParticipant2 = screen.getByTestId('in-participant2');
@@ -71,6 +79,12 @@ describe('<DashboardJoinDiscussion />', () => {
 
     // kick off participant 2
     fireEvent.click(kickButton);
+    act(() => {
+      // remove participant 2 from the waiting list
+      useJoinParticipant
+        .getState()
+        .removeParticipantFromDiscussion(participant2);
+    });
 
     // nobody in the waiting list nor in the discussion
     expect(screen.queryByTestId('ask-participant1')).not.toBeInTheDocument();

--- a/src/frontend/components/DashboardJoinDiscussion/index.spec.tsx
+++ b/src/frontend/components/DashboardJoinDiscussion/index.spec.tsx
@@ -1,0 +1,81 @@
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
+import React from 'react';
+
+import { useJoinParticipant } from '../../data/stores/useJoinParticipant';
+import { wrapInIntlProvider } from '../../utils/tests/intl';
+import { DashboardJoinDiscussion } from '.';
+
+jest.mock('../../utils/window', () => ({
+  converse: {
+    acceptParticipantToJoin: jest.fn(),
+    kickParticipant: jest.fn(),
+    rejectParticipantToJoin: jest.fn(),
+  },
+}));
+
+describe('<DashboardJoinDiscussion />', () => {
+  it('renders the components and updates the participant list', () => {
+    const participant1 = {
+      id: 'participant1',
+      name: 'John Doe',
+    };
+    const participant2 = {
+      id: 'participant2',
+      name: 'Jane Doe',
+    };
+
+    useJoinParticipant.getState().addParticipantAskingToJoin(participant1);
+
+    render(wrapInIntlProvider(<DashboardJoinDiscussion />));
+
+    // participant 1 is in the waiting list
+    const askParticipant1 = screen.getByTestId('ask-participant1');
+    within(askParticipant1).getByText('John Doe');
+    within(askParticipant1).getByRole('button', { name: 'accept' });
+    const rejectJohnDoe = within(askParticipant1).getByRole('button', {
+      name: 'reject',
+    });
+
+    // reject the request
+    fireEvent.click(rejectJohnDoe);
+
+    // nobody is in the waiting list
+    expect(screen.queryByTestId('ask-participant1')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('ask-participant2')).not.toBeInTheDocument();
+
+    act(() => {
+      // add participant 2 to the waiting list
+      useJoinParticipant.getState().addParticipantAskingToJoin(participant2);
+    });
+
+    const askParticipant2 = screen.getByTestId('ask-participant2');
+    within(askParticipant2).getByText('Jane Doe');
+    const acceptParticipant2 = within(askParticipant2).getByRole('button', {
+      name: 'accept',
+    });
+    within(askParticipant1).getByRole('button', { name: 'reject' });
+
+    // nobody is in the discussion
+    expect(screen.queryByTestId('in-participant1')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('in-participant2')).not.toBeInTheDocument();
+
+    // accept the participant 2
+    fireEvent.click(acceptParticipant2);
+
+    // participant 2 is in the discussion
+    const inParticipant2 = screen.getByTestId('in-participant2');
+
+    const kickButton = within(inParticipant2).getByRole('button', {
+      name: 'kick out participant',
+    });
+
+    // kick off participant 2
+    fireEvent.click(kickButton);
+
+    // nobody in the waiting list nor in the discussion
+    expect(screen.queryByTestId('ask-participant1')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('ask-participant2')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('in-participant1')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('in-participant2')).not.toBeInTheDocument();
+  });
+});

--- a/src/frontend/components/DashboardJoinDiscussion/index.spec.tsx
+++ b/src/frontend/components/DashboardJoinDiscussion/index.spec.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, render, screen, within } from '@testing-library/react';
 import React from 'react';
 
 import { useJoinParticipant } from '../../data/stores/useJoinParticipant';
+import { videoMockFactory } from '../../utils/tests/factories';
 import { wrapInIntlProvider } from '../../utils/tests/intl';
 import { DashboardJoinDiscussion } from '.';
 
@@ -24,9 +25,10 @@ describe('<DashboardJoinDiscussion />', () => {
       name: 'Jane Doe',
     };
 
+    const video = videoMockFactory();
     useJoinParticipant.getState().addParticipantAskingToJoin(participant1);
 
-    render(wrapInIntlProvider(<DashboardJoinDiscussion />));
+    render(wrapInIntlProvider(<DashboardJoinDiscussion video={video} />));
 
     // participant 1 is in the waiting list
     const askParticipant1 = screen.getByTestId('ask-participant1');

--- a/src/frontend/components/DashboardJoinDiscussion/index.tsx
+++ b/src/frontend/components/DashboardJoinDiscussion/index.tsx
@@ -6,6 +6,7 @@ import { DashboardJoinDiscussionAcceptButton } from '../DashboardJoinDiscussionA
 import { DashboardJoinDiscussionRejectButton } from '../DashboardJoinDiscussionRejectButton';
 import { DashboardJoinDiscussionKickButton } from '../DashboardJoinDiscussionKickButton';
 import { useJoinParticipant } from '../../data/stores/useJoinParticipant';
+import { Video } from '../../types/tracks';
 
 const messages = defineMessages({
   participantAsking: {
@@ -22,7 +23,13 @@ const messages = defineMessages({
   },
 });
 
-export const DashboardJoinDiscussion = () => {
+interface DashboardJoinDiscussionProps {
+  video: Video;
+}
+
+export const DashboardJoinDiscussion = ({
+  video,
+}: DashboardJoinDiscussionProps) => {
   const { participantsAskingToJoin, participantsInDiscussion } =
     useJoinParticipant((state) => ({
       participantsAskingToJoin: state.participantsAskingToJoin,
@@ -43,7 +50,10 @@ export const DashboardJoinDiscussion = () => {
             {participant.name}{' '}
           </Text>
           <FormattedMessage {...messages.participantAsking} />
-          <DashboardJoinDiscussionAcceptButton participant={participant} />
+          <DashboardJoinDiscussionAcceptButton
+            participant={participant}
+            video={video}
+          />
           <DashboardJoinDiscussionRejectButton participant={participant} />
         </Box>
       ))}

--- a/src/frontend/components/DashboardJoinDiscussion/index.tsx
+++ b/src/frontend/components/DashboardJoinDiscussion/index.tsx
@@ -1,0 +1,67 @@
+import { Box, Text } from 'grommet';
+import React from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+
+import { DashboardJoinDiscussionAcceptButton } from '../DashboardJoinDiscussionAcceptButton';
+import { DashboardJoinDiscussionRejectButton } from '../DashboardJoinDiscussionRejectButton';
+import { DashboardJoinDiscussionKickButton } from '../DashboardJoinDiscussionKickButton';
+import { useJoinParticipant } from '../../data/stores/useJoinParticipant';
+
+const messages = defineMessages({
+  participantAsking: {
+    defaultMessage: 'is asking to join the discussion.',
+    description:
+      'Message to inform the instructor that a participant is asking to join the discussion',
+    id: 'components.DashboardJoinDiscussion.participantAsking',
+  },
+  participantInDiscussion: {
+    defaultMessage: 'has joined the discussion.',
+    description:
+      'Message to inform the instructor that a participant has joined the discussion',
+    id: 'components.DashboardJoinDiscussion.participantInDiscussion',
+  },
+});
+
+export const DashboardJoinDiscussion = () => {
+  const { participantsAskingToJoin, participantsInDiscussion } =
+    useJoinParticipant((state) => ({
+      participantsAskingToJoin: state.participantsAskingToJoin,
+      participantsInDiscussion: state.participantsInDiscussion,
+    }));
+
+  return (
+    <Box direction="column" margin="small">
+      {participantsAskingToJoin.map((participant) => (
+        <Box
+          direction="row"
+          align="center"
+          margin="small"
+          key={`${participant.id}`}
+          data-testid={`ask-${participant.id}`}
+        >
+          <Text weight="bold" margin="small">
+            {participant.name}{' '}
+          </Text>
+          <FormattedMessage {...messages.participantAsking} />
+          <DashboardJoinDiscussionAcceptButton participant={participant} />
+          <DashboardJoinDiscussionRejectButton participant={participant} />
+        </Box>
+      ))}
+      {participantsInDiscussion.map((participant) => (
+        <Box
+          direction="row"
+          align="center"
+          margin="small"
+          key={`${participant.id}`}
+          data-testid={`in-${participant.id}`}
+        >
+          <Text weight="bold" margin="small">
+            {participant.name}{' '}
+          </Text>
+          <FormattedMessage {...messages.participantInDiscussion} />
+          <DashboardJoinDiscussionKickButton participant={participant} />
+        </Box>
+      ))}
+    </Box>
+  );
+};

--- a/src/frontend/components/DashboardJoinDiscussionAcceptButton/index.spec.tsx
+++ b/src/frontend/components/DashboardJoinDiscussionAcceptButton/index.spec.tsx
@@ -1,0 +1,42 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { useJoinParticipant } from '../../data/stores/useJoinParticipant';
+import { wrapInIntlProvider } from '../../utils/tests/intl';
+import * as mockWindow from '../../utils/window';
+import { DashboardJoinDiscussionAcceptButton } from '.';
+
+jest.mock('../../utils/window', () => ({
+  converse: {
+    acceptParticipantToJoin: jest.fn(),
+  },
+}));
+
+describe('<DashboardJoinDiscussionAcceptButton />', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+  it('renders the accept button and click on it', () => {
+    const participant = {
+      id: 'participant1',
+      name: 'John Doe',
+    };
+
+    render(
+      wrapInIntlProvider(
+        <DashboardJoinDiscussionAcceptButton participant={participant} />,
+      ),
+    );
+
+    const acceptButton = screen.getByRole('button', { name: 'accept' });
+
+    fireEvent.click(acceptButton);
+
+    expect(mockWindow.converse.acceptParticipantToJoin).toHaveBeenCalledWith(
+      participant,
+    );
+    expect(useJoinParticipant.getState().participantsInDiscussion).toContain(
+      participant,
+    );
+  });
+});

--- a/src/frontend/components/DashboardJoinDiscussionAcceptButton/index.spec.tsx
+++ b/src/frontend/components/DashboardJoinDiscussionAcceptButton/index.spec.tsx
@@ -1,7 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 
-import { useJoinParticipant } from '../../data/stores/useJoinParticipant';
 import { wrapInIntlProvider } from '../../utils/tests/intl';
 import * as mockWindow from '../../utils/window';
 import { DashboardJoinDiscussionAcceptButton } from '.';
@@ -33,9 +32,6 @@ describe('<DashboardJoinDiscussionAcceptButton />', () => {
     fireEvent.click(acceptButton);
 
     expect(mockWindow.converse.acceptParticipantToJoin).toHaveBeenCalledWith(
-      participant,
-    );
-    expect(useJoinParticipant.getState().participantsInDiscussion).toContain(
       participant,
     );
   });

--- a/src/frontend/components/DashboardJoinDiscussionAcceptButton/index.spec.tsx
+++ b/src/frontend/components/DashboardJoinDiscussionAcceptButton/index.spec.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 
+import { videoMockFactory } from '../../utils/tests/factories';
 import { wrapInIntlProvider } from '../../utils/tests/intl';
 import * as mockWindow from '../../utils/window';
 import { DashboardJoinDiscussionAcceptButton } from '.';
@@ -21,9 +22,14 @@ describe('<DashboardJoinDiscussionAcceptButton />', () => {
       name: 'John Doe',
     };
 
+    const video = videoMockFactory();
+
     render(
       wrapInIntlProvider(
-        <DashboardJoinDiscussionAcceptButton participant={participant} />,
+        <DashboardJoinDiscussionAcceptButton
+          participant={participant}
+          video={video}
+        />,
       ),
     );
 
@@ -33,6 +39,7 @@ describe('<DashboardJoinDiscussionAcceptButton />', () => {
 
     expect(mockWindow.converse.acceptParticipantToJoin).toHaveBeenCalledWith(
       participant,
+      video,
     );
   });
 });

--- a/src/frontend/components/DashboardJoinDiscussionAcceptButton/index.tsx
+++ b/src/frontend/components/DashboardJoinDiscussionAcceptButton/index.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 
 import { Participant } from '../../types/Participant';
+import { Video } from '../../types/tracks';
 import { converse } from '../../utils/window';
 
 const messages = defineMessages({
@@ -15,10 +16,12 @@ const messages = defineMessages({
 
 interface DashboardJoinDiscussionAcceptButtonProps {
   participant: Participant;
+  video: Video;
 }
 
 export const DashboardJoinDiscussionAcceptButton = ({
   participant,
+  video,
 }: DashboardJoinDiscussionAcceptButtonProps) => {
   const onClick = () => {
     converse.acceptParticipantToJoin(participant, video);

--- a/src/frontend/components/DashboardJoinDiscussionAcceptButton/index.tsx
+++ b/src/frontend/components/DashboardJoinDiscussionAcceptButton/index.tsx
@@ -1,0 +1,41 @@
+import { Button } from 'grommet';
+import React from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+
+import { useJoinParticipant } from '../../data/stores/useJoinParticipant';
+import { Participant } from '../../types/Participant';
+import { converse } from '../../utils/window';
+
+const messages = defineMessages({
+  acceptParticipant: {
+    defaultMessage: 'accept',
+    description: 'Accept the participant in the discussion',
+    id: 'components.DashboardJoinDiscussionAcceptButton.acceptParticipant',
+  },
+});
+
+interface DashboardJoinDiscussionAcceptButtonProps {
+  participant: Participant;
+}
+
+export const DashboardJoinDiscussionAcceptButton = ({
+  participant,
+}: DashboardJoinDiscussionAcceptButtonProps) => {
+  const moveParticipantToDiscussion = useJoinParticipant(
+    (state) => state.moveParticipantToDiscussion,
+  );
+
+  const onClick = () => {
+    converse.acceptParticipantToJoin(participant, video);
+  };
+
+  return (
+    <Button
+      label={<FormattedMessage {...messages.acceptParticipant} />}
+      primary={true}
+      onClick={onClick}
+      margin="small"
+      size="small"
+    />
+  );
+};

--- a/src/frontend/components/DashboardJoinDiscussionAcceptButton/index.tsx
+++ b/src/frontend/components/DashboardJoinDiscussionAcceptButton/index.tsx
@@ -2,7 +2,6 @@ import { Button } from 'grommet';
 import React from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 
-import { useJoinParticipant } from '../../data/stores/useJoinParticipant';
 import { Participant } from '../../types/Participant';
 import { converse } from '../../utils/window';
 
@@ -21,10 +20,6 @@ interface DashboardJoinDiscussionAcceptButtonProps {
 export const DashboardJoinDiscussionAcceptButton = ({
   participant,
 }: DashboardJoinDiscussionAcceptButtonProps) => {
-  const moveParticipantToDiscussion = useJoinParticipant(
-    (state) => state.moveParticipantToDiscussion,
-  );
-
   const onClick = () => {
     converse.acceptParticipantToJoin(participant, video);
   };

--- a/src/frontend/components/DashboardJoinDiscussionKickButton/index.spec.tsx
+++ b/src/frontend/components/DashboardJoinDiscussionKickButton/index.spec.tsx
@@ -1,0 +1,46 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { useJoinParticipant } from '../../data/stores/useJoinParticipant';
+import { wrapInIntlProvider } from '../../utils/tests/intl';
+import * as mockWindow from '../../utils/window';
+import { DashboardJoinDiscussionKickButton } from '.';
+
+jest.mock('../../utils/window', () => ({
+  converse: {
+    kickParticipant: jest.fn(),
+  },
+}));
+
+describe('<DashboardJoinDiscussionKickButton />', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+  it('renders the button and click on it', () => {
+    const participant = {
+      id: 'participant1',
+      name: 'John Doe',
+    };
+    // add participant in discussion
+    useJoinParticipant.getState().addParticipantToDiscussion(participant);
+
+    render(
+      wrapInIntlProvider(
+        <DashboardJoinDiscussionKickButton participant={participant} />,
+      ),
+    );
+
+    const kickButton = screen.getByRole('button', {
+      name: 'kick out participant',
+    });
+
+    fireEvent.click(kickButton);
+
+    expect(
+      useJoinParticipant.getState().participantsInDiscussion,
+    ).not.toContain(participant);
+    expect(mockWindow.converse.kickParticipant).toHaveBeenCalledWith(
+      participant,
+    );
+  });
+});

--- a/src/frontend/components/DashboardJoinDiscussionKickButton/index.spec.tsx
+++ b/src/frontend/components/DashboardJoinDiscussionKickButton/index.spec.tsx
@@ -1,7 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 
-import { useJoinParticipant } from '../../data/stores/useJoinParticipant';
 import { wrapInIntlProvider } from '../../utils/tests/intl';
 import * as mockWindow from '../../utils/window';
 import { DashboardJoinDiscussionKickButton } from '.';
@@ -21,8 +20,6 @@ describe('<DashboardJoinDiscussionKickButton />', () => {
       id: 'participant1',
       name: 'John Doe',
     };
-    // add participant in discussion
-    useJoinParticipant.getState().addParticipantToDiscussion(participant);
 
     render(
       wrapInIntlProvider(
@@ -36,9 +33,6 @@ describe('<DashboardJoinDiscussionKickButton />', () => {
 
     fireEvent.click(kickButton);
 
-    expect(
-      useJoinParticipant.getState().participantsInDiscussion,
-    ).not.toContain(participant);
     expect(mockWindow.converse.kickParticipant).toHaveBeenCalledWith(
       participant,
     );

--- a/src/frontend/components/DashboardJoinDiscussionKickButton/index.tsx
+++ b/src/frontend/components/DashboardJoinDiscussionKickButton/index.tsx
@@ -1,0 +1,42 @@
+import { Button } from 'grommet';
+import React from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+
+import { useJoinParticipant } from '../../data/stores/useJoinParticipant';
+import { Participant } from '../../types/Participant';
+import { converse } from '../../utils/window';
+
+const messages = defineMessages({
+  kickParticipant: {
+    defaultMessage: 'kick out participant',
+    description: 'Kick the participant out of the discussion',
+    id: 'components.DashboardJoinDiscussionKickButton.kickParticipant',
+  },
+});
+
+interface DashboardJoinDiscussionKickButtonProps {
+  participant: Participant;
+}
+
+export const DashboardJoinDiscussionKickButton = ({
+  participant,
+}: DashboardJoinDiscussionKickButtonProps) => {
+  const removeParticipantInDiscussion = useJoinParticipant(
+    (state) => state.removeParticipantInDiscussion,
+  );
+
+  const onClick = () => {
+    converse.kickParticipant(participant);
+    removeParticipantInDiscussion(participant);
+  };
+
+  return (
+    <Button
+      label={<FormattedMessage {...messages.kickParticipant} />}
+      primary={true}
+      onClick={onClick}
+      margin="small"
+      size="small"
+    />
+  );
+};

--- a/src/frontend/components/DashboardJoinDiscussionKickButton/index.tsx
+++ b/src/frontend/components/DashboardJoinDiscussionKickButton/index.tsx
@@ -2,7 +2,6 @@ import { Button } from 'grommet';
 import React from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 
-import { useJoinParticipant } from '../../data/stores/useJoinParticipant';
 import { Participant } from '../../types/Participant';
 import { converse } from '../../utils/window';
 
@@ -21,13 +20,8 @@ interface DashboardJoinDiscussionKickButtonProps {
 export const DashboardJoinDiscussionKickButton = ({
   participant,
 }: DashboardJoinDiscussionKickButtonProps) => {
-  const removeParticipantInDiscussion = useJoinParticipant(
-    (state) => state.removeParticipantInDiscussion,
-  );
-
   const onClick = () => {
     converse.kickParticipant(participant);
-    removeParticipantInDiscussion(participant);
   };
 
   return (

--- a/src/frontend/components/DashboardJoinDiscussionRejectButton/index.spec.tsx
+++ b/src/frontend/components/DashboardJoinDiscussionRejectButton/index.spec.tsx
@@ -1,7 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 
-import { useJoinParticipant } from '../../data/stores/useJoinParticipant';
 import { wrapInIntlProvider } from '../../utils/tests/intl';
 import * as mockWindow from '../../utils/window';
 import { DashboardJoinDiscussionRejectButton } from '.';
@@ -21,8 +20,6 @@ describe('<DashboardJoinDiscussionRejectButton />', () => {
       id: 'participant1',
       name: 'John Doe',
     };
-    // add participant in discussion
-    useJoinParticipant.getState().addParticipantAskingToJoin(participant);
 
     render(
       wrapInIntlProvider(

--- a/src/frontend/components/DashboardJoinDiscussionRejectButton/index.spec.tsx
+++ b/src/frontend/components/DashboardJoinDiscussionRejectButton/index.spec.tsx
@@ -1,0 +1,40 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { useJoinParticipant } from '../../data/stores/useJoinParticipant';
+import { wrapInIntlProvider } from '../../utils/tests/intl';
+import * as mockWindow from '../../utils/window';
+import { DashboardJoinDiscussionRejectButton } from '.';
+
+jest.mock('../../utils/window', () => ({
+  converse: {
+    rejectParticipantToJoin: jest.fn(),
+  },
+}));
+
+describe('<DashboardJoinDiscussionRejectButton />', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+  it('renders the button and click on it', () => {
+    const participant = {
+      id: 'participant1',
+      name: 'John Doe',
+    };
+    // add participant in discussion
+    useJoinParticipant.getState().addParticipantAskingToJoin(participant);
+
+    render(
+      wrapInIntlProvider(
+        <DashboardJoinDiscussionRejectButton participant={participant} />,
+      ),
+    );
+
+    const rejectButton = screen.getByRole('button', { name: 'reject' });
+
+    fireEvent.click(rejectButton);
+    expect(mockWindow.converse.rejectParticipantToJoin).toHaveBeenCalledWith(
+      participant,
+    );
+  });
+});

--- a/src/frontend/components/DashboardJoinDiscussionRejectButton/index.tsx
+++ b/src/frontend/components/DashboardJoinDiscussionRejectButton/index.tsx
@@ -2,7 +2,6 @@ import { Button } from 'grommet';
 import React from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 
-import { useJoinParticipant } from '../../data/stores/useJoinParticipant';
 import { Participant } from '../../types/Participant';
 import { converse } from '../../utils/window';
 
@@ -21,10 +20,6 @@ interface DashboardJoinDiscussionRejectButtonProps {
 export const DashboardJoinDiscussionRejectButton = ({
   participant,
 }: DashboardJoinDiscussionRejectButtonProps) => {
-  const removeParticipantAskingToJoin = useJoinParticipant(
-    (state) => state.removeParticipantAskingToJoin,
-  );
-
   const onClick = () => {
     converse.rejectParticipantToJoin(participant);
   };

--- a/src/frontend/components/DashboardJoinDiscussionRejectButton/index.tsx
+++ b/src/frontend/components/DashboardJoinDiscussionRejectButton/index.tsx
@@ -1,0 +1,40 @@
+import { Button } from 'grommet';
+import React from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+
+import { useJoinParticipant } from '../../data/stores/useJoinParticipant';
+import { Participant } from '../../types/Participant';
+import { converse } from '../../utils/window';
+
+const messages = defineMessages({
+  rejectParticipant: {
+    defaultMessage: 'reject',
+    description: 'Reject the participant who requests to join the discussion',
+    id: 'components.DashboardJoinDiscussionRejectButton.rejectParticipant',
+  },
+});
+
+interface DashboardJoinDiscussionRejectButtonProps {
+  participant: Participant;
+}
+
+export const DashboardJoinDiscussionRejectButton = ({
+  participant,
+}: DashboardJoinDiscussionRejectButtonProps) => {
+  const removeParticipantAskingToJoin = useJoinParticipant(
+    (state) => state.removeParticipantAskingToJoin,
+  );
+
+  const onClick = () => {
+    converse.rejectParticipantToJoin(participant);
+  };
+
+  return (
+    <Button
+      label={<FormattedMessage {...messages.rejectParticipant} />}
+      onClick={onClick}
+      margin="small"
+      size="small"
+    />
+  );
+};

--- a/src/frontend/components/DashboardPaneButtons/DashboardButtons.tsx
+++ b/src/frontend/components/DashboardPaneButtons/DashboardButtons.tsx
@@ -1,0 +1,31 @@
+import { Button } from 'grommet';
+import styled from 'styled-components';
+
+import { withLink } from '../withLink/withLink';
+
+export const DashboardButton = styled(Button)`
+  flex-grow: 1;
+  flex-basis: 8rem;
+  max-width: 50%;
+  position: relative;
+
+  :first-child {
+    margin-right: 1rem;
+  }
+
+  :last-child {
+    margin-left: 1rem;
+  }
+`;
+
+export const DashboardButtonBeta = styled(DashboardButton)`
+  :after {
+    color: #ff6a00;
+    content: '(BETA)';
+    font-size: 0.5em;
+    position: absolute;
+    top: -0.4em;
+  }
+`;
+
+export const DashboardButtonWithLink = withLink(DashboardButton);

--- a/src/frontend/components/DashboardPaneButtons/index.tsx
+++ b/src/frontend/components/DashboardPaneButtons/index.tsx
@@ -1,7 +1,6 @@
-import { Box, Button } from 'grommet';
+import { Box } from 'grommet';
 import React from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
-import styled from 'styled-components';
 
 import { Document } from '../../types/file';
 import { modelName } from '../../types/models';
@@ -12,7 +11,7 @@ import { DashboardVideoLiveConfigureButton } from '../DashboardVideoLiveConfigur
 import { PLAYER_ROUTE } from '../routes';
 import { UPLOAD_FORM_ROUTE } from '../UploadForm/route';
 import { useUploadManager } from '../UploadManager';
-import { withLink } from '../withLink/withLink';
+import { DashboardButtonWithLink } from './DashboardButtons';
 
 const messages = {
   [modelName.VIDEOS]: defineMessages({
@@ -56,33 +55,6 @@ const messages = {
     },
   }),
 };
-
-export const DashboardButton = styled(Button)`
-  flex-grow: 1;
-  flex-basis: 8rem;
-  max-width: 50%;
-  position: relative;
-
-  :first-child {
-    margin-right: 1rem;
-  }
-
-  :last-child {
-    margin-left: 1rem;
-  }
-`;
-
-export const DashboardButtonBeta = styled(DashboardButton)`
-  :after {
-    color: #ff6a00;
-    content: '(BETA)';
-    font-size: 0.5em;
-    position: absolute;
-    top: -0.4em;
-  }
-`;
-
-export const DashboardButtonWithLink = withLink(DashboardButton);
 
 /** Props shape for the DashboardVideoPaneButtons component. */
 export interface DashboardPaneButtonsProps {

--- a/src/frontend/components/DashboardVideoHarvested/index.tsx
+++ b/src/frontend/components/DashboardVideoHarvested/index.tsx
@@ -6,7 +6,7 @@ import { Redirect } from 'react-router-dom';
 import {
   DashboardButton,
   DashboardButtonWithLink,
-} from '../DashboardPaneButtons';
+} from '../DashboardPaneButtons/DashboardButtons';
 import { PLAYER_ROUTE } from '../routes';
 import { FULL_SCREEN_ERROR_ROUTE } from '../ErrorComponents/route';
 import { updateResource } from '../../data/sideEffects/updateResource';

--- a/src/frontend/components/DashboardVideoLive/index.tsx
+++ b/src/frontend/components/DashboardVideoLive/index.tsx
@@ -125,6 +125,7 @@ export const DashboardVideoLive = ({ video }: DashboardVideoLiveProps) => {
           video={video}
           setCanShowStartButton={setCanShowStartButton}
           setCanStartLive={setCanStartLive}
+          isInstructor={true}
         />
       )}
       <Box direction={'row'} justify={'center'} margin={'small'}>

--- a/src/frontend/components/DashboardVideoLiveConfigureButton/index.tsx
+++ b/src/frontend/components/DashboardVideoLiveConfigureButton/index.tsx
@@ -9,7 +9,7 @@ import { modelName } from '../../types/models';
 import { LiveModeType, Video } from '../../types/tracks';
 import { Nullable } from '../../utils/types';
 import { DASHBOARD_ROUTE } from '../Dashboard/route';
-import { DashboardButtonBeta } from '../DashboardPaneButtons';
+import { DashboardButtonBeta } from '../DashboardPaneButtons/DashboardButtons';
 import { FULL_SCREEN_ERROR_ROUTE } from '../ErrorComponents/route';
 import { Loader } from '../Loader';
 

--- a/src/frontend/components/DashboardVideoLiveJitsi/index.spec.tsx
+++ b/src/frontend/components/DashboardVideoLiveJitsi/index.spec.tsx
@@ -59,6 +59,7 @@ describe('<DashboardVideoLiveJitsi />', () => {
         video={video}
         setCanStartLive={jest.fn()}
         setCanShowStartButton={jest.fn()}
+        isInstructor={true}
       />,
     );
     const toolbarButtons = [
@@ -131,6 +132,7 @@ describe('<DashboardVideoLiveJitsi />', () => {
         video={{ ...video, live_state: liveState.RUNNING }}
         setCanStartLive={jest.fn()}
         setCanShowStartButton={jest.fn()}
+        isInstructor={true}
       />,
     );
 
@@ -149,6 +151,7 @@ describe('<DashboardVideoLiveJitsi />', () => {
         video={{ ...video, live_state: liveState.STOPPING }}
         setCanStartLive={jest.fn()}
         setCanShowStartButton={jest.fn()}
+        isInstructor={true}
       />,
     );
 
@@ -185,6 +188,7 @@ describe('<DashboardVideoLiveJitsi />', () => {
         video={video}
         setCanStartLive={jest.fn()}
         setCanShowStartButton={jest.fn()}
+        isInstructor={true}
       />,
     );
 
@@ -251,6 +255,7 @@ describe('<DashboardVideoLiveJitsi />', () => {
         video={video}
         setCanStartLive={mockCanStartLive}
         setCanShowStartButton={jest.fn()}
+        isInstructor={true}
       />,
     );
 
@@ -301,6 +306,7 @@ describe('<DashboardVideoLiveJitsi />', () => {
         video={video}
         setCanStartLive={mockCanStartLive}
         setCanShowStartButton={mockCanShowStartButton}
+        isInstructor={true}
       />,
     );
 
@@ -343,6 +349,7 @@ describe('<DashboardVideoLiveJitsi />', () => {
         video={video}
         setCanStartLive={jest.fn()}
         setCanShowStartButton={mockCanShowStartButton}
+        isInstructor={true}
       />,
     );
 
@@ -352,5 +359,32 @@ describe('<DashboardVideoLiveJitsi />', () => {
     dispatch('videoConferenceJoined', {});
 
     expect(mockCanShowStartButton).toHaveBeenLastCalledWith(true);
+  });
+
+  it('does not start recording when isInstructor is False', () => {
+    const video = videoMockFactory({
+      live_info: {
+        jitsi: {
+          domain: 'meet.jit.si',
+          external_api_url: 'https://meet.jit.si/external_api.js',
+          config_overwrite: {},
+          interface_config_overwrite: {},
+        },
+      },
+      live_state: liveState.RUNNING,
+      live_type: LiveModeType.JITSI,
+    });
+    global.JitsiMeetExternalAPI = mockJitsi;
+
+    render(<DashboardVideoLiveJitsi video={video} isInstructor={false} />);
+
+    expect(mockExecuteCommand).not.toHaveBeenCalledWith(
+      'startRecording',
+      expect.any({}),
+    );
+    expect(mockExecuteCommand).not.toHaveBeenCalledWith(
+      'stopRecording',
+      expect.any(String),
+    );
   });
 });

--- a/src/frontend/components/DashboardVideoLiveRunning/index.spec.tsx
+++ b/src/frontend/components/DashboardVideoLiveRunning/index.spec.tsx
@@ -74,31 +74,17 @@ describe('<DashboardVideoLiveRunning />  displays "show live" and "show chat onl
     screen.getByText('chat component');
   });
 
-  it('shows and hides the chat during a jitsi live.', () => {
+  it('shows chat directly during a jitsi live.', () => {
     const video = videoMockFactory({
       live_type: LiveModeType.JITSI,
     });
 
-    const { debug } = render(
+    render(
       wrapInIntlProvider(
         wrapInRouter(<DashboardVideoLiveRunning video={video} />),
       ),
     );
 
-    const showChatButton = screen.getByRole('button', { name: /show chat/ });
-    expect(screen.queryByText('chat component')).not.toBeInTheDocument();
-
-    // show chat
-    fireEvent.click(showChatButton);
-
     screen.getByText('chat component');
-    screen.getByText('standalone: true');
-
-    const hideChatButton = screen.getByRole('button', { name: /hide chat/ });
-
-    // hide chat
-    fireEvent.click(hideChatButton);
-
-    expect(screen.queryByText('chat component')).not.toBeInTheDocument();
   });
 });

--- a/src/frontend/components/DashboardVideoLiveRunning/index.tsx
+++ b/src/frontend/components/DashboardVideoLiveRunning/index.tsx
@@ -62,7 +62,7 @@ export const DashboardVideoLiveRunning = ({
       </Box>
       {video.live_type === LiveModeType.JITSI && (
         <React.Fragment>
-          <DashboardJoinDiscussion />
+          <DashboardJoinDiscussion video={video} />
           <Chat video={video} standalone={true} />
         </React.Fragment>
       )}

--- a/src/frontend/components/DashboardVideoLiveRunning/index.tsx
+++ b/src/frontend/components/DashboardVideoLiveRunning/index.tsx
@@ -3,10 +3,7 @@ import React, { useState } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 
 import { DashboardVideoLiveStopButton } from '../DashboardVideoLiveStopButton';
-import {
-  DashboardButton,
-  DashboardButtonWithLink,
-} from '../DashboardPaneButtons';
+import { DashboardButtonWithLink } from '../DashboardPaneButtons/DashboardButtons';
 import { Chat } from '../Chat';
 import { CHAT_ROUTE } from '../Chat/route';
 import { PLAYER_ROUTE } from '../routes';

--- a/src/frontend/components/DashboardVideoLiveRunning/index.tsx
+++ b/src/frontend/components/DashboardVideoLiveRunning/index.tsx
@@ -9,6 +9,7 @@ import { CHAT_ROUTE } from '../Chat/route';
 import { PLAYER_ROUTE } from '../routes';
 import { modelName } from '../../types/models';
 import { LiveModeType, Video } from '../../types/tracks';
+import { DashboardJoinDiscussion } from '../DashboardJoinDiscussion';
 
 const messages = defineMessages({
   showLive: {
@@ -40,10 +41,6 @@ interface DashboardVideoLiveRunningProps {
 export const DashboardVideoLiveRunning = ({
   video,
 }: DashboardVideoLiveRunningProps) => {
-  const [displayChat, setDisplayChat] = useState(false);
-  const displayChatMessage = displayChat
-    ? messages.hideChat
-    : messages.showChat;
   return (
     <Box direction="column" fill={true}>
       <Box direction="row">
@@ -61,15 +58,14 @@ export const DashboardVideoLiveRunning = ({
             />
           </React.Fragment>
         )}
-        {video.live_type === LiveModeType.JITSI && (
-          <DashboardButton
-            label={<FormattedMessage {...displayChatMessage} />}
-            onClick={() => setDisplayChat(!displayChat)}
-          />
-        )}
         <DashboardVideoLiveStopButton video={video} />
       </Box>
-      {displayChat && <Chat video={video} standalone={true} />}
+      {video.live_type === LiveModeType.JITSI && (
+        <React.Fragment>
+          <DashboardJoinDiscussion />
+          <Chat video={video} standalone={true} />
+        </React.Fragment>
+      )}
     </Box>
   );
 };

--- a/src/frontend/components/JoinDiscussionAskButton/index.spec.tsx
+++ b/src/frontend/components/JoinDiscussionAskButton/index.spec.tsx
@@ -1,0 +1,110 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { PUBLIC_JITSI_ROUTE } from '../PublicVideoLiveJitsi/route';
+import { useParticipantWorkflow } from '../../data/stores/useParticipantWorkflow';
+import { wrapInIntlProvider } from '../../utils/tests/intl';
+import { wrapInRouter } from '../../utils/tests/router';
+import * as mockWindow from '../../utils/window';
+import { JoinDiscussionAskButton } from '.';
+
+jest.mock('../../utils/window', () => ({
+  converse: {
+    askParticipantToJoin: jest.fn(),
+  },
+}));
+
+describe('<JoinDiscussionAskButton />', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+  it('renders the ask button', () => {
+    render(wrapInIntlProvider(<JoinDiscussionAskButton />));
+
+    screen.getByRole('button', { name: 'Send request to join the discussion' });
+    expect(
+      screen.queryByText("Waiting for Instructor's response"),
+    ).not.toBeInTheDocument();
+  });
+
+  it('clicks on the button to ask to join the discussion', () => {
+    render(wrapInIntlProvider(<JoinDiscussionAskButton />));
+
+    const askButton = screen.getByRole('button', {
+      name: 'Send request to join the discussion',
+    });
+    expect(
+      screen.queryByText("Waiting for Instructor's response"),
+    ).not.toBeInTheDocument();
+
+    expect(useParticipantWorkflow.getState().asked).toEqual(false);
+    fireEvent.click(askButton);
+
+    expect(mockWindow.converse.askParticipantToJoin).toHaveBeenCalled();
+    expect(useParticipantWorkflow.getState().asked).toEqual(true);
+
+    screen.getByText("Waiting for Instructor's response");
+    expect(
+      screen.queryByRole('button', {
+        name: 'Send request to join the discussion',
+      }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('redirects to JITSI PUBLIC route when accepted', () => {
+    render(
+      wrapInIntlProvider(
+        wrapInRouter(<JoinDiscussionAskButton />, [
+          {
+            path: PUBLIC_JITSI_ROUTE(),
+            render: ({ match }) => {
+              return <span>{'public video jitsi'}</span>;
+            },
+          },
+        ]),
+      ),
+    );
+
+    screen.getByRole('button', { name: 'Send request to join the discussion' });
+
+    act(() => {
+      // set accepted to true
+      useParticipantWorkflow.getState().setAccepted();
+    });
+
+    screen.getByText('public video jitsi');
+  });
+
+  it('clicks on the button to ask to join the discussion and the request is rejected', () => {
+    render(wrapInIntlProvider(<JoinDiscussionAskButton />));
+
+    const askButton = screen.getByRole('button', {
+      name: 'Send request to join the discussion',
+    });
+    expect(
+      screen.queryByText("Waiting for Instructor's response"),
+    ).not.toBeInTheDocument();
+
+    expect(useParticipantWorkflow.getState().asked).toEqual(false);
+    fireEvent.click(askButton);
+
+    expect(mockWindow.converse.askParticipantToJoin).toHaveBeenCalled();
+    expect(useParticipantWorkflow.getState().asked).toEqual(true);
+
+    screen.getByText("Waiting for Instructor's response");
+    expect(
+      screen.queryByRole('button', {
+        name: 'Send request to join the discussion',
+      }),
+    ).not.toBeInTheDocument();
+
+    act(() => {
+      // set rejected to true
+      useParticipantWorkflow.getState().setRejected();
+    });
+
+    screen.getByText(
+      'Your request to join the discussion has not been accepted.',
+    );
+  });
+});

--- a/src/frontend/components/JoinDiscussionAskButton/index.tsx
+++ b/src/frontend/components/JoinDiscussionAskButton/index.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+import { Redirect } from 'react-router-dom';
+
+import { useParticipantWorkflow } from '../../data/stores/useParticipantWorkflow';
+import { DashboardButton } from '../DashboardPaneButtons/DashboardButtons';
+
+import { converse } from '../../utils/window';
+import { PUBLIC_JITSI_ROUTE } from '../PublicVideoLiveJitsi/route';
+
+const messages = defineMessages({
+  askInstructor: {
+    defaultMessage: 'Send request to join the discussion',
+    description: 'Ask the instructor to join the discussion',
+    id: 'components.JoinDiscussionAskButton.askInstructor',
+  },
+  waitingInstructor: {
+    defaultMessage: "Waiting for Instructor's response",
+    description: `Text that replace the JoinDiscussion button before the instructor response.`,
+    id: 'components.JoinDiscussionAskButton.waitingInstructor',
+  },
+  rejected: {
+    defaultMessage:
+      'Your request to join the discussion has not been accepted.',
+    description: 'Text to tell participant his/her request is not accepted',
+    id: 'components.JoinDiscussionAskButton.rejected',
+  },
+});
+
+export const JoinDiscussionAskButton = () => {
+  const { asked, accepted, rejected, setAsked } = useParticipantWorkflow(
+    (state) => ({
+      asked: state.asked,
+      accepted: state.accepted,
+      rejected: state.rejected,
+      setAsked: state.setAsked,
+    }),
+  );
+
+  const onClick = () => {
+    converse.askParticipantToJoin();
+    setAsked();
+  };
+
+  if (accepted) {
+    return <Redirect to={PUBLIC_JITSI_ROUTE()} />;
+  }
+
+  if (rejected) {
+    return <FormattedMessage {...messages.rejected} />;
+  }
+
+  return asked ? (
+    <FormattedMessage {...messages.waitingInstructor} />
+  ) : (
+    <DashboardButton
+      label={<FormattedMessage {...messages.askInstructor} />}
+      primary={true}
+      onClick={onClick}
+    />
+  );
+};

--- a/src/frontend/components/JoinDiscussionLeaveButton/index.spec.tsx
+++ b/src/frontend/components/JoinDiscussionLeaveButton/index.spec.tsx
@@ -1,0 +1,49 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { wrapInIntlProvider } from '../../utils/tests/intl';
+import { wrapInRouter } from '../../utils/tests/router';
+import * as mockWindow from '../../utils/window';
+import { JoinDiscussionLeaveButton } from '.';
+import { PLAYER_ROUTE } from '../routes';
+
+jest.mock('../../utils/window', () => ({
+  converse: {
+    participantLeaves: jest.fn(),
+  },
+}));
+
+describe('<JoinDiscussionLeaveButton />', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+  it('renders the leave button', () => {
+    render(wrapInIntlProvider(wrapInRouter(<JoinDiscussionLeaveButton />)));
+
+    screen.getByRole('button', { name: 'Leave the discussion' });
+  });
+
+  it('clicks on the leave button and is redirected to the player', () => {
+    render(
+      wrapInIntlProvider(
+        wrapInRouter(<JoinDiscussionLeaveButton />, [
+          {
+            path: PLAYER_ROUTE(),
+            render: ({ match }) => {
+              return <span>{'video player'}</span>;
+            },
+          },
+        ]),
+      ),
+    );
+
+    const leaveButton = screen.getByRole('button', {
+      name: 'Leave the discussion',
+    });
+
+    fireEvent.click(leaveButton);
+
+    screen.getByText('video player');
+    expect(mockWindow.converse.participantLeaves).toHaveBeenCalled();
+  });
+});

--- a/src/frontend/components/JoinDiscussionLeaveButton/index.tsx
+++ b/src/frontend/components/JoinDiscussionLeaveButton/index.tsx
@@ -1,0 +1,35 @@
+import React, { useState } from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+import { withRouter } from 'react-router';
+
+import { DashboardButton } from '../DashboardPaneButtons/DashboardButtons';
+import { converse } from '../../utils/window';
+import { PLAYER_ROUTE } from '../routes';
+import { modelName } from '../../types/models';
+import { useParticipantWorkflow } from '../../data/stores/useParticipantWorkflow';
+
+const messages = defineMessages({
+  leaveDiscussion: {
+    defaultMessage: 'Leave the discussion',
+    description: 'Leave the discussion',
+    id: 'components.JoinDiscussionLeaveButton.leaveDiscussion',
+  },
+});
+
+export const JoinDiscussionLeaveButton = withRouter(({ history }) => {
+  const reset = useParticipantWorkflow((state) => state.reset);
+
+  const onClick = () => {
+    converse.participantLeaves();
+    reset();
+    history.push(PLAYER_ROUTE(modelName.VIDEOS));
+  };
+
+  return (
+    <DashboardButton
+      label={<FormattedMessage {...messages.leaveDiscussion} />}
+      primary={true}
+      onClick={onClick}
+    />
+  );
+});

--- a/src/frontend/components/LTIRoutes/index.tsx
+++ b/src/frontend/components/LTIRoutes/index.tsx
@@ -11,6 +11,7 @@ import { FULL_SCREEN_ERROR_ROUTE } from '../ErrorComponents/route';
 import { ErrorComponentsProps } from '../ErrorComponents';
 import { InstructorWrapper } from '../InstructorWrapper';
 import { Loader } from '../Loader';
+import { PUBLIC_JITSI_ROUTE } from '../PublicVideoLiveJitsi/route';
 import { RedirectOnLoad } from '../RedirectOnLoad';
 import { REDIRECT_ON_LOAD_ROUTE } from '../RedirectOnLoad/route';
 import { PLAYER_ROUTE } from '../routes';
@@ -28,6 +29,7 @@ const DashboardDocument = lazy(() => import('../DashboardDocument'));
 const DashboardVideo = lazy(() => import('../DashboardVideo'));
 const DocumentPlayer = lazy(() => import('../DocumentPlayer'));
 const PublicVideoDashboard = lazy(() => import('../PublicVideoDashboard'));
+const PublicVideoLiveJitsi = lazy(() => import('../PublicVideoLiveJitsi'));
 
 const Wrappers = ({ children }: React.PropsWithChildren<{}>) => (
   <MemoryRouter>
@@ -66,6 +68,17 @@ export const Routes = () => (
                   <DocumentPlayer document={appData.document} />
                 </InstructorWrapper>
               );
+            }
+
+            return <Redirect push to={FULL_SCREEN_ERROR_ROUTE('notFound')} />;
+          }}
+        />
+        <Route
+          exact
+          path={PUBLIC_JITSI_ROUTE()}
+          render={() => {
+            if (appData.modelName === modelName.VIDEOS && appData.video?.xmpp) {
+              return <PublicVideoLiveJitsi video={appData.video} />;
             }
 
             return <Redirect push to={FULL_SCREEN_ERROR_ROUTE('notFound')} />;

--- a/src/frontend/components/PublicVideoDashboard/index.tsx
+++ b/src/frontend/components/PublicVideoDashboard/index.tsx
@@ -14,11 +14,13 @@ import { useTimedTextTrack } from '../../data/stores/useTimedTextTrack';
 import { useVideo } from '../../data/stores/useVideo';
 import { modelName } from '../../types/models';
 import {
+  LiveModeType,
   liveState,
   timedTextMode,
   TimedTextTranscript,
   Video,
 } from '../../types/tracks';
+import { JoinDiscussionAskButton } from '../JoinDiscussionAskButton';
 
 interface PublicVideoDashboardProps {
   video: Video;
@@ -38,17 +40,29 @@ const PublicVideoDashboard = ({
     switch (video.live_state) {
       case liveState.RUNNING:
         return (
-          <Box direction="row">
-            <Box basis={video.xmpp ? 'xlarge' : 'auto'}>
-              <VideoPlayer
-                video={video}
-                playerType={playerType}
-                timedTextTracks={[]}
-              />
+          <Box>
+            <Box direction="row">
+              <Box basis={video.xmpp ? 'xlarge' : 'auto'}>
+                <VideoPlayer
+                  video={video}
+                  playerType={playerType}
+                  timedTextTracks={[]}
+                />
+              </Box>
+              {video.xmpp && (
+                <Box>
+                  <Chat video={video} />
+                </Box>
+              )}
             </Box>
-            {video.xmpp && (
-              <Box>
-                <Chat video={video} />
+            {video.xmpp && video.live_type === LiveModeType.JITSI && (
+              <Box
+                direction="row"
+                margin="small"
+                alignContent="center"
+                justify="center"
+              >
+                <JoinDiscussionAskButton />
               </Box>
             )}
           </Box>

--- a/src/frontend/components/PublicVideoLiveJitsi/index.spec.tsx
+++ b/src/frontend/components/PublicVideoLiveJitsi/index.spec.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { LiveModeType, liveState } from '../../types/tracks';
+import { videoMockFactory } from '../../utils/tests/factories';
+import { wrapInIntlProvider } from '../../utils/tests/intl';
+import { wrapInRouter } from '../../utils/tests/router';
+import PublicVideoLiveJitsi from '.';
+
+const mockVideo = videoMockFactory({
+  live_info: {
+    jitsi: {
+      domain: 'meet.jit.si',
+      external_api_url: 'https://meet.jit.si/external_api.js',
+      config_overwrite: {},
+      interface_config_overwrite: {},
+    },
+  },
+  live_state: liveState.CREATING,
+  live_type: LiveModeType.JITSI,
+});
+
+jest.mock('../../data/appData', () => ({
+  appData: {
+    video: mockVideo,
+  },
+}));
+
+const mockExecuteCommand = jest.fn();
+const mockJitsi = jest.fn().mockImplementation(() => ({
+  executeCommand: mockExecuteCommand,
+  addListener: jest.fn(),
+}));
+
+describe('<PublicVideoLiveJitsi />', () => {
+  it('renders jitsi and the leave button', () => {
+    global.JitsiMeetExternalAPI = mockJitsi;
+    render(
+      wrapInRouter(
+        wrapInIntlProvider(<PublicVideoLiveJitsi video={mockVideo} />),
+      ),
+    );
+
+    expect(mockJitsi).toHaveBeenCalled();
+    screen.getByRole('button', { name: 'Leave the discussion' });
+  });
+});

--- a/src/frontend/components/PublicVideoLiveJitsi/index.tsx
+++ b/src/frontend/components/PublicVideoLiveJitsi/index.tsx
@@ -1,0 +1,42 @@
+import { Box } from 'grommet';
+import React from 'react';
+import { Redirect } from 'react-router-dom';
+
+import { useParticipantWorkflow } from '../../data/stores/useParticipantWorkflow';
+import { useVideo } from '../../data/stores/useVideo';
+import { Video } from '../../types/tracks';
+import { JoinDiscussionLeaveButton } from '../JoinDiscussionLeaveButton';
+import DashboardVideoLiveJitsi from '../DashboardVideoLiveJitsi';
+import { PLAYER_ROUTE } from '../routes';
+import { modelName } from '../../types/models';
+
+interface PublicVideoLiveJitsiProps {
+  video: Video;
+}
+
+const PublicVideoLiveJitsi = ({
+  video: baseVideo,
+}: PublicVideoLiveJitsiProps) => {
+  const video = useVideo((state) => state.getVideo(baseVideo));
+  const kicked = useParticipantWorkflow((state) => state.kicked);
+
+  if (kicked) {
+    return <Redirect to={PLAYER_ROUTE(modelName.VIDEOS)} />;
+  }
+
+  return (
+    <React.Fragment>
+      <DashboardVideoLiveJitsi video={video} />
+      <Box
+        direction="row"
+        margin="small"
+        alignContent="center"
+        justify="center"
+      >
+        <JoinDiscussionLeaveButton />
+      </Box>
+    </React.Fragment>
+  );
+};
+
+export default PublicVideoLiveJitsi;

--- a/src/frontend/components/PublicVideoLiveJitsi/route.ts
+++ b/src/frontend/components/PublicVideoLiveJitsi/route.ts
@@ -1,0 +1,3 @@
+export const PUBLIC_JITSI_ROUTE = () => {
+  return `/public/jitsi`;
+};

--- a/src/frontend/data/stores/useJoinParticipant/index.spec.ts
+++ b/src/frontend/data/stores/useJoinParticipant/index.spec.ts
@@ -1,0 +1,101 @@
+import { useJoinParticipant } from '.';
+
+describe('useJoinParticipant', () => {
+  it('executes addParticipantAskingToJoin/removeParticipantAskingToJoin', () => {
+    // initial state
+    expect(useJoinParticipant.getState()).toEqual(
+      expect.objectContaining({
+        participantsAskingToJoin: [],
+        participantsInDiscussion: [],
+      }),
+    );
+
+    const participant = {
+      id: 'particpant1',
+      name: 'John Doe',
+    };
+
+    useJoinParticipant.getState().addParticipantAskingToJoin(participant);
+
+    expect(useJoinParticipant.getState()).toEqual(
+      expect.objectContaining({
+        participantsAskingToJoin: [participant],
+        participantsInDiscussion: [],
+      }),
+    );
+
+    useJoinParticipant.getState().removeParticipantAskingToJoin(participant);
+
+    expect(useJoinParticipant.getState()).toEqual(
+      expect.objectContaining({
+        participantsAskingToJoin: [],
+        participantsInDiscussion: [],
+      }),
+    );
+  });
+
+  it('executes addParticipantToDiscussion/removeParticipantInDiscussion', () => {
+    expect(useJoinParticipant.getState()).toEqual(
+      expect.objectContaining({
+        participantsAskingToJoin: [],
+        participantsInDiscussion: [],
+      }),
+    );
+
+    const participant = {
+      id: 'particpant1',
+      name: 'John Doe',
+    };
+
+    useJoinParticipant.getState().addParticipantToDiscussion(participant);
+
+    expect(useJoinParticipant.getState()).toEqual(
+      expect.objectContaining({
+        participantsAskingToJoin: [],
+        participantsInDiscussion: [participant],
+      }),
+    );
+
+    useJoinParticipant.getState().removeParticipantInDiscussion(participant);
+
+    expect(useJoinParticipant.getState()).toEqual(
+      expect.objectContaining({
+        participantsAskingToJoin: [],
+        participantsInDiscussion: [],
+      }),
+    );
+  });
+
+  it('executes moveParticipantToDiscussion', () => {
+    // initial state
+    expect(useJoinParticipant.getState()).toEqual(
+      expect.objectContaining({
+        participantsAskingToJoin: [],
+        participantsInDiscussion: [],
+      }),
+    );
+
+    const participant = {
+      id: 'particpant1',
+      name: 'John Doe',
+    };
+
+    useJoinParticipant.getState().addParticipantAskingToJoin(participant);
+
+    expect(useJoinParticipant.getState()).toEqual(
+      expect.objectContaining({
+        participantsAskingToJoin: [participant],
+        participantsInDiscussion: [],
+      }),
+    );
+
+    useJoinParticipant.getState().moveParticipantToDiscussion(participant);
+
+    expect(useJoinParticipant.getState()).toEqual(
+      expect.objectContaining({
+        participantsAskingToJoin: [],
+        participantsInDiscussion: [participant],
+      }),
+    );
+  });
+});

--- a/src/frontend/data/stores/useJoinParticipant/index.spec.ts
+++ b/src/frontend/data/stores/useJoinParticipant/index.spec.ts
@@ -34,7 +34,7 @@ describe('useJoinParticipant', () => {
     );
   });
 
-  it('executes addParticipantToDiscussion/removeParticipantInDiscussion', () => {
+  it('executes addParticipantToDiscussion/removeParticipantFromDiscussion', () => {
     expect(useJoinParticipant.getState()).toEqual(
       expect.objectContaining({
         participantsAskingToJoin: [],
@@ -56,7 +56,7 @@ describe('useJoinParticipant', () => {
       }),
     );
 
-    useJoinParticipant.getState().removeParticipantInDiscussion(participant);
+    useJoinParticipant.getState().removeParticipantFromDiscussion(participant);
 
     expect(useJoinParticipant.getState()).toEqual(
       expect.objectContaining({

--- a/src/frontend/data/stores/useJoinParticipant/index.ts
+++ b/src/frontend/data/stores/useJoinParticipant/index.ts
@@ -7,7 +7,7 @@ type State = {
   addParticipantAskingToJoin: (particpant: Participant) => void;
   addParticipantToDiscussion: (participant: Participant) => void;
   removeParticipantAskingToJoin: (participant: Participant) => void;
-  removeParticipantInDiscussion: (participant: Participant) => void;
+  removeParticipantFromDiscussion: (participant: Participant) => void;
   moveParticipantToDiscussion: (participant: Participant) => void;
 };
 
@@ -37,7 +37,7 @@ export const useJoinParticipant = create<State>((set, get) => ({
       ),
     });
   },
-  removeParticipantInDiscussion: (participantToRemove: Participant) => {
+  removeParticipantFromDiscussion: (participantToRemove: Participant) => {
     const participantsInDiscussion = get().participantsInDiscussion;
     set({
       participantsInDiscussion: participantsInDiscussion.filter(

--- a/src/frontend/data/stores/useJoinParticipant/index.ts
+++ b/src/frontend/data/stores/useJoinParticipant/index.ts
@@ -1,0 +1,60 @@
+import create from 'zustand';
+import { Participant } from '../../../types/Participant';
+
+type State = {
+  participantsAskingToJoin: Participant[];
+  participantsInDiscussion: Participant[];
+  addParticipantAskingToJoin: (particpant: Participant) => void;
+  addParticipantToDiscussion: (participant: Participant) => void;
+  removeParticipantAskingToJoin: (participant: Participant) => void;
+  removeParticipantInDiscussion: (participant: Participant) => void;
+  moveParticipantToDiscussion: (participant: Participant) => void;
+};
+
+export const useJoinParticipant = create<State>((set, get) => ({
+  participantsAskingToJoin: [],
+  participantsInDiscussion: [],
+  addParticipantAskingToJoin: (participant: Participant) => {
+    const participantsAskingToJoin = get().participantsAskingToJoin;
+    participantsAskingToJoin.push(participant);
+    set({
+      participantsAskingToJoin,
+    });
+  },
+  addParticipantToDiscussion: (participant: Participant) => {
+    const participantsInDiscussion = get().participantsInDiscussion;
+    participantsInDiscussion.push(participant);
+
+    set({
+      participantsInDiscussion,
+    });
+  },
+  removeParticipantAskingToJoin: (participantToRemove: Participant) => {
+    const participantsAskingToJoin = get().participantsAskingToJoin;
+    set({
+      participantsAskingToJoin: participantsAskingToJoin.filter(
+        (participant) => participant.id !== participantToRemove.id,
+      ),
+    });
+  },
+  removeParticipantInDiscussion: (participantToRemove: Participant) => {
+    const participantsInDiscussion = get().participantsInDiscussion;
+    set({
+      participantsInDiscussion: participantsInDiscussion.filter(
+        (participant) => participant.id !== participantToRemove.id,
+      ),
+    });
+  },
+  moveParticipantToDiscussion: (participantToMove: Participant) => {
+    const participantsInDiscussion = get().participantsInDiscussion;
+    const participantsAskingToJoin = get().participantsAskingToJoin;
+
+    participantsInDiscussion.push(participantToMove);
+    set({
+      participantsInDiscussion,
+      participantsAskingToJoin: participantsAskingToJoin.filter(
+        (participant) => participant.id !== participantToMove.id,
+      ),
+    });
+  },
+}));

--- a/src/frontend/data/stores/useParticipantWorkflow/index.spec.ts
+++ b/src/frontend/data/stores/useParticipantWorkflow/index.spec.ts
@@ -1,0 +1,118 @@
+import { useParticipantWorkflow } from '.';
+
+describe('useParticipantWorkflow', () => {
+  it('executes setAsked', () => {
+    // initial state
+    expect(useParticipantWorkflow.getState()).toEqual(
+      expect.objectContaining({
+        asked: false,
+        accepted: false,
+        rejected: false,
+        kicked: false,
+      }),
+    );
+    useParticipantWorkflow.getState().setAsked();
+    expect(useParticipantWorkflow.getState()).toEqual(
+      expect.objectContaining({
+        asked: true,
+        accepted: false,
+        rejected: false,
+        kicked: false,
+      }),
+    );
+  });
+
+  it('executes setAccepted', () => {
+    // initial state
+    expect(useParticipantWorkflow.getState()).toEqual(
+      expect.objectContaining({
+        asked: false,
+        accepted: false,
+        rejected: false,
+        kicked: false,
+      }),
+    );
+    useParticipantWorkflow.getState().setAccepted();
+    expect(useParticipantWorkflow.getState()).toEqual(
+      expect.objectContaining({
+        asked: false,
+        accepted: true,
+        rejected: false,
+        kicked: false,
+      }),
+    );
+  });
+
+  it('executes setRejected', () => {
+    // initial state
+    expect(useParticipantWorkflow.getState()).toEqual(
+      expect.objectContaining({
+        asked: false,
+        accepted: false,
+        rejected: false,
+        kicked: false,
+      }),
+    );
+    useParticipantWorkflow.getState().setRejected();
+    expect(useParticipantWorkflow.getState()).toEqual(
+      expect.objectContaining({
+        asked: false,
+        accepted: false,
+        rejected: true,
+        kicked: false,
+      }),
+    );
+  });
+
+  it('executes setKicked', () => {
+    // initial state
+    expect(useParticipantWorkflow.getState()).toEqual(
+      expect.objectContaining({
+        asked: false,
+        accepted: false,
+        rejected: false,
+        kicked: false,
+      }),
+    );
+    useParticipantWorkflow.getState().setKicked();
+    expect(useParticipantWorkflow.getState()).toEqual(
+      expect.objectContaining({
+        asked: false,
+        accepted: false,
+        rejected: false,
+        kicked: true,
+      }),
+    );
+  });
+
+  it('executes reset', () => {
+    // initial state
+    expect(useParticipantWorkflow.getState()).toEqual(
+      expect.objectContaining({
+        asked: false,
+        accepted: false,
+        rejected: false,
+        kicked: false,
+      }),
+    );
+    useParticipantWorkflow.getState().setKicked();
+    expect(useParticipantWorkflow.getState()).toEqual(
+      expect.objectContaining({
+        asked: false,
+        accepted: false,
+        rejected: false,
+        kicked: true,
+      }),
+    );
+
+    useParticipantWorkflow.getState().reset();
+    expect(useParticipantWorkflow.getState()).toEqual(
+      expect.objectContaining({
+        asked: false,
+        accepted: false,
+        rejected: false,
+        kicked: false,
+      }),
+    );
+  });
+});

--- a/src/frontend/data/stores/useParticipantWorkflow/index.ts
+++ b/src/frontend/data/stores/useParticipantWorkflow/index.ts
@@ -1,0 +1,60 @@
+import create from 'zustand';
+
+type State = {
+  accepted: boolean;
+  asked: boolean;
+  kicked: boolean;
+  rejected: boolean;
+  reset: () => void;
+  setAccepted: () => void;
+  setAsked: () => void;
+  setKicked: () => void;
+  setRejected: () => void;
+};
+
+export const useParticipantWorkflow = create<State>((set, get) => ({
+  asked: false,
+  accepted: false,
+  rejected: false,
+  kicked: false,
+  setAsked: () => {
+    set({
+      asked: true,
+      accepted: false,
+      rejected: false,
+      kicked: false,
+    });
+  },
+  setAccepted: () => {
+    set({
+      asked: false,
+      accepted: true,
+      rejected: false,
+      kicked: false,
+    });
+  },
+  setRejected: () => {
+    set({
+      asked: false,
+      accepted: false,
+      rejected: true,
+      kicked: false,
+    });
+  },
+  setKicked: () => {
+    set({
+      asked: false,
+      accepted: false,
+      rejected: false,
+      kicked: true,
+    });
+  },
+  reset: () => {
+    set({
+      asked: false,
+      accepted: false,
+      rejected: false,
+      kicked: false,
+    });
+  },
+}));

--- a/src/frontend/types/Participant.ts
+++ b/src/frontend/types/Participant.ts
@@ -1,0 +1,4 @@
+export interface Participant {
+  id: string;
+  name: string;
+}

--- a/src/frontend/types/XMPP.ts
+++ b/src/frontend/types/XMPP.ts
@@ -1,0 +1,23 @@
+import { Nullable } from '../utils/types'
+
+/* XMPP representation */
+export interface XMPP {
+  bosh_url: Nullable<string>;
+  websocket_url: Nullable<string>;
+  conference_url: string;
+  prebind_url: string;
+  jid: string;
+}
+
+export enum MessageType {
+  GROUPCHAT = 'groupchat',
+  EVENT = 'event',
+}
+
+export enum EventType {
+  ACCEPT = 'accept',
+  REJECT = 'reject',
+  KICK = 'kick',
+  LEAVE = 'leave',
+  PARTICIPANTASKTOMOUNT = 'participantAskToMount',
+}

--- a/src/frontend/types/XMPP.ts
+++ b/src/frontend/types/XMPP.ts
@@ -1,23 +1,26 @@
-import { Nullable } from '../utils/types'
+import { Nullable } from '../utils/types';
 
 /* XMPP representation */
 export interface XMPP {
   bosh_url: Nullable<string>;
-  websocket_url: Nullable<string>;
   conference_url: string;
-  prebind_url: string;
   jid: string;
+  prebind_url: string;
+  websocket_url: Nullable<string>;
 }
 
 export enum MessageType {
-  GROUPCHAT = 'groupchat',
   EVENT = 'event',
+  GROUPCHAT = 'groupchat',
 }
 
 export enum EventType {
   ACCEPT = 'accept',
-  REJECT = 'reject',
+  ACCEPTED = 'accepted',
   KICK = 'kick',
+  KICKED = 'kicked',
   LEAVE = 'leave',
-  PARTICIPANTASKTOMOUNT = 'participantAskToMount',
+  PARTICIPANT_ASK_TO_JOIN = 'participantAskToJoin',
+  REJECT = 'reject',
+  REJECTED = 'rejected',
 }

--- a/src/frontend/types/libs/window.d.ts
+++ b/src/frontend/types/libs/window.d.ts
@@ -1,11 +1,20 @@
+import { Participant } from '../Participant';
+import { Video } from '../tracks';
+
 // Ensure this is treated as a module.
 export {};
 
 declare global {
   interface Window {
     converse: {
+      acceptParticipantToJoin: (participant: Participant, video: Video) => void;
+      askParticipantToJoin: () => void;
+      kickParticipant: (participant: Participant) => void;
+      rejectParticipantToJoin: (participant: Participant) => void;
+      participantLeaves: () => void;
       insertInto: (container: HTMLElement) => void;
       initialize: (options: any) => void;
+      env: any;
       plugins: {
         add: (name: string, plugin: any) => void;
       };

--- a/src/frontend/types/tracks.ts
+++ b/src/frontend/types/tracks.ts
@@ -1,5 +1,6 @@
 import { Nullable } from '../utils/types';
 import { Document } from './file';
+import { XMPP } from './XMPP';
 
 /** Base shape for all resources to extend. */
 export interface Resource {
@@ -69,15 +70,6 @@ export interface Playlist {
   portable_to: PlaylistLite[];
   title: string;
   users: string[];
-}
-
-/* XMPP representation */
-export interface XMPP {
-  bosh_url: Nullable<string>;
-  websocket_url: Nullable<string>;
-  conference_url: string;
-  prebind_url: string;
-  jid: string;
 }
 
 /** A timed text track record as it exists on the backend. */

--- a/src/frontend/utils/converse.spec.ts
+++ b/src/frontend/utils/converse.spec.ts
@@ -80,9 +80,9 @@ describe('converseMounter', () => {
         toggle_occupants: false,
       },
       websocket_url: null,
-      whitelisted_plugins: ['marsha'],
+      whitelisted_plugins: ['marsha', 'marsha-join-discussion'],
     });
-    expect(mockWindow.converse.plugins.add).toHaveBeenCalledTimes(1);
+    expect(mockWindow.converse.plugins.add).toHaveBeenCalledTimes(2);
     expect(mockWindow.converse.plugins.add).toHaveBeenCalledWith('marsha', {
       initialize: expect.any(Function),
     });
@@ -93,6 +93,6 @@ describe('converseMounter', () => {
 
     expect(mockWindow.converse.initialize).toHaveBeenCalledTimes(1);
     expect(mockWindow.converse.insertInto).toHaveBeenCalledTimes(1);
-    expect(mockWindow.converse.plugins.add).toHaveBeenCalledTimes(1);
+    expect(mockWindow.converse.plugins.add).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/frontend/utils/converse.spec.ts
+++ b/src/frontend/utils/converse.spec.ts
@@ -1,6 +1,8 @@
 import { converseMounter } from './converse';
 import * as mockWindow from './window';
 
+import { videoMockFactory } from './tests/factories';
+
 jest.mock('./window', () => ({
   converse: {
     initialize: jest.fn(),
@@ -11,8 +13,12 @@ jest.mock('./window', () => ({
   },
 }));
 let mockDecodedJwtToken = {};
+const mockVideo = videoMockFactory();
 jest.mock('../data/appData', () => ({
   getDecodedJwt: () => mockDecodedJwtToken,
+  appData: {
+    video: mockVideo,
+  },
 }));
 
 describe('converseMounter', () => {


### PR DESCRIPTION
## Purpose

As a participant I want to join a jitsi conference. For this an instructor should receive a request asking to join the discussion. Then the instructor is able to accept or reject the request.  Once accepted, the player is removed and jitsi is added and the participant is in the jitsi conference. 
An instructor can kick a participant in the room and the participant can leave the discussion alone.

All the dialog is made with XMPP. Messages are sent in the same MUC room used by the chat


https://user-images.githubusercontent.com/767834/127136290-877ba4c0-6876-465b-8533-aadd90f7a260.mp4



## Proposal

- [x] create a participant type
- [x] Create zustand stores to manage participant states
- [x] Manage components to join a discussion
- [x] Create a dedicated component displaying jitsi without start recording feature


