### PR TITLE
💚(e2e) fix chrome install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -519,6 +519,9 @@ jobs:
             equal: [ chrome, << parameters.browser_channel >> ]
           steps:
             - run:
+                name: Build apt cache
+                command: apt update
+            - run:
                 name: Install chrome
                 command: python -m playwright install chrome
       - run:


### PR DESCRIPTION
## Purpose

Playwright image has recently intruduced apt cache cleaning and installing chrome requires wget

## Proposal

Add `apt update` and `apt install wget` before installing chrome in e2e circle-ci job.