### PR TITLE
🔧(aws) use amazon lambda image from ECR public repo 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,7 @@ jobs:
 
   build-lambda-docker:
     machine:
-      image: ubuntu-2004:202010-01
+      image: ubuntu-2004:202107-02
     working_directory: ~/marsha
     steps:
       # Checkout repository sources
@@ -938,7 +938,7 @@ jobs:
 
   lambda-publish:
     machine:
-      image: ubuntu-2004:202010-01
+      image: ubuntu-2004:202107-02
     working_directory: ~/marsha
     steps:
       - checkout

--- a/src/aws/Dockerfile
+++ b/src/aws/Dockerfile
@@ -6,7 +6,7 @@ ARG MEDIAINFO_VERSION=20.09
 RUN wget https://mediaarea.net/download/binary/mediainfo/20.09/MediaInfo_CLI_${MEDIAINFO_VERSION}_Lambda.zip && \
     unzip MediaInfo_CLI_${MEDIAINFO_VERSION}_Lambda.zip -d /tmp/mediainfo
 
-FROM amazon/aws-lambda-nodejs:14 as core
+FROM public.ecr.aws/lambda/nodejs:14 as core
 
 # COPY mediainfo in core stage
 COPY --from=mediainfo /tmp/mediainfo/bin/mediainfo /opt/bin/mediainfo


### PR DESCRIPTION
## Purpose

The amazon/aws-lambda-nodejs host on docker hub use the ARM64
architecture, it seems it is a bug. docker hub is a mirror of ECR public
repo host on amazon. We choose to directly use the image hosted on ECR
to avoid this kind of issue. The image can be found at this url
https://gallery.ecr.aws/lambda/nodejs

We also updated the ubuntu image used in circleci to use a more recent one with more recent tools.

## Proposal

- [x] upgrade machine executor image to ubuntu-2004:202107-02
- [x] use amazon lambda image from ECR public repo

