### PR TITLE
Postpone AWS creation stack to the first live start action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Postpone AWS creation stack to the first live start action
+
 ## [3.26.0] - 2021-10-22
 
 ### Added

--- a/src/aws/lambda-medialive/src/channelStateChanged.js
+++ b/src/aws/lambda-medialive/src/channelStateChanged.js
@@ -5,14 +5,13 @@ module.exports = async (channel, event, context) => {
   const status = event.detail.state;
 
   const correspondingStatus = {
-    'CREATED': 'idle',
-    'RUNNING': 'running',
-    'STOPPED': 'stopped',
-  }
+    RUNNING: 'running',
+    STOPPED: 'stopped',
+  };
 
   if (!correspondingStatus[status]) {
     throw new Error(
-      `Expected status are CREATED, RUNNING and STOPPED. ${status} received`,
+      `Expected status are RUNNING and STOPPED. ${status} received`,
     );
   }
 

--- a/src/aws/lambda-medialive/src/channelStateChanged.spec.js
+++ b/src/aws/lambda-medialive/src/channelStateChanged.spec.js
@@ -46,7 +46,7 @@ describe('src/channel_state_changed', () => {
       await channelStateChanged(channel, event, context);
     } catch (error) {
       expect(error.message).toEqual(
-        'Expected status are CREATED, RUNNING and STOPPED. STARTING received',
+        'Expected status are RUNNING and STOPPED. STARTING received',
       );
     }
 
@@ -127,51 +127,6 @@ describe('src/channel_state_changed', () => {
     const expectedBody = {
       logGroupName: '/aws/lambda/dev-test-marsha-medialive',
       state: 'stopped',
-    };
-
-    await channelStateChanged(channel, event, context);
-
-    expect(mockComputeSignature).toHaveBeenCalledWith(
-      'some secret',
-      JSON.stringify(expectedBody),
-    );
-    expect(mockSendRequest).toHaveBeenCalledWith(
-      expectedBody,
-      'foo',
-      false,
-      `${marshaUrl}/api/videos/video-id/update-live-state/`,
-      'PATCH',
-    );
-  });
-
-  it('receives a CREATED event and updates live state', async () => {
-    const event = {
-      version: '0',
-      id: '0495e5eb-9b99-56f2-7849-96389238fb55',
-      'detail-type': 'MediaLive Channel State Change',
-      source: 'aws.medialive',
-      account: 'account_id',
-      time: '2020-06-15T15:18:29Z',
-      region: 'eu-west-1',
-      resources: ['arn:aws:medialive:eu-west-1:account_id:channel:1234567'],
-      detail: {
-        channel_arn: 'arn:aws:medialive:eu-west-1:account_id:channel:1234567',
-        state: 'CREATED',
-        message: 'Created channel',
-        pipelines_running_count: 0,
-      },
-    };
-
-    const context = {
-      logGroupName: '/aws/lambda/dev-test-marsha-medialive',
-    };
-
-    const channel = { Name: 'test_video-id_stamp' };
-
-    mockComputeSignature.mockReturnValue('foo');
-    const expectedBody = {
-      logGroupName: '/aws/lambda/dev-test-marsha-medialive',
-      state: 'idle',
     };
 
     await channelStateChanged(channel, event, context);

--- a/src/backend/marsha/core/defaults.py
+++ b/src/backend/marsha/core/defaults.py
@@ -15,7 +15,6 @@ from django.utils.translation import gettext_lazy as _
     STOPPING,
     RUNNING,
     DELETED,
-    CREATING,
 ) = (
     "pending",
     "processing",
@@ -29,7 +28,6 @@ from django.utils.translation import gettext_lazy as _
     "stopping",
     "running",
     "deleted",
-    "creating",
 )
 STATE_CHOICES = (
     (PENDING, _("pending")),
@@ -42,7 +40,6 @@ STATE_CHOICES = (
 )
 
 LIVE_CHOICES = (
-    (CREATING, _("creating")),
     (IDLE, _("idle")),
     (STARTING, _("starting")),
     (RUNNING, _("running")),

--- a/src/backend/marsha/core/tests/test_utils_medialive_utils.py
+++ b/src/backend/marsha/core/tests/test_utils_medialive_utils.py
@@ -799,6 +799,24 @@ class MediaLiveUtilsTestCase(TestCase):
 
             medialive_utils.delete_aws_element_stack(video)
 
+    def test_wait_medialive_channel_is_created(self):
+        """Should call describe_channel while state is not IDLE."""
+        with Stubber(medialive_utils.medialive_client) as medialive_stubber:
+            medialive_stubber.add_response(
+                "describe_channel",
+                expected_params={"ChannelId": "medialive_channel1"},
+                service_response={"State": "CREATING"},
+            )
+
+            medialive_stubber.add_response(
+                "describe_channel",
+                expected_params={"ChannelId": "medialive_channel1"},
+                service_response={"State": "IDLE"},
+            )
+
+            medialive_utils.wait_medialive_channel_is_created("medialive_channel1")
+            medialive_stubber.assert_no_pending_responses()
+
     def test_list_mediapackage_channels(self):
         """Should recursively get all mediapackage channels."""
         with Stubber(

--- a/src/backend/marsha/core/utils/medialive_utils.py
+++ b/src/backend/marsha/core/utils/medialive_utils.py
@@ -284,6 +284,14 @@ def create_live_stream(key):
     }
 
 
+def wait_medialive_channel_is_created(channel_id):
+    """Wait until medialive channel is created."""
+    input_waiter = medialive_client.get_waiter("channel_created")
+    input_waiter.wait(
+        ChannelId=channel_id, WaiterConfig={"Delay": 1, "MaxAttempts": 20}
+    )
+
+
 def start_live_channel(channel_id):
     """Start an existing medialive channel."""
     medialive_client.start_channel(ChannelId=channel_id)

--- a/src/frontend/components/DashboardVideoLive/index.spec.tsx
+++ b/src/frontend/components/DashboardVideoLive/index.spec.tsx
@@ -203,7 +203,7 @@ describe('components/DashboardVideoLive', () => {
     );
 
     screen.getByText(
-      'Live streaming is starting. Wait before starting your stream.',
+      'Live streaming is starting. This can take a few minutes.',
     );
     expect(fetchMock.called()).not.toBeTruthy();
 
@@ -216,7 +216,7 @@ describe('components/DashboardVideoLive', () => {
       Authorization: 'Bearer cool_token_m8',
     });
     screen.getByText(
-      'Live streaming is starting. Wait before starting your stream.',
+      'Live streaming is starting. This can take a few minutes.',
     );
 
     // The live will be running in further response

--- a/src/frontend/components/DashboardVideoLive/index.tsx
+++ b/src/frontend/components/DashboardVideoLive/index.tsx
@@ -32,15 +32,8 @@ const messages = defineMessages({
     description: 'Video url streaming.',
     id: 'components.DashboardVideoLive.url',
   },
-  liveCreating: {
-    defaultMessage:
-      'Live streaming is being created. You will be able to start it in a few seconds',
-    description: 'Helptext explainig to wait until the live is created.',
-    id: 'components.DashboardVideoLive.liveCreating',
-  },
   liveStarting: {
-    defaultMessage:
-      'Live streaming is starting. Wait before starting your stream.',
+    defaultMessage: 'Live streaming is starting. This can take a few minutes.',
     description: 'Helptext explainig to wait until the live is ready.',
     id: 'components.DashboardVideoLive.liveStarting',
   },
@@ -92,15 +85,8 @@ export const DashboardVideoLive = ({ video }: DashboardVideoLiveProps) => {
   };
 
   useEffect(() => {
-    const intervalMs = {
-      [liveState.STARTING]: 15000,
-      [liveState.CREATING]: 2000,
-    };
-    if (
-      video.live_state === liveState.STARTING ||
-      video.live_state === liveState.CREATING
-    ) {
-      const interval = setInterval(pollForVideo, intervalMs[video.live_state]);
+    if (video.live_state === liveState.STARTING) {
+      const interval = setInterval(pollForVideo, 15000);
       return () => clearInterval(interval);
     }
   }, [video.live_state]);
@@ -129,11 +115,6 @@ export const DashboardVideoLive = ({ video }: DashboardVideoLiveProps) => {
         />
       )}
       <Box direction={'row'} justify={'center'} margin={'small'}>
-        {video.live_state === liveState.CREATING && (
-          <Text>
-            <FormattedMessage {...messages.liveCreating} />
-          </Text>
-        )}
         {video.live_state === liveState.IDLE && (
           <React.Fragment>
             {video.live_type === LiveModeType.RAW && (

--- a/src/frontend/components/DashboardVideoLiveJitsi/index.spec.tsx
+++ b/src/frontend/components/DashboardVideoLiveJitsi/index.spec.tsx
@@ -70,7 +70,7 @@ describe('<DashboardVideoLiveJitsi />', () => {
           interface_config_overwrite: {},
         },
       },
-      live_state: liveState.CREATING,
+      live_state: liveState.IDLE,
       live_type: LiveModeType.JITSI,
     });
     global.JitsiMeetExternalAPI = mockJitsi;
@@ -221,7 +221,7 @@ describe('<DashboardVideoLiveJitsi />', () => {
             interface_config_overwrite: {},
           },
         },
-        live_state: liveState.CREATING,
+        live_state: liveState.IDLE,
         live_type: LiveModeType.JITSI,
       });
       global.JitsiMeetExternalAPI = mockJitsi;
@@ -332,9 +332,11 @@ describe('<DashboardVideoLiveJitsi />', () => {
 
     expect(events.recordingStatusChanged).toBeDefined();
 
-    expect(mockExecuteCommand).toHaveBeenCalledWith('startRecording', {
-      mode: 'stream',
-      rtmpStreamKey: 'rtmp://1.2.3.4:1935/marsha/stream-key-primary',
+    await waitFor(() => {
+      expect(mockExecuteCommand).toHaveBeenCalledWith('startRecording', {
+        mode: 'stream',
+        rtmpStreamKey: 'rtmp://1.2.3.4:1935/marsha/stream-key-primary',
+      });
     });
     expect(mockExecuteCommand).not.toHaveBeenCalledWith(
       'stopRecording',

--- a/src/frontend/components/ObjectStatusPicker/index.spec.tsx
+++ b/src/frontend/components/ObjectStatusPicker/index.spec.tsx
@@ -12,7 +12,7 @@ jest.mock('../../data/appData', () => ({}));
 
 const { DELETED, ERROR, HARVESTED, HARVESTING, PENDING, PROCESSING, READY } =
   uploadState;
-const { CREATING, IDLE, STARTING, RUNNING, STOPPED, STOPPING } = liveState;
+const { IDLE, STARTING, RUNNING, STOPPED, STOPPING } = liveState;
 
 describe('<ObjectStatusPicker />', () => {
   describe('upload state', () => {
@@ -350,29 +350,6 @@ describe('<ObjectStatusPicker />', () => {
       );
 
       screen.getByText('Live is stopping');
-    });
-
-    it('renders status info for an object in live state CREATING', () => {
-      const object = {
-        id: uuidv4(),
-        live_state: CREATING,
-        upload_state: PENDING,
-      } as UploadableObject;
-
-      render(
-        wrapInIntlProvider(
-          <UploadManagerContext.Provider
-            value={{
-              setUploadState: () => {},
-              uploadManagerState: {},
-            }}
-          >
-            <ObjectStatusPicker object={object} />
-          </UploadManagerContext.Provider>,
-        ),
-      );
-
-      screen.getByText('Creating');
     });
   });
 });

--- a/src/frontend/components/ObjectStatusPicker/index.tsx
+++ b/src/frontend/components/ObjectStatusPicker/index.tsx
@@ -13,14 +13,9 @@ import { UploadManagerStatus, useUploadManager } from '../UploadManager';
 
 const { DELETED, ERROR, HARVESTED, HARVESTING, PENDING, PROCESSING, READY } =
   uploadState;
-const { CREATING, IDLE, STARTING, RUNNING, STOPPED, STOPPING } = liveStateTrack;
+const { IDLE, STARTING, RUNNING, STOPPED, STOPPING } = liveStateTrack;
 
 const messages = defineMessages({
-  [CREATING]: {
-    defaultMessage: 'Creating',
-    description: 'Live video in creation status',
-    id: 'components.ObjectStatusPicker.CREATING',
-  },
   [DELETED]: {
     defaultMessage: 'Deleted',
     description: 'Status information for a video/audio/timed text track',

--- a/src/frontend/components/PublicVideoDashboard/index.spec.tsx
+++ b/src/frontend/components/PublicVideoDashboard/index.spec.tsx
@@ -355,26 +355,24 @@ describe('PublicVideoDashboard', () => {
   });
 
   it('displays the WaitingLiveVideo component when live is not ready', () => {
-    [liveState.IDLE, liveState.CREATING, liveState.STARTING].forEach(
-      (state) => {
-        const video = videoMockFactory({
-          live_state: state,
-        });
-        render(
-          wrapInIntlProvider(
-            wrapInRouter(
-              <PublicVideoDashboard video={video} playerType="videojs" />,
-            ),
+    [liveState.IDLE, liveState.STARTING].forEach((state) => {
+      const video = videoMockFactory({
+        live_state: state,
+      });
+      render(
+        wrapInIntlProvider(
+          wrapInRouter(
+            <PublicVideoDashboard video={video} playerType="videojs" />,
           ),
-        );
+        ),
+      );
 
-        screen.getByText('Live will begin soon');
-        screen.getByText(
-          'The live is going to start. You can wait here, the player will start once the live is ready.',
-        );
+      screen.getByText('Live will begin soon');
+      screen.getByText(
+        'The live is going to start. You can wait here, the player will start once the live is ready.',
+      );
 
-        cleanup();
-      },
-    );
+      cleanup();
+    });
   });
 });

--- a/src/frontend/components/PublicVideoLiveJitsi/index.spec.tsx
+++ b/src/frontend/components/PublicVideoLiveJitsi/index.spec.tsx
@@ -16,7 +16,7 @@ const mockVideo = videoMockFactory({
       interface_config_overwrite: {},
     },
   },
-  live_state: liveState.CREATING,
+  live_state: liveState.IDLE,
   live_type: LiveModeType.JITSI,
 });
 

--- a/src/frontend/types/tracks.ts
+++ b/src/frontend/types/tracks.ts
@@ -32,7 +32,6 @@ export enum uploadState {
 }
 
 export enum liveState {
-  CREATING = 'creating',
   IDLE = 'idle',
   STARTING = 'starting',
   RUNNING = 'running',


### PR DESCRIPTION
## Purpose

We want to create a live video without creating all the associated mediaelement stack. To do this, the `initiate-live` is changed, no call to AWS are made, just the video properties are modified.
The mediaelement stack creation is postpone when the start button is clicked for the first time. We detect that nothing is created on AWS, we create all the stack and then we start it.

## Proposal

- [x] create AWS stack if not existing when starting live
- [x] do not call update-state when medialive channel is created
- [x] modify DashboardVideoLiveJitsi to work witout live_info 
