### PR TITLE
Start and stop live for student view

### DIFF
--- a/src/frontend/Player/createVideojsPlayer.spec.tsx
+++ b/src/frontend/Player/createVideojsPlayer.spec.tsx
@@ -1,15 +1,15 @@
 import { render } from '@testing-library/react';
 import React from 'react';
 
-import VideoPlayer from '../components/VideoPlayer';
+import VideoPlayer from 'components/VideoPlayer';
+import { useTranscriptTimeSelector } from 'data/stores/useTranscriptTimeSelector';
+import { liveState, timedTextMode, uploadState } from 'types/tracks';
+import { isMSESupported } from 'utils/isMSESupported';
+import { videoMockFactory } from 'utils/tests/factories';
+import { wrapInIntlProvider } from 'utils/tests/intl';
+import { VideoXAPIStatementInterface, XAPIStatement } from 'XAPI';
 
-import { useTranscriptTimeSelector } from '../data/stores/useTranscriptTimeSelector';
 import { createVideojsPlayer } from './createVideojsPlayer';
-import { liveState, timedTextMode, uploadState } from '../types/tracks';
-import { isMSESupported } from '../utils/isMSESupported';
-import { videoMockFactory } from '../utils/tests/factories';
-import { wrapInIntlProvider } from '../utils/tests/intl';
-import { VideoXAPIStatementInterface, XAPIStatement } from '../XAPI';
 
 const mockXAPIStatementInterface: VideoXAPIStatementInterface = {
   initialized: jest.fn(),

--- a/src/frontend/Player/createVideojsPlayer.ts
+++ b/src/frontend/Player/createVideojsPlayer.ts
@@ -8,23 +8,25 @@ import 'videojs-contrib-quality-levels';
 import 'videojs-http-source-selector';
 import './videojs/qualitySelectorPlugin';
 
-import { appData, getDecodedJwt } from '../data/appData';
-import { useTranscriptTimeSelector } from '../data/stores/useTranscriptTimeSelector';
+import { appData, getDecodedJwt } from 'data/appData';
+import { getResource } from 'data/sideEffects/getResource';
+import { useTranscriptTimeSelector } from 'data/stores/useTranscriptTimeSelector';
 import {
   QualityLevels,
   VideoJsExtendedSourceObject,
-} from '../types/libs/video.js/extend';
-import { Video, videoSize } from '../types/tracks';
+} from 'types/libs/video.js/extend';
+import { modelName } from 'types/models';
+import { Video, videoSize } from 'types/tracks';
 import {
   InitializedContextExtensions,
   InteractedContextExtensions,
-} from '../types/XAPI';
-import { report } from '../utils/errors/report';
-import { isMSESupported } from '../utils/isMSESupported';
-import { Nullable } from '../utils/types';
-import { VideoXAPIStatementInterface, XAPIStatement } from '../XAPI';
+} from 'types/XAPI';
+import { report } from 'utils/errors/report';
+import { isMSESupported } from 'utils/isMSESupported';
+import { Nullable } from 'utils/types';
+import { VideoXAPIStatementInterface, XAPIStatement } from 'XAPI';
 
-import { intl } from '../index';
+import { intl } from 'index';
 import { Events } from './videojs/qualitySelectorPlugin/types';
 
 export const createVideojsPlayer = (
@@ -166,6 +168,13 @@ export const createVideojsPlayer = (
     xapiStatement.paused({
       time: player.currentTime(),
     });
+  });
+
+  player.on('ended', async () => {
+    // When video is live, fetch the resource to detect live_state modification
+    if (video.live_state !== null) {
+      await getResource(modelName.VIDEOS, video.id);
+    }
   });
 
   /**************** Seeked statement ***********************/

--- a/src/frontend/components/PublicPausedLiveVideo/index.spec.tsx
+++ b/src/frontend/components/PublicPausedLiveVideo/index.spec.tsx
@@ -1,0 +1,138 @@
+import { Grommet } from 'grommet';
+import { DateTime } from 'luxon';
+import React from 'react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+
+import { videoMockFactory } from '../../utils/tests/factories';
+import { wrapInIntlProvider } from '../../utils/tests/intl';
+import { PublicPausedLiveVideo } from '.';
+
+describe('PublicPausedLiveVideo', () => {
+  beforeEach(() => {
+    /*
+      make sure to remove all body children, grommet layer gets rendered twice, known issue
+      https://github.com/grommet/grommet/issues/5200
+    */
+    document.body.innerHTML = '';
+    document.body.appendChild(document.createElement('div'));
+  });
+
+  it('renders the component with the timer', () => {
+    const video = videoMockFactory({
+      live_info: {
+        paused_at: `${DateTime.now().minus({ seconds: 5 }).toSeconds()}`,
+      },
+    });
+    const videoNode = document.createElement('video');
+
+    render(
+      wrapInIntlProvider(
+        <Grommet>
+          <PublicPausedLiveVideo video={video} videoNodeRef={videoNode} />
+        </Grommet>,
+      ),
+    );
+
+    screen.getByText('Webinar is paused');
+    screen.getByText(
+      'The webinar is paused. When resumed, the video will start again.',
+    );
+    const waitingSentence = screen.getByText(/the webinar is paused since/i);
+    expect(waitingSentence).toHaveTextContent(
+      'The webinar is paused since 00:00:05',
+    );
+  });
+
+  it('renders the component without timer', () => {
+    const video = videoMockFactory();
+    const videoNode = document.createElement('video');
+
+    render(
+      wrapInIntlProvider(
+        <Grommet>
+          <PublicPausedLiveVideo video={video} videoNodeRef={videoNode} />
+        </Grommet>,
+      ),
+    );
+
+    screen.getByText('Webinar is paused');
+    screen.getByText(
+      'The webinar is paused. When resumed, the video will start again.',
+    );
+    expect(
+      screen.queryByText(/the webinar is in paused since/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it('displays day and time when live is paused since more than 24 hours', () => {
+    jest.useFakeTimers();
+    const video = videoMockFactory({
+      live_info: {
+        paused_at: `${DateTime.now().minus({ days: 1, hours: 3 }).toSeconds()}`,
+      },
+    });
+    const videoNode = document.createElement('video');
+    mockResumeLive.mockResolvedValue();
+
+    render(
+      wrapInIntlProvider(
+        <Grommet>
+          <PublicPausedLiveVideo video={video} videoNodeRef={videoNode} />
+        </Grommet>,
+      ),
+    );
+
+    screen.getByText('Webinar is paused');
+    screen.getByText(
+      'The webinar is paused. When resumed, the video will start again.',
+    );
+    const waitingSentence = screen.getByText(/the webinar is paused since/i);
+    expect(waitingSentence).toHaveTextContent(
+      'The webinar is paused since 1 day + 03:00:00',
+    );
+  });
+
+  it('resets the Clock and displays day when the live overtakes 24 hours', async () => {
+    const video = videoMockFactory({
+      live_info: {
+        paused_at: `${DateTime.now()
+          .minus({ hours: 23, minutes: 59, seconds: 59 })
+          .toSeconds()}`,
+      },
+    });
+    const videoNode = document.createElement('video');
+    mockResumeLive.mockResolvedValue();
+
+    render(
+      wrapInIntlProvider(
+        <Grommet>
+          <PublicPausedLiveVideo video={video} videoNodeRef={videoNode} />
+        </Grommet>,
+      ),
+    );
+
+    await screen.findByText('Webinar is paused');
+    screen.getByText(
+      'The webinar is paused. When resumed, the video will start again.',
+    );
+    const waitingSentence = await screen.findByText(
+      /the webinar is paused since/i,
+    );
+    expect(waitingSentence).toHaveTextContent(
+      'The webinar is paused since 23:59:59',
+    );
+
+    act(() => {
+      // advance time by 5 seconds and few milliseconds to avoid the
+      // div added by the component Clock while digits are changing
+      jest.advanceTimersByTime(5600);
+    });
+
+    const newWaitingSentence = await screen.findByText(
+      /the webinar is paused since 1 day +/i,
+    );
+    expect(newWaitingSentence).toHaveTextContent(
+      'The webinar is paused since 1 day + 00:00:03',
+    );
+  });
+});

--- a/src/frontend/components/PublicPausedLiveVideo/index.spec.tsx
+++ b/src/frontend/components/PublicPausedLiveVideo/index.spec.tsx
@@ -3,9 +3,34 @@ import { DateTime } from 'luxon';
 import React from 'react';
 import { act, render, screen, waitFor } from '@testing-library/react';
 
-import { videoMockFactory } from '../../utils/tests/factories';
-import { wrapInIntlProvider } from '../../utils/tests/intl';
+import { getResource } from 'data/sideEffects/getResource';
+import { resumeLive } from 'utils/resumeLive';
+import { videoMockFactory } from 'utils/tests/factories';
+import { wrapInIntlProvider } from 'utils/tests/intl';
 import { PublicPausedLiveVideo } from '.';
+import { modelName } from 'types/models';
+
+jest.mock('video.js', () => ({
+  __esModule: true,
+  default: {
+    getPlayers: () => ({
+      bb8: {
+        currentSource: () => 'https://live.m3u8',
+        src: jest.fn(),
+      },
+    }),
+  },
+}));
+
+jest.mock('data/sideEffects/getResource', () => ({
+  getResource: jest.fn(),
+}));
+jest.mock('utils/resumeLive', () => ({
+  resumeLive: jest.fn(),
+}));
+
+const mockResumeLive = resumeLive as jest.MockedFunction<typeof resumeLive>;
+const mockGetResource = getResource as jest.MockedFunction<typeof getResource>;
 
 describe('PublicPausedLiveVideo', () => {
   beforeEach(() => {
@@ -17,6 +42,10 @@ describe('PublicPausedLiveVideo', () => {
     document.body.appendChild(document.createElement('div'));
   });
 
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('renders the component with the timer', () => {
     const video = videoMockFactory({
       live_info: {
@@ -24,6 +53,7 @@ describe('PublicPausedLiveVideo', () => {
       },
     });
     const videoNode = document.createElement('video');
+    mockResumeLive.mockResolvedValue();
 
     render(
       wrapInIntlProvider(
@@ -41,11 +71,13 @@ describe('PublicPausedLiveVideo', () => {
     expect(waitingSentence).toHaveTextContent(
       'The webinar is paused since 00:00:05',
     );
+    expect(mockGetResource).not.toHaveBeenCalled();
   });
 
   it('renders the component without timer', () => {
     const video = videoMockFactory();
     const videoNode = document.createElement('video');
+    mockResumeLive.mockResolvedValue();
 
     render(
       wrapInIntlProvider(
@@ -62,6 +94,39 @@ describe('PublicPausedLiveVideo', () => {
     expect(
       screen.queryByText(/the webinar is in paused since/i),
     ).not.toBeInTheDocument();
+
+    expect(mockResumeLive).toHaveBeenCalledWith(video);
+    expect(mockGetResource).not.toHaveBeenCalled();
+  });
+
+  it('calls getResource to refresh video state if resumeLive function fails', async () => {
+    const video = videoMockFactory({
+      live_info: {
+        paused_at: `${DateTime.now().minus({ seconds: 5 }).toSeconds()}`,
+      },
+    });
+    const videoNode = document.createElement('video');
+    mockResumeLive.mockRejectedValue('');
+
+    render(
+      wrapInIntlProvider(
+        <Grommet>
+          <PublicPausedLiveVideo video={video} videoNodeRef={videoNode} />
+        </Grommet>,
+      ),
+    );
+
+    screen.getByText('Webinar is paused');
+    screen.getByText(
+      'The webinar is paused. When resumed, the video will start again.',
+    );
+    const waitingSentence = screen.getByText(/the webinar is paused since/i);
+    expect(waitingSentence).toHaveTextContent(
+      'The webinar is paused since 00:00:05',
+    );
+    await waitFor(() =>
+      expect(mockGetResource).toHaveBeenCalledWith(modelName.VIDEOS, video.id),
+    );
   });
 
   it('displays day and time when live is paused since more than 24 hours', () => {

--- a/src/frontend/components/PublicPausedLiveVideo/index.tsx
+++ b/src/frontend/components/PublicPausedLiveVideo/index.tsx
@@ -1,0 +1,123 @@
+import { Box, Clock, Layer, Paragraph } from 'grommet';
+import { DateTime, DurationObjectUnits } from 'luxon';
+import React, { useMemo, useState } from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+
+import { H2 } from 'components/Headings';
+import { Video } from 'types/tracks';
+import { useAsyncEffect } from 'utils/useAsyncEffect';
+import { resumeLive } from '../../utils/resumeLive';
+
+const messages = defineMessages({
+  pausedSince: {
+    defaultMessage: 'The webinar is paused since ',
+    description:
+      'Information about the time since which the webinar is paused.',
+    id: 'components.PublicPausedLive.pausedSince',
+  },
+  pausedDays: {
+    defaultMessage: '{pausedDays} {pausedDays, plural, one {day} other {days}}',
+  },
+  title: {
+    defaultMessage: 'Webinar is paused',
+    description: 'Title for the public paused live component',
+    id: 'components.PublicPausedLive.title',
+  },
+  text: {
+    defaultMessage:
+      'The webinar is paused. When resumed, the video will start again.',
+    description: 'Message for the public when live is paused',
+    id: 'components.PublicPausedLive.message',
+  },
+});
+
+interface PublicPausedLiveVideoProps {
+  video: Video;
+  videoNodeRef: HTMLVideoElement;
+}
+
+export const PublicPausedLiveVideo = ({
+  video,
+  videoNodeRef,
+}: PublicPausedLiveVideoProps) => {
+  const diffSincePause = useMemo<DurationObjectUnits | null>(() => {
+    if (video.live_info.paused_at === undefined) {
+      return null;
+    }
+
+    const now = DateTime.now();
+    const pausedAt = DateTime.fromSeconds(Number(video.live_info.paused_at));
+    return now
+      .diff(pausedAt, ['days', 'hours', 'minutes', 'seconds'])
+      .toObject();
+  }, []);
+  const time = useMemo<string | undefined>(() => {
+    if (!diffSincePause) {
+      return undefined;
+    }
+
+    return `PT${diffSincePause.hours}H${diffSincePause.minutes}M${diffSincePause.seconds}S`;
+  }, [diffSincePause]);
+  const [days, setDays] = useState(diffSincePause?.days ?? 0);
+
+  useAsyncEffect(async () => {
+    try {
+      await resumeLive(video);
+    } catch (error) {
+      await getResource(modelName.VIDEOS, video.id);
+    }
+
+    const player = Object.values(videojs.getPlayers())[0];
+    player.src(player.currentSource());
+  }, []);
+
+  const onChangeClock = (timer: string) => {
+    if (timer === 'P0H0M0S') {
+      setDays(days + 1);
+    }
+  };
+
+  return (
+    <Layer background={{ opacity: true }} modal={true} target={videoNodeRef}>
+      <Box gap="medium" align="center" justify="center" pad="large">
+        {time && (
+          <Box
+            background="light-2"
+            direction="column"
+            align="center"
+            pad="medium"
+            round
+          >
+            <FormattedMessage {...messages.pausedSince} />{' '}
+            {days > 0 && (
+              <React.Fragment>
+                <FormattedMessage
+                  {...messages.pausedDays}
+                  values={{ pausedDays: days }}
+                />
+                {' + '}
+              </React.Fragment>
+            )}
+            <Clock type="digital" time={time} onChange={onChangeClock} />
+          </Box>
+        )}
+        <Box
+          background="light-2"
+          direction="column"
+          align="center"
+          justify="center"
+          pad="medium"
+          gap="small"
+          round
+        >
+          <H2>
+            <FormattedMessage {...messages.title} />
+          </H2>
+          <Paragraph>
+            <FormattedMessage {...messages.text} />
+          </Paragraph>
+        </Box>
+      </Box>
+    </Layer>
+  );
+};

--- a/src/frontend/components/PublicPausedLiveVideo/index.tsx
+++ b/src/frontend/components/PublicPausedLiveVideo/index.tsx
@@ -2,11 +2,14 @@ import { Box, Clock, Layer, Paragraph } from 'grommet';
 import { DateTime, DurationObjectUnits } from 'luxon';
 import React, { useMemo, useState } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
+import videojs from 'video.js';
 
 import { H2 } from 'components/Headings';
+import { getResource } from 'data/sideEffects/getResource';
 import { Video } from 'types/tracks';
+import { modelName } from 'types/models';
 import { useAsyncEffect } from 'utils/useAsyncEffect';
-import { resumeLive } from '../../utils/resumeLive';
+import { resumeLive } from 'utils/resumeLive';
 
 const messages = defineMessages({
   pausedSince: {

--- a/src/frontend/components/PublicVideoDashboard/index.spec.tsx
+++ b/src/frontend/components/PublicVideoDashboard/index.spec.tsx
@@ -26,6 +26,21 @@ jest.mock('index', () => ({
     locale: 'en',
   },
 }));
+jest.mock('utils/resumeLive', () => ({
+  resumeLive: jest.fn().mockResolvedValue(null),
+}));
+jest.mock('video.js', () => ({
+  __esModule: true,
+  default: {
+    getPlayers: () => ({
+      r2d2: {
+        currentSource: () => 'https://live.m3u8',
+        src: jest.fn(),
+      },
+    }),
+  },
+}));
+
 const mockCreatePlayer = createPlayer as jest.MockedFunction<
   typeof createPlayer
 >;

--- a/src/frontend/components/PublicVideoDashboard/index.tsx
+++ b/src/frontend/components/PublicVideoDashboard/index.tsx
@@ -6,9 +6,10 @@ import { Chat } from 'components/Chat';
 import { DASHBOARD_ROUTE } from 'components/Dashboard/route';
 import { DownloadVideo } from 'components/DownloadVideo';
 import { FULL_SCREEN_ERROR_ROUTE } from 'components/ErrorComponents/route';
+import { JoinDiscussionAskButton } from 'components/JoinDiscussionAskButton';
+import { SubscribeScheduledVideo } from 'components/SubscribeScheduledVideo';
 import { Transcripts } from 'components/Transcripts';
 import VideoPlayer from 'components/VideoPlayer';
-import { SubscribeScheduledVideo } from 'components/SubscribeScheduledVideo';
 import { WaitingLiveVideo } from 'components/WaitingLiveVideo';
 import { getDecodedJwt } from 'data/appData';
 import { useTimedTextTrack } from 'data/stores/useTimedTextTrack';
@@ -20,8 +21,7 @@ import {
   timedTextMode,
   TimedTextTranscript,
   Video,
-} from '../../types/tracks';
-import { JoinDiscussionAskButton } from '../JoinDiscussionAskButton';
+} from 'types/tracks';
 
 interface PublicVideoDashboardProps {
   video: Video;
@@ -36,10 +36,16 @@ const PublicVideoDashboard = ({
   const timedTextTracks = useTimedTextTrack((state) =>
     state.getTimedTextTracks(),
   );
+  const displayJoinDiscussionAskButton =
+    video.xmpp &&
+    video.live_type === LiveModeType.JITSI &&
+    ![liveState.STOPPING, liveState.PAUSED].includes(video.live_state!);
 
   if (video.live_state !== null) {
     switch (video.live_state) {
       case liveState.RUNNING:
+      case liveState.PAUSED:
+      case liveState.STOPPING:
         return (
           <Box>
             <Box direction="row">
@@ -56,7 +62,7 @@ const PublicVideoDashboard = ({
                 </Box>
               )}
             </Box>
-            {video.xmpp && video.live_type === LiveModeType.JITSI && (
+            {displayJoinDiscussionAskButton && (
               <Box
                 direction="row"
                 margin="small"
@@ -69,7 +75,6 @@ const PublicVideoDashboard = ({
           </Box>
         );
       case liveState.STOPPED:
-      case liveState.STOPPING:
         // user has update permission, we redirect him to the dashboard
         if (getDecodedJwt().permissions.can_update) {
           return <Redirect push to={DASHBOARD_ROUTE(modelName.VIDEOS)} />;

--- a/src/frontend/components/VideoPlayer/index.spec.tsx
+++ b/src/frontend/components/VideoPlayer/index.spec.tsx
@@ -2,21 +2,32 @@ import { act, render, screen, waitFor } from '@testing-library/react';
 import fetchMock from 'fetch-mock';
 import React from 'react';
 
-import { createPlayer } from '../../Player/createPlayer';
-import { liveState, timedTextMode, uploadState } from '../../types/tracks';
-import { VideoPlayerInterface } from '../../types/VideoPlayer';
-import {
-  timedTextMockFactory,
-  videoMockFactory,
-} from '../../utils/tests/factories';
-import { Deferred } from '../../utils/tests/Deferred';
-import { wrapInIntlProvider } from '../../utils/tests/intl';
+import { createPlayer } from 'Player/createPlayer';
+import { liveState, timedTextMode, uploadState } from 'types/tracks';
+import { VideoPlayerInterface } from 'types/VideoPlayer';
+import { timedTextMockFactory, videoMockFactory } from 'utils/tests/factories';
+import { Deferred } from 'utils/tests/Deferred';
+import { wrapInIntlProvider } from 'utils/tests/intl';
 import VideoPlayer from './index';
 
 jest.mock('jwt-decode', () => jest.fn());
 
-jest.mock('../../Player/createPlayer', () => ({
+jest.mock('Player/createPlayer', () => ({
   createPlayer: jest.fn(),
+}));
+jest.mock('utils/resumeLive', () => ({
+  resumeLive: jest.fn().mockResolvedValue(null),
+}));
+jest.mock('video.js', () => ({
+  __esModule: true,
+  default: {
+    getPlayers: () => [
+      {
+        currentSource: () => 'https://live.m3u8',
+        src: jest.fn(),
+      },
+    ],
+  },
 }));
 
 const mockCreatePlayer = createPlayer as jest.MockedFunction<
@@ -149,6 +160,7 @@ describe('VideoPlayer', () => {
     expect(videoElement.poster).toEqual(
       'https://example.com/thumbnail/1080p.jpg',
     );
+    expect(screen.queryByText('Webinar is paused')).not.toBeInTheDocument();
   });
 
   it('displays a waiting message while live is not ready', async () => {
@@ -197,5 +209,51 @@ describe('VideoPlayer', () => {
 
     const videoElement = container.querySelector('video')!;
     expect(videoElement.tabIndex).toEqual(-1);
+    expect(screen.queryByText('Webinar is paused')).not.toBeInTheDocument();
+  });
+
+  it('displays the waiting message when a live is paused or stopping', async () => {
+    const pausedStates = [liveState.STOPPING, liveState.PAUSED];
+    const video = videoMockFactory({
+      live_state: pausedStates[Math.floor(Math.random() * pausedStates.length)],
+      urls: {
+        manifests: {
+          hls: 'https://example.com/hls.m3u8',
+        },
+        mp4: {},
+        thumbnails: {},
+      },
+      xmpp: {
+        bosh_url: 'https://xmpp-server.com/http-bind',
+        websocket_url: null,
+        conference_url:
+          '870c467b-d66e-4949-8ee5-fcf460c72e88@conference.xmpp-server.com',
+        prebind_url: 'https://xmpp-server.com/http-pre-bind',
+        jid: 'xmpp-server.com',
+      },
+    });
+
+    const { container } = render(
+      wrapInIntlProvider(
+        <VideoPlayer
+          video={video}
+          playerType={'videojs'}
+          timedTextTracks={[]}
+        />,
+      ),
+    );
+    await waitFor(() =>
+      // The player is created and initialized with DashJS for adaptive bitrate
+      expect(mockCreatePlayer).toHaveBeenCalledWith(
+        'videojs',
+        expect.any(Element),
+        expect.anything(),
+        video,
+      ),
+    );
+
+    const videoElement = container.querySelector('video')!;
+    expect(videoElement.tabIndex).toEqual(-1);
+    screen.getByText('Webinar is paused');
   });
 });

--- a/src/frontend/components/VideoPlayer/index.tsx
+++ b/src/frontend/components/VideoPlayer/index.tsx
@@ -2,16 +2,24 @@ import { Box } from 'grommet';
 import React, { useRef, useState } from 'react';
 import { Redirect } from 'react-router';
 
-import { WaitingLiveVideo } from '../WaitingLiveVideo';
-import { useThumbnail } from '../../data/stores/useThumbnail';
-import { useTimedTextTrackLanguageChoices } from '../../data/stores/useTimedTextTrackLanguageChoices';
-import { useVideoProgress } from '../../data/stores/useVideoProgress';
-import { createPlayer } from '../../Player/createPlayer';
-import { TimedText, timedTextMode, Video, videoSize } from '../../types/tracks';
-import { VideoPlayerInterface } from '../../types/VideoPlayer';
-import { useAsyncEffect } from '../../utils/useAsyncEffect';
-import { Nullable } from '../../utils/types';
-import { FULL_SCREEN_ERROR_ROUTE } from '../ErrorComponents/route';
+import { FULL_SCREEN_ERROR_ROUTE } from 'components/ErrorComponents/route';
+import { PublicPausedLiveVideo } from 'components/PublicPausedLiveVideo';
+import { WaitingLiveVideo } from 'components/WaitingLiveVideo';
+
+import { useThumbnail } from 'data/stores/useThumbnail';
+import { useTimedTextTrackLanguageChoices } from 'data/stores/useTimedTextTrackLanguageChoices';
+import { useVideoProgress } from 'data/stores/useVideoProgress';
+import { createPlayer } from 'Player/createPlayer';
+import {
+  liveState,
+  TimedText,
+  timedTextMode,
+  Video,
+  videoSize,
+} from 'types/tracks';
+import { VideoPlayerInterface } from 'types/VideoPlayer';
+import { useAsyncEffect } from 'utils/useAsyncEffect';
+import { Nullable } from 'utils/types';
 
 const trackTextKind: { [key in timedTextMode]?: string } = {
   [timedTextMode.CLOSED_CAPTIONING]: 'captions',
@@ -31,6 +39,10 @@ const VideoPlayer = ({
 }: BaseVideoPlayerProps) => {
   const [player, setPlayer] = useState<VideoPlayerInterface>();
   const videoNodeRef = useRef(null as Nullable<HTMLVideoElement>);
+  const isLiveStarting = !player && video?.live_state;
+  const isLivePausedOrStopping =
+    video?.live_state &&
+    [liveState.STOPPING, liveState.PAUSED].includes(video.live_state);
 
   const { choices, getChoices } = useTimedTextTrackLanguageChoices(
     (state) => state,
@@ -135,7 +147,13 @@ const VideoPlayer = ({
             />
           ))}
       </video>
-      {!player && video.live_state && <WaitingLiveVideo />}
+      {isLiveStarting && <WaitingLiveVideo />}
+      {isLivePausedOrStopping && (
+        <PublicPausedLiveVideo
+          video={video}
+          videoNodeRef={videoNodeRef.current!}
+        />
+      )}
     </Box>
   );
 };

--- a/src/frontend/types/libs/m3u8-parser/index.d.ts
+++ b/src/frontend/types/libs/m3u8-parser/index.d.ts
@@ -1,0 +1,1 @@
+declare module 'm3u8-parser';

--- a/src/frontend/types/tracks.ts
+++ b/src/frontend/types/tracks.ts
@@ -152,6 +152,7 @@ export interface Video extends Resource {
       config_overwrite: JitsiMeetExternalAPI.ConfigOverwriteOptions;
       interface_config_overwrite: JitsiMeetExternalAPI.InterfaceConfigOverwrtieOptions;
     };
+    paused_at?: string;
   };
   live_type: Nullable<LiveModeType>;
   xmpp: Nullable<XMPP>;

--- a/src/frontend/utils/resumeLive.spec.ts
+++ b/src/frontend/utils/resumeLive.spec.ts
@@ -1,0 +1,137 @@
+import { waitFor } from '@testing-library/react';
+import fetchMock from 'fetch-mock';
+
+import { getResource } from 'data/sideEffects/getResource';
+import { requestStatus } from 'types/api';
+import { modelName } from 'types/models';
+
+import { videoMockFactory } from './tests/factories';
+import { resumeLive } from './resumeLive';
+
+jest.mock('data/appData', () => ({
+  appData: {
+    jwt: 'some token',
+  },
+}));
+
+jest.mock('data/sideEffects/getResource', () => ({
+  getResource: jest.fn(),
+}));
+
+const mockGetResource = getResource as jest.MockedFunction<typeof getResource>;
+
+describe('resumeLive', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers('modern');
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    fetchMock.restore();
+  });
+  it('waits until manifest is not ended', async () => {
+    const video = videoMockFactory({
+      urls: {
+        manifests: {
+          hls: 'https://c223d9abb67d57c7.mediapackage.eu-west-1.amazonaws.com/out/v1/0a5924bddfff4fe68e8c10a2a671a503/dev-manu_030aaea4-bb0b-4915-88a4-521fc8b59366_1637050264_hls.m3u8',
+        },
+        mp4: {},
+        thumbnails: {},
+      },
+    });
+    mockGetResource.mockResolvedValue(requestStatus.SUCCESS);
+
+    fetchMock.mock(
+      'https://c223d9abb67d57c7.mediapackage.eu-west-1.amazonaws.com/out/v1/0a5924bddfff4fe68e8c10a2a671a503/dev-manu_030aaea4-bb0b-4915-88a4-521fc8b59366_1637050264_hls.m3u8',
+      `
+      #EXTM3U
+      #EXT-X-VERSION:3
+      #EXT-X-INDEPENDENT-SEGMENTS
+      #EXT-X-STREAM-INF:BANDWIDTH=1404480,AVERAGE-BANDWIDTH=1205600,RESOLUTION=854x480,FRAME-RATE=24.000,CODECS="avc1.640029,mp4a.40.2"
+      dev-manu_030aaea4-bb0b-4915-88a4-521fc8b59366_1637050264_hls_1.m3u8
+      #EXT-X-STREAM-INF:BANDWIDTH=4440449,AVERAGE-BANDWIDTH=3735564,RESOLUTION=1280x720,FRAME-RATE=24.000,CODECS="avc1.640029,mp4a.40.2"
+      dev-manu_030aaea4-bb0b-4915-88a4-521fc8b59366_1637050264_hls_2.m3u8
+      #EXT-X-STREAM-INF:BANDWIDTH=518276,AVERAGE-BANDWIDTH=455345,RESOLUTION=426x240,FRAME-RATE=24.000,CODECS="avc1.4D401E,mp4a.40.2"
+      dev-manu_030aaea4-bb0b-4915-88a4-521fc8b59366_1637050264_hls_3.m3u8
+      `,
+    );
+
+    fetchMock.mock(
+      'https://c223d9abb67d57c7.mediapackage.eu-west-1.amazonaws.com/out/v1/0a5924bddfff4fe68e8c10a2a671a503/dev-manu_030aaea4-bb0b-4915-88a4-521fc8b59366_1637050264_hls_1.m3u8',
+      `
+      #EXTM3U
+      #EXT-X-VERSION:3
+      #EXT-X-TARGETDURATION:4
+      #EXT-X-MEDIA-SEQUENCE:848
+      #EXT-X-DISCONTINUITY-SEQUENCE:21
+      #EXTINF:1.500,
+      dev-manu_030aaea4-bb0b-4915-88a4-521fc8b59366_1637050264_hls_1_848.ts?m=1637050263
+      #EXT-X-ENDLIST
+      `,
+    );
+
+    resumeLive(video);
+
+    await waitFor(() => {
+      expect(
+        fetchMock.calls(
+          'https://c223d9abb67d57c7.mediapackage.eu-west-1.amazonaws.com/out/v1/0a5924bddfff4fe68e8c10a2a671a503/dev-manu_030aaea4-bb0b-4915-88a4-521fc8b59366_1637050264_hls.m3u8',
+          {
+            method: 'GET',
+          },
+        ),
+      ).toHaveLength(1);
+    });
+    expect(mockGetResource).not.toHaveBeenCalled();
+
+    await waitFor(() => {
+      expect(
+        fetchMock.calls(
+          'https://c223d9abb67d57c7.mediapackage.eu-west-1.amazonaws.com/out/v1/0a5924bddfff4fe68e8c10a2a671a503/dev-manu_030aaea4-bb0b-4915-88a4-521fc8b59366_1637050264_hls_1.m3u8',
+          {
+            method: 'GET',
+          },
+        ),
+      ).toHaveLength(1);
+    });
+    expect(mockGetResource).not.toHaveBeenCalled();
+
+    jest.advanceTimersToNextTimer();
+
+    await waitFor(() => {
+      expect(
+        fetchMock.calls(
+          'https://c223d9abb67d57c7.mediapackage.eu-west-1.amazonaws.com/out/v1/0a5924bddfff4fe68e8c10a2a671a503/dev-manu_030aaea4-bb0b-4915-88a4-521fc8b59366_1637050264_hls_1.m3u8',
+          {
+            method: 'GET',
+          },
+        ),
+      ).toHaveLength(2);
+    });
+    expect(mockGetResource).not.toHaveBeenCalled();
+
+    fetchMock.mock(
+      'https://c223d9abb67d57c7.mediapackage.eu-west-1.amazonaws.com/out/v1/0a5924bddfff4fe68e8c10a2a671a503/dev-manu_030aaea4-bb0b-4915-88a4-521fc8b59366_1637050264_hls_1.m3u8',
+      `
+      #EXTM3U
+      #EXT-X-VERSION:3
+      #EXT-X-TARGETDURATION:4
+      #EXT-X-MEDIA-SEQUENCE:848
+      #EXT-X-DISCONTINUITY-SEQUENCE:21
+      #EXTINF:1.500,
+      dev-manu_030aaea4-bb0b-4915-88a4-521fc8b59366_1637050264_hls_1_848.ts?m=1637050263
+      `,
+      {
+        overwriteRoutes: true,
+      },
+    );
+
+    jest.advanceTimersToNextTimer();
+
+    await waitFor(() => {
+      expect(mockGetResource).toHaveBeenCalledWith(modelName.VIDEOS, video.id);
+    });
+  });
+});

--- a/src/frontend/utils/resumeLive.ts
+++ b/src/frontend/utils/resumeLive.ts
@@ -1,0 +1,38 @@
+// module responsible to fetch an HLS manifest and detect when tag
+// EXT-X-ENDLIST has been removed in it.
+import { Parser } from 'm3u8-parser';
+
+import { getResource } from 'data/sideEffects/getResource';
+import { modelName } from 'types/models';
+import { Video } from 'types/tracks';
+
+const regex = /^(https.*)\/.*\.m3u8$/;
+
+export const resumeLive = async (video: Video) => {
+  const manifestUrl = video.urls?.manifests.hls!;
+
+  const mainManifest = await fetchManifest(manifestUrl);
+  const firstManifest = mainManifest.playlists[0].uri;
+  const matches = manifestUrl.match(regex);
+
+  await pollEndedManifest(`${matches![1]}/${firstManifest}`);
+  await getResource(modelName.VIDEOS, video.id);
+};
+
+const pollEndedManifest = async (manifestUrl: string) => {
+  const manifest = await fetchManifest(manifestUrl);
+
+  if (manifest.endList) {
+    await new Promise((resolve) => window.setTimeout(resolve, 2500));
+    await pollEndedManifest(manifestUrl);
+  }
+};
+
+const fetchManifest = async (manifestUrl: string) => {
+  const manifest = await fetch(manifestUrl).then((response) => response.text());
+  const hlsParser = new Parser();
+  hlsParser.push(manifest);
+  hlsParser.end();
+
+  return hlsParser.manifest;
+};


### PR DESCRIPTION
## Purpose

in #1207 we managed all the mechanism allowing an instructor to start and stop the live. Once this done we have to manage this feature for a student.
We have to pause the player once the live paused and then resume it without interruption once the live resumed itself.



## Proposal

A dedicated component is created to manage a live once this one paused. It adds a layer over the player, displaying a waiting message and since when the live is paused.
To detect when the live is paused, we listen the video `pause` event and if in this event the video is a live and the video is ended, we fetch the video to refresh its state.
To detect when the live is resumed, the HLS manifest poll and parsed to see if the #EXT-X-ENDLIST` tag is removed. When removed, we can refresh the video to start it again.

- [x] create `<PublicPausedLiveVideo />` managing paused live 
- [x] detect when a live is resumed to update video store 
- [x] reload videojs sources once live resumed 
