### PR TITLE
⬆️(aws) upgrade terraform to version 1

### DIFF
--- a/src/aws/.terraform.lock.hcl
+++ b/src/aws/.terraform.lock.hcl
@@ -2,19 +2,20 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "3.25.0"
-  constraints = "~> 3.25"
+  version     = "3.55.0"
+  constraints = "~> 3.55"
   hashes = [
-    "h1:9bXU5cFO/2DX8z5whaGMA7wcCalKQJZrBm89AuePuEM=",
-    "zh:2d3c65461bc63ec39bce7b5afdbed9a3b4dd5c2c8ee94616ad1866e24cf9b8f0",
-    "zh:2fb2ea6ccac30b909b603e183433737a30c58ec1f9a6a8b5565f0f051490c07a",
-    "zh:31a5f192c8cf29fb677cd639824f9a685578a2564c6b790517db33ea56229045",
-    "zh:437a12cf9a4d7bc92c9bf14ee7e224d5d3545cbd2154ba113ae82c4bb68edc27",
-    "zh:4bbdc3155a5dea90b2d50adfa460b0759c4dd959efaf7f66b2a0385a53b469b2",
-    "zh:63a8cd523ba31358692a34a06e111d88769576ac6d0e5adad8e0b4ae0a2d8882",
-    "zh:c4301ce86e8cb2c464949bb99e729ffe7b0c55eaf34b82ba526bb5039bca36f3",
-    "zh:c97b84861c6c550b8d2feb12d089660fffbf51dc7d660dcc9d54d4a7b3c2c882",
-    "zh:d6a103570e2d5c387b068fac4b88654dfa21d44ca1bdfa4bc8ab94c88effd71a",
-    "zh:f08cf2faf960a8ca374ac860f37c31c88ed2bab460116ac74678e0591babaac5",
+    "h1:pQzssRQ6BMdyO65Lq5PRx766l8swjcCNKrNyCkcJa6I=",
+    "zh:1795562df65e9e5a604c90fac17ab1a706bc398b38271a11bc43565d45532595",
+    "zh:266fd71ace988b5fecd72dae5f2f503e953a4d2ea51d8d490d22d1218b1407dc",
+    "zh:4b2daf1038352fb33df40a2bf9033f66383bb1f6509df70da08f86f4539df9f3",
+    "zh:59fa40d453baa15cee845fd62d8c807fc4d5204a5560ee7e54ebeef3a3143404",
+    "zh:5ad9f515354c654d53849d1193ee56e335b3b9cf8e8cbfa98479114e87089cc3",
+    "zh:69c3ebd945ce747e0b30315656bc8b4aec2f2486013c2a78d04890bff96d137d",
+    "zh:6bdb22a77b4d85b6d9f2403bce23d6c3c932dadd7c7541395cbbd51ec101842e",
+    "zh:7d5ba001be98432d6a1d385679a720cf0d6e6c0b1ee7d45384d2d6213e262b21",
+    "zh:ce4b85f470605c5cd24f8acfe05c6546d962a32ecf69a61034f0884c2e79fbcf",
+    "zh:d0b20e4e9e877279520162b7979e9cb8aa961cf06fb37d9f3e4ac7023c177545",
+    "zh:e029951f18e9dadd8929dddc752a5b354a4c9956b8ec1b67f4db7bc641199d22",
   ]
 }

--- a/src/aws/bin/terraform
+++ b/src/aws/bin/terraform
@@ -57,7 +57,7 @@ function terraform() {
         -v "${PWD}/:/app" \
         -w "/app" \
         --env-file ./env.d/${MARSHA_TERRAFORM_ENV_FILE} \
-        "hashicorp/terraform:0.14.5" \
+        "hashicorp/terraform:1.0.5" \
         "$@"
     else
         docker run --rm -it \
@@ -66,7 +66,7 @@ function terraform() {
         -w "/app" \
         --env-file ./env.d/${MARSHA_TERRAFORM_ENV_FILE} \
         -e TF_VAR_marsha_base_url="${NGROK_URL}" \
-        "hashicorp/terraform:0.14.5" \
+        "hashicorp/terraform:1.0.5" \
         "$@"
     fi
 }

--- a/src/aws/output.tf
+++ b/src/aws/output.tf
@@ -16,6 +16,7 @@ output "iam_trusted_signer_access_key_id" {
 
 output "iam_secret_access_key" {
   value = aws_iam_access_key.marsha_access_key.secret
+  sensitive = true
 }
 
 output "medialive_role_arn" {

--- a/src/aws/provider.tf
+++ b/src/aws/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.25"
+      version = "~> 3.55"
     }
   }
 }


### PR DESCRIPTION
## Purpose

Terraform version has been released in june. Only one change is needed
for us to upgrade to this version, we have to flag the AWS secret access
key as sensitive. AWS provider is also updated to version 3.55

## Proposal

- [x] upgrade terraform to version 1

