### PR TITLE
🐛(front) listen video play event instead of playing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Trigger XAPI initialized action before a first play 
   for a live video
+- listen video play event instead of playing to send the XAPI played event
 
 ## [3.24.1] - 2021-09-14
 

--- a/src/frontend/Player/createVideojsPlayer.spec.tsx
+++ b/src/frontend/Player/createVideojsPlayer.spec.tsx
@@ -268,7 +268,7 @@ describe('createVideoJsPlayer', () => {
     player.trigger('canplaythrough');
     expect(mockXAPIStatementInterface.initialized).toHaveBeenCalled();
 
-    player.trigger('playing');
+    player.trigger('play');
     expect(mockXAPIStatementInterface.played).toHaveBeenCalled();
 
     player.trigger('pause');

--- a/src/frontend/Player/createVideojsPlayer.ts
+++ b/src/frontend/Player/createVideojsPlayer.ts
@@ -13,7 +13,7 @@ import {
   QualityLevels,
   VideoJsExtendedSourceObject,
 } from '../types/libs/video.js/extend';
-import { liveState, Video, videoSize, VideoUrls } from '../types/tracks';
+import { Video, videoSize } from '../types/tracks';
 import {
   InitializedContextExtensions,
   InteractedContextExtensions,
@@ -150,7 +150,7 @@ export const createVideojsPlayer = (
 
   player.on('canplaythrough', initialize);
 
-  player.on('playing', () => {
+  player.on('play', () => {
     xapiStatement.played({
       time: player.currentTime(),
     });


### PR DESCRIPTION
## Purpose

The video html element dispatches 2 differents events related to
playback. `play` and `playing`. In a VOD context using one or the other
lead to the same result. Moreover, when we used plyr player, we follow
its documentation [1] to implement video events and listen the correct one
in order to send XAPI request, and this documentation is not really the
same as the MDN one [2].
In a live context, the `playing` is triggered when a new video fragment is
loaded. So we can have thousands of `played` XAPI events and this is
wrong. We must listen video `play` event. And this event is also the
good one to listen in a VOD context.

[1]: https://github.com/sampotts/plyr#events
[2]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video#events


## Proposal

- [x] listen video play event instead of playing