### PR TITLE
🔧(front) enable smacks in converse conf when websocket is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- enable smacks in converse conf when websocket is used
+  https://modules.prosody.im/mod_smacks
+
 ## [3.24.1] - 2021-09-14
 
 ### Fixed

--- a/src/frontend/types/libs/converse/index.d.ts
+++ b/src/frontend/types/libs/converse/index.d.ts
@@ -44,8 +44,10 @@ declare namespace converse {
     bosh_service_url?: Nullable<string>;
     clear_cache_on_logout?: boolean;
     discover_connection_methods?: boolean;
+    enable_smacks?: boolean;
     hide_muc_participants?: boolean;
     jid?: string;
+    loglevel?: string;
     modtools_disable_assign?: boolean;
     muc_instant_rooms?: boolean;
     muc_nickname_from_jid?: boolean;

--- a/src/frontend/utils/converse.spec.ts
+++ b/src/frontend/utils/converse.spec.ts
@@ -36,7 +36,7 @@ describe('converseMounter', () => {
 
     const xmpp = {
       bosh_url: 'https://xmpp-server.com/http-bind',
-      websocket_url: null,
+      websocket_url: 'wss://xmpp-server.com/xmpp-websocket',
       conference_url:
         '870c467b-d66e-4949-8ee5-fcf460c72e88@conference.xmpp-server.com',
       prebind_url: 'https://xmpp-server.com/http-pre-bind',
@@ -69,6 +69,7 @@ describe('converseMounter', () => {
       bosh_service_url: 'https://xmpp-server.com/http-bind',
       clear_cache_on_logout: true,
       discover_connection_methods: false,
+      enable_smacks: true,
       hide_muc_participants: true,
       jid: 'xmpp-server.com',
       modtools_disable_assign: true,
@@ -86,7 +87,7 @@ describe('converseMounter', () => {
         spoiler: false,
         toggle_occupants: false,
       },
-      websocket_url: null,
+      websocket_url: 'wss://xmpp-server.com/xmpp-websocket',
       whitelisted_plugins: ['marsha', 'marsha-join-discussion'],
     });
     expect(mockWindow.converse.plugins.add).toHaveBeenCalledTimes(2);

--- a/src/frontend/utils/converse.ts
+++ b/src/frontend/utils/converse.ts
@@ -32,6 +32,7 @@ export const converseMounter = () => {
         bosh_service_url: xmpp.bosh_url,
         clear_cache_on_logout: true,
         discover_connection_methods: false,
+        enable_smacks: !!xmpp.websocket_url,
         hide_muc_participants: true,
         jid: xmpp.jid,
         modtools_disable_assign: true,


### PR DESCRIPTION
## Purpose

We want to use [smacks feature](https://modules.prosody.im/mod_smacks) when converse connect to the XMPP server using a websocket connection.

> By default XMPP is as reliable as your network is. Unfortunately in some cases that is not very reliable - in some network conditions disconnects can be frequent and message loss can occur.

> To overcome this, XMPP has an optional extension (XEP-0198: Stream Management) which, when supported by both the client and server, can allow a client to resume a disconnected session, and prevent message loss.


## Proposal

- [x] enable smacks in converse conf when websocket is used


