### PR TITLE
Remove support of IE11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Removed
+
+- IE11 is no longer supported
+
 ## [3.25.0] - 2021-09-29
 
 ### Added

--- a/src/frontend/babel.config.js
+++ b/src/frontend/babel.config.js
@@ -17,7 +17,7 @@ module.exports = {
       {
         corejs: 3,
         forceAllTransforms: true,
-        targets: 'last 1 version, >0.2%, IE 11',
+        targets: 'last 1 version, >0.2%, not IE <= 11',
         useBuiltIns: 'entry',
       },
     ],

--- a/src/frontend/index.tsx
+++ b/src/frontend/index.tsx
@@ -53,15 +53,6 @@ document.addEventListener('DOMContentLoaded', async (event) => {
       await import(`intl/locale-data/jsonp/${localeCode}.js`);
     }
 
-    // Video player uses CustomEvents which we consume in our xapi event infrastructure
-    try {
-      // We need to specifically attempt to use the constructor as `CustomEvent` exists in some browsers
-      // (eg. IE11) but does not support the constructor.
-      const test = new CustomEvent('CustomEventConstructorIsSupported');
-    } catch (e) {
-      await import('custom-event-polyfill');
-    }
-
     if (!Intl.PluralRules) {
       await import('intl-pluralrules');
     }

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -84,7 +84,6 @@
     "clipboard": "2.0.8",
     "converse.js": "<8",
     "core-js": "3.18.1",
-    "custom-event-polyfill": "1.0.7",
     "grommet": "2.18.0",
     "iframe-resizer": "4.3.2",
     "intl": "1.2.5",

--- a/src/frontend/types/libs/custom-event-polyfill/index.d.ts
+++ b/src/frontend/types/libs/custom-event-polyfill/index.d.ts
@@ -1,1 +1,0 @@
-declare module 'custom-event-polyfill';

--- a/src/frontend/yarn.lock
+++ b/src/frontend/yarn.lock
@@ -6531,11 +6531,6 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
-custom-event-polyfill@1.0.7:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/custom-event-polyfill/-/custom-event-polyfill-1.0.7.tgz#9bc993ddda937c1a30ccd335614c6c58c4f87aee"
-  integrity sha512-TDDkd5DkaZxZFM8p+1I3yAlvM3rSr1wbrOliG4yJiwinMZN8z/iGL7BTlDkrJcYTmgUSb4ywVCc3ZaUtOtC76w==
-
 cyclist@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"


### PR DESCRIPTION
## Purpose

We stop the suppor for IE11. We can remove this browser from the target
list defined in babel.
custom-event-polyfill was used build marsha for IE11. IE11 is not
supported any more, this polyfill can be removed.


## Proposal

- [x] Remove IE11 from babel browser target
- [x] Remove custom-event-polyfill 

