### PR TITLE
✨(back) Add user group to admin site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Add user group to admin site
+
 ## [3.22.0] - 2021-08-19
 
 ### Added

--- a/src/backend/marsha/core/admin.py
+++ b/src/backend/marsha/core/admin.py
@@ -2,6 +2,7 @@
 
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin as DefaultUserAdmin
+from django.contrib.auth.models import Group
 from django.urls import reverse
 from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
@@ -164,6 +165,7 @@ admin_site = MarshaAdminSite(name="admin")
 admin_site.register(waffle_admin.Flag, waffle_admin.FlagAdmin)
 admin_site.register(waffle_admin.Sample, waffle_admin.SampleAdmin)
 admin_site.register(waffle_admin.Switch, waffle_admin.SwitchAdmin)
+admin_site.register(Group)
 
 
 class UserOrganizationsInline(admin.TabularInline):


### PR DESCRIPTION
## Purpose

We want to create groups to assign them to some users. The group model
was not added to the admin, this commit add it.

## Proposal

- [x] enable group in admin site

