### PR TITLE
🐛(front) update store while waiting for live

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Users with wrong email in token is properly detected as registered
 - Users waiting on the registration page are redirected if video is started 
   earlier
+- Update store in the WaitingLiveVideo component 
 
 ### Removed
 

--- a/src/frontend/Player/createPlayer.spec.ts
+++ b/src/frontend/Player/createPlayer.spec.ts
@@ -1,12 +1,10 @@
 import { waitFor } from '@testing-library/react';
 import fetchMock from 'fetch-mock';
-
-import { videoMockFactory } from '../utils/tests/factories';
+import { liveState } from 'types/tracks';
+import { report } from 'utils/errors/report';
+import { videoMockFactory } from 'utils/tests/factories';
 import { createPlayer } from './createPlayer';
 import { createVideojsPlayer } from './createVideojsPlayer';
-import { liveState } from '../types/tracks';
-import { report } from '../utils/errors/report';
-
 jest.mock('jwt-decode', () => {
   return jest.fn().mockImplementation(() => ({
     locale: 'en',
@@ -14,7 +12,7 @@ jest.mock('jwt-decode', () => {
   }));
 });
 
-jest.mock('../data/appData', () => ({
+jest.mock('data/appData', () => ({
   appData: {
     flags: {},
     jwt: 'foo',
@@ -22,7 +20,7 @@ jest.mock('../data/appData', () => ({
 }));
 
 jest.mock('./createVideojsPlayer');
-jest.mock('../utils/errors/report');
+jest.mock('utils/errors/report');
 
 describe('createPlayer', () => {
   beforeEach(() => {

--- a/src/frontend/Player/createPlayer.ts
+++ b/src/frontend/Player/createPlayer.ts
@@ -11,7 +11,7 @@ export const createPlayer: VideoPlayerCreator = async (
 ) => {
   if (video.live_state) {
     ref.classList.add('offscreen');
-    await pollForLive(video.urls!);
+    await pollForLive(video);
     ref.classList.remove('offscreen');
   }
 

--- a/src/frontend/components/UploadManager/LTIUploadHandlers.spec.tsx
+++ b/src/frontend/components/UploadManager/LTIUploadHandlers.spec.tsx
@@ -2,24 +2,23 @@ import { render, waitFor } from '@testing-library/react';
 import React from 'react';
 import { v4 as uuidv4 } from 'uuid';
 
-import { getResource as fetchResource } from '../../data/sideEffects/getResource';
-import { updateResource } from '../../data/sideEffects/updateResource';
-import { addResource, getResource } from '../../data/stores/generics';
-import { requestStatus } from '../../types/api';
-import { modelName } from '../../types/models';
-import { Thumbnail, Video } from '../../types/tracks';
+import { getResource as fetchResource } from 'data/sideEffects/getResource';
+import { updateResource } from 'data/sideEffects/updateResource';
+import { addResource, getResource } from 'data/stores/generics';
+import { modelName } from 'types/models';
+import { Thumbnail, Video } from 'types/tracks';
 import { LTIUploadHandlers } from './LTIUploadHandlers';
 import { UploadManagerContext, UploadManagerStatus } from '.';
 
-jest.mock('../../data/appData', () => ({}));
-jest.mock('../../data/sideEffects/updateResource', () => ({
+jest.mock('data/appData', () => ({}));
+jest.mock('data/sideEffects/updateResource', () => ({
   updateResource: jest.fn(),
 }));
-jest.mock('../../data/stores/generics', () => ({
+jest.mock('data/stores/generics', () => ({
   addResource: jest.fn(),
   getResource: jest.fn(),
 }));
-jest.mock('../../data/sideEffects/getResource', () => ({
+jest.mock('data/sideEffects/getResource', () => ({
   getResource: jest.fn(),
 }));
 
@@ -94,7 +93,7 @@ describe('<LTIUploadHandlers />', () => {
   });
 
   it('fetch the resource when the upload manager status is UPLOADING', async () => {
-    mockFetResource.mockResolvedValue(requestStatus.SUCCESS);
+    mockFetResource.mockResolvedValue(object);
 
     const { rerender } = render(
       <UploadManagerContext.Provider

--- a/src/frontend/components/WaitingLiveVideo/index.spec.tsx
+++ b/src/frontend/components/WaitingLiveVideo/index.spec.tsx
@@ -2,21 +2,20 @@ import { render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 
 import { getResource } from '../../data/sideEffects/getResource';
-import { pollForLive } from '../../data/sideEffects/pollForLive';
-import { requestStatus } from '../../types/api';
-import { modelName } from '../../types/models';
-import { videoMockFactory } from '../../utils/tests/factories';
-import { wrapInIntlProvider } from '../../utils/tests/intl';
+import { pollForLive } from 'data/sideEffects/pollForLive';
+import { modelName } from 'types/models';
+import { videoMockFactory } from 'utils/tests/factories';
+import { wrapInIntlProvider } from 'utils/tests/intl';
 import { WaitingLiveVideo } from '.';
 
-jest.mock('../../data/appData', () => ({
+jest.mock('data/appData', () => ({
   appData: {},
 }));
 
-jest.mock('../../data/sideEffects/getResource', () => ({
+jest.mock('data/sideEffects/getResource', () => ({
   getResource: jest.fn(),
 }));
-jest.mock('../../data/sideEffects/pollForLive', () => ({
+jest.mock('data/sideEffects/pollForLive', () => ({
   pollForLive: jest.fn(),
 }));
 const mockGetResource = getResource as jest.MockedFunction<typeof getResource>;
@@ -51,7 +50,7 @@ describe('WaitingLiveVideo', () => {
     });
 
     mockPollForLive.mockResolvedValue(null);
-    mockGetResource.mockResolvedValue(requestStatus.SUCCESS);
+    mockGetResource.mockResolvedValue(video);
 
     render(wrapInIntlProvider(<WaitingLiveVideo video={video} />));
 
@@ -65,6 +64,6 @@ describe('WaitingLiveVideo', () => {
     });
 
     expect(mockGetResource).toHaveBeenCalledWith(modelName.VIDEOS, video.id);
-    expect(mockPollForLive).toHaveBeenCalledWith(video.urls);
+    expect(mockPollForLive).toHaveBeenCalledWith(video);
   });
 });

--- a/src/frontend/components/WaitingLiveVideo/index.tsx
+++ b/src/frontend/components/WaitingLiveVideo/index.tsx
@@ -49,7 +49,7 @@ interface WaitingLiveVideoProps {
 export const WaitingLiveVideo = ({ video }: WaitingLiveVideoProps) => {
   useAsyncEffect(async () => {
     if (video) {
-      await pollForLive(video.urls!);
+      await pollForLive(video);
       await getResource(modelName.VIDEOS, video.id);
     }
   }, []);

--- a/src/frontend/data/sideEffects/getResource/index.spec.tsx
+++ b/src/frontend/data/sideEffects/getResource/index.spec.tsx
@@ -40,13 +40,13 @@ describe('sideEffects/getResource', () => {
       }),
     );
 
-    const status = await getResource(modelName.VIDEOS, video.id);
+    const newVideo = await getResource(modelName.VIDEOS, video.id);
 
-    expect(status).toEqual(requestStatus.SUCCESS);
-    expect(mockAddResource).toHaveBeenCalledWith(modelName.VIDEOS, {
+    expect(newVideo).toEqual({
       ...video,
       title: 'updated title',
     });
+    expect(mockAddResource).toHaveBeenCalledWith(modelName.VIDEOS, newVideo);
   });
 
   it('resolves with a failure and handles it when it fails to get the resource (local)', async () => {

--- a/src/frontend/data/sideEffects/getResource/index.tsx
+++ b/src/frontend/data/sideEffects/getResource/index.tsx
@@ -1,9 +1,10 @@
-import { requestStatus } from '../../../types/api';
-import { API_ENDPOINT } from '../../../settings';
-import { modelName } from '../../../types/models';
-import { appData } from '../../appData';
-import { addResource } from '../../stores/generics';
-import { report } from '../../../utils/errors/report';
+import { appData } from 'data/appData';
+import { addResource } from 'data/stores/generics';
+import { requestStatus } from 'types/api';
+import { modelName } from 'types/models';
+import { UploadableObject } from 'types/tracks';
+import { report } from 'utils/errors/report';
+import { API_ENDPOINT } from 'settings';
 
 /**
  * Fetch a resource to update its state in our store.
@@ -14,7 +15,7 @@ import { report } from '../../../utils/errors/report';
 export async function getResource(
   resourceName: modelName,
   resourceId: string,
-): Promise<requestStatus> {
+): Promise<UploadableObject | requestStatus.FAILURE> {
   const endpoint = `${API_ENDPOINT}/${resourceName}/${resourceId}/`;
 
   try {
@@ -30,9 +31,9 @@ export async function getResource(
         `Failed to fetch resource ${resourceName} with id ${resourceId}`,
       );
     }
-
-    await addResource(resourceName, await response.json());
-    return requestStatus.SUCCESS;
+    const resource = await response.json();
+    await addResource(resourceName, resource);
+    return resource;
   } catch (error) {
     report(error);
     return requestStatus.FAILURE;

--- a/src/frontend/data/sideEffects/pollForLive/index.spec.tsx
+++ b/src/frontend/data/sideEffects/pollForLive/index.spec.tsx
@@ -1,9 +1,13 @@
 import { waitFor } from '@testing-library/react';
 import fetchMock from 'fetch-mock';
-
-import { videoMockFactory } from '../../../utils/tests/factories';
+import { useVideo } from 'data/stores/useVideo';
+import { videoMockFactory } from 'utils/tests/factories';
 import { pollForLive } from '.';
 
+jest.mock('data/appData', () => ({
+  appData: {},
+  getDecodedJwt: () => ({}),
+}));
 describe('createPlayer', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -27,8 +31,7 @@ describe('createPlayer', () => {
         thumbnails: {},
       },
     });
-
-    pollForLive(video.urls!);
+    pollForLive(video);
 
     await waitFor(() => {
       expect(
@@ -50,6 +53,47 @@ describe('createPlayer', () => {
           method: 'GET',
         }),
       ).toHaveLength(2);
+    });
+  });
+
+  it('polls while the video has no manifest', async () => {
+    const video = videoMockFactory({ urls: null });
+    fetchMock.get(`/api/videos/${video.id}/`, video);
+
+    fetchMock.get('https://marsha.education/live.m3u8', 200);
+
+    pollForLive(video);
+    await waitFor(() =>
+      expect(fetchMock.calls(`/api/videos/${video.id}/`)).toHaveLength(1),
+    );
+    expect(useVideo.getState().videos[video.id]).toEqual(video);
+
+    const newDataVideo = {
+      ...video,
+      urls: {
+        manifests: {
+          hls: 'https://marsha.education/live.m3u8',
+        },
+        mp4: {},
+        thumbnails: {},
+      },
+    };
+    fetchMock.get(`/api/videos/${video.id}/`, newDataVideo, {
+      overwriteRoutes: true,
+    });
+
+    jest.advanceTimersToNextTimer();
+    await waitFor(() =>
+      expect(fetchMock.calls(`/api/videos/${video.id}/`)).toHaveLength(2),
+    );
+    expect(useVideo.getState().videos[video.id]).toEqual(newDataVideo);
+    jest.advanceTimersToNextTimer();
+    await waitFor(() => {
+      expect(
+        fetchMock.calls('https://marsha.education/live.m3u8', {
+          method: 'GET',
+        }),
+      ).toHaveLength(1);
     });
   });
 });

--- a/src/frontend/data/sideEffects/pollForLive/index.tsx
+++ b/src/frontend/data/sideEffects/pollForLive/index.tsx
@@ -1,17 +1,26 @@
-import { VideoUrls } from '../../../types/tracks';
+import { getResource } from 'data/sideEffects/getResource';
+import { modelName } from 'types/models';
+import { Video } from 'types/tracks';
 
 export const pollForLive = async (
-  urls: VideoUrls,
+  video: Video,
   timeout: number = 2000,
 ): Promise<null> => {
   try {
-    const response = await fetch(urls.manifests.hls);
+    if (!video.urls || !video.urls.manifests.hls) {
+      throw new Error('no url defined');
+    }
+    const response = await fetch(video.urls.manifests.hls);
     if (response.status === 404) {
       throw new Error('missing manifest');
     }
   } catch (error) {
+    if (!video.urls || !video.urls.manifests.hls) {
+      video = (await getResource(modelName.VIDEOS, video.id)) as Video;
+    }
     await new Promise((resolve) => window.setTimeout(resolve, timeout));
-    return await pollForLive(urls);
+
+    return await pollForLive(video);
   }
 
   return null;

--- a/src/frontend/utils/resumeLive.spec.ts
+++ b/src/frontend/utils/resumeLive.spec.ts
@@ -2,7 +2,6 @@ import { waitFor } from '@testing-library/react';
 import fetchMock from 'fetch-mock';
 
 import { getResource } from 'data/sideEffects/getResource';
-import { requestStatus } from 'types/api';
 import { modelName } from 'types/models';
 
 import { videoMockFactory } from './tests/factories';
@@ -41,7 +40,7 @@ describe('resumeLive', () => {
         thumbnails: {},
       },
     });
-    mockGetResource.mockResolvedValue(requestStatus.SUCCESS);
+    mockGetResource.mockResolvedValue(video);
 
     fetchMock.mock(
       'https://c223d9abb67d57c7.mediapackage.eu-west-1.amazonaws.com/out/v1/0a5924bddfff4fe68e8c10a2a671a503/dev-manu_030aaea4-bb0b-4915-88a4-521fc8b59366_1637050264_hls.m3u8',


### PR DESCRIPTION

## Purpose

If urls of video are not created loading the component WaitingLiveVideo,
live will never be able to start as video object is not updated.
We update the store in this specific case.

## Proposal

update store in pollVideo

