### PR TITLE
Custom frontend and backend apps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -340,7 +340,7 @@ jobs:
                 dockerize \
                   -wait tcp://localhost:5432 \
                   -timeout 60s \
-                    ~/.local/bin/pytest marsha/core/tests
+                    ~/.local/bin/pytest marsha --ignore=marsha/e2e
 
   # ---- Front-end jobs ----
   build-front:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Prepare backend to manage apps
+- Prepare frontend to manage apps
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Prepare backend to manage apps
+
 ### Changed
 
 - Postpone AWS creation stack to the first live start action

--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,7 @@ prosody-admin: ## create prosody admin user
 
 test:  ## Run django tests for the marsha project.
 	@echo "$(BOLD)Running tests$(RESET)"
-	bin/pytest marsha/core/tests/
+	bin/pytest marsha --ignore=marsha/e2e
 .PHONY: test
 
 build-e2e: ## build the e2e container

--- a/src/backend/marsha/core/admin.py
+++ b/src/backend/marsha/core/admin.py
@@ -166,6 +166,7 @@ admin_site.register(waffle_admin.Flag, waffle_admin.FlagAdmin)
 admin_site.register(waffle_admin.Sample, waffle_admin.SampleAdmin)
 admin_site.register(waffle_admin.Switch, waffle_admin.SwitchAdmin)
 admin_site.register(Group)
+admin.autodiscover()
 
 
 class UserOrganizationsInline(admin.TabularInline):

--- a/src/backend/marsha/core/tests/test_views_lti_video.py
+++ b/src/backend/marsha/core/tests/test_views_lti_video.py
@@ -1247,6 +1247,7 @@ class VideoLTIViewTestCase(TestCase):
         self.assertEqual(
             context,
             {
+                "appName": "",
                 "environment": "test",
                 "flags": {
                     "sentry": True,

--- a/src/backend/marsha/core/views.py
+++ b/src/backend/marsha/core/views.py
@@ -149,6 +149,7 @@ class BaseLTIView(ABC, TemplateResponseMixin, View):
             {
                 "frontend": "LTI",
                 "modelName": self.model.RESOURCE_NAME,
+                "appName": self.request.resolver_match.app_name,
             }
         )
         return app_data

--- a/src/frontend/.storybook/main.js
+++ b/src/frontend/.storybook/main.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 module.exports = {
   stories: ['../components/**/*.stories.@(js|jsx|ts|tsx)'],
   addons: [
@@ -9,4 +11,11 @@ module.exports = {
       },
     },
   ],
+  webpackFinal: (config) => ({
+    ...config,
+    resolve: {
+      ...config.resolve,
+      modules: [path.resolve(__dirname, '..'), 'node_modules'],
+    },
+  }),
 };

--- a/src/frontend/components/SelectContent/index.tsx
+++ b/src/frontend/components/SelectContent/index.tsx
@@ -13,7 +13,7 @@ import {
 } from 'grommet';
 import { Copy, DocumentMissing, DocumentUpload, Monitor } from 'grommet-icons';
 import { Icon } from 'grommet-icons/icons';
-import React, { useEffect } from 'react';
+import React, { lazy, useEffect, Suspense } from 'react';
 import { toast } from 'react-hot-toast';
 import {
   defineMessages,
@@ -26,6 +26,8 @@ import styled from 'styled-components';
 import { Document } from '../../types/file';
 import { Playlist, Video, videoSize } from '../../types/tracks';
 import { Nullable } from '../../utils/types';
+import { APPS } from '../../settings';
+import { Loader } from '../Loader';
 
 const messages = defineMessages({
   playlistTitle: {
@@ -241,7 +243,7 @@ interface SelectContentSectionProps {
   selectContent: (url: string, title: string) => void;
 }
 
-const SelectContentSection = ({
+export const SelectContentSection = ({
   addMessage,
   newTitle,
   newLtiUrl,
@@ -303,6 +305,12 @@ export const SelectContent = ({
   const [contentItemsValue, setContentItemsValue] = React.useState('');
   const formRef = React.useRef<HTMLFormElement>(null);
   const intl = useIntl();
+
+  const tabs: React.LazyExoticComponent<
+    React.ComponentType<SelectContentTabProps>
+  >[] = APPS.map((name) =>
+    lazy(() => import(`../../apps/${name}/SelectContentTab`)),
+  );
 
   useEffect(() => {
     if (formRef.current && contentItemsValue) {
@@ -389,7 +397,17 @@ export const SelectContent = ({
             selectContent={selectContent}
           />
         </Tab>
+
+        <Suspense fallback={<Loader />}>
+          {tabs.map((LazyComponent, index) => (
+            <LazyComponent key={index} selectContent={selectContent} />
+          ))}
+        </Suspense>
       </Tabs>
     </Box>
   );
 };
+
+export interface SelectContentTabProps {
+  selectContent: (url: string, title: string) => void;
+}

--- a/src/frontend/index.tsx
+++ b/src/frontend/index.tsx
@@ -83,13 +83,24 @@ document.addEventListener('DOMContentLoaded', async (event) => {
   );
 
   let App: () => JSX.Element;
-  try {
-    const { Routes } = await import(`./components/${appData.frontend}Routes`);
-    App = Routes;
-  } catch (e) {
-    throw new Error(
-      `${appData.frontend} is not an expected value for appData.frontend`,
-    );
+  if (appData.appName) {
+    try {
+      const { Routes } = await import(`./apps/${appData.appName}/Routes`);
+      App = Routes;
+    } catch (e) {
+      throw new Error(
+        `${appData.appName} is not an expected value for appData.appName (${e})`,
+      );
+    }
+  } else {
+    try {
+      const { Routes } = await import(`./components/${appData.frontend}Routes`);
+      App = Routes;
+    } catch (e) {
+      throw new Error(
+        `${appData.frontend} is not an expected value for appData.frontend (${e})`,
+      );
+    }
   }
 
   const queryClient = new QueryClient();

--- a/src/frontend/jest.config.js
+++ b/src/frontend/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  moduleDirectories: [__dirname, 'node_modules'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'css'],
   moduleNameMapper: {
     '\\.(css)$': '<rootDir>/__mocks__/styleMock.js',

--- a/src/frontend/settings.ts
+++ b/src/frontend/settings.ts
@@ -5,3 +5,5 @@ export const API_LIST_DEFAULT_PARAMS = {
   limit: 20,
   offset: 0,
 };
+
+export const APPS = [];

--- a/src/frontend/types/AppData.ts
+++ b/src/frontend/types/AppData.ts
@@ -20,7 +20,9 @@ export interface AppData {
   videos?: Video[];
   document?: Nullable<Document>;
   documents?: Document[];
+  resource?: any;
   modelName: modelName.VIDEOS | modelName.DOCUMENTS;
+  appName: string;
   new_document_url?: string;
   new_video_url?: string;
   lti_select_form_action_url?: string;

--- a/src/frontend/utils/parseDataElements/parseDataElements.spec.ts
+++ b/src/frontend/utils/parseDataElements/parseDataElements.spec.ts
@@ -1,5 +1,6 @@
 import { modelName } from '../../types/models';
 import { parseDataElements } from './parseDataElements';
+import { AppData } from '../../types/AppData';
 
 describe.only('utils/parseDataElements', () => {
   describe('parseDataElements()', () => {
@@ -13,6 +14,7 @@ describe.only('utils/parseDataElements', () => {
 
       const data = parseDataElements(dataElement);
       expect(data.video).toEqual(context.resource);
+      expect(data.resource).toEqual(undefined);
     });
 
     it('parses the data-context and creates a document attribute', () => {
@@ -25,9 +27,10 @@ describe.only('utils/parseDataElements', () => {
 
       const data = parseDataElements(dataElement);
       expect(data.document).toEqual(context.resource);
+      expect(data.resource).toEqual(undefined);
     });
 
-    it('throws an error when the model name is not supported', () => {
+    it('leaves the context unmodified when the model is unknown', () => {
       const dataElement = document.createElement('div');
       const context = {
         modelName: modelName.THUMBNAILS,
@@ -35,9 +38,8 @@ describe.only('utils/parseDataElements', () => {
       };
       dataElement.setAttribute('data-context', JSON.stringify(context));
 
-      expect(() => {
-        parseDataElements(dataElement);
-      }).toThrowError(`Model ${modelName.THUMBNAILS} not supported`);
+      const data = parseDataElements(dataElement);
+      expect(data).toEqual(context);
     });
   });
 });

--- a/src/frontend/utils/parseDataElements/parseDataElements.ts
+++ b/src/frontend/utils/parseDataElements/parseDataElements.ts
@@ -8,16 +8,13 @@ export const parseDataElements = (element: Element): AppData => {
     switch (context.modelName) {
       case modelName.VIDEOS:
         context.video = context.resource;
+        delete context.resource;
         break;
       case modelName.DOCUMENTS:
         context.document = context.resource;
+        delete context.resource;
         break;
-      default:
-        throw new Error(`Model ${context.modelName} not supported`);
     }
-
-    delete context.resource;
   }
-
   return context;
 };

--- a/src/frontend/webpack.config.js
+++ b/src/frontend/webpack.config.js
@@ -34,6 +34,7 @@ const config = {
   resolve: {
     // Add '.ts' and '.tsx' as resolvable extensions.
     extensions: ['.ts', '.tsx', '.js', '.json'],
+    modules: [__dirname, 'node_modules'],
     fallback: {
       buffer: require.resolve('buffer/'),
       stream: require.resolve('stream-browserify'),


### PR DESCRIPTION
## Purpose

We need a clean way to manage more resource types in Marsha.

## Proposal

### Backend

Classic Django apps will be created in `src/backend/marsha/`

### Frontend

New apps will be created in `src/frontend/apps/`
If appName exists in appData,  matching  `src/frontends/apps/${appData.appName}/Routes` file will be loaded in `src/frontend/index.tsx` 
And if `src/frontends//apps/${name}/SelectContentTab` exists, it will be loaded in `SelectContent` component.
