### PR TITLE
♻️(front) each resource is responsible to redirect the user on load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Redirect instructor to the waiting jitsi page once conference left
 - Only a webinar using jitsi can be created
 
+### Changed
+
+- On app load instructor is redirected to the dashboard when the video
+  is a live
+
 ### Removed
 
 - IE11 is no longer supported

--- a/src/frontend/components/Dashboard/index.tsx
+++ b/src/frontend/components/Dashboard/index.tsx
@@ -1,4 +1,4 @@
-import React, { lazy } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 
 import { Document } from '../../types/file';

--- a/src/frontend/components/RedirectOnLoad/RedirectDocument.spec.tsx
+++ b/src/frontend/components/RedirectOnLoad/RedirectDocument.spec.tsx
@@ -1,0 +1,106 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { documentMockFactory } from '../../utils/tests/factories';
+import { wrapInRouter } from '../../utils/tests/router';
+import { modelName } from '../../types/models';
+import { DASHBOARD_ROUTE } from '../Dashboard/route';
+import { FULL_SCREEN_ERROR_ROUTE } from '../ErrorComponents/route';
+import { PLAYER_ROUTE } from '../routes';
+import { RedirectDocument } from './RedirectDocument';
+
+let mockCanUpdate: boolean;
+jest.mock('../../data/appData', () => ({
+  getDecodedJwt: () => ({
+    permissions: {
+      can_update: mockCanUpdate,
+    },
+  }),
+}));
+
+describe('RedirectDocument', () => {
+  beforeEach(() => jest.resetAllMocks());
+
+  it('redirects to the player when the document is ready to show', () => {
+    const document = documentMockFactory({
+      is_ready_to_show: true,
+    });
+
+    render(
+      wrapInRouter(<RedirectDocument document={document} />, [
+        {
+          path: DASHBOARD_ROUTE(modelName.DOCUMENTS),
+          render: () => <span>dashboard</span>,
+        },
+        {
+          path: FULL_SCREEN_ERROR_ROUTE(),
+          render: ({ match }) => (
+            <span>{`Error Component: ${match.params.code}`}</span>
+          ),
+        },
+        {
+          path: PLAYER_ROUTE(modelName.DOCUMENTS),
+          render: () => <span>document player</span>,
+        },
+      ]),
+    );
+
+    screen.getByText('document player');
+  });
+
+  it('redirects to the dashboard when the user has update permission and the document is not ready to show', () => {
+    mockCanUpdate = true;
+    const document = documentMockFactory({
+      is_ready_to_show: false,
+    });
+
+    render(
+      wrapInRouter(<RedirectDocument document={document} />, [
+        {
+          path: DASHBOARD_ROUTE(modelName.DOCUMENTS),
+          render: () => <span>dashboard</span>,
+        },
+        {
+          path: FULL_SCREEN_ERROR_ROUTE(),
+          render: ({ match }) => (
+            <span>{`Error Component: ${match.params.code}`}</span>
+          ),
+        },
+        {
+          path: PLAYER_ROUTE(modelName.DOCUMENTS),
+          render: () => <span>document player</span>,
+        },
+      ]),
+    );
+
+    screen.getByText('dashboard');
+  });
+
+  it('redirects to the error view when the user has no update permission and the document is not ready to show', () => {
+    mockCanUpdate = false;
+    const document = documentMockFactory({
+      is_ready_to_show: false,
+    });
+
+    render(
+      wrapInRouter(<RedirectDocument document={document} />, [
+        {
+          path: DASHBOARD_ROUTE(modelName.DOCUMENTS),
+          render: () => <span>dashboard</span>,
+        },
+        {
+          path: FULL_SCREEN_ERROR_ROUTE(),
+          render: ({ match }) => (
+            <span>{`Error Component: ${match.params.code}`}</span>
+          ),
+        },
+        {
+          path: PLAYER_ROUTE(modelName.DOCUMENTS),
+          render: () => <span>document player</span>,
+        },
+      ]),
+    );
+
+    screen.getByText('Error Component: notFound');
+  });
+});

--- a/src/frontend/components/RedirectOnLoad/RedirectDocument.tsx
+++ b/src/frontend/components/RedirectOnLoad/RedirectDocument.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Redirect } from 'react-router-dom';
+
+import { DASHBOARD_ROUTE } from '../Dashboard/route';
+import { FULL_SCREEN_ERROR_ROUTE } from '../ErrorComponents/route';
+import { PLAYER_ROUTE } from '../routes';
+import { getDecodedJwt } from '../../data/appData';
+import { modelName } from '../../types/models';
+import { Document } from '../../types/file';
+
+interface RedirectDocumentProps {
+  document: Document;
+}
+
+export const RedirectDocument = ({ document }: RedirectDocumentProps) => {
+  if (document.is_ready_to_show) {
+    return <Redirect push to={PLAYER_ROUTE(modelName.DOCUMENTS)} />;
+  }
+
+  if (getDecodedJwt().permissions.can_update) {
+    return <Redirect push to={DASHBOARD_ROUTE(modelName.DOCUMENTS)} />;
+  }
+
+  // For safety default to the 404 view: this is for users without update permission
+  // when the document is not ready to show.
+  return <Redirect push to={FULL_SCREEN_ERROR_ROUTE('notFound')} />;
+};

--- a/src/frontend/components/RedirectOnLoad/RedirectVideo.spec.tsx
+++ b/src/frontend/components/RedirectOnLoad/RedirectVideo.spec.tsx
@@ -1,0 +1,137 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { videoMockFactory } from '../../utils/tests/factories';
+import { wrapInRouter } from '../../utils/tests/router';
+import { modelName } from '../../types/models';
+import { LiveModeType } from '../../types/tracks';
+import { DASHBOARD_ROUTE } from '../Dashboard/route';
+import { FULL_SCREEN_ERROR_ROUTE } from '../ErrorComponents/route';
+import { PLAYER_ROUTE } from '../routes';
+import { RedirectVideo } from './RedirectVideo';
+
+let mockCanUpdate: boolean;
+jest.mock('../../data/appData', () => ({
+  getDecodedJwt: () => ({
+    permissions: {
+      can_update: mockCanUpdate,
+    },
+  }),
+}));
+
+describe('RedirectVideo', () => {
+  it('redirects to the dashboard when the video is a live and user has update permission', () => {
+    mockCanUpdate = true;
+    const video = videoMockFactory({
+      is_ready_to_show: true,
+      live_type: LiveModeType.JITSI,
+    });
+
+    render(
+      wrapInRouter(<RedirectVideo video={video} />, [
+        {
+          path: DASHBOARD_ROUTE(modelName.VIDEOS),
+          render: () => <span>dashboard</span>,
+        },
+        {
+          path: FULL_SCREEN_ERROR_ROUTE(),
+          render: ({ match }) => (
+            <span>{`Error Component: ${match.params.code}`}</span>
+          ),
+        },
+        {
+          path: PLAYER_ROUTE(modelName.VIDEOS),
+          render: () => <span>video player</span>,
+        },
+      ]),
+    );
+
+    screen.getByText('dashboard');
+  });
+
+  it('redirects to the player when the video is ready to show', () => {
+    const liveTypes = [null, LiveModeType.JITSI];
+    mockCanUpdate = false;
+    const video = videoMockFactory({
+      is_ready_to_show: true,
+      live_type: liveTypes[Math.floor(Math.random() * liveTypes.length)],
+    });
+
+    render(
+      wrapInRouter(<RedirectVideo video={video} />, [
+        {
+          path: DASHBOARD_ROUTE(modelName.VIDEOS),
+          render: () => <span>dashboard</span>,
+        },
+        {
+          path: FULL_SCREEN_ERROR_ROUTE(),
+          render: ({ match }) => (
+            <span>{`Error Component: ${match.params.code}`}</span>
+          ),
+        },
+        {
+          path: PLAYER_ROUTE(modelName.VIDEOS),
+          render: () => <span>video player</span>,
+        },
+      ]),
+    );
+
+    screen.getByText('video player');
+  });
+
+  it('redirects to the dashboard when the user has update permission', () => {
+    mockCanUpdate = true;
+    const video = videoMockFactory({
+      is_ready_to_show: false,
+    });
+
+    render(
+      wrapInRouter(<RedirectVideo video={video} />, [
+        {
+          path: DASHBOARD_ROUTE(modelName.VIDEOS),
+          render: () => <span>dashboard</span>,
+        },
+        {
+          path: FULL_SCREEN_ERROR_ROUTE(),
+          render: ({ match }) => (
+            <span>{`Error Component: ${match.params.code}`}</span>
+          ),
+        },
+        {
+          path: PLAYER_ROUTE(modelName.VIDEOS),
+          render: () => <span>video player</span>,
+        },
+      ]),
+    );
+
+    screen.getByText('dashboard');
+  });
+
+  it('redirects to the error view when the user has no update permission and the video is not ready to show', () => {
+    mockCanUpdate = false;
+    const video = videoMockFactory({
+      is_ready_to_show: false,
+    });
+
+    render(
+      wrapInRouter(<RedirectVideo video={video} />, [
+        {
+          path: DASHBOARD_ROUTE(modelName.VIDEOS),
+          render: () => <span>dashboard</span>,
+        },
+        {
+          path: FULL_SCREEN_ERROR_ROUTE(),
+          render: ({ match }) => (
+            <span>{`Error Component: ${match.params.code}`}</span>
+          ),
+        },
+        {
+          path: PLAYER_ROUTE(modelName.VIDEOS),
+          render: () => <span>video player</span>,
+        },
+      ]),
+    );
+
+    screen.getByText('Error Component: notFound');
+  });
+});

--- a/src/frontend/components/RedirectOnLoad/RedirectVideo.tsx
+++ b/src/frontend/components/RedirectOnLoad/RedirectVideo.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Redirect } from 'react-router-dom';
+
+import { DASHBOARD_ROUTE } from '../Dashboard/route';
+import { FULL_SCREEN_ERROR_ROUTE } from '../ErrorComponents/route';
+import { PLAYER_ROUTE } from '../routes';
+import { getDecodedJwt } from '../../data/appData';
+import { modelName } from '../../types/models';
+import { Video } from '../../types/tracks';
+
+interface RedirectVideoProps {
+  video: Video;
+}
+
+export const RedirectVideo = ({ video }: RedirectVideoProps) => {
+  if (video.live_type && getDecodedJwt().permissions.can_update) {
+    return <Redirect push to={DASHBOARD_ROUTE(modelName.VIDEOS)} />;
+  }
+
+  if (video.is_ready_to_show) {
+    return <Redirect push to={PLAYER_ROUTE(modelName.VIDEOS)} />;
+  }
+
+  if (getDecodedJwt().permissions.can_update) {
+    return <Redirect push to={DASHBOARD_ROUTE(modelName.VIDEOS)} />;
+  }
+
+  // For safety default to the 404 view: this is for users without update permission
+  // when the video is not live and not ready to show,
+  return <Redirect push to={FULL_SCREEN_ERROR_ROUTE('notFound')} />;
+};

--- a/src/frontend/components/RedirectOnLoad/index.tsx
+++ b/src/frontend/components/RedirectOnLoad/index.tsx
@@ -1,12 +1,13 @@
 import * as React from 'react';
 import { Redirect } from 'react-router-dom';
 
-import { appData, getDecodedJwt } from '../../data/appData';
+import { appData } from '../../data/appData';
 import { appState } from '../../types/AppData';
-import { DASHBOARD_ROUTE } from '../Dashboard/route';
+import { modelName } from '../../types/models';
 import { FULL_SCREEN_ERROR_ROUTE } from '../ErrorComponents/route';
-import { PLAYER_ROUTE } from '../routes';
 import { SELECT_CONTENT_ROUTE } from '../SelectContent/route';
+import { RedirectVideo } from './RedirectVideo';
+import { RedirectDocument } from './RedirectDocument';
 
 // RedirectOnLoad assesses the initial state of the application using appData and determines the proper
 // route to load in the Router
@@ -25,15 +26,10 @@ export const RedirectOnLoad = () => {
     return <Redirect push to={FULL_SCREEN_ERROR_ROUTE('notFound')} />;
   }
 
-  if (resource && resource.is_ready_to_show) {
-    return <Redirect push to={PLAYER_ROUTE(appData.modelName)} />;
+  switch (appData.modelName) {
+    case modelName.DOCUMENTS:
+      return <RedirectDocument document={appData.document!} />;
+    case modelName.VIDEOS:
+      return <RedirectVideo video={appData.video!} />;
   }
-
-  if (getDecodedJwt().permissions.can_update) {
-    return <Redirect push to={DASHBOARD_ROUTE(appData.modelName)} />;
-  }
-
-  // For safety default to the 404 view: this is for users not able to edit the current resource
-  // when this one is not ready.
-  return <Redirect push to={FULL_SCREEN_ERROR_ROUTE('notFound')} />;
 };


### PR DESCRIPTION
## Purpose

Depending the loaded resource, we want to redirect the user to different
route. Since now not having this architecture was enough because we
didn't have specfifc case based on the resource itself. Now we want to
redirect the user on the dashboard if it's a video live and he has the
update permission.

## Proposal

- [x] On app load instructor is redirected to the dashboard when the video is a live

