### PR TITLE
⚡️(frontend) specific timeout set while manifest is not ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Users waiting on the registration page are redirected if video is started 
   earlier
 - Update store in the WaitingLiveVideo component 
+- Set specific timeout to 30 seconds in pollForLive to update the store
 
 ### Removed
 

--- a/src/frontend/data/sideEffects/pollForLive/index.spec.tsx
+++ b/src/frontend/data/sideEffects/pollForLive/index.spec.tsx
@@ -58,6 +58,7 @@ describe('createPlayer', () => {
 
   it('polls while the video has no manifest', async () => {
     const video = videoMockFactory({ urls: null });
+    jest.spyOn(global, 'setTimeout');
     fetchMock.get(`/api/videos/${video.id}/`, video);
 
     fetchMock.get('https://marsha.education/live.m3u8', 200);
@@ -83,11 +84,16 @@ describe('createPlayer', () => {
     });
 
     jest.advanceTimersToNextTimer();
+    // video.url doesn't exist timer must be every 30 seconds
+    expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 30000);
     await waitFor(() =>
       expect(fetchMock.calls(`/api/videos/${video.id}/`)).toHaveLength(2),
     );
     expect(useVideo.getState().videos[video.id]).toEqual(newDataVideo);
+    // video.url exists timer must be every 2 seconds
     jest.advanceTimersToNextTimer();
+    expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 2000);
+
     await waitFor(() => {
       expect(
         fetchMock.calls('https://marsha.education/live.m3u8', {

--- a/src/frontend/data/sideEffects/pollForLive/index.tsx
+++ b/src/frontend/data/sideEffects/pollForLive/index.tsx
@@ -2,10 +2,7 @@ import { getResource } from 'data/sideEffects/getResource';
 import { modelName } from 'types/models';
 import { Video } from 'types/tracks';
 
-export const pollForLive = async (
-  video: Video,
-  timeout: number = 2000,
-): Promise<null> => {
+export const pollForLive = async (video: Video): Promise<null> => {
   try {
     if (!video.urls || !video.urls.manifests.hls) {
       throw new Error('no url defined');
@@ -18,7 +15,12 @@ export const pollForLive = async (
     if (!video.urls || !video.urls.manifests.hls) {
       video = (await getResource(modelName.VIDEOS, video.id)) as Video;
     }
-    await new Promise((resolve) => window.setTimeout(resolve, timeout));
+    await new Promise((resolve) =>
+      window.setTimeout(
+        resolve,
+        !video.urls || !video.urls.manifests.hls ? 30000 : 2000,
+      ),
+    );
 
     return await pollForLive(video);
   }


### PR DESCRIPTION


## Purpose

When users are waiting for the live to start, there is two different
cases. The first one, urls of the manifest exist and in that case, we
only fetch this url, having a timeout of two seconds is fine. The
second case is when the video doesn't have a manifest ready to read,
we then need to fetch the API to update the video store. We want to
wait another 30 seconds in this case not to load our server.

## Proposal

Setting timeout to 30 seconds to update the store, 2 seconds otherwise

