### PR TITLE
✨ Add a mechanism to connect external devices to a video live

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Add frontend components to register an email for scheduled webinars
 - Add API endpoints to pair an external device to Jitsi live videos
 - Add a store in the frontend to control live layout
+- Add frontend components to pair an external device to Jitsi live videos
 
 ### Changed
 

--- a/src/backend/marsha/core/serializers/video.py
+++ b/src/backend/marsha/core/serializers/video.py
@@ -300,8 +300,15 @@ class LivePairingSerializer(serializers.ModelSerializer):
 
     class Meta:  # noqa
         model = LivePairing
-        fields = ("secret",)
-        read_only_fields = ("secret",)
+        fields = ("secret", "expires_in")
+        read_only_fields = ("secret", "expires_in")
+
+    expires_in = serializers.SerializerMethodField()
+
+    # pylint: disable=unused-argument
+    def get_expires_in(self, obj):
+        """Returns LivePairing expiration setting."""
+        return settings.LIVE_PAIRING_EXPIRATION_SECONDS
 
 
 class PairingChallengeSerializer(serializers.Serializer):

--- a/src/backend/marsha/core/tests/test_api_video_live_pairing.py
+++ b/src/backend/marsha/core/tests/test_api_video_live_pairing.py
@@ -109,6 +109,9 @@ class PairingDeviceAPITest(TestCase):
         self.assertEqual(response.status_code, 200)
         video.refresh_from_db()
         self.assertEqual(str(video.live_pairing.secret), response.json().get("secret"))
+        self.assertEqual(
+            settings.LIVE_PAIRING_EXPIRATION_SECONDS, response.json().get("expires_in")
+        )
 
     def test_api_video_instructor_pairing_secret_2nd_request(self):
         """An instructor should be able to request several times a live pairing secret."""

--- a/src/frontend/components/DashboardVideoLive/index.spec.tsx
+++ b/src/frontend/components/DashboardVideoLive/index.spec.tsx
@@ -38,6 +38,12 @@ jest.mock(
     },
 );
 
+jest.mock('components/DashboardVideoLivePairing', () => ({
+  DashboardVideoLivePairing: (props: { video: Video }) => (
+    <span title={`Pairing button for ${props.video.id}`} />
+  ),
+}));
+
 describe('components/DashboardVideoLive', () => {
   beforeEach(() => jest.useFakeTimers());
 
@@ -476,5 +482,27 @@ describe('components/DashboardVideoLive', () => {
     screen.getByDisplayValue(/maths/i);
     screen.getByText(/wonderful class!/i);
     screen.getByRole('textbox', { name: /description/i });
+  });
+
+  it('shows the pairing button when the status is not STOPPED', () => {
+    for (const state of Object.values(liveState)) {
+      const { getByTitle, queryByTitle } = render(
+        wrapInIntlProvider(
+          wrapInRouter(
+            <Suspense fallback="loading...">
+              <DashboardVideoLive video={{ ...video, live_state: state }} />
+            </Suspense>,
+          ),
+        ),
+      );
+      if (state !== liveState.STOPPED) {
+        getByTitle(`Pairing button for ${video.id}`);
+      } else {
+        expect(
+          queryByTitle(`Pairing button for ${video.id}`),
+        ).not.toBeInTheDocument();
+      }
+      cleanup();
+    }
   });
 });

--- a/src/frontend/components/DashboardVideoLive/index.tsx
+++ b/src/frontend/components/DashboardVideoLive/index.tsx
@@ -8,6 +8,7 @@ import { API_ENDPOINT } from 'settings';
 import { Video, liveState, LiveModeType } from 'types/tracks';
 import { report } from 'utils/errors/report';
 import { DashboardVideoLiveEndButton } from 'components/DashboardVideoLiveEndButton';
+import { DashboardVideoLivePairing } from 'components/DashboardVideoLivePairing';
 import { DashboardVideoLiveStartButton } from 'components/DashboardVideoLiveStartButton';
 import { DashboardVideoLiveRunning } from 'components/DashboardVideoLiveRunning';
 import { DashboardVideoLiveConfigureButton } from 'components/DashboardVideoLiveConfigureButton';
@@ -158,6 +159,11 @@ export const DashboardVideoLive = ({ video }: DashboardVideoLiveProps) => {
           </Text>
         )}
       </Box>
+      {video.live_state !== liveState.STOPPED && (
+        <Box direction={'row'} justify={'center'} margin={'small'}>
+          <DashboardVideoLivePairing video={video} />
+        </Box>
+      )}
       {video.live_state === liveState.IDLE && (
         <ScheduledVideoForm video={video} />
       )}

--- a/src/frontend/components/DashboardVideoLivePairing/index.spec.tsx
+++ b/src/frontend/components/DashboardVideoLivePairing/index.spec.tsx
@@ -1,0 +1,97 @@
+import { act, render, screen } from '@testing-library/react';
+import fetchMock from 'fetch-mock';
+import { Grommet } from 'grommet';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from 'react-query';
+
+import { Deferred } from 'utils/tests/Deferred';
+import { videoMockFactory } from 'utils/tests/factories';
+import { wrapInIntlProvider } from 'utils/tests/intl';
+
+import { DashboardVideoLivePairing } from '.';
+
+jest.mock('data/appData', () => ({
+  appData: {
+    jwt: 'some token',
+  },
+}));
+
+describe('<DashboardVideoLivePairing />', () => {
+  beforeEach(() => jest.useFakeTimers());
+
+  afterEach(() => {
+    fetchMock.restore();
+    jest.useRealTimers();
+  });
+
+  it('requests a pairing secret', async () => {
+    const video = videoMockFactory();
+
+    const pairingSecretDefered = new Deferred();
+    fetchMock.get(
+      `/api/videos/${video.id}/pairing-secret/`,
+      pairingSecretDefered.promise,
+    );
+
+    const queryClient = new QueryClient();
+    render(
+      wrapInIntlProvider(
+        <Grommet>
+          <QueryClientProvider client={queryClient}>
+            <DashboardVideoLivePairing video={video} />
+          </QueryClientProvider>
+        </Grommet>,
+      ),
+    );
+
+    const pairButton = screen.getByRole('button', {
+      name: /pair an external device/i,
+    });
+    pairButton.click();
+
+    await act(async () =>
+      pairingSecretDefered.resolve({ secret: '123456', expires_in: '60' }),
+    );
+
+    expect(fetchMock.lastCall()![0]).toEqual(
+      `/api/videos/${video.id}/pairing-secret/`,
+    );
+    expect(fetchMock.lastCall()![1]).toEqual({
+      headers: {
+        Authorization: 'Bearer some token',
+        'Content-Type': 'application/json',
+      },
+      method: 'GET',
+    });
+
+    screen.getByText('Pairing secret: 123456');
+
+    // secret is stll displayed after 59 seconds
+    act(() => {
+      // advance time by 59 second
+      jest.advanceTimersByTime(1000 * 59);
+    });
+    screen.getByText('Pairing secret: 123456');
+
+    // secret expiration is displayed after 1 minute
+    act(() => {
+      // advance time by 3 second
+      jest.advanceTimersByTime(1000 * 3);
+    });
+    screen.getByText('Pairing secret expired');
+    const pairingSecretDisplay = screen.queryByText('Pairing secret: 123456');
+    expect(pairingSecretDisplay).not.toBeInTheDocument();
+    const pairingSecretLabel = screen.queryByText('Pair an external device');
+    expect(pairingSecretLabel).not.toBeInTheDocument();
+
+    act(() => {
+      // advance time by 4 second
+      jest.advanceTimersByTime(1000 * 4);
+    });
+    screen.getByText('Pair an external device');
+    const pairingSecretExpiration = screen.queryByText(
+      'Pairing secret expired',
+    );
+    expect(pairingSecretExpiration).not.toBeInTheDocument();
+  });
+});

--- a/src/frontend/components/DashboardVideoPane/index.spec.tsx
+++ b/src/frontend/components/DashboardVideoPane/index.spec.tsx
@@ -2,26 +2,34 @@ import { cleanup, render, screen, act } from '@testing-library/react';
 import fetchMock from 'fetch-mock';
 import React, { Suspense } from 'react';
 
-import { modelName } from '../../types/models';
-import { LiveModeType, liveState, uploadState } from '../../types/tracks';
-import { report } from '../../utils/errors/report';
-import { Deferred } from '../../utils/tests/Deferred';
-import { videoMockFactory } from '../../utils/tests/factories';
-import { wrapInIntlProvider } from '../../utils/tests/intl';
-import { wrapInRouter } from '../../utils/tests/router';
-import { FULL_SCREEN_ERROR_ROUTE } from '../ErrorComponents/route';
-import { UploadManagerContext, UploadManagerStatus } from '../UploadManager';
+import { modelName } from 'types/models';
+import { LiveModeType, liveState, uploadState, Video } from 'types/tracks';
+import { report } from 'utils/errors/report';
+import { Deferred } from 'utils/tests/Deferred';
+import { videoMockFactory } from 'utils/tests/factories';
+import { wrapInIntlProvider } from 'utils/tests/intl';
+import { wrapInRouter } from 'utils/tests/router';
+import { FULL_SCREEN_ERROR_ROUTE } from 'components/ErrorComponents/route';
+import {
+  UploadManagerContext,
+  UploadManagerStatus,
+} from 'components/UploadManager';
 import { DashboardVideoPane } from '.';
 
 jest.mock('jwt-decode', () => jest.fn());
-jest.mock('../../data/appData', () => ({
+jest.mock('data/appData', () => ({
   appData: {
     jwt: 'cool_token_m8',
     flags: {},
     uploadPollInterval: 60,
   },
 }));
-jest.mock('../../utils/errors/report', () => ({ report: jest.fn() }));
+jest.mock('utils/errors/report', () => ({ report: jest.fn() }));
+jest.mock('components/DashboardVideoLivePairing', () => ({
+  DashboardVideoLivePairing: (props: { video: Video }) => (
+    <span title={`Pairing button for ${props.video.id}`} />
+  ),
+}));
 
 const { ERROR, PENDING, PROCESSING, READY } = uploadState;
 

--- a/src/frontend/data/queries/actionOne.spec.tsx
+++ b/src/frontend/data/queries/actionOne.spec.tsx
@@ -37,6 +37,52 @@ describe('queries/actionOne', () => {
     expect(response).toEqual({ key: 'value' });
   });
 
+  it('allows empty request body', async () => {
+    mockAppData = { jwt: 'some token' };
+    fetchMock.mock('/api/model-name/1/action/', { key: 'value' });
+
+    const response = await actionOne({
+      name: 'model-name',
+      id: '1',
+      action: 'action',
+    });
+
+    expect(fetchMock.lastCall()![0]).toEqual('/api/model-name/1/action/');
+    expect(fetchMock.lastCall()![1]).toEqual({
+      headers: {
+        Authorization: 'Bearer some token',
+        'Content-Type': 'application/json',
+      },
+      method: 'PATCH',
+    });
+    expect(response).toEqual({ key: 'value' });
+  });
+
+  it('allows defining request method', async () => {
+    mockAppData = { jwt: 'some token' };
+    const objectToUpdate = { object: 'data' };
+    fetchMock.mock('/api/model-name/1/action/', { key: 'value' });
+
+    const response = await actionOne({
+      name: 'model-name',
+      id: '1',
+      action: 'action',
+      method: 'GET',
+      object: objectToUpdate,
+    });
+
+    expect(fetchMock.lastCall()![0]).toEqual('/api/model-name/1/action/');
+    expect(fetchMock.lastCall()![1]).toEqual({
+      headers: {
+        Authorization: 'Bearer some token',
+        'Content-Type': 'application/json',
+      },
+      method: 'GET',
+      body: JSON.stringify(objectToUpdate),
+    });
+    expect(response).toEqual({ key: 'value' });
+  });
+
   it('requests the resource list without JWT token', async () => {
     mockAppData = {};
     const objectToUpdate = { object: 'data' };

--- a/src/frontend/data/queries/actionOne.tsx
+++ b/src/frontend/data/queries/actionOne.tsx
@@ -6,16 +6,19 @@ import { appData } from 'data/appData';
  */
 export const actionOne: MutationFunction<
   any,
-  { name: string; id: string; action: string; object: any }
-> = async ({ name, id, action, object }) => {
-  const response = await fetch(`/api/${name}/${id}/${action}/`, {
+  { name: string; id: string; action: string; method?: string; object?: any }
+> = async ({ name, id, action, method, object }) => {
+  const init: RequestInit = {
     headers: {
       'Content-Type': 'application/json',
       ...(appData.jwt ? { Authorization: `Bearer ${appData.jwt}` } : {}),
     },
-    method: 'PATCH',
-    body: JSON.stringify(object),
-  });
+    method: method || 'PATCH',
+  };
+  if (object) {
+    init.body = JSON.stringify(object);
+  }
+  const response = await fetch(`/api/${name}/${id}/${action}/`, init);
 
   if (!response.ok) {
     if (response.status === 400) {

--- a/src/frontend/data/queries/index.spec.tsx
+++ b/src/frontend/data/queries/index.spec.tsx
@@ -6,6 +6,7 @@ import { renderHook, WrapperComponent } from '@testing-library/react-hooks';
 import {
   useCreateVideo,
   useOrganization,
+  usePairingVideo,
   usePlaylist,
   usePlaylists,
   useThumbnail,
@@ -524,6 +525,58 @@ describe('queries', () => {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
         },
+      });
+      expect(result.current.data).toEqual(undefined);
+      expect(result.current.status).toEqual('error');
+    });
+  });
+
+  describe('usePairingingVideo', () => {
+    it('updates the resource', async () => {
+      const video = videoMockFactory();
+      fetchMock.get(`/api/videos/${video.id}/pairing-secret/`, {
+        secret: '12345',
+      });
+
+      const { result, waitFor } = renderHook(() => usePairingVideo(video.id), {
+        wrapper: Wrapper,
+      });
+      result.current.mutate();
+      await waitFor(() => result.current.isSuccess);
+
+      expect(fetchMock.lastCall()![0]).toEqual(
+        `/api/videos/${video.id}/pairing-secret/`,
+      );
+      expect(fetchMock.lastCall()![1]).toEqual({
+        headers: {
+          Authorization: 'Bearer some token',
+          'Content-Type': 'application/json',
+        },
+        method: 'GET',
+      });
+      expect(result.current.data).toEqual({ secret: '12345' });
+      expect(result.current.status).toEqual('success');
+    });
+
+    it('fails to update the resource', async () => {
+      const video = videoMockFactory();
+      fetchMock.get(`/api/videos/${video.id}/pairing-secret/`, 400);
+
+      const { result, waitFor } = renderHook(() => usePairingVideo(video.id), {
+        wrapper: Wrapper,
+      });
+      result.current.mutate();
+      await waitFor(() => result.current.isError);
+
+      expect(fetchMock.lastCall()![0]).toEqual(
+        `/api/videos/${video.id}/pairing-secret/`,
+      );
+      expect(fetchMock.lastCall()![1]).toEqual({
+        headers: {
+          Authorization: 'Bearer some token',
+          'Content-Type': 'application/json',
+        },
+        method: 'GET',
       });
       expect(result.current.data).toEqual(undefined);
       expect(result.current.status).toEqual('error');

--- a/src/frontend/data/queries/index.tsx
+++ b/src/frontend/data/queries/index.tsx
@@ -9,6 +9,7 @@ import {
 import { APIList } from '../../types/api';
 import { Playlist, Thumbnail, TimedText, Video } from '../../types/tracks';
 import { Organization } from '../../types/Organization';
+import { actionOne } from './actionOne';
 import { createOne } from './createOne';
 import { fetchList } from './fetchList';
 import { fetchOne } from './fetchOne';
@@ -154,4 +155,42 @@ export const useVideos = (
 ) => {
   const key = ['videos', params];
   return useQuery<VideosResponse, 'videos'>(key, fetchList, queryConfig);
+};
+
+type usePairingVideoError = { code: 'exception' };
+type usePairingVideoResponse = {
+  secret: string;
+};
+type usePairingVideoOptions = UseMutationOptions<
+  usePairingVideoResponse,
+  usePairingVideoError
+>;
+export const usePairingVideo = (
+  id: string,
+  options?: usePairingVideoOptions,
+) => {
+  const queryClient = useQueryClient();
+  return useMutation<usePairingVideoResponse, usePairingVideoError>(
+    () =>
+      actionOne({
+        name: 'videos',
+        id,
+        action: 'pairing-secret',
+        method: 'GET',
+      }),
+    {
+      onSuccess: (data, variables, context) => {
+        queryClient.invalidateQueries('videos');
+        if (options?.onSuccess) {
+          options.onSuccess(data, variables, context);
+        }
+      },
+      onError: (error, variables, context) => {
+        queryClient.invalidateQueries('videos');
+        if (options?.onError) {
+          options.onError(error, variables, context);
+        }
+      },
+    },
+  );
 };

--- a/src/frontend/data/queries/index.tsx
+++ b/src/frontend/data/queries/index.tsx
@@ -160,6 +160,7 @@ export const useVideos = (
 type usePairingVideoError = { code: 'exception' };
 type usePairingVideoResponse = {
   secret: string;
+  expires_in: number;
 };
 type usePairingVideoOptions = UseMutationOptions<
   usePairingVideoResponse,


### PR DESCRIPTION
## Purpose

We want to allow pairing external devices to Marsha live. External devices are cameras or set-top boxes that can act as video and sound sources for a live in Marsha.

This PR should be merged after #1213 

- [x] Update frontend actionOne to permit
  - usage of any request method
  - usage of empty body request
- [x] Add a frontend query to request `/api/video/<id>/pairing-secret/`
- [x] Add a frontend component which:
  - request a secret
  - displays the secret
  - displays a countdown timer initially set to 1 minutes

(Following demo has an expiry set to 5 seconds)
![pairing-secret6](https://user-images.githubusercontent.com/720491/144267243-73547fd2-4040-4ab1-9595-4b2e310923c8.gif)



#1196 