### PR TITLE
Command clean media stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Playlist portability management through LTI (resource sharing between courses)
+- Command to clean all development environments having a living stack on AWS medialive
+  and mediapackage
 
 ## [3.23.0] - 2021-08-23
 

--- a/src/backend/marsha/core/management/commands/clean_medialive_dev_stack.py
+++ b/src/backend/marsha/core/management/commands/clean_medialive_dev_stack.py
@@ -1,0 +1,74 @@
+"""Clean medialive stack for developement environment."""
+from datetime import timedelta
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+from marsha.core.utils.medialive_utils import (
+    delete_mediapackage_channel,
+    list_medialive_channels,
+    medialive_client,
+    mediapackage_client,
+)
+from marsha.core.utils.time_utils import to_datetime
+
+
+class Command(BaseCommand):
+    """Clean medialive stack for development environment."""
+
+    help = (
+        "Check every resources created on medialive and mediapackage and remove all resources"
+        "belonging to a development environment created more than "
+        f"{settings.NB_SECONDS_LIVING_DEV_STACK} minutes ago."
+    )
+
+    def handle(self, *args, **options):
+        """Execute management command."""
+        now = timezone.now()
+
+        for medialive_channel in list_medialive_channels():
+            tags = medialive_channel.get("Tags", {})
+            # the channel must be a marsha one and the environment must start with dev-
+            if tags.get("app") == "marsha" and tags.get("environment", "").startswith(
+                "dev-"
+            ):
+                # the channel name contains the environment, the primary key and the created_at
+                # stamp. Here we want to use the timestamp
+                environment, pk, stamp = medialive_channel["Name"].split("_")
+                created_at = to_datetime(stamp)
+
+                if (
+                    created_at + timedelta(seconds=settings.NB_SECONDS_LIVING_DEV_STACK)
+                    <= now
+                ):
+                    self.stdout.write(
+                        f"Cleaning stack with name {medialive_channel['Name']}"
+                    )
+
+                    if medialive_channel["State"] == "RUNNING":
+                        self.stdout.write(
+                            "Medialive channel is running, we must stop it first."
+                        )
+                        channel_waiter = medialive_client.get_waiter("channel_stopped")
+                        medialive_client.stop_channel(ChannelId=medialive_channel["Id"])
+                        channel_waiter.wait(ChannelId=medialive_channel["Id"])
+
+                    medialive_client.delete_channel(ChannelId=medialive_channel["Id"])
+                    input_waiter = medialive_client.get_waiter("input_detached")
+                    for medialive_input in medialive_channel["InputAttachments"]:
+                        input_waiter.wait(InputId=medialive_input["InputId"])
+                        medialive_client.delete_input(
+                            InputId=medialive_input["InputId"]
+                        )
+
+                    try:
+                        # the mediapackage channel can already be deleted when the dev stack
+                        # have ngrok up and running.
+                        delete_mediapackage_channel(medialive_channel["Name"])
+                    except mediapackage_client.exceptions.NotFoundException:
+                        pass
+
+                    self.stdout.write(
+                        f"Stack with name {medialive_channel['Name']} deleted"
+                    )

--- a/src/backend/marsha/core/tests/test_command_clean_medialive_dev_stack.py
+++ b/src/backend/marsha/core/tests/test_command_clean_medialive_dev_stack.py
@@ -1,0 +1,305 @@
+"""Test clean_medialive_dev_stack command."""
+from datetime import datetime, timezone
+from io import StringIO
+from unittest import mock
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from botocore.stub import Stubber
+
+from ..management.commands import clean_medialive_dev_stack
+
+
+class CleanMedialigeDevStackCommandTest(TestCase):
+    """Test clean_medialive_dev_stack command."""
+
+    def test_clean_medialive_dev_stack_non_running_medialive_channel(self):
+        """Dev stack is deleted and channel waiter not used when channel is not running."""
+        out = StringIO()
+        with mock.patch(
+            "marsha.core.management.commands.clean_medialive_dev_stack.list_medialive_channels"
+        ) as list_medialive_channels_mock, mock.patch(
+            "marsha.core.management.commands.clean_medialive_dev_stack.delete_mediapackage_channel"
+        ) as delete_mediapackage_channel_mock, mock.patch(
+            "django.utils.timezone.now",
+            return_value=datetime(2021, 8, 26, 13, 25, tzinfo=timezone.utc),
+        ), Stubber(
+            clean_medialive_dev_stack.medialive_client
+        ) as medialive_client_stubber:
+            list_medialive_channels_mock.return_value = [
+                {
+                    # non dev environment are ignored
+                    "Name": "production_333c8b00-bb21-44e8-b1b4-286f7e83dd2e_1629984950",
+                    "Tags": {
+                        "app": "marsha",
+                        "environment": "production",
+                    },
+                },
+                {
+                    "Name": "dev-foo_2389cabd-fc46-4ead-8f82-610f35c37d63_1629984950",
+                    "Tags": {"app": "marsha", "environment": "dev-foo"},
+                },
+                {
+                    "Name": "dev-bar_99d60314-20f2-4847-84a4-d2f47bf7fe38_1629982356",
+                    "Tags": {
+                        "app": "marsha",
+                        "environment": "dev-bar",
+                    },
+                    "Id": "562345",
+                    "State": "IDLE",
+                    "InputAttachments": [
+                        {
+                            "InputId": "876294",
+                        }
+                    ],
+                },
+            ]
+
+            medialive_client_stubber.add_response(
+                "delete_channel",
+                expected_params={"ChannelId": "562345"},
+                service_response={},
+            )
+
+            medialive_client_stubber.add_response(
+                "describe_input",
+                expected_params={"InputId": "876294"},
+                service_response={"State": "DETACHED"},
+            )
+            medialive_client_stubber.add_response(
+                "delete_input",
+                expected_params={"InputId": "876294"},
+                service_response={},
+            )
+
+            call_command("clean_medialive_dev_stack", stdout=out)
+
+            delete_mediapackage_channel_mock.assert_called_once_with(
+                "dev-bar_99d60314-20f2-4847-84a4-d2f47bf7fe38_1629982356"
+            )
+            medialive_client_stubber.assert_no_pending_responses()
+        print(out.getvalue())
+
+        self.assertEqual(
+            (
+                "Cleaning stack with name "
+                "dev-bar_99d60314-20f2-4847-84a4-d2f47bf7fe38_1629982356\n"
+                "Stack with name "
+                "dev-bar_99d60314-20f2-4847-84a4-d2f47bf7fe38_1629982356 deleted\n"
+            ),
+            out.getvalue(),
+        )
+        out.close()
+
+    def test_clean_medialive_dev_stack_running_medialive_channel(self):
+        """Running medialive channel is stopped before deleting all the stack."""
+        out = StringIO()
+        with mock.patch(
+            "marsha.core.management.commands.clean_medialive_dev_stack.list_medialive_channels"
+        ) as list_medialive_channels_mock, mock.patch(
+            "marsha.core.management.commands.clean_medialive_dev_stack.delete_mediapackage_channel"
+        ) as delete_mediapackage_channel_mock, mock.patch(
+            "django.utils.timezone.now",
+            return_value=datetime(2021, 8, 26, 13, 25, tzinfo=timezone.utc),
+        ), Stubber(
+            clean_medialive_dev_stack.medialive_client
+        ) as medialive_client_stubber:
+            list_medialive_channels_mock.return_value = [
+                {
+                    # non dev environment are ignored
+                    "Name": "production_333c8b00-bb21-44e8-b1b4-286f7e83dd2e_1629984950",
+                    "Tags": {
+                        "app": "marsha",
+                        "environment": "production",
+                    },
+                },
+                {
+                    "Name": "dev-foo_2389cabd-fc46-4ead-8f82-610f35c37d63_1629984950",
+                    "Tags": {"app": "marsha", "environment": "dev-foo"},
+                },
+                {
+                    "Name": "dev-bar_99d60314-20f2-4847-84a4-d2f47bf7fe38_1629982356",
+                    "Tags": {
+                        "app": "marsha",
+                        "environment": "dev-bar",
+                    },
+                    "Id": "562345",
+                    "State": "RUNNING",
+                    "InputAttachments": [
+                        {
+                            "InputId": "876294",
+                        }
+                    ],
+                },
+            ]
+
+            medialive_client_stubber.add_response(
+                "stop_channel",
+                expected_params={"ChannelId": "562345"},
+                service_response={},
+            )
+            medialive_client_stubber.add_response(
+                "describe_channel",
+                expected_params={"ChannelId": "562345"},
+                service_response={"State": "IDLE"},
+            )
+            medialive_client_stubber.add_response(
+                "delete_channel",
+                expected_params={"ChannelId": "562345"},
+                service_response={},
+            )
+
+            medialive_client_stubber.add_response(
+                "describe_input",
+                expected_params={"InputId": "876294"},
+                service_response={"State": "DETACHED"},
+            )
+            medialive_client_stubber.add_response(
+                "delete_input",
+                expected_params={"InputId": "876294"},
+                service_response={},
+            )
+
+            call_command("clean_medialive_dev_stack", stdout=out)
+
+            delete_mediapackage_channel_mock.assert_called_once_with(
+                "dev-bar_99d60314-20f2-4847-84a4-d2f47bf7fe38_1629982356"
+            )
+            medialive_client_stubber.assert_no_pending_responses()
+
+        self.assertEqual(
+            (
+                "Cleaning stack with name "
+                "dev-bar_99d60314-20f2-4847-84a4-d2f47bf7fe38_1629982356\n"
+                "Medialive channel is running, we must stop it first.\n"
+                "Stack with name "
+                "dev-bar_99d60314-20f2-4847-84a4-d2f47bf7fe38_1629982356 deleted\n"
+            ),
+            out.getvalue(),
+        )
+        out.close()
+
+    def test_clean_medialive_dev_stack_multiple_outdated_medialive_channels(self):
+        """Multiple channels are outdates and must be deleted."""
+        out = StringIO()
+        with mock.patch(
+            "marsha.core.management.commands.clean_medialive_dev_stack.list_medialive_channels"
+        ) as list_medialive_channels_mock, mock.patch(
+            "marsha.core.management.commands.clean_medialive_dev_stack.delete_mediapackage_channel"
+        ) as delete_mediapackage_channel_mock, mock.patch(
+            "django.utils.timezone.now",
+            return_value=datetime(2021, 8, 26, 13, 25, tzinfo=timezone.utc),
+        ), Stubber(
+            clean_medialive_dev_stack.medialive_client
+        ) as medialive_client_stubber:
+            list_medialive_channels_mock.return_value = [
+                {
+                    # non dev environment are ignored
+                    "Name": "production_333c8b00-bb21-44e8-b1b4-286f7e83dd2e_1629984950",
+                    "Tags": {
+                        "app": "marsha",
+                        "environment": "production",
+                    },
+                },
+                {
+                    "Name": "dev-foo_2389cabd-fc46-4ead-8f82-610f35c37d63_1629984950",
+                    "Tags": {"app": "marsha", "environment": "dev-foo"},
+                },
+                {
+                    "Name": "dev-bar_99d60314-20f2-4847-84a4-d2f47bf7fe38_1629982356",
+                    "Tags": {
+                        "app": "marsha",
+                        "environment": "dev-bar",
+                    },
+                    "Id": "562345",
+                    "State": "RUNNING",
+                    "InputAttachments": [
+                        {
+                            "InputId": "876294",
+                        }
+                    ],
+                },
+                {
+                    "Name": "dev-baz_fe8a4a85-f955-4db5-ac25-e7972c3095a4_1629982356",
+                    "Tags": {
+                        "app": "marsha",
+                        "environment": "dev-baz",
+                    },
+                    "Id": "194672",
+                    "State": "IDLE",
+                    "InputAttachments": [
+                        {
+                            "InputId": "375107",
+                        }
+                    ],
+                },
+            ]
+
+            medialive_client_stubber.add_response(
+                "stop_channel",
+                expected_params={"ChannelId": "562345"},
+                service_response={},
+            )
+            medialive_client_stubber.add_response(
+                "describe_channel",
+                expected_params={"ChannelId": "562345"},
+                service_response={"State": "IDLE"},
+            )
+            medialive_client_stubber.add_response(
+                "delete_channel",
+                expected_params={"ChannelId": "562345"},
+                service_response={},
+            )
+            medialive_client_stubber.add_response(
+                "describe_input",
+                expected_params={"InputId": "876294"},
+                service_response={"State": "DETACHED"},
+            )
+            medialive_client_stubber.add_response(
+                "delete_input",
+                expected_params={"InputId": "876294"},
+                service_response={},
+            )
+
+            medialive_client_stubber.add_response(
+                "delete_channel",
+                expected_params={"ChannelId": "194672"},
+                service_response={},
+            )
+            medialive_client_stubber.add_response(
+                "describe_input",
+                expected_params={"InputId": "375107"},
+                service_response={"State": "DETACHED"},
+            )
+            medialive_client_stubber.add_response(
+                "delete_input",
+                expected_params={"InputId": "375107"},
+                service_response={},
+            )
+
+            call_command("clean_medialive_dev_stack", stdout=out)
+
+            delete_mediapackage_channel_mock.assert_any_call(
+                "dev-bar_99d60314-20f2-4847-84a4-d2f47bf7fe38_1629982356"
+            )
+            delete_mediapackage_channel_mock.assert_any_call(
+                "dev-baz_fe8a4a85-f955-4db5-ac25-e7972c3095a4_1629982356"
+            )
+            medialive_client_stubber.assert_no_pending_responses()
+
+        self.assertEqual(
+            (
+                "Cleaning stack with name "
+                "dev-bar_99d60314-20f2-4847-84a4-d2f47bf7fe38_1629982356\n"
+                "Medialive channel is running, we must stop it first.\n"
+                "Stack with name "
+                "dev-bar_99d60314-20f2-4847-84a4-d2f47bf7fe38_1629982356 deleted\n"
+                "Cleaning stack with name "
+                "dev-baz_fe8a4a85-f955-4db5-ac25-e7972c3095a4_1629982356\n"
+                "Stack with name "
+                "dev-baz_fe8a4a85-f955-4db5-ac25-e7972c3095a4_1629982356 deleted\n"
+            ),
+            out.getvalue(),
+        )
+        out.close()

--- a/src/backend/marsha/core/tests/test_utils_medialive_utils.py
+++ b/src/backend/marsha/core/tests/test_utils_medialive_utils.py
@@ -164,7 +164,10 @@ class MediaLiveUtilsTestCase(TestCase):
             mediapackage_stubber.add_response(
                 "create_channel",
                 service_response=mediapackage_create_channel_response,
-                expected_params={"Id": f"test_{key}", "Tags": {"environment": "test"}},
+                expected_params={
+                    "Id": f"test_{key}",
+                    "Tags": {"environment": "test", "app": "marsha"},
+                },
             )
             ssm_stubber.add_response(
                 "put_parameter",
@@ -174,7 +177,10 @@ class MediaLiveUtilsTestCase(TestCase):
                     "Description": "video-key MediaPackage Primary Ingest Username",
                     "Value": "password1",
                     "Type": "String",
-                    "Tags": [{"Key": "environment", "Value": "test"}],
+                    "Tags": [
+                        {"Key": "environment", "Value": "test"},
+                        {"Key": "app", "Value": "marsha"},
+                    ],
                 },
             )
             ssm_stubber.add_response(
@@ -185,7 +191,10 @@ class MediaLiveUtilsTestCase(TestCase):
                     "Description": "video-key MediaPackage Secondary Ingest Username",
                     "Value": "password2",
                     "Type": "String",
-                    "Tags": [{"Key": "environment", "Value": "test"}],
+                    "Tags": [
+                        {"Key": "environment", "Value": "test"},
+                        {"Key": "app", "Value": "marsha"},
+                    ],
                 },
             )
             mediapackage_stubber.add_response(
@@ -205,7 +214,7 @@ class MediaLiveUtilsTestCase(TestCase):
                         "ProgramDateTimeIntervalSeconds": 0,
                         "SegmentDurationSeconds": 5,
                     },
-                    "Tags": {"environment": "test"},
+                    "Tags": {"environment": "test", "app": "marsha"},
                 },
             )
 
@@ -253,7 +262,7 @@ class MediaLiveUtilsTestCase(TestCase):
                         {"StreamName": "video-key-primary"},
                         {"StreamName": "video-key-secondary"},
                     ],
-                    "Tags": {"environment": "test"},
+                    "Tags": {"environment": "test", "app": "marsha"},
                 },
             )
 
@@ -620,7 +629,7 @@ class MediaLiveUtilsTestCase(TestCase):
                             },
                         ],
                     },
-                    "Tags": {"environment": "test"},
+                    "Tags": {"environment": "test", "app": "marsha"},
                 },
             )
 

--- a/src/backend/marsha/core/utils/medialive_utils.py
+++ b/src/backend/marsha/core/utils/medialive_utils.py
@@ -50,7 +50,7 @@ def create_mediapackage_channel(key):
     # Create mediapackage channel
     channel = mediapackage_client.create_channel(
         Id=f"{settings.AWS_BASE_NAME}_{key}",
-        Tags={"environment": settings.AWS_BASE_NAME},
+        Tags={"environment": settings.AWS_BASE_NAME, "app": "marsha"},
     )
 
     # Add primary U/P to SSM parameter store
@@ -59,7 +59,10 @@ def create_mediapackage_channel(key):
         Description=f"{key} MediaPackage Primary Ingest Username",
         Value=channel["HlsIngest"]["IngestEndpoints"][0]["Password"],
         Type="String",
-        Tags=[{"Key": "environment", "Value": settings.AWS_BASE_NAME}],
+        Tags=[
+            {"Key": "environment", "Value": settings.AWS_BASE_NAME},
+            {"Key": "app", "Value": "marsha"},
+        ],
     )
 
     # Add Secondary U/P to SSM Parameter store
@@ -68,7 +71,10 @@ def create_mediapackage_channel(key):
         Description=f"{key} MediaPackage Secondary Ingest Username",
         Value=channel["HlsIngest"]["IngestEndpoints"][1]["Password"],
         Type="String",
-        Tags=[{"Key": "environment", "Value": settings.AWS_BASE_NAME}],
+        Tags=[
+            {"Key": "environment", "Value": settings.AWS_BASE_NAME},
+            {"Key": "app", "Value": "marsha"},
+        ],
     )
 
     # Create a HLS endpoint. This endpoint will be used to watch the stream.
@@ -86,7 +92,7 @@ def create_mediapackage_channel(key):
             "ProgramDateTimeIntervalSeconds": 0,
             "SegmentDurationSeconds": settings.LIVE_SEGMENT_DURATION_SECONDS,
         },
-        Tags={"environment": settings.AWS_BASE_NAME},
+        Tags={"environment": settings.AWS_BASE_NAME, "app": "marsha"},
     )
 
     return [channel, hls_endpoint]
@@ -140,7 +146,7 @@ def create_medialive_input(key):
             {"StreamName": f"{key}-primary"},
             {"StreamName": f"{key}-secondary"},
         ],
-        Tags={"environment": settings.AWS_BASE_NAME},
+        Tags={"environment": settings.AWS_BASE_NAME, "app": "marsha"},
     )
 
     return medialive_input
@@ -228,7 +234,7 @@ def create_medialive_channel(key, medialive_input, mediapackage_channel):
         Name=f"{settings.AWS_BASE_NAME}_{key}",
         RoleArn=settings.AWS_MEDIALIVE_ROLE_ARN,
         EncoderSettings=encoder_settings,
-        Tags={"environment": settings.AWS_BASE_NAME},
+        Tags={"environment": settings.AWS_BASE_NAME, "app": "marsha"},
     )
 
     return medialive_channel

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -279,6 +279,7 @@ class Base(Configuration):
     # LIVE SETTINGS
     NB_DAYS_BEFORE_DELETING_LIVE_RECORDINGS = values.Value(14)
     NB_DAYS_KEEPING_LIVE_IDLE = values.Value(7)
+    NB_SECONDS_LIVING_DEV_STACK = values.PositiveIntegerValue(600)
     LIVE_PLAYLIST_WINDOW_SECONDS = values.PositiveIntegerValue(10)
     LIVE_SEGMENT_DURATION_SECONDS = values.PositiveIntegerValue(4)
     LIVE_FRAMERATE_NUMERATOR = values.PositiveIntegerValue(24000)


### PR DESCRIPTION
## Purpose

During development we can forget to delete resources on AWS medialive
but these resources are charged. We want to delete as soon as possible a
development stack. We think that a development stack should not live
more than 30 minutes and should be deleted after this delay.

## Proposal

- [x] add app tag to medialive and mediapackage resources
- [x]  add command to clean medialive development stack

