### PR TITLE
🐛(front) force xapi initialized action for a live video

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - enable smacks in converse conf when websocket is used
   https://modules.prosody.im/mod_smacks
 
+### Fixed
+
+- Trigger XAPI initialized action before a first play 
+  for a live video
+
 ## [3.24.1] - 2021-09-14
 
 ### Fixed


### PR DESCRIPTION
## Purpose

For a live video, no event to detect when the video is fully initialized is
triggered before the first "play" action. To mitigate this, we can call
"initialize" on the first "interact" action and abort the interact itself.
The first interact action is when the first quality to play is chosen, the
default one. To choose it, all quality available must be read in the HLS
manifest. So we can consider at this time that the video is initialized.

## Proposal

- [x] force xapi initialized action for a live video

Closes #1065 

