### PR TITLE
🐛(front) implement useTranscriptTimeSelector with videojs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,11 +24,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Redirect instructor to the waiting jitsi page once conference left
 - Only a webinar using jitsi can be created
 - Hide timed text pane when video is not a VOD
-
-### Changed
-
 - On app load instructor is redirected to the dashboard when the video
   is a live
+
+### Fixed
+
+- Implement useTranscriptTimeSelector with videojs
 
 ### Removed
 

--- a/src/frontend/Player/createVideojsPlayer.ts
+++ b/src/frontend/Player/createVideojsPlayer.ts
@@ -9,6 +9,7 @@ import 'videojs-http-source-selector';
 import './videojs/qualitySelectorPlugin';
 
 import { appData, getDecodedJwt } from '../data/appData';
+import { useTranscriptTimeSelector } from '../data/stores/useTranscriptTimeSelector';
 import {
   QualityLevels,
   VideoJsExtendedSourceObject,
@@ -98,6 +99,11 @@ export const createVideojsPlayer = (
   }
 
   const tracks = player.remoteTextTracks();
+
+  useTranscriptTimeSelector.subscribe(
+    (time) => player.currentTime(time as number),
+    (state) => state.time,
+  );
 
   /************************** XAPI **************************/
 

--- a/src/frontend/types/libs/video.js/extend.d.ts
+++ b/src/frontend/types/libs/video.js/extend.d.ts
@@ -17,6 +17,9 @@ declare module 'video.js' {
     videojs_quality_selector_plugin_is_paused?: boolean;
     videojs_quality_selector_plugin_currentime?: number;
     videojs_quality_selector_plugin_default?: string;
+    cache_: {
+      initTime: number;
+    };
     // videojs-http-source-selector
     httpSourceSelector: () => void;
     qualitySelector: () => {


### PR DESCRIPTION
## Purpose

The hook useTranscriptTimeSelector was made in the time we used plyr
player. When we implemented videojs player we missed to implement this
feature. Clicking on a transcript sentence has no effect. This commit
implement this missing behaviour.

## Proposal

- [x] implement useTranscriptTimeSelector with videojs

