### PR TITLE
Fix/back registrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Users with empty email in their token can register to scheduled webinars
+- Users with wrong email in token is properly detected as registered
 
 ## [3.26.0] - 2021-10-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Postpone AWS creation stack to the first live start action
+- Scheduled videos have a live_state set to IDLE
 
 ## [3.26.0] - 2021-10-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Postpone AWS creation stack to the first live start action
 - Scheduled videos have a live_state set to IDLE
 
+### Fixed
+
+- Users with empty email in their token can register to scheduled webinars
+
 ## [3.26.0] - 2021-10-22
 
 ### Added

--- a/src/backend/marsha/core/models/video.py
+++ b/src/backend/marsha/core/models/video.py
@@ -6,7 +6,7 @@ from django.utils import timezone
 from django.utils.functional import lazy
 from django.utils.translation import gettext_lazy as _
 
-from ..defaults import DELETED, HARVESTED, LIVE_CHOICES, LIVE_TYPE_CHOICES
+from ..defaults import DELETED, HARVESTED, IDLE, LIVE_CHOICES, LIVE_TYPE_CHOICES
 from ..utils.time_utils import to_timestamp
 from ..validators import validate_date_is_future
 from .base import BaseModel
@@ -149,7 +149,7 @@ class Video(BaseFile):
         return (
             self.starting_at is not None
             and self.starting_at > timezone.now()
-            and self.live_state is None
+            and self.live_state == IDLE
         )
 
     @property
@@ -182,7 +182,7 @@ class Video(BaseFile):
             | models.Q(
                 starting_at__isnull=False,
                 starting_at__gte=timezone.now(),
-                live_state__isnull=True,
+                live_state=IDLE,
             )
         )
 

--- a/src/backend/marsha/core/serializers/video.py
+++ b/src/backend/marsha/core/serializers/video.py
@@ -347,15 +347,15 @@ class LiveRegistrationSerializer(serializers.ModelSerializer):
                 Playlist.objects.get(
                     lti_id=user.token.payload["context_id"]
                 ).consumer_site
-                if user.token.payload.get("context_id") is not None
+                if user.token.payload.get("context_id")
                 else None
             )
 
-            if user.token.payload.get("user") is not None:
+            if user.token.payload.get("user"):
                 attrs["lti_user_id"] = user.token.payload["user"]["id"]
 
                 # If email is present in token, we make sure the one sent is the one expected
-                if user.token.payload["user"].get("email") is not None:
+                if user.token.payload["user"].get("email"):
                     if attrs["email"] != user.token.payload["user"].get("email"):
                         raise serializers.ValidationError(
                             {
@@ -368,7 +368,7 @@ class LiveRegistrationSerializer(serializers.ModelSerializer):
                 # We can identify the user for this context_id, we make sure this user hasn't
                 # already registered for this video. It's only relevant if context_id is defined.
                 if (
-                    user.token.payload.get("context_id") is not None
+                    user.token.payload.get("context_id")
                     and LiveRegistration.objects.filter(
                         consumer_site=attrs["consumer_site"],
                         deleted=None,
@@ -558,13 +558,13 @@ class VideoSerializer(VideoBaseSerializer):
 
     def validate_starting_at(self, value):
         """Add extra controls for starting_at field."""
-        # Field starting at has a new value
+        # Field starting_at has a new value
         if value != self.instance.starting_at:
             # Check live_state is in IDLE state as expected when scheduling a live
             if self.instance.live_state != IDLE:
                 raise serializers.ValidationError(
                     "Field starting_at can't be changed, video live is "
-                    + "not in default mode."
+                    "not in default mode."
                 )
             # Initial value is already past, it can't be updated anymore
             if (
@@ -573,7 +573,7 @@ class VideoSerializer(VideoBaseSerializer):
             ):
                 raise serializers.ValidationError(
                     f"Field starting_at {self.instance.starting_at} is already "
-                    + "past and can't be updated!"
+                    "past and can't be updated!"
                 )
 
         return value

--- a/src/backend/marsha/core/tests/test_api_liveregistration.py
+++ b/src/backend/marsha/core/tests/test_api_liveregistration.py
@@ -9,6 +9,7 @@ from django.utils import timezone
 
 from rest_framework_simplejwt.tokens import AccessToken
 
+from ..defaults import IDLE, RAW
 from ..factories import (
     ConsumerSiteFactory,
     LiveRegistrationFactory,
@@ -1224,7 +1225,11 @@ class LiveRegistrationApiTest(TestCase):
         self,
     ):
         """Token with no user's info can create a liveRegistration."""
-        video = VideoFactory(starting_at=timezone.now() + timedelta(days=100))
+        video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=100),
+        )
         self.assertTrue(video.is_scheduled)
         # token with no context_id and no user informations
         jwt_token = AccessToken()
@@ -1254,7 +1259,11 @@ class LiveRegistrationApiTest(TestCase):
         self,
     ):
         """Token with no user info can create a liveRegistration."""
-        video = VideoFactory(starting_at=timezone.now() + timedelta(days=100))
+        video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=100),
+        )
         self.assertTrue(video.is_scheduled)
         other_playlist = PlaylistFactory()
         jwt_token = AccessToken()
@@ -1285,7 +1294,11 @@ class LiveRegistrationApiTest(TestCase):
         self,
     ):
         """Token with user info, no email & no context_id can create a liveRegistration."""
-        video = VideoFactory(starting_at=timezone.now() + timedelta(days=100))
+        video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=100),
+        )
         self.assertTrue(video.is_scheduled)
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(video.id)
@@ -1320,7 +1333,11 @@ class LiveRegistrationApiTest(TestCase):
         self,
     ):
         """Token with user info, no email & context_id can create a liveRegistration."""
-        video = VideoFactory(starting_at=timezone.now() + timedelta(days=100))
+        video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=100),
+        )
         self.assertTrue(video.is_scheduled)
         # token has same context_id than the video
         jwt_token = AccessToken()
@@ -1355,7 +1372,11 @@ class LiveRegistrationApiTest(TestCase):
         self,
     ):
         """Token with no email can create a liveRegistration from other context_id than video."""
-        video = VideoFactory(starting_at=timezone.now() + timedelta(days=100))
+        video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=100),
+        )
         self.assertTrue(video.is_scheduled)
         other_playlist = PlaylistFactory()
         # token has different context_id than the video
@@ -1391,7 +1412,11 @@ class LiveRegistrationApiTest(TestCase):
         self,
     ):
         """Token with email should be able to create a liveRegistration."""
-        video = VideoFactory(starting_at=timezone.now() + timedelta(days=100))
+        video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=100),
+        )
         self.assertTrue(video.is_scheduled)
         # token has email and no context_id
         jwt_token = AccessToken()
@@ -1425,7 +1450,11 @@ class LiveRegistrationApiTest(TestCase):
         self,
     ):
         """Token with user info can create a liveRegistration in the same context_id."""
-        video = VideoFactory(starting_at=timezone.now() + timedelta(days=100))
+        video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=100),
+        )
         self.assertTrue(video.is_scheduled)
         # token has email and same context_id than the video
         jwt_token = AccessToken()
@@ -1460,7 +1489,11 @@ class LiveRegistrationApiTest(TestCase):
         self,
     ):
         """User with token from other context_id than the video can create a liveRegistration."""
-        video = VideoFactory(starting_at=timezone.now() + timedelta(days=100))
+        video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=100),
+        )
         self.assertTrue(video.is_scheduled)
         other_playlist = PlaylistFactory()
         # token has email and different context_id than the video
@@ -1496,7 +1529,11 @@ class LiveRegistrationApiTest(TestCase):
         self,
     ):
         """Student users can create a liveRegistration with no context_id or user info in token."""
-        video = VideoFactory(starting_at=timezone.now() + timedelta(days=100))
+        video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=100),
+        )
         self.assertTrue(video.is_scheduled)
         # token has no user info and no context_id
         jwt_token = AccessToken()
@@ -1527,7 +1564,11 @@ class LiveRegistrationApiTest(TestCase):
         self,
     ):
         """Student can create a liveRegistration in the same context_id than the video."""
-        video = VideoFactory(starting_at=timezone.now() + timedelta(days=100))
+        video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=100),
+        )
         self.assertTrue(video.is_scheduled)
         # token has same context_id than the video and no user informations
         jwt_token = AccessToken()
@@ -1559,7 +1600,11 @@ class LiveRegistrationApiTest(TestCase):
         self,
     ):
         """Student from other context_id than the video can create a liveRegistration."""
-        video = VideoFactory(starting_at=timezone.now() + timedelta(days=100))
+        video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=100),
+        )
         other_playlist = PlaylistFactory()
         self.assertTrue(video.is_scheduled)
         # token has different context_id than the video and no user informations
@@ -1592,7 +1637,11 @@ class LiveRegistrationApiTest(TestCase):
         self,
     ):
         """Student users should be able to create a liveRegistration with no context_id."""
-        video = VideoFactory(starting_at=timezone.now() + timedelta(days=100))
+        video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=100),
+        )
         self.assertTrue(video.is_scheduled)
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(video.id)
@@ -1626,7 +1675,11 @@ class LiveRegistrationApiTest(TestCase):
         self,
     ):
         """Student can create a liveRegistration in the same context_id than the video."""
-        video = VideoFactory(starting_at=timezone.now() + timedelta(days=100))
+        video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=100),
+        )
         self.assertTrue(video.is_scheduled)
         # token has same context_id than the video and user informations
         jwt_token = AccessToken()
@@ -1662,7 +1715,11 @@ class LiveRegistrationApiTest(TestCase):
         self,
     ):
         """Student can create a liveRegistration in a different context_id than the video."""
-        video = VideoFactory(starting_at=timezone.now() + timedelta(days=100))
+        video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=100),
+        )
         self.assertTrue(video.is_scheduled)
         other_playlist = PlaylistFactory()
         # token has same context_id than the video and user informations
@@ -1699,7 +1756,11 @@ class LiveRegistrationApiTest(TestCase):
         self,
     ):
         """Admin/instructors from other context_id than the video can create a liveRegistration."""
-        video = VideoFactory(starting_at=timezone.now() + timedelta(days=100))
+        video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=100),
+        )
         self.assertTrue(video.is_scheduled)
         other_playlist = PlaylistFactory()
         jwt_token = AccessToken()
@@ -1735,7 +1796,11 @@ class LiveRegistrationApiTest(TestCase):
         self,
     ):
         """Admin/Intructors can create a liveRegistration with no context_id & user in token."""
-        video = VideoFactory(starting_at=timezone.now() + timedelta(days=100))
+        video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=100),
+        )
         self.assertTrue(video.is_scheduled)
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(video.id)
@@ -1765,7 +1830,11 @@ class LiveRegistrationApiTest(TestCase):
         self,
     ):
         """Admin/Intructors can create a liveRegistration in the same context_id than the video."""
-        video = VideoFactory(starting_at=timezone.now() + timedelta(days=100))
+        video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=100),
+        )
         self.assertTrue(video.is_scheduled)
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(video.id)
@@ -1796,7 +1865,11 @@ class LiveRegistrationApiTest(TestCase):
         self,
     ):
         """Admin/Intructors can create a liveRegistration linked to their token's context_id."""
-        video = VideoFactory(starting_at=timezone.now() + timedelta(days=100))
+        video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=100),
+        )
         other_playlist = PlaylistFactory()
         self.assertTrue(video.is_scheduled)
         # token has no user information
@@ -1830,7 +1903,11 @@ class LiveRegistrationApiTest(TestCase):
         self,
     ):
         """Admin/Intructors can create a liveRegistration with no context_id."""
-        video = VideoFactory(starting_at=timezone.now() + timedelta(days=100))
+        video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=100),
+        )
         self.assertTrue(video.is_scheduled)
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(video.id)
@@ -1864,7 +1941,11 @@ class LiveRegistrationApiTest(TestCase):
         self,
     ):
         """Admin/Intructors can create a liveRegistration in the same context_id than the video."""
-        video = VideoFactory(starting_at=timezone.now() + timedelta(days=100))
+        video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=100),
+        )
         self.assertTrue(video.is_scheduled)
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(video.id)
@@ -1899,7 +1980,11 @@ class LiveRegistrationApiTest(TestCase):
         self,
     ):
         """Admin/Intructors from other context_id than the video can create a liveRegistration."""
-        video = VideoFactory(starting_at=timezone.now() + timedelta(days=100))
+        video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=100),
+        )
         other_playlist = PlaylistFactory()
         self.assertTrue(video.is_scheduled)
         jwt_token = AccessToken()
@@ -1936,7 +2021,7 @@ class LiveRegistrationApiTest(TestCase):
     ):
         """Same email can be used for the same video if context_id is different."""
         starting_at = timezone.now() + timedelta(days=5)
-        video = VideoFactory(starting_at=starting_at)
+        video = VideoFactory(live_state=IDLE, live_type=RAW, starting_at=starting_at)
         # no consumer_site
         LiveRegistrationFactory(
             email="salome@test-fun-mooc.fr",
@@ -1982,7 +2067,7 @@ class LiveRegistrationApiTest(TestCase):
     ):
         """Same email can be used for the same video if context_id is different."""
         starting_at = timezone.now() + timedelta(days=5)
-        video = VideoFactory(starting_at=starting_at)
+        video = VideoFactory(live_state=IDLE, live_type=RAW, starting_at=starting_at)
         # registration with consumer_site
         LiveRegistrationFactory(
             email="salome@test-fun-mooc.fr",
@@ -2028,7 +2113,7 @@ class LiveRegistrationApiTest(TestCase):
     ):
         """Same email can be used for the same video if context_id is different."""
         starting_at = timezone.now() + timedelta(days=5)
-        video = VideoFactory(starting_at=starting_at)
+        video = VideoFactory(live_state=IDLE, live_type=RAW, starting_at=starting_at)
         # registration with consumer_site
         LiveRegistrationFactory(
             email="salome@test-fun-mooc.fr",
@@ -2077,7 +2162,7 @@ class LiveRegistrationApiTest(TestCase):
     ):
         """Same email can be used for the same video if context_id is different."""
         starting_at = timezone.now() + timedelta(days=5)
-        video = VideoFactory(starting_at=starting_at)
+        video = VideoFactory(live_state=IDLE, live_type=RAW, starting_at=starting_at)
         self.assertTrue(video.is_scheduled)
         # registration with consumer_site
         LiveRegistrationFactory(
@@ -2127,7 +2212,7 @@ class LiveRegistrationApiTest(TestCase):
     ):
         """Same email can be used for the same video if context_id is different."""
         starting_at = timezone.now() + timedelta(days=5)
-        video = VideoFactory(starting_at=starting_at)
+        video = VideoFactory(live_state=IDLE, live_type=RAW, starting_at=starting_at)
         self.assertTrue(video.is_scheduled)
         # registration with consumer_site
         LiveRegistrationFactory(
@@ -2176,7 +2261,11 @@ class LiveRegistrationApiTest(TestCase):
 
     def test_api_liveregistration_create_role_none_restrict_email_context_none(self):
         """Users with email in their token can only register for their email."""
-        video = VideoFactory(starting_at=timezone.now() + timedelta(days=100))
+        video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=100),
+        )
         self.assertTrue(video.is_scheduled)
         # token with no context_id
         jwt_token = AccessToken()
@@ -2208,7 +2297,11 @@ class LiveRegistrationApiTest(TestCase):
 
     def test_api_liveregistration_create_role_none_restrict_email_context_with(self):
         """Users with role and email in token can only register for their email."""
-        video = VideoFactory(starting_at=timezone.now() + timedelta(days=100))
+        video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=100),
+        )
         self.assertTrue(video.is_scheduled)
         # token with context_id
         jwt_token = AccessToken()
@@ -2240,7 +2333,11 @@ class LiveRegistrationApiTest(TestCase):
 
     def test_api_liveregistration_create_roles_restrict_email_context_with(self):
         """Users with role and email in token can only register for their email."""
-        video = VideoFactory(starting_at=timezone.now() + timedelta(days=100))
+        video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=100),
+        )
         self.assertTrue(video.is_scheduled)
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(video.id)
@@ -2276,7 +2373,11 @@ class LiveRegistrationApiTest(TestCase):
 
     def test_api_liveregistration_create_roles_restrict_email_context_none(self):
         """Users with role and email in token can only register for their email."""
-        video = VideoFactory(starting_at=timezone.now() + timedelta(days=100))
+        video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=100),
+        )
         self.assertTrue(video.is_scheduled)
         # token with no context_id
         jwt_token = AccessToken()
@@ -2359,7 +2460,7 @@ class LiveRegistrationApiTest(TestCase):
     def test_api_liveregistration_create_cant_register_when_no_email(self):
         """Can't register to a scheduled video if there is no email."""
         starting_at = timezone.now() + timedelta(days=5)
-        video = VideoFactory(starting_at=starting_at)
+        video = VideoFactory(live_state=IDLE, live_type=RAW, starting_at=starting_at)
         self.assertTrue(video.is_scheduled)
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(video.id)
@@ -2381,7 +2482,7 @@ class LiveRegistrationApiTest(TestCase):
     ):
         """Trio email/consumer_site/video must be unique."""
         starting_at = timezone.now() + timedelta(days=5)
-        video = VideoFactory(starting_at=starting_at)
+        video = VideoFactory(live_state=IDLE, live_type=RAW, starting_at=starting_at)
         # registration with consumer_site
         LiveRegistrationFactory(
             email="salome@test-fun-mooc.fr",
@@ -2420,7 +2521,7 @@ class LiveRegistrationApiTest(TestCase):
     ):
         """Duo email/video must be unique when consumer_site is not defined."""
         starting_at = timezone.now() + timedelta(days=5)
-        video = VideoFactory(starting_at=starting_at)
+        video = VideoFactory(live_state=IDLE, live_type=RAW, starting_at=starting_at)
         # registration with no consumer_site
         LiveRegistrationFactory(email="salome@test-fun-mooc.fr", video=video)
         self.assertTrue(video.is_scheduled)
@@ -2454,7 +2555,7 @@ class LiveRegistrationApiTest(TestCase):
         Same combination email/video/lti_user_id can be used for different consumer site.
         """
         starting_at = timezone.now() + timedelta(days=5)
-        video = VideoFactory(starting_at=starting_at)
+        video = VideoFactory(live_state=IDLE, live_type=RAW, starting_at=starting_at)
         other_consumer_site = ConsumerSiteFactory()
         # registration with consumer_site
         LiveRegistrationFactory(
@@ -2509,7 +2610,7 @@ class LiveRegistrationApiTest(TestCase):
         Same combination email/video/lti_user_id can be used for different consumer site.
         """
         starting_at = timezone.now() + timedelta(days=5)
-        video = VideoFactory(starting_at=starting_at)
+        video = VideoFactory(live_state=IDLE, live_type=RAW, starting_at=starting_at)
         other_consumer_site = ConsumerSiteFactory()
         # registration with consumer_site
         LiveRegistrationFactory(
@@ -2565,7 +2666,7 @@ class LiveRegistrationApiTest(TestCase):
         consumer_site is not defined.
         """
         starting_at = timezone.now() + timedelta(days=5)
-        video = VideoFactory(starting_at=starting_at)
+        video = VideoFactory(live_state=IDLE, live_type=RAW, starting_at=starting_at)
         # no consumer_site is defined
         LiveRegistrationFactory(
             email="salome@test-fun-mooc.fr",
@@ -2616,7 +2717,7 @@ class LiveRegistrationApiTest(TestCase):
         used to identify a user in this case.
         """
         starting_at = timezone.now() + timedelta(days=5)
-        video = VideoFactory(starting_at=starting_at)
+        video = VideoFactory(live_state=IDLE, live_type=RAW, starting_at=starting_at)
         LiveRegistrationFactory(
             email="salome@test-fun-mooc.fr",
             video=video,
@@ -2655,8 +2756,16 @@ class LiveRegistrationApiTest(TestCase):
         self,
     ):
         """Same email can be used for two different videos when token has no context_id."""
-        video = VideoFactory(starting_at=timezone.now() + timedelta(days=5))
-        video2 = VideoFactory(starting_at=timezone.now() + timedelta(hours=1))
+        video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=5),
+        )
+        video2 = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(hours=1),
+        )
         # registration with no consumer_site
         LiveRegistrationFactory(email="chantal@test-fun-mooc.fr", video=video)
         # token with no context_id leading to no consumer_site
@@ -2691,8 +2800,16 @@ class LiveRegistrationApiTest(TestCase):
         self,
     ):
         """Same email can be used for different videos when token has context_id."""
-        video = VideoFactory(starting_at=timezone.now() + timedelta(days=5))
-        video2 = VideoFactory(starting_at=timezone.now() + timedelta(hours=1))
+        video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=5),
+        )
+        video2 = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(hours=1),
+        )
         # registration with consumer_site
         LiveRegistrationFactory(
             email="chantal@test-fun-mooc.fr",
@@ -2732,8 +2849,16 @@ class LiveRegistrationApiTest(TestCase):
         self,
     ):
         """Same email can be used for different videos when token has no context_id."""
-        video = VideoFactory(starting_at=timezone.now() + timedelta(days=5))
-        video2 = VideoFactory(starting_at=timezone.now() + timedelta(hours=1))
+        video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=5),
+        )
+        video2 = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(hours=1),
+        )
         # registration with no consumer_site
         LiveRegistrationFactory(
             email="chantal@test-fun-mooc.fr",
@@ -2776,8 +2901,16 @@ class LiveRegistrationApiTest(TestCase):
         self,
     ):
         """Same email can be used for different videos with token context_id/lti_user_id."""
-        video = VideoFactory(starting_at=timezone.now() + timedelta(days=5))
-        video2 = VideoFactory(starting_at=timezone.now() + timedelta(hours=1))
+        video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=5),
+        )
+        video2 = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(hours=1),
+        )
         # registration with consumer_site
         LiveRegistrationFactory(
             email="chantal@test-fun-mooc.fr",
@@ -2820,7 +2953,11 @@ class LiveRegistrationApiTest(TestCase):
 
     def test_api_liveregistration_update_put_anonymous_not_allowed(self):
         """Anonymous can't update liveregistration."""
-        video = VideoFactory(starting_at=timezone.now() + timedelta(days=100))
+        video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=100),
+        )
         LiveRegistrationFactory(email="chantal@test-fun-mooc.fr", video=video)
         response = self.client.put(
             "/api/liveregistrations/",
@@ -2835,7 +2972,11 @@ class LiveRegistrationApiTest(TestCase):
 
     def test_api_liveregistration_update_patch_anonymous_not_allowed(self):
         """Anonymous can't update liveregistration."""
-        video = VideoFactory(starting_at=timezone.now() + timedelta(days=100))
+        video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=100),
+        )
         LiveRegistrationFactory(email="chantal@test-fun-mooc.fr", video=video)
 
         response = self.client.patch(
@@ -2851,7 +2992,11 @@ class LiveRegistrationApiTest(TestCase):
 
     def test_api_liveregistration_update_put_with_token_not_allowed(self):
         """Update method is not allowed."""
-        video = VideoFactory(starting_at=timezone.now() + timedelta(days=100))
+        video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=100),
+        )
         LiveRegistrationFactory(email="chantal@test-fun-mooc.fr", video=video)
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(video.id)
@@ -2869,7 +3014,11 @@ class LiveRegistrationApiTest(TestCase):
 
     def test_api_liveregistration_update_with_token_patch_not_allowed(self):
         """Patch update is not allowed."""
-        video = VideoFactory(starting_at=timezone.now() + timedelta(days=100))
+        video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=100),
+        )
         LiveRegistrationFactory(email="chantal@test-fun-mooc.fr", video=video)
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(video.id)
@@ -2910,7 +3059,7 @@ class LiveRegistrationApiTest(TestCase):
     ):
         """Token with wrong resource_id should render a 404."""
         starting_at = timezone.now() + timedelta(days=5)
-        video = VideoFactory(starting_at=starting_at)
+        video = VideoFactory(live_state=IDLE, live_type=RAW, starting_at=starting_at)
         liveregistration = LiveRegistrationFactory(
             email="salome@test-fun-mooc.fr",
             consumer_site=video.playlist.consumer_site,
@@ -2947,8 +3096,16 @@ class LiveRegistrationApiTest(TestCase):
         be fetched only for an undefined consumer site and for the same video.
         """
         user = UserFactory()
-        video = VideoFactory(starting_at=timezone.now() + timedelta(days=100))
-        video2 = VideoFactory(starting_at=timezone.now() + timedelta(days=100))
+        video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=100),
+        )
+        video2 = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=100),
+        )
         # consumer_site is not defined
         liveregistration = LiveRegistrationFactory(
             email=user.email, lti_user_id=user.id, video=video
@@ -3006,8 +3163,16 @@ class LiveRegistrationApiTest(TestCase):
         for the same video and same consumer site.
         """
         user = UserFactory()
-        video = VideoFactory(starting_at=timezone.now() + timedelta(days=100))
-        video2 = VideoFactory(starting_at=timezone.now() + timedelta(days=100))
+        video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=100),
+        )
+        video2 = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=100),
+        )
         # consumer_site is defined
         liveregistration = LiveRegistrationFactory(
             consumer_site=video.playlist.consumer_site,
@@ -3072,8 +3237,16 @@ class LiveRegistrationApiTest(TestCase):
         Duo email/consumer_site or consumer_site/lti_user_id for a defined consumer_site is
         needed to read a liveregistration.
         """
-        video = VideoFactory(starting_at=timezone.now() + timedelta(days=100))
-        other_video = VideoFactory(starting_at=timezone.now() + timedelta(days=100))
+        video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=100),
+        )
+        other_video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=100),
+        )
         # liveregistration for the same video and lti_user_id but different consumer_site
         LiveRegistrationFactory(
             email="chantal@test-fun-mooc.fr",
@@ -3122,8 +3295,16 @@ class LiveRegistrationApiTest(TestCase):
         If token has no email, the user can read liveregistrations of this video for the
         same duo consumer_site/lti_user_id.
         """
-        video = VideoFactory(starting_at=timezone.now() + timedelta(days=100))
-        other_video = VideoFactory(starting_at=timezone.now() + timedelta(days=100))
+        video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=100),
+        )
+        other_video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=100),
+        )
         other_consumer = ConsumerSiteFactory()
         # liveregistration for the right video, lti_user_id and consumer_site
         liveregistration = LiveRegistrationFactory(
@@ -3199,8 +3380,16 @@ class LiveRegistrationApiTest(TestCase):
         be fetched only for an undefined consumer site and for the same video.
         """
         user = UserFactory()
-        video = VideoFactory(starting_at=timezone.now() + timedelta(days=100))
-        video2 = VideoFactory(starting_at=timezone.now() + timedelta(days=100))
+        video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=100),
+        )
+        video2 = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=100),
+        )
         # consumer_site is not defined
         liveregistration = LiveRegistrationFactory(
             email=user.email, lti_user_id=user.id, video=video
@@ -3259,8 +3448,16 @@ class LiveRegistrationApiTest(TestCase):
         for the same video and the same consumer site.
         """
         user = UserFactory()
-        video = VideoFactory(starting_at=timezone.now() + timedelta(days=100))
-        video2 = VideoFactory(starting_at=timezone.now() + timedelta(days=100))
+        video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=100),
+        )
+        video2 = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=100),
+        )
         # consumer_site is defined
         liveregistration = LiveRegistrationFactory(
             consumer_site=video.playlist.consumer_site,
@@ -3326,8 +3523,16 @@ class LiveRegistrationApiTest(TestCase):
         Duo email/consumer_site or consumer_site/lti_user_id for a defined consumer_site is
         needed to read a liveregistration.
         """
-        video = VideoFactory(starting_at=timezone.now() + timedelta(days=100))
-        other_video = VideoFactory(starting_at=timezone.now() + timedelta(days=100))
+        video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=100),
+        )
+        other_video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=100),
+        )
         # liveregistration for the same video and lti_user_id but different consumer_site
         LiveRegistrationFactory(
             email="chantal@test-fun-mooc.fr",
@@ -3377,8 +3582,16 @@ class LiveRegistrationApiTest(TestCase):
         If token has no email, the user can read liveregistrations of this video for the
         same duo consumer_site/lti_user_id.
         """
-        video = VideoFactory(starting_at=timezone.now() + timedelta(days=100))
-        other_video = VideoFactory(starting_at=timezone.now() + timedelta(days=100))
+        video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=100),
+        )
+        other_video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=100),
+        )
         other_consumer = ConsumerSiteFactory()
         # liveregistration for the right video, lti_user_id and consumer_site
         liveregistration = LiveRegistrationFactory(
@@ -3454,8 +3667,16 @@ class LiveRegistrationApiTest(TestCase):
         Will not receive liveregistrations other than the one corresponding to their consumer_site.
         If token has email, liveregistrations aren't filtered by this email.
         """
-        video = VideoFactory(starting_at=timezone.now() + timedelta(days=100))
-        other_video = VideoFactory(starting_at=timezone.now() + timedelta(days=100))
+        video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=100),
+        )
+        other_video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=100),
+        )
         other_consumer = ConsumerSiteFactory()
         liveregistration = LiveRegistrationFactory(
             email="chantal@test-fun-mooc.fr",
@@ -3533,8 +3754,16 @@ class LiveRegistrationApiTest(TestCase):
         Token has no consumer_site, liveregistrations will be filtered by undefined consumer_site.
         Token has email, liveregistrations aren't filtered by this email.
         """
-        video = VideoFactory(starting_at=timezone.now() + timedelta(days=100))
-        other_video = VideoFactory(starting_at=timezone.now() + timedelta(days=100))
+        video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=100),
+        )
+        other_video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=100),
+        )
         other_consumer = ConsumerSiteFactory()
         # liveregistration with no consumer_site
         liveregistration = LiveRegistrationFactory(
@@ -3609,8 +3838,16 @@ class LiveRegistrationApiTest(TestCase):
         Will not receive liveregistrations other than the one corresponding to their consumer_site.
         Token has no email, liveregistrations aren't filtered by token's user's id.
         """
-        video = VideoFactory(starting_at=timezone.now() + timedelta(days=100))
-        other_video = VideoFactory(starting_at=timezone.now() + timedelta(days=100))
+        video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=100),
+        )
+        other_video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=100),
+        )
         other_consumer = ConsumerSiteFactory()
         liveregistration = LiveRegistrationFactory(
             email="chantal@test-fun-mooc.fr",
@@ -3688,8 +3925,16 @@ class LiveRegistrationApiTest(TestCase):
         Token has no consumer_site, liveregistrations will be filtered by undefined consumer_site.
         Token has no email, liveregistrations aren't filtered by token's user's id.
         """
-        video = VideoFactory(starting_at=timezone.now() + timedelta(days=100))
-        other_video = VideoFactory(starting_at=timezone.now() + timedelta(days=100))
+        video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=100),
+        )
+        other_video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=100),
+        )
         other_consumer = ConsumerSiteFactory()
         # liveregistration with no consumer_site
         liveregistration = LiveRegistrationFactory(

--- a/src/backend/marsha/core/tests/test_api_video.py
+++ b/src/backend/marsha/core/tests/test_api_video.py
@@ -1743,7 +1743,7 @@ class VideoAPITest(TestCase):
                     "starting_at": [
                         (
                             f"Field starting_at {intial_starting_at} "
-                            + "is already past and can't be updated!"
+                            "is already past and can't be updated!"
                         )
                     ]
                 },
@@ -2085,7 +2085,7 @@ class VideoAPITest(TestCase):
                     "starting_at": [
                         (
                             f"Field starting_at {intial_starting_at} "
-                            + "is already past and can't be updated!"
+                            "is already past and can't be updated!"
                         )
                     ]
                 },
@@ -2125,7 +2125,7 @@ class VideoAPITest(TestCase):
                             [
                                 (
                                     "Field starting_at can't be changed, video live is not "
-                                    + "in default mode."
+                                    "in default mode."
                                 )
                             ]
                         )
@@ -2357,7 +2357,7 @@ class VideoAPITest(TestCase):
                             [
                                 (
                                     "Field starting_at can't be changed, video live is not "
-                                    + "in default mode."
+                                    "in default mode."
                                 )
                             ]
                         )

--- a/src/backend/marsha/core/tests/test_lti_utils.py
+++ b/src/backend/marsha/core/tests/test_lti_utils.py
@@ -10,7 +10,7 @@ from django.utils import timezone
 from pylti.common import LTIOAuthServer
 
 from .. import factories, models
-from ..defaults import LIVE_CHOICES, RAW, RUNNING, STATE_CHOICES
+from ..defaults import IDLE, LIVE_CHOICES, RAW, RUNNING, STATE_CHOICES
 from ..lti import LTI
 from ..lti.utils import (
     PortabilityError,
@@ -177,6 +177,8 @@ class PortabilityLTITestCase(TestCase):
             factories.VideoFactory,
             models.Video,
             {
+                "live_state": IDLE,
+                "live_type": RAW,
                 "starting_at": timezone.now() + timedelta(hours=1),
             },
         )
@@ -278,6 +280,8 @@ class PortabilityLTITestCase(TestCase):
             factories.VideoFactory,
             models.Video,
             {
+                "live_state": IDLE,
+                "live_type": RAW,
                 "starting_at": timezone.now() + timedelta(hours=1),
             },
         )
@@ -453,6 +457,8 @@ class PortabilityLTITestCase(TestCase):
             factories.VideoFactory,
             models.Video,
             {
+                "live_state": IDLE,
+                "live_type": RAW,
                 "starting_at": timezone.now() + timedelta(hours=1),
             },
         )
@@ -708,6 +714,8 @@ class PortabilityLTITestCase(TestCase):
             factories.VideoFactory,
             models.Video,
             {
+                "live_state": IDLE,
+                "live_type": RAW,
                 "starting_at": timezone.now() + timedelta(hours=1),
             },
         )
@@ -1000,7 +1008,11 @@ class PortabilityLTITestCase(TestCase):
             factories.VideoFactory,
             models.Video,
             is_portable_to_playlist=True,
-            factory_parameters={"starting_at": timezone.now() + timedelta(hours=1)},
+            factory_parameters={
+                "live_state": IDLE,
+                "live_type": RAW,
+                "starting_at": timezone.now() + timedelta(hours=1),
+            },
         )
 
     @mock.patch.object(LTIOAuthServer, "verify_request", return_value=True)
@@ -1042,7 +1054,11 @@ class PortabilityLTITestCase(TestCase):
             factories.VideoFactory,
             models.Video,
             is_portable_to_playlist=True,
-            factory_parameters={"starting_at": timezone.now() + timedelta(hours=1)},
+            factory_parameters={
+                "live_state": IDLE,
+                "live_type": RAW,
+                "starting_at": timezone.now() + timedelta(hours=1),
+            },
         )
 
     @mock.patch.object(LTIOAuthServer, "verify_request", return_value=True)
@@ -1101,6 +1117,8 @@ class PortabilityLTITestCase(TestCase):
             models.Video,
             is_portable_to_playlist=True,
             factory_parameters={
+                "live_state": IDLE,
+                "live_type": RAW,
                 "starting_at": timezone.now() + timedelta(hours=1),
             },
         )
@@ -1180,6 +1198,8 @@ class PortabilityLTITestCase(TestCase):
             models.Video,
             is_portable_to_playlist=False,
             factory_parameters={
+                "live_state": IDLE,
+                "live_type": RAW,
                 "starting_at": timezone.now() + timedelta(hours=1),
             },
         )
@@ -1269,6 +1289,8 @@ class PortabilityLTITestCase(TestCase):
             factories.VideoFactory,
             models.Video,
             {
+                "live_state": IDLE,
+                "live_type": RAW,
                 "starting_at": timezone.now() + timedelta(hours=1),
             },
         )
@@ -1369,6 +1391,8 @@ class PortabilityLTITestCase(TestCase):
             factories.VideoFactory,
             models.Video,
             {
+                "live_state": IDLE,
+                "live_type": RAW,
                 "starting_at": timezone.now() + timedelta(hours=1),
             },
         )
@@ -1627,6 +1651,8 @@ class PortabilityLTITestCase(TestCase):
             factories.VideoFactory,
             models.Video,
             {
+                "live_state": IDLE,
+                "live_type": RAW,
                 "starting_at": timezone.now() + timedelta(hours=1),
             },
         )
@@ -1722,6 +1748,8 @@ class PortabilityLTITestCase(TestCase):
             factories.VideoFactory,
             models.Video,
             {
+                "live_state": IDLE,
+                "live_type": RAW,
                 "starting_at": timezone.now() + timedelta(hours=1),
             },
         )
@@ -1823,6 +1851,8 @@ class PortabilityLTITestCase(TestCase):
             factories.VideoFactory,
             models.Video,
             {
+                "live_state": IDLE,
+                "live_type": RAW,
                 "starting_at": timezone.now() + timedelta(hours=1),
             },
         )
@@ -2082,6 +2112,8 @@ class PortabilityLTITestCase(TestCase):
             factories.VideoFactory,
             models.Video,
             {
+                "live_state": IDLE,
+                "live_type": RAW,
                 "starting_at": timezone.now() + timedelta(hours=1),
             },
         )
@@ -2347,6 +2379,8 @@ class PortabilityLTITestCase(TestCase):
             factories.VideoFactory,
             models.Video,
             {
+                "live_state": IDLE,
+                "live_type": RAW,
                 "starting_at": timezone.now() + timedelta(hours=1),
             },
         )
@@ -2618,7 +2652,11 @@ class PortabilityLTITestCase(TestCase):
         self._test_lti_get_resource_other_pl_site_not_portable_instructor(
             factories.VideoFactory,
             models.Video,
-            {"starting_at": timezone.now() + timedelta(hours=1)},
+            {
+                "live_state": IDLE,
+                "live_type": RAW,
+                "starting_at": timezone.now() + timedelta(hours=1),
+            },
         )
 
     @mock.patch.object(LTIOAuthServer, "verify_request", return_value=True)
@@ -2715,7 +2753,11 @@ class PortabilityLTITestCase(TestCase):
         self._test_lti_get_resource_other_pl_site_not_portable_student(
             factories.VideoFactory,
             models.Video,
-            {"starting_at": timezone.now() + timedelta(hours=1)},
+            {
+                "live_state": IDLE,
+                "live_type": RAW,
+                "starting_at": timezone.now() + timedelta(hours=1),
+            },
         )
 
     @mock.patch.object(LTIOAuthServer, "verify_request", return_value=True)
@@ -2806,7 +2848,11 @@ class PortabilityLTITestCase(TestCase):
         self._test_lti_get_resource_wrong_lti_id_intructor(
             factories.VideoFactory,
             models.Video,
-            {"starting_at": timezone.now() + timedelta(hours=1)},
+            {
+                "live_state": IDLE,
+                "live_type": RAW,
+                "starting_at": timezone.now() + timedelta(hours=1),
+            },
         )
 
     @mock.patch.object(LTIOAuthServer, "verify_request", return_value=True)
@@ -3018,6 +3064,8 @@ class LTISelectTestCase(TestCase):
             factories.VideoFactory,
             models.Video,
             {
+                "live_state": IDLE,
+                "live_type": RAW,
                 "starting_at": timezone.now() + timedelta(hours=1),
             },
         )
@@ -3118,7 +3166,11 @@ class LTISelectTestCase(TestCase):
         self._test_lti_get_selectable_resource_other_pl_pl_auto_portable_ready_to_show(
             factories.VideoFactory,
             models.Video,
-            {"starting_at": timezone.now() + timedelta(hours=1)},
+            {
+                "live_state": IDLE,
+                "live_type": RAW,
+                "starting_at": timezone.now() + timedelta(hours=1),
+            },
         )
 
     @mock.patch.object(LTIOAuthServer, "verify_request", return_value=True)
@@ -3226,6 +3278,8 @@ class LTISelectTestCase(TestCase):
             factories.VideoFactory,
             models.Video,
             {
+                "live_state": IDLE,
+                "live_type": RAW,
                 "starting_at": timezone.now() + timedelta(hours=1),
             },
         )


### PR DESCRIPTION
## Purpose

Master has evolved and further tests building the front of the scheduled videos feature have enlightened a few fixup around emails to write.

## Proposal


- changing the default live_state for scheduled videos
- users with empty email can register to scheduled webinars
- registrations for users with a different email in the token

