### PR TITLE
✨(backend) access to videos with a scheduled date past

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Postpone AWS creation stack to the first live start action
 - Scheduled videos have a live_state set to IDLE
+- Allow access to videos with a scheduled date past
 
 ### Fixed
 

--- a/src/backend/marsha/core/models/video.py
+++ b/src/backend/marsha/core/models/video.py
@@ -169,7 +169,8 @@ class Video(BaseFile):
         """Clause used in lti.utils.get_or_create_resource to filter the videos.
 
         Only show videos that have successfully gone through the upload process,
-        or live streams that are in the running state or videos that are in the scheduled mode.
+        or live streams that are in the running state or videos that have a starting_at
+        date defined and an IDLE live_state.
 
         Returns
         -------
@@ -181,7 +182,6 @@ class Video(BaseFile):
             | models.Q(live_state__isnull=False)
             | models.Q(
                 starting_at__isnull=False,
-                starting_at__gte=timezone.now(),
                 live_state=IDLE,
             )
         )

--- a/src/backend/marsha/core/tests/test_api_video.py
+++ b/src/backend/marsha/core/tests/test_api_video.py
@@ -92,6 +92,47 @@ class VideoAPITest(TestCase):
         )
         self.assertEqual(response.status_code, 200)
 
+    def test_api_video_read_detail_scheduled_video_student(self):
+        """Student users should be allowed to read a scheduled video detail."""
+        starting_at = timezone.now() + timedelta(days=100)
+        video = factories.VideoFactory(
+            live_state=IDLE, live_type=RAW, starting_at=starting_at
+        )
+        self.assertTrue(video.is_scheduled)
+        jwt_token = AccessToken()
+        jwt_token.payload["resource_id"] = str(video.id)
+        jwt_token.payload["roles"] = ["student"]
+        jwt_token.payload["permissions"] = {"can_update": False}
+        # Get the video linked to the JWT token
+        response = self.client.get(
+            f"/api/videos/{video.id}/",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_api_video_read_detail_scheduled_past_video_student(self):
+        """Student users can read a video detail with a starting_at date past."""
+        initial_starting_at = timezone.now() + timedelta(days=2)
+        video = factories.VideoFactory(
+            live_state=IDLE, live_type=RAW, starting_at=initial_starting_at
+        )
+        self.assertTrue(video.is_scheduled)
+        # now is set after video.starting_at
+        now = initial_starting_at + timedelta(days=10)
+        with mock.patch.object(timezone, "now", return_value=now):
+            self.assertFalse(video.is_scheduled)
+            self.assertEqual(video.live_state, IDLE)
+            jwt_token = AccessToken()
+            jwt_token.payload["resource_id"] = str(video.id)
+            jwt_token.payload["roles"] = ["student"]
+            jwt_token.payload["permissions"] = {"can_update": False}
+            # Get the video linked to the JWT token
+            response = self.client.get(
+                f"/api/videos/{video.id}/",
+                HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+            )
+            self.assertEqual(response.status_code, 200)
+
     def test_api_video_read_detail_student_other_video(self):
         """Student users should not be allowed to read an other video detail."""
         video = factories.VideoFactory()


### PR DESCRIPTION
## Purpose

If a video was scheduled and still in the IDLE live_state, users should
be allowed to access this video to wait for the live to start.

## Proposal

Allowing access independently of starting_date date, past and future
