### PR TITLE
✨(back) do not create harvest job when there is no manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Add user group to admin site
 
+### Changed
+
+- Do not create an harvest job if no manifest is created
+
 ### Fixed
 
 - Add aws permission to list mediapackage harvest jobs (fixes unusable 3.22.0 version)

--- a/src/backend/marsha/core/api.py
+++ b/src/backend/marsha/core/api.py
@@ -462,7 +462,7 @@ class VideoViewSet(ObjectPkMixin, viewsets.ModelViewSet):
                 400,
             )
 
-        start_live_channel(video.live_info.get("medialive").get("channel").get("id"))
+        start_live_channel(video.get_medialive_channel().get("id"))
         if settings.LIVE_CHAT_ENABLED:
             create_room(video.id)
 
@@ -510,7 +510,7 @@ class VideoViewSet(ObjectPkMixin, viewsets.ModelViewSet):
                 400,
             )
 
-        stop_live_channel(video.live_info.get("medialive").get("channel").get("id"))
+        stop_live_channel(video.get_medialive_channel().get("id"))
 
         video.live_state = defaults.STOPPING
         video.save()
@@ -595,9 +595,7 @@ class VideoViewSet(ObjectPkMixin, viewsets.ModelViewSet):
             try:
                 create_mediapackage_harvest_job(video)
             except ManifestMissingException:
-                delete_mediapackage_channel(
-                    video.live_info.get("mediapackage").get("channel").get("id")
-                )
+                delete_mediapackage_channel(video.get_mediapackage_channel().get("id"))
                 video.upload_state = defaults.DELETED
                 video.live_state = None
                 video.live_info = None

--- a/src/backend/marsha/core/models/video.py
+++ b/src/backend/marsha/core/models/video.py
@@ -158,6 +158,22 @@ class Video(BaseFile):
             live_state__isnull=False
         )
 
+    def get_medialive_input(self):
+        """Return the medialive input info if existing."""
+        return self.live_info.get("medialive").get("input")
+
+    def get_medialive_channel(self):
+        """Return the medialive channel info if existing."""
+        return self.live_info.get("medialive").get("channel")
+
+    def get_mediapackage_channel(self):
+        """Return the mediapackage channel info if existing."""
+        return self.live_info.get("mediapackage").get("channel")
+
+    def get_mediapackage_endpoints(self):
+        """Return the mediapackage enspoints info."""
+        return self.live_info.get("mediapackage").get("endpoints")
+
 
 class BaseTrack(UploadableFileMixin, BaseModel):
     """Base model for different kinds of tracks tied to a video."""

--- a/src/backend/marsha/core/utils/medialive_utils.py
+++ b/src/backend/marsha/core/utils/medialive_utils.py
@@ -5,6 +5,13 @@ import os
 from django.conf import settings
 
 import boto3
+import requests
+
+
+class ManifestMissingException(Exception):
+    """Exception used when a mediapackage manifest is missing."""
+
+    pass
 
 
 aws_credentials = {
@@ -283,6 +290,12 @@ def stop_live_channel(channel_id):
 
 def create_mediapackage_harvest_job(video):
     """Create a mediapackage harvest job."""
+    request = requests.get(
+        video.live_info.get("mediapackage").get("endpoints").get("hls").get("url")
+    )
+    if request.status_code == 404:
+        raise ManifestMissingException
+
     hls_endpoint = (
         video.live_info.get("mediapackage").get("endpoints").get("hls").get("id")
     )

--- a/src/backend/marsha/core/utils/medialive_utils.py
+++ b/src/backend/marsha/core/utils/medialive_utils.py
@@ -290,16 +290,12 @@ def stop_live_channel(channel_id):
 
 def create_mediapackage_harvest_job(video):
     """Create a mediapackage harvest job."""
-    request = requests.get(
-        video.live_info.get("mediapackage").get("endpoints").get("hls").get("url")
-    )
+    request = requests.get(video.get_mediapackage_endpoints().get("hls").get("url"))
     if request.status_code == 404:
         raise ManifestMissingException
 
-    hls_endpoint = (
-        video.live_info.get("mediapackage").get("endpoints").get("hls").get("id")
-    )
-    channel_id = video.live_info.get("mediapackage").get("channel").get("id")
+    hls_endpoint = video.get_mediapackage_endpoints().get("hls").get("id")
+    channel_id = video.get_mediapackage_channel().get("id")
 
     # split channel id to take the stamp in it {env}_{pk}_{stamp}
     elements = channel_id.split("_")
@@ -325,16 +321,13 @@ def delete_aws_element_stack(video):
     """
     # Medialive
     # First delete the channel
-    medialive_client.delete_channel(
-        ChannelId=video.live_info.get("medialive").get("channel").get("id")
-    )
+    medialive_client.delete_channel(ChannelId=video.get_medialive_channel().get("id"))
 
     # Once channel deleted we have to wait until input is detached
     input_waiter = medialive_client.get_waiter("input_detached")
-    input_waiter.wait(InputId=video.live_info.get("medialive").get("input").get("id"))
-    medialive_client.delete_input(
-        InputId=video.live_info.get("medialive").get("input").get("id")
-    )
+    medialive_input_id = video.get_medialive_input().get("id")
+    input_waiter.wait(InputId=medialive_input_id)
+    medialive_client.delete_input(InputId=medialive_input_id)
 
 
 def _get_items(  # nosec


### PR DESCRIPTION
## Purpose

If a live is stopped and mediapackage does not have created a manifest,
the harvest job will failed and the mediapackage stack will not be
detroyed. Before creating an harvest job we test if the manifest exists
and if not the mediapacakge stack is deleted and the video upload_state
set to DELETED.

## Proposal

- [x] do not create harvest job when there is no manifest
