### PR TITLE
🛂(aws) add mediapackage:ListHarvestJobs permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Add user group to admin site
 
+### Fixed
+
+- Add aws permission to list mediapackage harvest jobs (fixes unusable 3.22.0 version)
+
 ## [3.22.0] - 2021-08-19
 
 ### Added

--- a/src/aws/user.tf
+++ b/src/aws/user.tf
@@ -148,7 +148,8 @@ resource "aws_iam_user_policy" "live-streaming-policies" {
         "mediapackage:ListChannels",
         "mediapackage:UpdateOriginEndpoint",
         "mediapackage:TagResource",
-        "mediapackage:CreateHarvestJob"
+        "mediapackage:CreateHarvestJob",
+        "mediapackage:ListHarvestJobs"
       ],
       "Resource": "*"
     },


### PR DESCRIPTION
## Purpose

Management command clean_mediapackages lists mediapackage harvest jobs.
Related permission was missing.

