### PR TITLE
🩹(back) public token has no LTI context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Add missing translations
+- Erase `context_id` key from the token generated in a public context
 
 ## [3.24.0] - 2021-09-13
 

--- a/src/backend/marsha/core/tests/test_views_public_document.py
+++ b/src/backend/marsha/core/tests/test_views_public_document.py
@@ -76,6 +76,7 @@ class DocumentPublicViewTestCase(TestCase):
             },
         )
         self.assertEqual(context.get("modelName"), "documents")
+        self.assertIsNone(context.get("context_id"))
 
     def test_document_not_publicly_accessible(self):
         """Validate it is impossible to access to a non public document."""

--- a/src/backend/marsha/core/tests/test_views_public_video.py
+++ b/src/backend/marsha/core/tests/test_views_public_video.py
@@ -120,6 +120,7 @@ class VideoPublicViewTestCase(TestCase):
         )
         self.assertEqual(context.get("state"), "success")
         self.assertEqual(context.get("modelName"), "videos")
+        self.assertIsNone(context.get("context_id"))
 
     def test_video_not_publicly_accessible(self):
         """Validate it is impossible to access to a non public video."""

--- a/src/backend/marsha/core/tests/test_views_site.py
+++ b/src/backend/marsha/core/tests/test_views_site.py
@@ -53,6 +53,7 @@ class SiteViewTestCase(TestCase):
             context.get("static"),
             {"svg": {"icons": "/static/svg/icons.svg"}},
         )
+        self.assertIsNone(context.get("context_id"))
 
     @override_switch("site", active=False)
     def test_site_not_accessible(self):

--- a/src/backend/marsha/core/views.py
+++ b/src/backend/marsha/core/views.py
@@ -280,12 +280,14 @@ class BaseLTIView(ABC, TemplateResponseMixin, View):
 
             # Create a short-lived JWT token for the video
             jwt_token = AccessToken()
+
+            # Token only has a context_id if we are in a lti context.
+            if lti:
+                jwt_token.payload["context_id"] = lti.context_id
+
             jwt_token.payload.update(
                 {
                     "session_id": session_id,
-                    "context_id": lti.context_id
-                    if lti
-                    else app_data["resource"]["playlist"]["lti_id"],
                     "resource_id": str(lti.resource_id)
                     if lti
                     else app_data["resource"]["id"],

--- a/src/frontend/types/jwt.ts
+++ b/src/frontend/types/jwt.ts
@@ -1,7 +1,7 @@
 import { Nullable } from '../utils/types';
 
 export interface DecodedJwt {
-  context_id: string;
+  context_id?: string;
   email: string;
   roles: string[];
   session_id: string;


### PR DESCRIPTION
## Purpose

LTI context is a notion related to LTI. If a resource is visualized
from a public context, without an LTI Passeport, we shouldn't
specify any `context_id`. This notion is confusing and not
properly true. To avoid any misunderstanding, we erase from
the token the key `context_id` in a public context.

## Proposal

Getting rid of the key context_id in the token generated for a public resource

