### PR TITLE
📌(back) pin PyJWT to version 2.1.0

### DIFF
--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -28,7 +28,7 @@ requires-python = >=3.6
 install_requires =
     Brotli==1.0.9
     boto3==1.18.53
-    chardet==4.0.0 # pyup: >=3.0.2,<3.1.0
+    chardet==4.0.0
     coreapi==2.3.3
     cryptography==35.0.0
     django==3.2.7
@@ -46,6 +46,7 @@ install_requires =
     oauthlib==3.1.1
     psycopg2-binary==2.9.1
     PyLTI==0.7.0
+    PyJWT>=2.1.0,<2.2.0
     python-dateutil==2.8.2
     sentry-sdk==1.4.3
     requests==2.26.0


### PR DESCRIPTION
## Purpose

PyJWT is no more compatible with djangorestframework_simplejwt v4.8.0.
We must pin version 2.1.0 while a new version of
djangorestframework_simplejwt compatible is available.

## Proposal

- [x] pin PyJWT to version 2.1.0

