### PR TITLE
🔧(settings) change BBB_API_SECRET setting type

### DIFF
--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -237,7 +237,7 @@ class Base(Configuration):
     # BBB
     BBB_ENABLED = values.BooleanValue(False)
     BBB_API_ENDPOINT = values.Value()
-    BBB_API_SECRET = values.SecretValue()
+    BBB_API_SECRET = values.Value(None)
 
     # Cloud Front key pair for signed urls
     CLOUDFRONT_ACCESS_KEY_ID = values.Value(None)


### PR DESCRIPTION
## Purpose

As BBB usage is optional, BBB_API_SECRET, it shouldn't be mandatory to set it.

## Proposal

BBB_API_SECRET has been moved from SecretValue to Value, so it can be defaulted.
