### PR TITLE
🚨(make) remove usage of abspath formatter with flake8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ lint-black:  ## Run the black tool and update files that need to
 
 lint-flake8:  ## Run the flake8 tool
 	@echo "$(BOLD)Running flake8$(RESET)"
-	@$(COMPOSE_RUN_APP) flake8 marsha --format=abspath
+	@$(COMPOSE_RUN_APP) flake8 marsha
 .PHONY: lint-flake8
 
 lint-isort:  ## automatically re-arrange python imports in code base


### PR DESCRIPTION
## Purpose

In commit f26fba0 we removed all flake8 plugins. In these plugins one
was used to format CLI output using the abspath formatter. As this
plugin is not available anymore we must remove usage of this plugin.

## Proposal

- [x] remove usage of abspath formatter with flake8

