### PR TITLE
⬆️(back) upgrade black to version 21.10b0

### DIFF
--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -70,7 +70,7 @@ console_scripts =
 [options.extras_require]
 dev =
     bandit==1.7.0
-    black==20.8b1
+    black==21.10b0
     factory_boy==3.2.1
     flake8==4.0.1
     ipython==7.29.0


### PR DESCRIPTION
## Purpose

Renovate does not upgrade black. This dependency is not stable and only
pre-release are posted on pypi. We want to update black to the last
version.

## Proposal

- [x] upgrade black to version 21.10b0

