### PR TITLE
Merge overlapping played segments in xAPI logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   and mediapackage
 - Allow a participant to join a Jitsi conference
 
+### Changed
+
+- Merge overlapping played segments for xAPI events
+
 ## [3.23.0] - 2021-08-23
 
 ### Added

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,10 +1,12 @@
 # Marsha contributors (sorted alphabetically)
+
 # Please make sure you insert here the email with which your git is configured
 
 - [Mathieu Agopian](https://github.com/magopian) <mathieu@agopian.info>
 - [Stéphane Angel](https://github.com/twidi) <s.angel@twidi.com>
 - [Mehdi Benadda](https://github.com/mbenadda) <me@mbenadda.com>
 - [Nicolas Clerc](https://github.com/kernicpanel) <kernicpanel@nclerc.fr>
+- [Quitterie Lucas](https://github.com/quitterie-lcs) <quitterielucas@outlook.fr>
 - [Julien Maupetit](https://github.com/jmaupetit) <julien@maupetit.net>
 - [Richard Moch](https://github.com/rmoch) <richard.moch@gmail.com>
 - [Samuel Paccoud](https://github.com/sampaccoud) <samuel.paccoud@fun-mooc.fr>


### PR DESCRIPTION
## Purpose

xAPI logs are returned with played segments. However, there might be overlapping and it could dramatically increase the log size. The information of overlapping segments is neither necessary in the logs. It has been fixed to only keep global information about which segments are played.

## Proposal

Apply the reduction logic of `getProgress` function to `playedSegments` updating in xAPI handling
