### PR TITLE
♻️(front) hide timed text pane when video is not a live none a VOD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Redirect participant to the player once jitsi conference left
 - Redirect instructor to the waiting jitsi page once conference left
 - Only a webinar using jitsi can be created
+- Hide timed text pane when video is not a VOD
 
 ### Changed
 

--- a/src/frontend/components/DashboardVideo/index.spec.tsx
+++ b/src/frontend/components/DashboardVideo/index.spec.tsx
@@ -1,6 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 
+import { UploadManagerContext, UploadManagerStatus } from '../UploadManager';
+import { modelName } from '../../types/models';
 import { liveState, uploadState, Video } from '../../types/tracks';
 import { videoMockFactory } from '../../utils/tests/factories';
 import { wrapInIntlProvider } from '../../utils/tests/intl';
@@ -106,5 +108,83 @@ describe('<DashboardVideo />', () => {
     expect(
       screen.queryByText('dashboard timed text pane'),
     ).not.toBeInTheDocument();
+  });
+  it('hides timed text pane when the upload state is PENDING', () => {
+    const videoProps = videoMockFactory({
+      id: 'dd43',
+      upload_state: uploadState.PENDING,
+    });
+    render(wrapInIntlProvider(<DashboardVideo video={videoProps} />));
+
+    screen.getByTitle('dd43');
+    expect(
+      screen.queryByText('dashboard timed text pane'),
+    ).not.toBeInTheDocument();
+  });
+  it('shows the timed text pane when the upload state is  PROCESSING', () => {
+    const videoProps = videoMockFactory({
+      id: 'dd43',
+      upload_state: uploadState.PROCESSING,
+    });
+    render(wrapInIntlProvider(<DashboardVideo video={videoProps} />));
+
+    screen.getByTitle('dd43');
+    screen.getByText('dashboard timed text pane');
+  });
+  it('shows the timed text pane when the updload state is PENDING and the uploadManagerState is ongoing', () => {
+    const videoProps = videoMockFactory({
+      id: 'dd43',
+      upload_state: uploadState.PENDING,
+    });
+    const file = new File(['(⌐□_□)'], 'course.mp4', { type: 'video/mp4' });
+    render(
+      <UploadManagerContext.Provider
+        value={{
+          setUploadState: jest.fn(),
+          uploadManagerState: {
+            [videoProps.id]: {
+              file,
+              objectId: videoProps.id,
+              objectType: modelName.VIDEOS,
+              progress: 60,
+              status: UploadManagerStatus.UPLOADING,
+            },
+          },
+        }}
+      >
+        {wrapInIntlProvider(<DashboardVideo video={videoProps} />)}
+      </UploadManagerContext.Provider>,
+    );
+
+    screen.getByTitle('dd43');
+    screen.getByText('dashboard timed text pane');
+  });
+  it('shows the timed text pane when the updload state is PENDING and the uploadManagerState is succeeded', () => {
+    const videoProps = videoMockFactory({
+      id: 'dd43',
+      upload_state: uploadState.PENDING,
+    });
+    const file = new File(['(⌐□_□)'], 'course.mp4', { type: 'video/mp4' });
+    render(
+      <UploadManagerContext.Provider
+        value={{
+          setUploadState: jest.fn(),
+          uploadManagerState: {
+            [videoProps.id]: {
+              file,
+              objectId: videoProps.id,
+              objectType: modelName.VIDEOS,
+              progress: 60,
+              status: UploadManagerStatus.SUCCESS,
+            },
+          },
+        }}
+      >
+        {wrapInIntlProvider(<DashboardVideo video={videoProps} />)}
+      </UploadManagerContext.Provider>,
+    );
+
+    screen.getByTitle('dd43');
+    screen.getByText('dashboard timed text pane');
   });
 });

--- a/src/frontend/components/DashboardVideo/index.tsx
+++ b/src/frontend/components/DashboardVideo/index.tsx
@@ -1,11 +1,10 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { useVideo } from '../../data/stores/useVideo';
 import { uploadState, Video } from '../../types/tracks';
 import { DashboardTimedTextPane } from '../DashboardTimedTextPane';
 import { DashboardVideoPane } from '../DashboardVideoPane';
-
-const { READY, PENDING } = uploadState;
+import { UploadManagerStatus, useUploadManager } from '../UploadManager';
 
 interface DashboardVideoProps {
   video: Video;
@@ -13,13 +12,25 @@ interface DashboardVideoProps {
 
 const DashboardVideo = (props: DashboardVideoProps) => {
   const video = useVideo((state) => state.getVideo(props.video));
-  const displayTimedTextPane =
-    video.live_state === null &&
-    ![
-      uploadState.DELETED,
-      uploadState.HARVESTED,
-      uploadState.HARVESTING,
-    ].includes(video.upload_state);
+  const { uploadManagerState } = useUploadManager();
+  const [displayTimedTextPane, setDisplayTimedTextPane] = useState(false);
+
+  useEffect(() => {
+    setDisplayTimedTextPane(
+      video.live_state === null &&
+        (![
+          uploadState.DELETED,
+          uploadState.HARVESTED,
+          uploadState.HARVESTING,
+          uploadState.PENDING,
+        ].includes(video.upload_state) ||
+          (video.upload_state === uploadState.PENDING &&
+            (uploadManagerState[video.id]?.status ===
+              UploadManagerStatus.UPLOADING ||
+              uploadManagerState[video.id]?.status ===
+                UploadManagerStatus.SUCCESS))),
+    );
+  }, [video.live_state, video.upload_state, uploadManagerState]);
 
   return (
     <React.Fragment>


### PR DESCRIPTION
## Purpose

On the first screen, when the user have to choose between creating a
live or a VOD, the timed text pane is shown. We want to hide and show
it only when the user has decided to create a VOD.

## Proposal

- [x]  Hide timed text pane when video is not a live none a VOD

