### PR TITLE
✨(frontend) create store to control live layout panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Add a form to create a scheduled video on the Dashboard
 - Add frontend components to register an email for scheduled webinars
 - Add API endpoints to pair an external device to Jitsi live videos
+- Add a store in the frontend to control live layout
 
 ### Changed
 

--- a/src/frontend/data/stores/useLivePanelState/index.spec.ts
+++ b/src/frontend/data/stores/useLivePanelState/index.spec.ts
@@ -1,0 +1,297 @@
+import { LivePanelItem, useLivePanelState } from '.';
+
+describe('useLivePanelState()', () => {
+  it('init with default values', () => {
+    expect(useLivePanelState.getState().availableItems).toEqual([]);
+    expect(useLivePanelState.getState().currentItem).toEqual(undefined);
+    expect(useLivePanelState.getState().isPanelVisible).toBe(false);
+  });
+});
+
+describe('state.setAvailableItems()', () => {
+  it('has no side effect without change', () => {
+    useLivePanelState.setState({
+      isPanelVisible: true,
+      currentItem: LivePanelItem.CHAT,
+      availableItems: [LivePanelItem.APPLICATION, LivePanelItem.CHAT],
+    });
+
+    //  do not change the state with item to select
+    useLivePanelState
+      .getState()
+      .setAvailableItems(
+        [LivePanelItem.APPLICATION, LivePanelItem.CHAT],
+        LivePanelItem.CHAT,
+      );
+
+    expect(useLivePanelState.getState().availableItems).toEqual([
+      LivePanelItem.APPLICATION,
+      LivePanelItem.CHAT,
+    ]);
+    expect(useLivePanelState.getState().currentItem).toEqual(
+      LivePanelItem.CHAT,
+    );
+    expect(useLivePanelState.getState().isPanelVisible).toBe(true);
+  });
+
+  it('closes the panel and reset selected item with empty available items', () => {
+    useLivePanelState.setState({
+      isPanelVisible: true,
+      currentItem: LivePanelItem.CHAT,
+      availableItems: [LivePanelItem.APPLICATION, LivePanelItem.CHAT],
+    });
+
+    //  empty available items close the panel and select nothing
+    useLivePanelState.getState().setAvailableItems([]);
+
+    expect(useLivePanelState.getState().availableItems).toEqual([]);
+    expect(useLivePanelState.getState().currentItem).toEqual(undefined);
+    expect(useLivePanelState.getState().isPanelVisible).toBe(false);
+  });
+
+  it('updates available items and do not changes currentItem when it is still available', () => {
+    useLivePanelState.setState({
+      isPanelVisible: true,
+      currentItem: LivePanelItem.CHAT,
+      availableItems: [LivePanelItem.APPLICATION, LivePanelItem.CHAT],
+    });
+
+    //  configure available items
+    useLivePanelState.getState().setAvailableItems([LivePanelItem.CHAT]);
+
+    expect(useLivePanelState.getState().availableItems).toEqual([
+      LivePanelItem.CHAT,
+    ]);
+    expect(useLivePanelState.getState().currentItem).toEqual(
+      LivePanelItem.CHAT,
+    );
+    expect(useLivePanelState.getState().isPanelVisible).toBe(true);
+  });
+
+  it('updates available items and current item selected with a valid current item (within set available items)', () => {
+    useLivePanelState.setState({
+      isPanelVisible: true,
+      currentItem: LivePanelItem.CHAT,
+      availableItems: [LivePanelItem.APPLICATION, LivePanelItem.CHAT],
+    });
+
+    //  update with valid current selection
+    useLivePanelState
+      .getState()
+      .setAvailableItems(
+        [LivePanelItem.JOIN_DISCUSSION, LivePanelItem.APPLICATION],
+        LivePanelItem.APPLICATION,
+      );
+
+    expect(useLivePanelState.getState().availableItems).toEqual([
+      LivePanelItem.JOIN_DISCUSSION,
+      LivePanelItem.APPLICATION,
+    ]);
+    expect(useLivePanelState.getState().currentItem).toEqual(
+      LivePanelItem.APPLICATION,
+    );
+    expect(useLivePanelState.getState().isPanelVisible).toBe(true);
+  });
+
+  it('updates available items and prevents currentItem not beeing available (aka not within availableItems)', () => {
+    useLivePanelState.setState({
+      isPanelVisible: true,
+      currentItem: LivePanelItem.CHAT,
+      availableItems: [LivePanelItem.APPLICATION, LivePanelItem.CHAT],
+    });
+
+    //  update with invalid current selection
+    useLivePanelState
+      .getState()
+      .setAvailableItems(
+        [LivePanelItem.JOIN_DISCUSSION],
+        LivePanelItem.APPLICATION,
+      );
+
+    expect(useLivePanelState.getState().availableItems).toEqual([
+      LivePanelItem.JOIN_DISCUSSION,
+    ]);
+    expect(useLivePanelState.getState().currentItem).toEqual(
+      LivePanelItem.JOIN_DISCUSSION,
+    );
+    expect(useLivePanelState.getState().isPanelVisible).toBe(true);
+  });
+
+  it('removes current item from available ones and automatically selects the first one available', () => {
+    useLivePanelState.setState({
+      isPanelVisible: true,
+      currentItem: LivePanelItem.CHAT,
+      availableItems: [LivePanelItem.APPLICATION, LivePanelItem.CHAT],
+    });
+
+    //  restrict available items
+    useLivePanelState
+      .getState()
+      .setAvailableItems([
+        LivePanelItem.APPLICATION,
+        LivePanelItem.JOIN_DISCUSSION,
+      ]);
+
+    expect(useLivePanelState.getState().availableItems).toEqual([
+      LivePanelItem.APPLICATION,
+      LivePanelItem.JOIN_DISCUSSION,
+    ]);
+    expect(useLivePanelState.getState().currentItem).toEqual(
+      LivePanelItem.APPLICATION,
+    );
+    expect(useLivePanelState.getState().isPanelVisible).toBe(true);
+  });
+
+  it('ensures unicity in available states', () => {
+    useLivePanelState.setState({
+      isPanelVisible: true,
+      currentItem: LivePanelItem.CHAT,
+      availableItems: [LivePanelItem.APPLICATION, LivePanelItem.CHAT],
+    });
+
+    useLivePanelState
+      .getState()
+      .setAvailableItems([
+        LivePanelItem.APPLICATION,
+        LivePanelItem.APPLICATION,
+      ]);
+
+    expect(useLivePanelState.getState().availableItems).toEqual([
+      LivePanelItem.APPLICATION,
+    ]);
+    expect(useLivePanelState.getState().currentItem).toEqual(
+      LivePanelItem.APPLICATION,
+    );
+    expect(useLivePanelState.getState().isPanelVisible).toBe(true);
+  });
+});
+
+describe('state.setPanelVisibility()', () => {
+  it('has no side effect', () => {
+    useLivePanelState.setState({
+      availableItems: [LivePanelItem.APPLICATION, LivePanelItem.CHAT],
+      currentItem: LivePanelItem.CHAT,
+      isPanelVisible: true,
+    });
+
+    //  do not change the state with item to select
+    useLivePanelState.getState().setPanelVisibility(true, LivePanelItem.CHAT);
+
+    expect(useLivePanelState.getState().isPanelVisible).toBe(true);
+    expect(useLivePanelState.getState().currentItem).toEqual(
+      LivePanelItem.CHAT,
+    );
+    expect(useLivePanelState.getState().availableItems).toEqual([
+      LivePanelItem.APPLICATION,
+      LivePanelItem.CHAT,
+    ]);
+  });
+
+  it('updates the state changing selection with a valid item', () => {
+    useLivePanelState.setState({
+      availableItems: [LivePanelItem.APPLICATION, LivePanelItem.CHAT],
+      currentItem: LivePanelItem.CHAT,
+      isPanelVisible: true,
+    });
+
+    //  update current item with valid item
+    useLivePanelState
+      .getState()
+      .setPanelVisibility(true, LivePanelItem.APPLICATION);
+
+    expect(useLivePanelState.getState().isPanelVisible).toBe(true);
+    expect(useLivePanelState.getState().currentItem).toEqual(
+      LivePanelItem.APPLICATION,
+    );
+    expect(useLivePanelState.getState().availableItems).toEqual([
+      LivePanelItem.APPLICATION,
+      LivePanelItem.CHAT,
+    ]);
+  });
+
+  it('does not update the state changing selection with an invalid item', () => {
+    useLivePanelState.setState({
+      availableItems: [LivePanelItem.APPLICATION, LivePanelItem.CHAT],
+      currentItem: LivePanelItem.CHAT,
+      isPanelVisible: true,
+    });
+
+    //  update current item with invalid item
+    useLivePanelState
+      .getState()
+      .setPanelVisibility(true, LivePanelItem.JOIN_DISCUSSION);
+
+    expect(useLivePanelState.getState().isPanelVisible).toBe(true);
+    expect(useLivePanelState.getState().currentItem).toEqual(
+      LivePanelItem.CHAT,
+    );
+    expect(useLivePanelState.getState().availableItems).toEqual([
+      LivePanelItem.APPLICATION,
+      LivePanelItem.CHAT,
+    ]);
+  });
+
+  it('updates the state closing the panel', () => {
+    useLivePanelState.setState({
+      availableItems: [LivePanelItem.APPLICATION, LivePanelItem.CHAT],
+      currentItem: LivePanelItem.CHAT,
+      isPanelVisible: true,
+    });
+
+    //  update panel visibility
+    useLivePanelState.getState().setPanelVisibility(false);
+
+    expect(useLivePanelState.getState().isPanelVisible).toBe(false);
+    expect(useLivePanelState.getState().currentItem).toEqual(
+      LivePanelItem.CHAT,
+    );
+    expect(useLivePanelState.getState().availableItems).toEqual([
+      LivePanelItem.APPLICATION,
+      LivePanelItem.CHAT,
+    ]);
+  });
+
+  it('updates the state closing the panel and changing selection with a valid item', () => {
+    useLivePanelState.setState({
+      availableItems: [LivePanelItem.APPLICATION, LivePanelItem.CHAT],
+      currentItem: LivePanelItem.CHAT,
+      isPanelVisible: true,
+    });
+
+    //  update panel visibility with valid item to select
+    useLivePanelState
+      .getState()
+      .setPanelVisibility(false, LivePanelItem.APPLICATION);
+
+    expect(useLivePanelState.getState().isPanelVisible).toBe(false);
+    expect(useLivePanelState.getState().currentItem).toEqual(
+      LivePanelItem.APPLICATION,
+    );
+    expect(useLivePanelState.getState().availableItems).toEqual([
+      LivePanelItem.APPLICATION,
+      LivePanelItem.CHAT,
+    ]);
+  });
+
+  it('closes the panel and leave current item untouched', () => {
+    useLivePanelState.setState({
+      availableItems: [LivePanelItem.APPLICATION, LivePanelItem.CHAT],
+      currentItem: LivePanelItem.CHAT,
+      isPanelVisible: true,
+    });
+
+    //  update panel visibility with invalid item to select
+    useLivePanelState
+      .getState()
+      .setPanelVisibility(false, LivePanelItem.JOIN_DISCUSSION);
+
+    expect(useLivePanelState.getState().isPanelVisible).toBe(false);
+    expect(useLivePanelState.getState().currentItem).toEqual(
+      LivePanelItem.CHAT,
+    );
+    expect(useLivePanelState.getState().availableItems).toEqual([
+      LivePanelItem.APPLICATION,
+      LivePanelItem.CHAT,
+    ]);
+  });
+});

--- a/src/frontend/data/stores/useLivePanelState/index.ts
+++ b/src/frontend/data/stores/useLivePanelState/index.ts
@@ -1,0 +1,80 @@
+import create from 'zustand';
+
+export enum LivePanelItem {
+  JOIN_DISCUSSION = 'JOIN_DISCUSSION',
+  CHAT = 'CHAT',
+  APPLICATION = 'APPLICATION',
+}
+
+type State = {
+  /**
+   * By default, panel is not visible and doesn't support any item
+   */
+  availableItems: LivePanelItem[];
+  currentItem?: LivePanelItem;
+  isPanelVisible: boolean;
+  /**
+   * config the store to set available items and current selection
+   * @param items all available items in the panel
+   * @param itemToSelect optional item to select
+   * this item must be present in { @see items }
+   * @returns void
+   */
+  setAvailableItems: (
+    items: LivePanelItem[],
+    itemToSelect?: LivePanelItem,
+  ) => void;
+  /**
+   * open or close the panel and optionally change the selection in the panel
+   * @param isVisible visibility state wanted
+   * @param itemToSelect item we want to display in the panel,
+   * this item must be available in { @see state.availableItems }
+   * else item selection wont change
+   * @returns void
+   */
+  setPanelVisibility: (
+    isVisible: boolean,
+    itemToSelect?: LivePanelItem,
+  ) => void;
+};
+
+export const useLivePanelState = create<State>((set) => ({
+  availableItems: [],
+  currentItem: undefined,
+  isPanelVisible: false,
+  setAvailableItems: (items, itemToSelect) =>
+    set((state) => ({
+      //  update available items
+      availableItems: Array.from(new Set(items)),
+      //  close the pane if there is nothing to display in the panel
+      isPanelVisible: state.isPanelVisible && items.length > 0,
+      //  check item to select is within available items
+      //  this is an invariant for components using the store
+      currentItem:
+        //  if target item is defined and available
+        itemToSelect && items.includes(itemToSelect)
+          ? //  select it
+            itemToSelect
+          : //  else try current item
+          state.currentItem && items.includes(state.currentItem)
+          ? //  select it
+            state.currentItem
+          : //  else try available items
+          items.length > 0
+          ? //  select it
+            items[0]
+          : //  else pane will be closed
+            undefined,
+    })),
+  setPanelVisibility: (isVisible, itemToSelect) =>
+    set((state) => ({
+      //  update panel visibility
+      isPanelVisible: isVisible,
+      //  check item to select is within available items
+      //  this is an invariant for components using the store
+      currentItem:
+        itemToSelect && state.availableItems.includes(itemToSelect)
+          ? itemToSelect
+          : state.currentItem,
+    })),
+}));


### PR DESCRIPTION
## Purpose

New live layout needs to be control, we use a store to save the state and control the layout

## Proposal

Create the store and test functions exposed to control its state
The state will contains:
- the status of the panel (open or close)
- the list of available tabs (called detail) we can display in the panel
- the current detail selected
And 2 functions to update the state
