### PR TITLE
Prepare 3.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.27.0] - 2021-12-07
+
 ### Added
 
 - Prepare backend to manage apps
@@ -952,7 +954,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Minor fixes and improvements on features and tests
 
-[unreleased]: https://github.com/openfun/marsha/compare/v3.26.0...master
+[unreleased]: https://github.com/openfun/marsha/compare/v3.27.0...master
+[3.27.0]: https://github.com/openfun/marsha/compare/v3.26.0...v3.27.0
 [3.26.0]: https://github.com/openfun/marsha/compare/v3.25.0...v3.26.0
 [3.25.0]: https://github.com/openfun/marsha/compare/v3.24.1...v3.25.0
 [3.24.1]: https://github.com/openfun/marsha/compare/v3.24.0...v3.24.1

--- a/src/aws/Dockerfile
+++ b/src/aws/Dockerfile
@@ -6,7 +6,7 @@ ARG MEDIAINFO_VERSION=20.09
 RUN wget https://mediaarea.net/download/binary/mediainfo/20.09/MediaInfo_CLI_${MEDIAINFO_VERSION}_Lambda.zip && \
     unzip MediaInfo_CLI_${MEDIAINFO_VERSION}_Lambda.zip -d /tmp/mediainfo
 
-FROM public.ecr.aws/lambda/nodejs:14 as core
+FROM amazon/aws-lambda-nodejs:14 as core
 
 # COPY mediainfo in core stage
 COPY --from=mediainfo /tmp/mediainfo/bin/mediainfo /opt/bin/mediainfo

--- a/src/aws/lambda-complete/package.json
+++ b/src/aws/lambda-complete/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-complete",
-  "version": "3.26.0",
+  "version": "3.27.0",
   "engines": {
     "node": "14"
   },

--- a/src/aws/lambda-configure/package.json
+++ b/src/aws/lambda-configure/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-configure",
-  "version": "3.26.0",
+  "version": "3.27.0",
   "engines": {
     "node": "14"
   },

--- a/src/aws/lambda-elemental-routing/package.json
+++ b/src/aws/lambda-elemental-routing/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-elemental-routing",
-  "version": "3.26.0",
+  "version": "3.27.0",
   "engines": {
     "node": "14"
   },

--- a/src/aws/lambda-encode/package.json
+++ b/src/aws/lambda-encode/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-convert",
-  "version": "3.26.0",
+  "version": "3.27.0",
   "engines": {
     "node": "14"
   },

--- a/src/aws/lambda-medialive/package.json
+++ b/src/aws/lambda-medialive/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-medialive",
-  "version": "3.26.0",
+  "version": "3.27.0",
   "engines": {
     "node": "14"
   },

--- a/src/aws/lambda-mediapackage/package.json
+++ b/src/aws/lambda-mediapackage/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-mediapackage",
-  "version": "3.26.0",
+  "version": "3.27.0",
   "engines": {
     "node": "14"
   },

--- a/src/aws/lambda-migrate/package.json
+++ b/src/aws/lambda-migrate/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-migrate",
-  "version": "3.26.0",
+  "version": "3.27.0",
   "engines": {
     "node": "14"
   },

--- a/src/aws/utils/update-state/package.json
+++ b/src/aws/utils/update-state/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-update-state",
-  "version": "3.26.0",
+  "version": "3.27.0",
   "engines": {
     "node": "14"
   },

--- a/src/backend/locale/es_ES/LC_MESSAGES/django.po
+++ b/src/backend/locale/es_ES/LC_MESSAGES/django.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: marsha\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-10-07 14:19+0000\n"
-"PO-Revision-Date: 2021-10-22 07:48\n"
+"POT-Creation-Date: 2021-11-25 14:44+0000\n"
+"PO-Revision-Date: 2021-11-26 09:25\n"
 "Last-Translator: \n"
 "Language-Team: Spanish\n"
 "Language: es_ES\n"
@@ -17,85 +17,190 @@ msgstr ""
 "X-Crowdin-File: backend.pot\n"
 "X-Crowdin-File-ID: 6\n"
 
+#: marsha/bbb/admin.py:15
+msgid "Meeting"
+msgstr ""
+
+#: marsha/bbb/apps.py:12
+msgid "Big Blue Button"
+msgstr ""
+
+#: marsha/bbb/models.py:39 marsha/core/models/file.py:91
+#: marsha/core/models/playlist.py:92 marsha/core/models/playlist.py:180
+msgid "playlist"
+msgstr ""
+
+#: marsha/bbb/models.py:40
+msgid "playlist to which this meeting belongs"
+msgstr ""
+
+#: marsha/bbb/models.py:46 marsha/core/models/file.py:73
+#: marsha/core/models/playlist.py:19
+msgid "lti id"
+msgstr ""
+
+#: marsha/bbb/models.py:47 marsha/core/models/file.py:74
+#: marsha/core/models/playlist.py:20
+msgid "ID for synchronization with an external LTI tool"
+msgstr ""
+
+#: marsha/bbb/models.py:52 marsha/core/models/file.py:69
+#: marsha/core/models/playlist.py:15
+msgid "title"
+msgstr ""
+
+#: marsha/bbb/models.py:52
+msgid "title of the meeting"
+msgstr ""
+
+#: marsha/bbb/models.py:55 marsha/core/models/file.py:108
+msgid "description"
+msgstr ""
+
+#: marsha/bbb/models.py:56
+msgid "description of the meeting"
+msgstr ""
+
+#: marsha/bbb/models.py:61 marsha/core/models/file.py:114
+msgid "position"
+msgstr ""
+
+#: marsha/bbb/models.py:62
+msgid "position of this meeting in the playlist"
+msgstr ""
+
+#: marsha/bbb/models.py:67
+msgid "meeting id"
+msgstr ""
+
+#: marsha/bbb/models.py:68
+msgid "BBB id for the meeting as UUID"
+msgstr ""
+
+#: marsha/bbb/models.py:75
+msgid "Attendee Password"
+msgstr ""
+
+#: marsha/bbb/models.py:77
+msgid "The password that the join URL can later provide as its password parameter to indicate the user will join as a viewer."
+msgstr ""
+
+#: marsha/bbb/models.py:85
+msgid "Moderator Password"
+msgstr ""
+
+#: marsha/bbb/models.py:87
+msgid "The password that will join URL can later provide as its password parameter to indicate the user will as a moderator."
+msgstr ""
+
+#: marsha/bbb/models.py:94
+msgid "Welcome!"
+msgstr ""
+
+#: marsha/bbb/models.py:96
+msgid "A welcome message that gets displayed on the chat window when the participant joins."
+msgstr ""
+
+#: marsha/bbb/models.py:104
+msgid "started on"
+msgstr ""
+
+#: marsha/bbb/models.py:105
+msgid "datetime at which the meeting was started."
+msgstr ""
+
+#: marsha/bbb/models.py:114
+msgid "meeting"
+msgstr ""
+
+#: marsha/bbb/models.py:115
+msgid "meetings"
+msgstr ""
+
+#: marsha/bbb/models.py:147 marsha/core/models/account.py:259
+#: marsha/core/models/file.py:128 marsha/core/models/playlist.py:106
+msgid "{:s} [deleted]"
+msgstr ""
+
 #: marsha/core/admin.py:159
 #, python-brace-format
 msgid "{marsha_name} administration"
 msgstr "administración de {marsha_name}"
 
-#: marsha/core/admin.py:175 marsha/core/admin.py:198
+#: marsha/core/admin.py:176 marsha/core/admin.py:199
 #: marsha/core/models/account.py:392 marsha/core/models/account.py:424
 #: marsha/core/models/account.py:477
 msgid "organization"
 msgstr "organización"
 
-#: marsha/core/admin.py:176 marsha/core/admin.py:199
+#: marsha/core/admin.py:177 marsha/core/admin.py:200
 #: marsha/core/models/account.py:393
 msgid "organizations"
 msgstr "organización"
 
-#: marsha/core/admin.py:190 marsha/core/admin.py:241
+#: marsha/core/admin.py:191 marsha/core/admin.py:242
 #: marsha/core/models/account.py:51 marsha/core/models/account.py:321
 #: marsha/core/models/account.py:469 marsha/core/models/playlist.py:172
 msgid "user"
 msgstr "usuario"
 
-#: marsha/core/admin.py:191 marsha/core/admin.py:242
+#: marsha/core/admin.py:192 marsha/core/admin.py:243
 #: marsha/core/models/account.py:52 marsha/core/models/account.py:215
 #: marsha/core/models/account.py:384 marsha/core/models/playlist.py:63
 msgid "users"
 msgstr "usuarios"
 
-#: marsha/core/admin.py:207 marsha/core/admin.py:208 marsha/core/admin.py:319
-#: marsha/core/admin.py:320 marsha/core/models/account.py:204
+#: marsha/core/admin.py:208 marsha/core/admin.py:209 marsha/core/admin.py:320
+#: marsha/core/admin.py:321 marsha/core/models/account.py:204
 msgid "portable to"
 msgstr ""
 
-#: marsha/core/admin.py:249 marsha/core/models/account.py:252
+#: marsha/core/admin.py:250 marsha/core/models/account.py:252
 msgid "consumer site"
 msgstr ""
 
-#: marsha/core/admin.py:250 marsha/core/models/account.py:253
+#: marsha/core/admin.py:251 marsha/core/models/account.py:253
 msgid "consumer sites"
 msgstr ""
 
-#: marsha/core/admin.py:295 marsha/core/models/video.py:446
+#: marsha/core/admin.py:296 marsha/core/models/video.py:444
 msgid "Video"
 msgstr "Video"
 
-#: marsha/core/admin.py:302 marsha/core/models/video.py:76
-#: marsha/core/models/video.py:212 marsha/core/models/video.py:370
+#: marsha/core/admin.py:303 marsha/core/models/video.py:74
+#: marsha/core/models/video.py:210 marsha/core/models/video.py:368
 msgid "video"
 msgstr "video"
 
-#: marsha/core/admin.py:303 marsha/core/models/video.py:77
+#: marsha/core/admin.py:304 marsha/core/models/video.py:75
 msgid "videos"
 msgstr "videos"
 
-#: marsha/core/admin.py:310
+#: marsha/core/admin.py:311
 msgid "user access"
 msgstr ""
 
-#: marsha/core/admin.py:311
+#: marsha/core/admin.py:312
 msgid "users accesses"
 msgstr ""
 
-#: marsha/core/admin.py:329
+#: marsha/core/admin.py:330
 msgid "Document"
 msgstr ""
 
-#: marsha/core/admin.py:336 marsha/core/models/file.py:161
+#: marsha/core/admin.py:337 marsha/core/models/file.py:161
 msgid "document"
 msgstr ""
 
-#: marsha/core/admin.py:337 marsha/core/models/file.py:162
+#: marsha/core/admin.py:338 marsha/core/models/file.py:162
 msgid "documents"
 msgstr ""
 
-#: marsha/core/admin.py:403
+#: marsha/core/admin.py:404
 msgid "Playlist"
 msgstr ""
 
-#: marsha/core/admin.py:441 marsha/core/models/account.py:131
+#: marsha/core/admin.py:442 marsha/core/models/account.py:131
 msgid "LTI passport"
 msgstr "pasaporte LTI"
 
@@ -132,19 +237,19 @@ msgid "deleted"
 msgstr ""
 
 #: marsha/core/defaults.py:45
-msgid "creating"
-msgstr ""
-
-#: marsha/core/defaults.py:46
 msgid "idle"
 msgstr ""
 
+#: marsha/core/defaults.py:46
+msgid "paused"
+msgstr ""
+
 #: marsha/core/defaults.py:47
-msgid "starting"
+msgid "running"
 msgstr ""
 
 #: marsha/core/defaults.py:48
-msgid "running"
+msgid "starting"
 msgstr ""
 
 #: marsha/core/defaults.py:49
@@ -273,11 +378,6 @@ msgstr ""
 
 #: marsha/core/models/account.py:243
 msgid "default value used for every newly created video to determine if the links to download a video are shown by default."
-msgstr ""
-
-#: marsha/core/models/account.py:259 marsha/core/models/file.py:128
-#: marsha/core/models/playlist.py:106
-msgid "{:s} [deleted]"
 msgstr ""
 
 #: marsha/core/models/account.py:276
@@ -462,20 +562,8 @@ msgstr ""
 msgid "state of the upload in AWS."
 msgstr ""
 
-#: marsha/core/models/file.py:69 marsha/core/models/playlist.py:15
-msgid "title"
-msgstr ""
-
 #: marsha/core/models/file.py:69
 msgid "title of the file"
-msgstr ""
-
-#: marsha/core/models/file.py:73 marsha/core/models/playlist.py:19
-msgid "lti id"
-msgstr ""
-
-#: marsha/core/models/file.py:74 marsha/core/models/playlist.py:20
-msgid "ID for synchronization with an external LTI tool"
 msgstr ""
 
 #: marsha/core/models/file.py:81
@@ -484,11 +572,6 @@ msgstr ""
 
 #: marsha/core/models/file.py:82
 msgid "author of the file"
-msgstr ""
-
-#: marsha/core/models/file.py:91 marsha/core/models/playlist.py:92
-#: marsha/core/models/playlist.py:180
-msgid "playlist"
 msgstr ""
 
 #: marsha/core/models/file.py:92
@@ -503,16 +586,8 @@ msgstr ""
 msgid "original file this one was duplicated from"
 msgstr ""
 
-#: marsha/core/models/file.py:108
-msgid "description"
-msgstr ""
-
 #: marsha/core/models/file.py:109
 msgid "description of the file"
-msgstr ""
-
-#: marsha/core/models/file.py:114
-msgid "position"
 msgstr ""
 
 #: marsha/core/models/file.py:115
@@ -523,7 +598,7 @@ msgstr ""
 msgid "file extension"
 msgstr ""
 
-#: marsha/core/models/file.py:148 marsha/core/models/video.py:281
+#: marsha/core/models/file.py:148 marsha/core/models/video.py:279
 msgid "extension"
 msgstr ""
 
@@ -615,159 +690,159 @@ msgstr ""
 msgid "playlist accesses"
 msgstr ""
 
-#: marsha/core/models/video.py:23
+#: marsha/core/models/video.py:22
 msgid "starting at"
 msgstr ""
 
-#: marsha/core/models/video.py:24
+#: marsha/core/models/video.py:23
 msgid "date and time at which a video live is scheduled"
 msgstr ""
 
-#: marsha/core/models/video.py:30
+#: marsha/core/models/video.py:28
 msgid "use subtitle as transcript"
 msgstr ""
 
-#: marsha/core/models/video.py:32
+#: marsha/core/models/video.py:30
 msgid "When there is at least one subtitle but no transcript this flag allows to use subtitles as transcripts."
 msgstr ""
 
-#: marsha/core/models/video.py:40
+#: marsha/core/models/video.py:38
 msgid "video sizes"
 msgstr ""
 
-#: marsha/core/models/video.py:41
+#: marsha/core/models/video.py:39
 msgid "List of available sizes for this video"
 msgstr ""
 
-#: marsha/core/models/video.py:46
+#: marsha/core/models/video.py:44
 msgid "Live info"
 msgstr ""
 
-#: marsha/core/models/video.py:47
+#: marsha/core/models/video.py:45
 msgid "Information needed to manage live streaming"
 msgstr ""
 
-#: marsha/core/models/video.py:51
+#: marsha/core/models/video.py:49
 msgid "live state"
 msgstr ""
 
-#: marsha/core/models/video.py:52
+#: marsha/core/models/video.py:50
 msgid "state of the live mode."
 msgstr ""
 
-#: marsha/core/models/video.py:59
+#: marsha/core/models/video.py:57
 msgid "type of live"
 msgstr ""
 
-#: marsha/core/models/video.py:60
+#: marsha/core/models/video.py:58
 msgid "type of live."
 msgstr ""
 
-#: marsha/core/models/video.py:67
+#: marsha/core/models/video.py:65
 msgid "is video public"
 msgstr ""
 
-#: marsha/core/models/video.py:68
+#: marsha/core/models/video.py:66
 msgid "Is the video publicly accessible?"
 msgstr ""
 
-#: marsha/core/models/video.py:213
+#: marsha/core/models/video.py:211
 msgid "video for which this track is"
 msgstr ""
 
-#: marsha/core/models/video.py:220
+#: marsha/core/models/video.py:218
 msgid "language"
 msgstr ""
 
-#: marsha/core/models/video.py:221
+#: marsha/core/models/video.py:219
 msgid "language of this track"
 msgstr ""
 
-#: marsha/core/models/video.py:237
+#: marsha/core/models/video.py:235
 msgid "audio track"
 msgstr ""
 
-#: marsha/core/models/video.py:238
+#: marsha/core/models/video.py:236
 msgid "audio tracks"
 msgstr ""
 
-#: marsha/core/models/video.py:258
+#: marsha/core/models/video.py:256
 msgid "Subtitle"
 msgstr ""
 
-#: marsha/core/models/video.py:259
+#: marsha/core/models/video.py:257
 msgid "Transcript"
 msgstr ""
 
-#: marsha/core/models/video.py:260
+#: marsha/core/models/video.py:258
 msgid "Closed captioning"
 msgstr ""
 
-#: marsha/core/models/video.py:264
+#: marsha/core/models/video.py:262
 msgid "mode"
 msgstr ""
 
-#: marsha/core/models/video.py:268
+#: marsha/core/models/video.py:266
 msgid "Activate a special mode for this timed text track: simple subtitles, closed captioning (for deaf or hard of hearing viewers) or transcription (complete text below aside of the player)."
 msgstr ""
 
-#: marsha/core/models/video.py:278
+#: marsha/core/models/video.py:276
 msgid "timed text track extension"
 msgstr ""
 
-#: marsha/core/models/video.py:288
+#: marsha/core/models/video.py:286
 msgid "timed text track"
 msgstr ""
 
-#: marsha/core/models/video.py:289
+#: marsha/core/models/video.py:287
 msgid "timed text tracks"
 msgstr ""
 
-#: marsha/core/models/video.py:351
+#: marsha/core/models/video.py:349
 msgid "signs language track"
 msgstr ""
 
-#: marsha/core/models/video.py:352
+#: marsha/core/models/video.py:350
 msgid "signs language tracks"
 msgstr ""
 
-#: marsha/core/models/video.py:371
+#: marsha/core/models/video.py:369
 msgid "video for which this thumbnail is"
 msgstr ""
 
-#: marsha/core/models/video.py:380
+#: marsha/core/models/video.py:378
 msgid "thumbnail"
 msgstr ""
 
-#: marsha/core/models/video.py:413
+#: marsha/core/models/video.py:411
 msgid "email address"
 msgstr ""
 
-#: marsha/core/models/video.py:417
+#: marsha/core/models/video.py:415
 msgid "Only present for lti users."
 msgstr ""
 
-#: marsha/core/models/video.py:422
+#: marsha/core/models/video.py:420
 msgid "LTI consumer site"
 msgstr ""
 
-#: marsha/core/models/video.py:429
+#: marsha/core/models/video.py:427
 msgid "Unique identifier for the user on the tool consumer, only present for lti users."
 msgstr ""
 
-#: marsha/core/models/video.py:433
+#: marsha/core/models/video.py:431
 msgid "LTI user identifier"
 msgstr ""
 
-#: marsha/core/models/video.py:438
+#: marsha/core/models/video.py:436
 msgid "whether user reminders are enabled for this live"
 msgstr ""
 
-#: marsha/core/models/video.py:439
+#: marsha/core/models/video.py:437
 msgid "should send reminders"
 msgstr ""
 
-#: marsha/core/models/video.py:471
+#: marsha/core/models/video.py:469
 msgid "live registration"
 msgstr ""
 
@@ -779,11 +854,11 @@ msgstr ""
 msgid "Some playlists don't exist: {', '.join(ids_diff):s}."
 msgstr ""
 
-#: marsha/settings.py:194
+#: marsha/settings.py:195
 msgid "english"
 msgstr ""
 
-#: marsha/settings.py:194
+#: marsha/settings.py:195
 msgid "french"
 msgstr ""
 

--- a/src/backend/locale/fr_CA/LC_MESSAGES/django.po
+++ b/src/backend/locale/fr_CA/LC_MESSAGES/django.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: marsha\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-10-07 14:19+0000\n"
-"PO-Revision-Date: 2021-10-22 07:48\n"
+"POT-Creation-Date: 2021-11-25 14:44+0000\n"
+"PO-Revision-Date: 2021-11-26 09:25\n"
 "Last-Translator: \n"
 "Language-Team: French, Canada\n"
 "Language: fr_CA\n"
@@ -17,85 +17,190 @@ msgstr ""
 "X-Crowdin-File: backend.pot\n"
 "X-Crowdin-File-ID: 6\n"
 
+#: marsha/bbb/admin.py:15
+msgid "Meeting"
+msgstr ""
+
+#: marsha/bbb/apps.py:12
+msgid "Big Blue Button"
+msgstr ""
+
+#: marsha/bbb/models.py:39 marsha/core/models/file.py:91
+#: marsha/core/models/playlist.py:92 marsha/core/models/playlist.py:180
+msgid "playlist"
+msgstr ""
+
+#: marsha/bbb/models.py:40
+msgid "playlist to which this meeting belongs"
+msgstr ""
+
+#: marsha/bbb/models.py:46 marsha/core/models/file.py:73
+#: marsha/core/models/playlist.py:19
+msgid "lti id"
+msgstr ""
+
+#: marsha/bbb/models.py:47 marsha/core/models/file.py:74
+#: marsha/core/models/playlist.py:20
+msgid "ID for synchronization with an external LTI tool"
+msgstr ""
+
+#: marsha/bbb/models.py:52 marsha/core/models/file.py:69
+#: marsha/core/models/playlist.py:15
+msgid "title"
+msgstr ""
+
+#: marsha/bbb/models.py:52
+msgid "title of the meeting"
+msgstr ""
+
+#: marsha/bbb/models.py:55 marsha/core/models/file.py:108
+msgid "description"
+msgstr ""
+
+#: marsha/bbb/models.py:56
+msgid "description of the meeting"
+msgstr ""
+
+#: marsha/bbb/models.py:61 marsha/core/models/file.py:114
+msgid "position"
+msgstr ""
+
+#: marsha/bbb/models.py:62
+msgid "position of this meeting in the playlist"
+msgstr ""
+
+#: marsha/bbb/models.py:67
+msgid "meeting id"
+msgstr ""
+
+#: marsha/bbb/models.py:68
+msgid "BBB id for the meeting as UUID"
+msgstr ""
+
+#: marsha/bbb/models.py:75
+msgid "Attendee Password"
+msgstr ""
+
+#: marsha/bbb/models.py:77
+msgid "The password that the join URL can later provide as its password parameter to indicate the user will join as a viewer."
+msgstr ""
+
+#: marsha/bbb/models.py:85
+msgid "Moderator Password"
+msgstr ""
+
+#: marsha/bbb/models.py:87
+msgid "The password that will join URL can later provide as its password parameter to indicate the user will as a moderator."
+msgstr ""
+
+#: marsha/bbb/models.py:94
+msgid "Welcome!"
+msgstr ""
+
+#: marsha/bbb/models.py:96
+msgid "A welcome message that gets displayed on the chat window when the participant joins."
+msgstr ""
+
+#: marsha/bbb/models.py:104
+msgid "started on"
+msgstr ""
+
+#: marsha/bbb/models.py:105
+msgid "datetime at which the meeting was started."
+msgstr ""
+
+#: marsha/bbb/models.py:114
+msgid "meeting"
+msgstr ""
+
+#: marsha/bbb/models.py:115
+msgid "meetings"
+msgstr ""
+
+#: marsha/bbb/models.py:147 marsha/core/models/account.py:259
+#: marsha/core/models/file.py:128 marsha/core/models/playlist.py:106
+msgid "{:s} [deleted]"
+msgstr ""
+
 #: marsha/core/admin.py:159
 #, python-brace-format
 msgid "{marsha_name} administration"
 msgstr ""
 
-#: marsha/core/admin.py:175 marsha/core/admin.py:198
+#: marsha/core/admin.py:176 marsha/core/admin.py:199
 #: marsha/core/models/account.py:392 marsha/core/models/account.py:424
 #: marsha/core/models/account.py:477
 msgid "organization"
 msgstr ""
 
-#: marsha/core/admin.py:176 marsha/core/admin.py:199
+#: marsha/core/admin.py:177 marsha/core/admin.py:200
 #: marsha/core/models/account.py:393
 msgid "organizations"
 msgstr ""
 
-#: marsha/core/admin.py:190 marsha/core/admin.py:241
+#: marsha/core/admin.py:191 marsha/core/admin.py:242
 #: marsha/core/models/account.py:51 marsha/core/models/account.py:321
 #: marsha/core/models/account.py:469 marsha/core/models/playlist.py:172
 msgid "user"
 msgstr ""
 
-#: marsha/core/admin.py:191 marsha/core/admin.py:242
+#: marsha/core/admin.py:192 marsha/core/admin.py:243
 #: marsha/core/models/account.py:52 marsha/core/models/account.py:215
 #: marsha/core/models/account.py:384 marsha/core/models/playlist.py:63
 msgid "users"
 msgstr ""
 
-#: marsha/core/admin.py:207 marsha/core/admin.py:208 marsha/core/admin.py:319
-#: marsha/core/admin.py:320 marsha/core/models/account.py:204
+#: marsha/core/admin.py:208 marsha/core/admin.py:209 marsha/core/admin.py:320
+#: marsha/core/admin.py:321 marsha/core/models/account.py:204
 msgid "portable to"
 msgstr ""
 
-#: marsha/core/admin.py:249 marsha/core/models/account.py:252
+#: marsha/core/admin.py:250 marsha/core/models/account.py:252
 msgid "consumer site"
 msgstr ""
 
-#: marsha/core/admin.py:250 marsha/core/models/account.py:253
+#: marsha/core/admin.py:251 marsha/core/models/account.py:253
 msgid "consumer sites"
 msgstr ""
 
-#: marsha/core/admin.py:295 marsha/core/models/video.py:446
+#: marsha/core/admin.py:296 marsha/core/models/video.py:444
 msgid "Video"
 msgstr ""
 
-#: marsha/core/admin.py:302 marsha/core/models/video.py:76
-#: marsha/core/models/video.py:212 marsha/core/models/video.py:370
+#: marsha/core/admin.py:303 marsha/core/models/video.py:74
+#: marsha/core/models/video.py:210 marsha/core/models/video.py:368
 msgid "video"
 msgstr ""
 
-#: marsha/core/admin.py:303 marsha/core/models/video.py:77
+#: marsha/core/admin.py:304 marsha/core/models/video.py:75
 msgid "videos"
 msgstr ""
 
-#: marsha/core/admin.py:310
+#: marsha/core/admin.py:311
 msgid "user access"
 msgstr ""
 
-#: marsha/core/admin.py:311
+#: marsha/core/admin.py:312
 msgid "users accesses"
 msgstr ""
 
-#: marsha/core/admin.py:329
+#: marsha/core/admin.py:330
 msgid "Document"
 msgstr ""
 
-#: marsha/core/admin.py:336 marsha/core/models/file.py:161
+#: marsha/core/admin.py:337 marsha/core/models/file.py:161
 msgid "document"
 msgstr ""
 
-#: marsha/core/admin.py:337 marsha/core/models/file.py:162
+#: marsha/core/admin.py:338 marsha/core/models/file.py:162
 msgid "documents"
 msgstr ""
 
-#: marsha/core/admin.py:403
+#: marsha/core/admin.py:404
 msgid "Playlist"
 msgstr ""
 
-#: marsha/core/admin.py:441 marsha/core/models/account.py:131
+#: marsha/core/admin.py:442 marsha/core/models/account.py:131
 msgid "LTI passport"
 msgstr ""
 
@@ -132,19 +237,19 @@ msgid "deleted"
 msgstr ""
 
 #: marsha/core/defaults.py:45
-msgid "creating"
-msgstr ""
-
-#: marsha/core/defaults.py:46
 msgid "idle"
 msgstr ""
 
+#: marsha/core/defaults.py:46
+msgid "paused"
+msgstr ""
+
 #: marsha/core/defaults.py:47
-msgid "starting"
+msgid "running"
 msgstr ""
 
 #: marsha/core/defaults.py:48
-msgid "running"
+msgid "starting"
 msgstr ""
 
 #: marsha/core/defaults.py:49
@@ -273,11 +378,6 @@ msgstr ""
 
 #: marsha/core/models/account.py:243
 msgid "default value used for every newly created video to determine if the links to download a video are shown by default."
-msgstr ""
-
-#: marsha/core/models/account.py:259 marsha/core/models/file.py:128
-#: marsha/core/models/playlist.py:106
-msgid "{:s} [deleted]"
 msgstr ""
 
 #: marsha/core/models/account.py:276
@@ -462,20 +562,8 @@ msgstr ""
 msgid "state of the upload in AWS."
 msgstr ""
 
-#: marsha/core/models/file.py:69 marsha/core/models/playlist.py:15
-msgid "title"
-msgstr ""
-
 #: marsha/core/models/file.py:69
 msgid "title of the file"
-msgstr ""
-
-#: marsha/core/models/file.py:73 marsha/core/models/playlist.py:19
-msgid "lti id"
-msgstr ""
-
-#: marsha/core/models/file.py:74 marsha/core/models/playlist.py:20
-msgid "ID for synchronization with an external LTI tool"
 msgstr ""
 
 #: marsha/core/models/file.py:81
@@ -484,11 +572,6 @@ msgstr ""
 
 #: marsha/core/models/file.py:82
 msgid "author of the file"
-msgstr ""
-
-#: marsha/core/models/file.py:91 marsha/core/models/playlist.py:92
-#: marsha/core/models/playlist.py:180
-msgid "playlist"
 msgstr ""
 
 #: marsha/core/models/file.py:92
@@ -503,16 +586,8 @@ msgstr ""
 msgid "original file this one was duplicated from"
 msgstr ""
 
-#: marsha/core/models/file.py:108
-msgid "description"
-msgstr ""
-
 #: marsha/core/models/file.py:109
 msgid "description of the file"
-msgstr ""
-
-#: marsha/core/models/file.py:114
-msgid "position"
 msgstr ""
 
 #: marsha/core/models/file.py:115
@@ -523,7 +598,7 @@ msgstr ""
 msgid "file extension"
 msgstr ""
 
-#: marsha/core/models/file.py:148 marsha/core/models/video.py:281
+#: marsha/core/models/file.py:148 marsha/core/models/video.py:279
 msgid "extension"
 msgstr ""
 
@@ -615,159 +690,159 @@ msgstr ""
 msgid "playlist accesses"
 msgstr ""
 
-#: marsha/core/models/video.py:23
+#: marsha/core/models/video.py:22
 msgid "starting at"
 msgstr ""
 
-#: marsha/core/models/video.py:24
+#: marsha/core/models/video.py:23
 msgid "date and time at which a video live is scheduled"
 msgstr ""
 
-#: marsha/core/models/video.py:30
+#: marsha/core/models/video.py:28
 msgid "use subtitle as transcript"
 msgstr ""
 
-#: marsha/core/models/video.py:32
+#: marsha/core/models/video.py:30
 msgid "When there is at least one subtitle but no transcript this flag allows to use subtitles as transcripts."
 msgstr ""
 
-#: marsha/core/models/video.py:40
+#: marsha/core/models/video.py:38
 msgid "video sizes"
 msgstr ""
 
-#: marsha/core/models/video.py:41
+#: marsha/core/models/video.py:39
 msgid "List of available sizes for this video"
 msgstr ""
 
-#: marsha/core/models/video.py:46
+#: marsha/core/models/video.py:44
 msgid "Live info"
 msgstr ""
 
-#: marsha/core/models/video.py:47
+#: marsha/core/models/video.py:45
 msgid "Information needed to manage live streaming"
 msgstr ""
 
-#: marsha/core/models/video.py:51
+#: marsha/core/models/video.py:49
 msgid "live state"
 msgstr ""
 
-#: marsha/core/models/video.py:52
+#: marsha/core/models/video.py:50
 msgid "state of the live mode."
 msgstr ""
 
-#: marsha/core/models/video.py:59
+#: marsha/core/models/video.py:57
 msgid "type of live"
 msgstr ""
 
-#: marsha/core/models/video.py:60
+#: marsha/core/models/video.py:58
 msgid "type of live."
 msgstr ""
 
-#: marsha/core/models/video.py:67
+#: marsha/core/models/video.py:65
 msgid "is video public"
 msgstr ""
 
-#: marsha/core/models/video.py:68
+#: marsha/core/models/video.py:66
 msgid "Is the video publicly accessible?"
 msgstr ""
 
-#: marsha/core/models/video.py:213
+#: marsha/core/models/video.py:211
 msgid "video for which this track is"
 msgstr ""
 
-#: marsha/core/models/video.py:220
+#: marsha/core/models/video.py:218
 msgid "language"
 msgstr ""
 
-#: marsha/core/models/video.py:221
+#: marsha/core/models/video.py:219
 msgid "language of this track"
 msgstr ""
 
-#: marsha/core/models/video.py:237
+#: marsha/core/models/video.py:235
 msgid "audio track"
 msgstr ""
 
-#: marsha/core/models/video.py:238
+#: marsha/core/models/video.py:236
 msgid "audio tracks"
 msgstr ""
 
-#: marsha/core/models/video.py:258
+#: marsha/core/models/video.py:256
 msgid "Subtitle"
 msgstr ""
 
-#: marsha/core/models/video.py:259
+#: marsha/core/models/video.py:257
 msgid "Transcript"
 msgstr ""
 
-#: marsha/core/models/video.py:260
+#: marsha/core/models/video.py:258
 msgid "Closed captioning"
 msgstr ""
 
-#: marsha/core/models/video.py:264
+#: marsha/core/models/video.py:262
 msgid "mode"
 msgstr ""
 
-#: marsha/core/models/video.py:268
+#: marsha/core/models/video.py:266
 msgid "Activate a special mode for this timed text track: simple subtitles, closed captioning (for deaf or hard of hearing viewers) or transcription (complete text below aside of the player)."
 msgstr ""
 
-#: marsha/core/models/video.py:278
+#: marsha/core/models/video.py:276
 msgid "timed text track extension"
 msgstr ""
 
-#: marsha/core/models/video.py:288
+#: marsha/core/models/video.py:286
 msgid "timed text track"
 msgstr ""
 
-#: marsha/core/models/video.py:289
+#: marsha/core/models/video.py:287
 msgid "timed text tracks"
 msgstr ""
 
-#: marsha/core/models/video.py:351
+#: marsha/core/models/video.py:349
 msgid "signs language track"
 msgstr ""
 
-#: marsha/core/models/video.py:352
+#: marsha/core/models/video.py:350
 msgid "signs language tracks"
 msgstr ""
 
-#: marsha/core/models/video.py:371
+#: marsha/core/models/video.py:369
 msgid "video for which this thumbnail is"
 msgstr ""
 
-#: marsha/core/models/video.py:380
+#: marsha/core/models/video.py:378
 msgid "thumbnail"
 msgstr ""
 
-#: marsha/core/models/video.py:413
+#: marsha/core/models/video.py:411
 msgid "email address"
 msgstr ""
 
-#: marsha/core/models/video.py:417
+#: marsha/core/models/video.py:415
 msgid "Only present for lti users."
 msgstr ""
 
-#: marsha/core/models/video.py:422
+#: marsha/core/models/video.py:420
 msgid "LTI consumer site"
 msgstr ""
 
-#: marsha/core/models/video.py:429
+#: marsha/core/models/video.py:427
 msgid "Unique identifier for the user on the tool consumer, only present for lti users."
 msgstr ""
 
-#: marsha/core/models/video.py:433
+#: marsha/core/models/video.py:431
 msgid "LTI user identifier"
 msgstr ""
 
-#: marsha/core/models/video.py:438
+#: marsha/core/models/video.py:436
 msgid "whether user reminders are enabled for this live"
 msgstr ""
 
-#: marsha/core/models/video.py:439
+#: marsha/core/models/video.py:437
 msgid "should send reminders"
 msgstr ""
 
-#: marsha/core/models/video.py:471
+#: marsha/core/models/video.py:469
 msgid "live registration"
 msgstr ""
 
@@ -779,11 +854,11 @@ msgstr ""
 msgid "Some playlists don't exist: {', '.join(ids_diff):s}."
 msgstr ""
 
-#: marsha/settings.py:194
+#: marsha/settings.py:195
 msgid "english"
 msgstr ""
 
-#: marsha/settings.py:194
+#: marsha/settings.py:195
 msgid "french"
 msgstr ""
 

--- a/src/backend/locale/fr_FR/LC_MESSAGES/django.po
+++ b/src/backend/locale/fr_FR/LC_MESSAGES/django.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: marsha\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-10-07 14:19+0000\n"
-"PO-Revision-Date: 2021-10-22 07:48\n"
+"POT-Creation-Date: 2021-11-25 14:44+0000\n"
+"PO-Revision-Date: 2021-11-26 09:25\n"
 "Last-Translator: \n"
 "Language-Team: French\n"
 "Language: fr_FR\n"
@@ -17,85 +17,190 @@ msgstr ""
 "X-Crowdin-File: backend.pot\n"
 "X-Crowdin-File-ID: 6\n"
 
+#: marsha/bbb/admin.py:15
+msgid "Meeting"
+msgstr "Classe virtuelle"
+
+#: marsha/bbb/apps.py:12
+msgid "Big Blue Button"
+msgstr "Big Blue Button"
+
+#: marsha/bbb/models.py:39 marsha/core/models/file.py:91
+#: marsha/core/models/playlist.py:92 marsha/core/models/playlist.py:180
+msgid "playlist"
+msgstr "liste de lecture"
+
+#: marsha/bbb/models.py:40
+msgid "playlist to which this meeting belongs"
+msgstr "liste de lecture à laquelle appartient cette classe virtuelle"
+
+#: marsha/bbb/models.py:46 marsha/core/models/file.py:73
+#: marsha/core/models/playlist.py:19
+msgid "lti id"
+msgstr "ID LTI"
+
+#: marsha/bbb/models.py:47 marsha/core/models/file.py:74
+#: marsha/core/models/playlist.py:20
+msgid "ID for synchronization with an external LTI tool"
+msgstr "ID pour la synchronisation avec un outil LTI externe"
+
+#: marsha/bbb/models.py:52 marsha/core/models/file.py:69
+#: marsha/core/models/playlist.py:15
+msgid "title"
+msgstr "titre"
+
+#: marsha/bbb/models.py:52
+msgid "title of the meeting"
+msgstr "titre de la classe virtuelle"
+
+#: marsha/bbb/models.py:55 marsha/core/models/file.py:108
+msgid "description"
+msgstr "description"
+
+#: marsha/bbb/models.py:56
+msgid "description of the meeting"
+msgstr "description de la classe virtuelle"
+
+#: marsha/bbb/models.py:61 marsha/core/models/file.py:114
+msgid "position"
+msgstr "position"
+
+#: marsha/bbb/models.py:62
+msgid "position of this meeting in the playlist"
+msgstr "position de cette classe virtuelle au sein de la liste de lecture"
+
+#: marsha/bbb/models.py:67
+msgid "meeting id"
+msgstr "id de la classe virtuelle"
+
+#: marsha/bbb/models.py:68
+msgid "BBB id for the meeting as UUID"
+msgstr "ID de BBB pour la classe virtuelle sous forme de UUID"
+
+#: marsha/bbb/models.py:75
+msgid "Attendee Password"
+msgstr "Mot de passe du participant"
+
+#: marsha/bbb/models.py:77
+msgid "The password that the join URL can later provide as its password parameter to indicate the user will join as a viewer."
+msgstr "Le mot de passe que l'URL de connexion peut fournir plus tard comme paramètre de mot de passe pour indiquer que l'utilisateur se joindra en tant que spectateur."
+
+#: marsha/bbb/models.py:85
+msgid "Moderator Password"
+msgstr "Mot de passe du modérateur"
+
+#: marsha/bbb/models.py:87
+msgid "The password that will join URL can later provide as its password parameter to indicate the user will as a moderator."
+msgstr "Le mot de passe que l'URL de connexion peut fournir plus tard comme paramètre de mot de passe pour indiquer que l'utilisateur se joindra en tant que modérateur."
+
+#: marsha/bbb/models.py:94
+msgid "Welcome!"
+msgstr "Bienvenue !"
+
+#: marsha/bbb/models.py:96
+msgid "A welcome message that gets displayed on the chat window when the participant joins."
+msgstr "Message de bienvenue affiché dans la fenêtre de chat à l'arrivée d'un participant."
+
+#: marsha/bbb/models.py:104
+msgid "started on"
+msgstr "démarré le"
+
+#: marsha/bbb/models.py:105
+msgid "datetime at which the meeting was started."
+msgstr "date à laquelle la classe virtuelle a débuté."
+
+#: marsha/bbb/models.py:114
+msgid "meeting"
+msgstr "classe virtuelle"
+
+#: marsha/bbb/models.py:115
+msgid "meetings"
+msgstr "classes virtuelles"
+
+#: marsha/bbb/models.py:147 marsha/core/models/account.py:259
+#: marsha/core/models/file.py:128 marsha/core/models/playlist.py:106
+msgid "{:s} [deleted]"
+msgstr "{:s} [deleted]"
+
 #: marsha/core/admin.py:159
 #, python-brace-format
 msgid "{marsha_name} administration"
 msgstr "administration de {marsha_name}"
 
-#: marsha/core/admin.py:175 marsha/core/admin.py:198
+#: marsha/core/admin.py:176 marsha/core/admin.py:199
 #: marsha/core/models/account.py:392 marsha/core/models/account.py:424
 #: marsha/core/models/account.py:477
 msgid "organization"
 msgstr "organisation"
 
-#: marsha/core/admin.py:176 marsha/core/admin.py:199
+#: marsha/core/admin.py:177 marsha/core/admin.py:200
 #: marsha/core/models/account.py:393
 msgid "organizations"
 msgstr "organisations"
 
-#: marsha/core/admin.py:190 marsha/core/admin.py:241
+#: marsha/core/admin.py:191 marsha/core/admin.py:242
 #: marsha/core/models/account.py:51 marsha/core/models/account.py:321
 #: marsha/core/models/account.py:469 marsha/core/models/playlist.py:172
 msgid "user"
 msgstr "utilisateur"
 
-#: marsha/core/admin.py:191 marsha/core/admin.py:242
+#: marsha/core/admin.py:192 marsha/core/admin.py:243
 #: marsha/core/models/account.py:52 marsha/core/models/account.py:215
 #: marsha/core/models/account.py:384 marsha/core/models/playlist.py:63
 msgid "users"
 msgstr "utilisateurs"
 
-#: marsha/core/admin.py:207 marsha/core/admin.py:208 marsha/core/admin.py:319
-#: marsha/core/admin.py:320 marsha/core/models/account.py:204
+#: marsha/core/admin.py:208 marsha/core/admin.py:209 marsha/core/admin.py:320
+#: marsha/core/admin.py:321 marsha/core/models/account.py:204
 msgid "portable to"
 msgstr "portable à"
 
-#: marsha/core/admin.py:249 marsha/core/models/account.py:252
+#: marsha/core/admin.py:250 marsha/core/models/account.py:252
 msgid "consumer site"
 msgstr "site client"
 
-#: marsha/core/admin.py:250 marsha/core/models/account.py:253
+#: marsha/core/admin.py:251 marsha/core/models/account.py:253
 msgid "consumer sites"
 msgstr "sites clients"
 
-#: marsha/core/admin.py:295 marsha/core/models/video.py:446
+#: marsha/core/admin.py:296 marsha/core/models/video.py:444
 msgid "Video"
 msgstr "Vidéo"
 
-#: marsha/core/admin.py:302 marsha/core/models/video.py:76
-#: marsha/core/models/video.py:212 marsha/core/models/video.py:370
+#: marsha/core/admin.py:303 marsha/core/models/video.py:74
+#: marsha/core/models/video.py:210 marsha/core/models/video.py:368
 msgid "video"
 msgstr "vidéo"
 
-#: marsha/core/admin.py:303 marsha/core/models/video.py:77
+#: marsha/core/admin.py:304 marsha/core/models/video.py:75
 msgid "videos"
 msgstr "vidéos"
 
-#: marsha/core/admin.py:310
+#: marsha/core/admin.py:311
 msgid "user access"
 msgstr "accès utilisateur"
 
-#: marsha/core/admin.py:311
+#: marsha/core/admin.py:312
 msgid "users accesses"
 msgstr "accès utilisateur"
 
-#: marsha/core/admin.py:329
+#: marsha/core/admin.py:330
 msgid "Document"
 msgstr "Document"
 
-#: marsha/core/admin.py:336 marsha/core/models/file.py:161
+#: marsha/core/admin.py:337 marsha/core/models/file.py:161
 msgid "document"
 msgstr "document"
 
-#: marsha/core/admin.py:337 marsha/core/models/file.py:162
+#: marsha/core/admin.py:338 marsha/core/models/file.py:162
 msgid "documents"
 msgstr "documents"
 
-#: marsha/core/admin.py:403
+#: marsha/core/admin.py:404
 msgid "Playlist"
 msgstr "Liste de lecture"
 
-#: marsha/core/admin.py:441 marsha/core/models/account.py:131
+#: marsha/core/admin.py:442 marsha/core/models/account.py:131
 msgid "LTI passport"
 msgstr "passeport LTI"
 
@@ -132,20 +237,20 @@ msgid "deleted"
 msgstr "supprimé"
 
 #: marsha/core/defaults.py:45
-msgid "creating"
-msgstr "création en cours"
-
-#: marsha/core/defaults.py:46
 msgid "idle"
 msgstr "inactif"
 
-#: marsha/core/defaults.py:47
-msgid "starting"
-msgstr "démarrage"
+#: marsha/core/defaults.py:46
+msgid "paused"
+msgstr "en pause"
 
-#: marsha/core/defaults.py:48
+#: marsha/core/defaults.py:47
 msgid "running"
 msgstr "en cours"
+
+#: marsha/core/defaults.py:48
+msgid "starting"
+msgstr "démarrage"
 
 #: marsha/core/defaults.py:49
 msgid "stopped"
@@ -274,11 +379,6 @@ msgstr "afficher le téléchargement vidéo"
 #: marsha/core/models/account.py:243
 msgid "default value used for every newly created video to determine if the links to download a video are shown by default."
 msgstr "valeur par défaut utilisée pour chaque vidéo nouvellement créée pour déterminer si les liens pour télécharger une vidéo sont affichés par défaut."
-
-#: marsha/core/models/account.py:259 marsha/core/models/file.py:128
-#: marsha/core/models/playlist.py:106
-msgid "{:s} [deleted]"
-msgstr "{:s} [deleted]"
 
 #: marsha/core/models/account.py:276
 msgid "source site"
@@ -462,21 +562,9 @@ msgstr "état du chargement"
 msgid "state of the upload in AWS."
 msgstr "état de l'envoi dans AWS."
 
-#: marsha/core/models/file.py:69 marsha/core/models/playlist.py:15
-msgid "title"
-msgstr "titre"
-
 #: marsha/core/models/file.py:69
 msgid "title of the file"
 msgstr "titre du document"
-
-#: marsha/core/models/file.py:73 marsha/core/models/playlist.py:19
-msgid "lti id"
-msgstr "ID LTI"
-
-#: marsha/core/models/file.py:74 marsha/core/models/playlist.py:20
-msgid "ID for synchronization with an external LTI tool"
-msgstr "ID pour la synchronisation avec un outil LTI externe"
 
 #: marsha/core/models/file.py:81
 msgid "author"
@@ -485,11 +573,6 @@ msgstr "auteur"
 #: marsha/core/models/file.py:82
 msgid "author of the file"
 msgstr "auteur du document"
-
-#: marsha/core/models/file.py:91 marsha/core/models/playlist.py:92
-#: marsha/core/models/playlist.py:180
-msgid "playlist"
-msgstr "liste de lecture"
 
 #: marsha/core/models/file.py:92
 msgid "playlist to which this file belongs"
@@ -503,17 +586,9 @@ msgstr "dupliqué de"
 msgid "original file this one was duplicated from"
 msgstr "fichier d'origine depuis lequel celui-ci a été dupliqué"
 
-#: marsha/core/models/file.py:108
-msgid "description"
-msgstr "description"
-
 #: marsha/core/models/file.py:109
 msgid "description of the file"
 msgstr "description du fichier"
-
-#: marsha/core/models/file.py:114
-msgid "position"
-msgstr "position"
 
 #: marsha/core/models/file.py:115
 msgid "position of this file in the playlist"
@@ -523,7 +598,7 @@ msgstr "position de ce fichier dans la liste de lecture"
 msgid "file extension"
 msgstr "extension de fichier"
 
-#: marsha/core/models/file.py:148 marsha/core/models/video.py:281
+#: marsha/core/models/file.py:148 marsha/core/models/video.py:279
 msgid "extension"
 msgstr "extension"
 
@@ -615,161 +690,161 @@ msgstr "accès à la liste de lecture"
 msgid "playlist accesses"
 msgstr "accès à la liste de lecture"
 
-#: marsha/core/models/video.py:23
+#: marsha/core/models/video.py:22
 msgid "starting at"
-msgstr ""
+msgstr "démarrage le"
 
-#: marsha/core/models/video.py:24
+#: marsha/core/models/video.py:23
 msgid "date and time at which a video live is scheduled"
-msgstr ""
+msgstr "date et heure à laquelle un webinaire est programmé"
 
-#: marsha/core/models/video.py:30
+#: marsha/core/models/video.py:28
 msgid "use subtitle as transcript"
 msgstr "utiliser les sous-titres comme transcription"
 
-#: marsha/core/models/video.py:32
+#: marsha/core/models/video.py:30
 msgid "When there is at least one subtitle but no transcript this flag allows to use subtitles as transcripts."
 msgstr "Lorsqu'il y a au moins un sous-titre mais aucune transcription, cette option permet d'utiliser les sous-titres comme transcription."
 
-#: marsha/core/models/video.py:40
+#: marsha/core/models/video.py:38
 msgid "video sizes"
 msgstr "résolutions de la vidéo"
 
-#: marsha/core/models/video.py:41
+#: marsha/core/models/video.py:39
 msgid "List of available sizes for this video"
 msgstr "Liste des résolutions disponibles pour cette vidéo"
 
-#: marsha/core/models/video.py:46
+#: marsha/core/models/video.py:44
 msgid "Live info"
 msgstr "Info du direct"
 
-#: marsha/core/models/video.py:47
+#: marsha/core/models/video.py:45
 msgid "Information needed to manage live streaming"
 msgstr "Informations nécessaires pour gérer la diffusion en direct"
 
-#: marsha/core/models/video.py:51
+#: marsha/core/models/video.py:49
 msgid "live state"
 msgstr "état du direct"
 
-#: marsha/core/models/video.py:52
+#: marsha/core/models/video.py:50
 msgid "state of the live mode."
 msgstr "état du direct."
 
-#: marsha/core/models/video.py:59
+#: marsha/core/models/video.py:57
 msgid "type of live"
 msgstr "type de direct"
 
-#: marsha/core/models/video.py:60
+#: marsha/core/models/video.py:58
 msgid "type of live."
 msgstr "type de direct."
 
-#: marsha/core/models/video.py:67
+#: marsha/core/models/video.py:65
 msgid "is video public"
 msgstr "vidéo publique"
 
-#: marsha/core/models/video.py:68
+#: marsha/core/models/video.py:66
 msgid "Is the video publicly accessible?"
 msgstr "La vidéo est-elle accessible publiquement ?"
 
-#: marsha/core/models/video.py:213
+#: marsha/core/models/video.py:211
 msgid "video for which this track is"
 msgstr "vidéo à laquelle cette piste est"
 
-#: marsha/core/models/video.py:220
+#: marsha/core/models/video.py:218
 msgid "language"
 msgstr "langue"
 
-#: marsha/core/models/video.py:221
+#: marsha/core/models/video.py:219
 msgid "language of this track"
 msgstr "langue de cette piste"
 
-#: marsha/core/models/video.py:237
+#: marsha/core/models/video.py:235
 msgid "audio track"
 msgstr "piste audio"
 
-#: marsha/core/models/video.py:238
+#: marsha/core/models/video.py:236
 msgid "audio tracks"
 msgstr "pistes audio"
 
-#: marsha/core/models/video.py:258
+#: marsha/core/models/video.py:256
 msgid "Subtitle"
 msgstr "Sous-titre"
 
-#: marsha/core/models/video.py:259
+#: marsha/core/models/video.py:257
 msgid "Transcript"
 msgstr "Transcription"
 
-#: marsha/core/models/video.py:260
+#: marsha/core/models/video.py:258
 msgid "Closed captioning"
 msgstr "Sous-titres"
 
-#: marsha/core/models/video.py:264
+#: marsha/core/models/video.py:262
 msgid "mode"
 msgstr "mode"
 
-#: marsha/core/models/video.py:268
+#: marsha/core/models/video.py:266
 msgid "Activate a special mode for this timed text track: simple subtitles, closed captioning (for deaf or hard of hearing viewers) or transcription (complete text below aside of the player)."
 msgstr "Activez un mode spécial pour cette piste de texte temporisé : sous-titres simples, sous-titres codés (sourds et malentendants) ou transcription (texte complet sous la vidéo)."
 
-#: marsha/core/models/video.py:278
+#: marsha/core/models/video.py:276
 msgid "timed text track extension"
 msgstr "extension de piste de texte temporisé"
 
-#: marsha/core/models/video.py:288
+#: marsha/core/models/video.py:286
 msgid "timed text track"
 msgstr "piste de texte temporisé"
 
-#: marsha/core/models/video.py:289
+#: marsha/core/models/video.py:287
 msgid "timed text tracks"
 msgstr "pistes de texte temporisé"
 
-#: marsha/core/models/video.py:351
+#: marsha/core/models/video.py:349
 msgid "signs language track"
 msgstr "piste langue des signes"
 
-#: marsha/core/models/video.py:352
+#: marsha/core/models/video.py:350
 msgid "signs language tracks"
 msgstr "pistes langue des signes"
 
-#: marsha/core/models/video.py:371
+#: marsha/core/models/video.py:369
 msgid "video for which this thumbnail is"
 msgstr "vidéo pour laquelle cette vignette est"
 
-#: marsha/core/models/video.py:380
+#: marsha/core/models/video.py:378
 msgid "thumbnail"
 msgstr "vignette"
 
-#: marsha/core/models/video.py:413
+#: marsha/core/models/video.py:411
 msgid "email address"
-msgstr ""
+msgstr "adresse e-mail"
 
-#: marsha/core/models/video.py:417
+#: marsha/core/models/video.py:415
 msgid "Only present for lti users."
-msgstr ""
+msgstr "Présent seulement pour les utilisateurs lti."
 
-#: marsha/core/models/video.py:422
+#: marsha/core/models/video.py:420
 msgid "LTI consumer site"
-msgstr ""
+msgstr "Site client LTI"
 
-#: marsha/core/models/video.py:429
+#: marsha/core/models/video.py:427
 msgid "Unique identifier for the user on the tool consumer, only present for lti users."
-msgstr ""
+msgstr "Identifiant unique de l'utilisateur au sein du consommateur, présent seulement pour les utilisateurs lti."
 
-#: marsha/core/models/video.py:433
+#: marsha/core/models/video.py:431
 msgid "LTI user identifier"
-msgstr ""
+msgstr "Identifiant de l'utilisateur LTI"
 
-#: marsha/core/models/video.py:438
+#: marsha/core/models/video.py:436
 msgid "whether user reminders are enabled for this live"
-msgstr ""
+msgstr "si les rappels d'utilisateurs sont activés pour ce live"
 
-#: marsha/core/models/video.py:439
+#: marsha/core/models/video.py:437
 msgid "should send reminders"
-msgstr ""
+msgstr "devrait envoyer des rappels"
 
-#: marsha/core/models/video.py:471
+#: marsha/core/models/video.py:469
 msgid "live registration"
-msgstr ""
+msgstr "inscription au webinaire"
 
 #: marsha/core/serializers/playlist.py:53
 msgid "Playlist is not portable to itself."
@@ -777,13 +852,13 @@ msgstr "La liste de lecture n'est pas partageable avec elle-même."
 
 #: marsha/core/serializers/playlist.py:73
 msgid "Some playlists don't exist: {', '.join(ids_diff):s}."
-msgstr ""
+msgstr "Certaines listes de lecture n'existent pas : {', '.join(ids_diff):s}."
 
-#: marsha/settings.py:194
+#: marsha/settings.py:195
 msgid "english"
 msgstr "anglais"
 
-#: marsha/settings.py:194
+#: marsha/settings.py:195
 msgid "french"
 msgstr "français"
 

--- a/src/backend/marsha/bbb/models.py
+++ b/src/backend/marsha/bbb/models.py
@@ -84,8 +84,8 @@ class Meeting(BaseModel):
         max_length=50,
         verbose_name=_("Moderator Password"),
         help_text=_(
-            "The password that will join URL can later provide as its password parameter "
-            "to indicate the user will as a moderator."
+            "The password that the join URL can later provide as its password parameter "
+            "to indicate the user will join as a moderator."
         ),
         blank=True,
         null=True,

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = marsha
 description = A FUN video provider for Open edX
-version = 3.26.0
+version = 3.27.0
 author = Open FUN (France Universite Numerique)
 author_email = fun.dev@fun-mooc.fr
 license = MIT

--- a/src/frontend/i18n/es_ES.json
+++ b/src/frontend/i18n/es_ES.json
@@ -1,4 +1,112 @@
 {
+  "apps.bbb.SelectContent.addMeeting": {
+    "description": "Text displayed on a button to add a new meeting.",
+    "message": "Add a meeting"
+  },
+  "apps.bbb.SelectContent.loadingMeetings": {
+    "description": "Accessible message for the spinner while loading the meetings in lti select view.",
+    "message": "Loading meetings..."
+  },
+  "apps.bbb.SelectContent.newMeeting": {
+    "description": "Default LTI consumer title for a new meeting.",
+    "message": "New meeting"
+  },
+  "apps.bbb.SelectContent.notStarted": {
+    "description": "Text helper displayed if a meeting is not started.",
+    "message": "Not started"
+  },
+  "apps.bbb.SelectContent.select": {
+    "description": "Accessible message for selecting a meeting.",
+    "message": "Select {title}"
+  },
+  "apps.bbb.SelectContent.started": {
+    "description": "Text helper displayed if a meeting is started.",
+    "message": "Started"
+  },
+  "component.DashboardMeeting.loadingMeeting": {
+    "description": "Accessible message for the spinner while loading the meeting in dashboard view.",
+    "message": "Loading meeting..."
+  },
+  "component.DashboardMeeting.startMeetingFail": {
+    "description": "Message when meeting start failed.",
+    "message": "Meeting not started!"
+  },
+  "component.DashboardMeeting.startMeetingSuccess": {
+    "description": "Message when meeting start is successful.",
+    "message": "Meeting started."
+  },
+  "component.DashboardMeetingAskUsername.cancel": {
+    "description": "Button label for discarding ask username form in meeting dashboard view.",
+    "message": "Cancel"
+  },
+  "component.DashboardMeetingAskUsername.join": {
+    "description": "Button label for setting username and joining the meeting in meeting dashboard view.",
+    "message": "Join"
+  },
+  "component.DashboardMeetingAskUsername.label": {
+    "description": "Label for asking username to join the meeting.",
+    "message": "Please enter your name to join the meeting"
+  },
+  "component.DashboardMeetingForm.createMeetingFail": {
+    "description": "Message when meeting creation failed.",
+    "message": "Meeting not created!"
+  },
+  "component.DashboardMeetingForm.createMeetingLabel": {
+    "description": "Label for confirm button in meeting creation form.",
+    "message": "Create meeting in BBB"
+  },
+  "component.DashboardMeetingForm.titleLabel": {
+    "description": "Label for title in meeting creation form.",
+    "message": "Title"
+  },
+  "component.DashboardMeetingForm.welcomeTextLabel": {
+    "description": "Label for welcome text in meeting creation form.",
+    "message": "Welcome text"
+  },
+  "component.DashboardMeetingInfos.listeners": {
+    "description": "Role name for listeners in dashboard meeting info view.",
+    "message": "Listeners"
+  },
+  "component.DashboardMeetingInfos.moderators": {
+    "description": "Role name for moderators in dashboard meeting info view.",
+    "message": "Moderators"
+  },
+  "component.DashboardMeetingInfos.participants": {
+    "description": "Role name for participants in dashboard meeting info view.",
+    "message": "Participants"
+  },
+  "component.DashboardMeetingInstructor.createMeetingFail": {
+    "description": "Message when meeting creation failed.",
+    "message": "Meeting not created!"
+  },
+  "component.DashboardMeetingInstructor.endMeetingLabel": {
+    "description": "Label for ending meeting in instructor dashboard.",
+    "message": "End meeting"
+  },
+  "component.DashboardMeetingInstructor.endingMeetingPending": {
+    "description": "Message when ending meeting is pending.",
+    "message": "Ending meeting…"
+  },
+  "component.DashboardMeetingInstructor.joinMeetingLabel": {
+    "description": "Label for joining meeting in instructor dashboard.",
+    "message": "Join meeting"
+  },
+  "component.DashboardMeetingJoin.blockedPopups": {
+    "description": "Message when browser is blocking popups.",
+    "message": "Your browser is blocking popups."
+  },
+  "component.DashboardMeetingJoin.joinLinkLabel": {
+    "description": "Label for link used to join a meeting.",
+    "message": "Please click here to access meeting."
+  },
+  "component.DashboardMeetingStudent.meetingNotStarted": {
+    "description": "Message when meeting is not started.",
+    "message": "Meeting not started yet."
+  },
+  "component.DashboardMeetingStudent.meetingRedirection": {
+    "description": "Message when meeting is started and redirection should be triggered.",
+    "message": "You should be redirected to the meeting."
+  },
   "component.DashboardVideoPaneDownloadOption.allowDownload": {
     "description": "",
     "message": "Permitir descarga de vídeos"
@@ -183,21 +291,17 @@
     "description": "DashboardVideoLive jitsi title.",
     "message": "Webinar"
   },
-  "components.DashboardVideoLive.liveCreating": {
-    "description": "Helptext explainig to wait until the live is created.",
-    "message": "Live streaming is being created. You will be able to start it in a few seconds"
-  },
   "components.DashboardVideoLive.liveStarting": {
     "description": "Helptext explainig to wait until the live is ready.",
-    "message": "Live streaming is starting. Wait before starting your stream."
+    "message": "Live streaming is starting. This can take a few minutes."
   },
   "components.DashboardVideoLive.liveStopped": {
     "description": "Helptext explaining that the live is ended and the live to VOD process has started.",
     "message": "Live streaming is ended. The process to transform the live to VOD has started. You can close the window and come back later."
   },
   "components.DashboardVideoLive.liveStopping": {
-    "description": "Helptext explaining that the live is ending and the live to VOD process will start.",
-    "message": "Live streaming is ending. The process to transform the live to VOD will begin soon. You can close the window and come back later."
+    "description": "Helptext explaining that the live is stopping and will be paused in few moments.",
+    "message": "Pause live streaming, please wait a few moments to be able to resume it."
   },
   "components.DashboardVideoLive.raw": {
     "description": "DashboardVideoLive main title.",
@@ -206,6 +310,14 @@
   "components.DashboardVideoLive.url": {
     "description": "Video url streaming.",
     "message": "url"
+  },
+  "components.DashboardVideoLiveEndButton.confirmEndLive": {
+    "description": "Confirmation to end the video streaming.",
+    "message": "Are you sure you want to end the video streaming ? This action is definitive"
+  },
+  "components.DashboardVideoLiveEndButton.endLive": {
+    "description": "End a video streaming.",
+    "message": "End live"
   },
   "components.DashboardVideoLiveInfo.copied": {
     "description": "Message displayed when endpoints info are copied.",
@@ -247,13 +359,21 @@
     "description": "button to redirect use to video player.",
     "message": "show live"
   },
+  "components.DashboardVideoLiveStartButton.confirmResumeLive": {
+    "description": "Confirmation to resume a video streaming.",
+    "message": "Are you sure you want to resume a video streaming ?"
+  },
   "components.DashboardVideoLiveStartButton.confirmStartLive": {
     "description": "Confirmation to start a video streaming.",
     "message": "Are you sure you want to start a video streaming ?"
   },
+  "components.DashboardVideoLiveStartButton.resumeLive": {
+    "description": "Resume a video streaming.",
+    "message": "Resume streaming"
+  },
   "components.DashboardVideoLiveStartButton.startLive": {
     "description": "Start a video streaming.",
-    "message": "start streaming"
+    "message": "Start streaming"
   },
   "components.DashboardVideoLiveStartButton.startLiveHelper": {
     "description": "Helper message explaining why the start live button is disabled",
@@ -261,11 +381,11 @@
   },
   "components.DashboardVideoLiveStopButton.confirmStopLive": {
     "description": "Confirmation to stop the video streaming.",
-    "message": "Are you sure you want to stop the video streaming ?"
+    "message": "Are you sure you want to pause the video streaming ?"
   },
   "components.DashboardVideoLiveStopButton.startLive": {
     "description": "Stop a video streaming.",
-    "message": "stop streaming"
+    "message": "pause ⏸"
   },
   "components.DashboardVideoPane.helpTextDeleted": {
     "description": "Dashboard helptext for when the video is in DELETED state",
@@ -431,10 +551,6 @@
     "description": "Title for the Instructor View. Describes the area appearing right above, which is a preview\n      of what the student will see there.",
     "message": "Preview"
   },
-  "components.ObjectStatusPicker.CREATING": {
-    "description": "Live video in creation status",
-    "message": "Creando"
-  },
   "components.ObjectStatusPicker.DELETED": {
     "description": "Status information for a video/audio/timed text track",
     "message": "Eliminado"
@@ -454,6 +570,10 @@
   "components.ObjectStatusPicker.IDLE": {
     "description": "The video is in live state and ready to be start",
     "message": "Ready to start live"
+  },
+  "components.ObjectStatusPicker.PAUSED": {
+    "description": "The video is in live state and is paused",
+    "message": "Live is paused"
   },
   "components.ObjectStatusPicker.PENDING": {
     "description": "Status information for a video/audio/timed text track",
@@ -539,6 +659,78 @@
     "description": "Title for the list of videos in the playlist view.",
     "message": "Videos"
   },
+  "components.PublicPausedLive.message": {
+    "description": "Message for the public when live is paused",
+    "message": "The webinar is paused. When resumed, the video will start again."
+  },
+  "components.PublicPausedLive.pausedSince": {
+    "description": "Information about the time since which the webinar is paused.",
+    "message": "The webinar is paused since"
+  },
+  "components.PublicPausedLive.title": {
+    "description": "Title for the public paused live component",
+    "message": "Webinar is paused"
+  },
+  "components.ScheduledVideo.form.date": {
+    "description": "Label of the input field to add/update the scheduled date and time of the webinar",
+    "message": "Starting date and time"
+  },
+  "components.ScheduledVideo.form.description": {
+    "description": "Label of the input field to add/update the description of the webinar",
+    "message": "Description"
+  },
+  "components.ScheduledVideo.form.error": {
+    "description": "Error message while saving the form",
+    "message": "An error occured while updating the scheduled webinar, please try again."
+  },
+  "components.ScheduledVideo.form.error.starting_at": {
+    "description": "Error message while saving the form, date is not defined or in the past",
+    "message": "Scheduled date must be in the future and have a date and hour defined."
+  },
+  "components.ScheduledVideo.form.error.starting_at_already_past": {
+    "description": "Error message while saving the form, initial scheduled date of this webinar is already past, invit user to create a new webinar or to start this one.",
+    "message": "This webinar has an initial date that is already past, it can't be updated in the future. Please, create a new webinar or start this one."
+  },
+  "components.ScheduledVideo.form.error.title": {
+    "description": "Error on field title, this one cannot be empty",
+    "message": "Title must be defined."
+  },
+  "components.ScheduledVideo.form.intro": {
+    "description": "Title of the form to create or update the scheduled webinar",
+    "message": "Schedule a webinar"
+  },
+  "components.ScheduledVideo.form.placeholder.description": {
+    "description": "Placeholder of the description field in the form",
+    "message": "Description"
+  },
+  "components.ScheduledVideo.form.placeholder.title": {
+    "description": "Placeholder of the title field in the form",
+    "message": "Title"
+  },
+  "components.ScheduledVideo.form.success": {
+    "description": "message to confirm webinar has been updated",
+    "message": "Your webinar has been updated"
+  },
+  "components.ScheduledVideo.form.success.openregistration": {
+    "description": "message to confirm users can now register to the webinar",
+    "message": "Your can now ask users to register to your webinar"
+  },
+  "components.ScheduledVideo.form.title": {
+    "description": "Label of the input field to add/update the title to the webinar",
+    "message": "Title"
+  },
+  "components.ScheduledVideo.infoScheduledEvent": {
+    "description": "Message informing webinar is scheduled and giving the current date.",
+    "message": "Webinar is scheduled at {date}."
+  },
+  "components.ScheduledVideo.infoWasScheduledEvent": {
+    "description": "Message informing webinar was scheduled and giving the initial scheduled date.",
+    "message": "Webinar was scheduled at {date}."
+  },
+  "components.ScheduledVideo.infoWasScheduledEventDescription": {
+    "description": "Message informing that scheduled date is past and telling the user he can either start it or create a new one.",
+    "message": "Date is past, please, create a new webinar or start this one"
+  },
   "components.SelectContent.addDocument": {
     "description": "Text displayed on a button to add a new document.",
     "message": "Añadir un documento"
@@ -598,6 +790,42 @@
   "components.SiteHeader.logInBtn": {
     "description": "Text for the login button in the header of the marsha site",
     "message": "Iniciar sesión"
+  },
+  "components.SubscribScheduledVideo.daysLeft": {
+    "description": "Text message to inform on number of days left before the event starts",
+    "message": "Days left {daysLeft,number} {daysLeft, plural, =0 {day} one {day} other {days}}"
+  },
+  "components.SubscribScheduledVideo.register": {
+    "description": "Title message to register to this event",
+    "message": "Register to this event starting on {date}"
+  },
+  "components.SubscribScheduledVideoEmail.form.email": {
+    "description": "Label of the input field to add an email to subscribe to the event",
+    "message": "Type your email to subscribe"
+  },
+  "components.SubscribScheduledVideoEmail.form.email.default.error": {
+    "description": "Error message to warn the user that his email registration did not work. Ask user to check his email adress otherwise to contact us or to try later.",
+    "message": "Impossible to register your email {email} for this event. Make sure your email is valid otherwise, please try again later or contact us."
+  },
+  "components.SubscribScheduledVideoEmail.form.email.existing.error": {
+    "description": "Error message to warn the user that his email registration did not work because this email is already registered.",
+    "message": "Impossible to register, {email} is already registered for this event with another account."
+  },
+  "components.SubscribScheduledVideoEmail.form.email.invalid.error": {
+    "description": "Error message to warn the user that his email registration did not work because this email is not valid.",
+    "message": "Impossible to register, {email} is not valid."
+  },
+  "components.SubscribScheduledVideoEmail.form.labelRegisterSubmitButton": {
+    "description": "Label of the input to register to the event",
+    "message": "Register"
+  },
+  "components.SubscribScheduledVideoEmail.form.success": {
+    "description": "message display when the email is successfully registered for this event",
+    "message": "Email {email} successfully registered for this event"
+  },
+  "components.SubscribScheduledVideoEmail.waitingMessage": {
+    "description": "Message reminding the user, he has already registered and giving back the starting at date.",
+    "message": "You are registered for this event. Live will start at {date}."
   },
   "components.TimedTextCreationForm.addTrackBtn": {
     "description": "Text for the button in the dashboard to go upload a new timed text file.",
@@ -858,5 +1086,8 @@
   "message.key": {
     "description": "",
     "message": "Our title"
+  },
+  "zgxKi7": {
+    "message": "{pausedDays} {pausedDays, plural, one {day} other {days}}"
   }
 }

--- a/src/frontend/i18n/fr_CA.json
+++ b/src/frontend/i18n/fr_CA.json
@@ -1,4 +1,112 @@
 {
+  "apps.bbb.SelectContent.addMeeting": {
+    "description": "Text displayed on a button to add a new meeting.",
+    "message": "Add a meeting"
+  },
+  "apps.bbb.SelectContent.loadingMeetings": {
+    "description": "Accessible message for the spinner while loading the meetings in lti select view.",
+    "message": "Loading meetings..."
+  },
+  "apps.bbb.SelectContent.newMeeting": {
+    "description": "Default LTI consumer title for a new meeting.",
+    "message": "New meeting"
+  },
+  "apps.bbb.SelectContent.notStarted": {
+    "description": "Text helper displayed if a meeting is not started.",
+    "message": "Not started"
+  },
+  "apps.bbb.SelectContent.select": {
+    "description": "Accessible message for selecting a meeting.",
+    "message": "Select {title}"
+  },
+  "apps.bbb.SelectContent.started": {
+    "description": "Text helper displayed if a meeting is started.",
+    "message": "Started"
+  },
+  "component.DashboardMeeting.loadingMeeting": {
+    "description": "Accessible message for the spinner while loading the meeting in dashboard view.",
+    "message": "Loading meeting..."
+  },
+  "component.DashboardMeeting.startMeetingFail": {
+    "description": "Message when meeting start failed.",
+    "message": "Meeting not started!"
+  },
+  "component.DashboardMeeting.startMeetingSuccess": {
+    "description": "Message when meeting start is successful.",
+    "message": "Meeting started."
+  },
+  "component.DashboardMeetingAskUsername.cancel": {
+    "description": "Button label for discarding ask username form in meeting dashboard view.",
+    "message": "Cancel"
+  },
+  "component.DashboardMeetingAskUsername.join": {
+    "description": "Button label for setting username and joining the meeting in meeting dashboard view.",
+    "message": "Join"
+  },
+  "component.DashboardMeetingAskUsername.label": {
+    "description": "Label for asking username to join the meeting.",
+    "message": "Please enter your name to join the meeting"
+  },
+  "component.DashboardMeetingForm.createMeetingFail": {
+    "description": "Message when meeting creation failed.",
+    "message": "Meeting not created!"
+  },
+  "component.DashboardMeetingForm.createMeetingLabel": {
+    "description": "Label for confirm button in meeting creation form.",
+    "message": "Create meeting in BBB"
+  },
+  "component.DashboardMeetingForm.titleLabel": {
+    "description": "Label for title in meeting creation form.",
+    "message": "Title"
+  },
+  "component.DashboardMeetingForm.welcomeTextLabel": {
+    "description": "Label for welcome text in meeting creation form.",
+    "message": "Welcome text"
+  },
+  "component.DashboardMeetingInfos.listeners": {
+    "description": "Role name for listeners in dashboard meeting info view.",
+    "message": "Listeners"
+  },
+  "component.DashboardMeetingInfos.moderators": {
+    "description": "Role name for moderators in dashboard meeting info view.",
+    "message": "Moderators"
+  },
+  "component.DashboardMeetingInfos.participants": {
+    "description": "Role name for participants in dashboard meeting info view.",
+    "message": "Participants"
+  },
+  "component.DashboardMeetingInstructor.createMeetingFail": {
+    "description": "Message when meeting creation failed.",
+    "message": "Meeting not created!"
+  },
+  "component.DashboardMeetingInstructor.endMeetingLabel": {
+    "description": "Label for ending meeting in instructor dashboard.",
+    "message": "End meeting"
+  },
+  "component.DashboardMeetingInstructor.endingMeetingPending": {
+    "description": "Message when ending meeting is pending.",
+    "message": "Ending meeting…"
+  },
+  "component.DashboardMeetingInstructor.joinMeetingLabel": {
+    "description": "Label for joining meeting in instructor dashboard.",
+    "message": "Join meeting"
+  },
+  "component.DashboardMeetingJoin.blockedPopups": {
+    "description": "Message when browser is blocking popups.",
+    "message": "Your browser is blocking popups."
+  },
+  "component.DashboardMeetingJoin.joinLinkLabel": {
+    "description": "Label for link used to join a meeting.",
+    "message": "Please click here to access meeting."
+  },
+  "component.DashboardMeetingStudent.meetingNotStarted": {
+    "description": "Message when meeting is not started.",
+    "message": "Meeting not started yet."
+  },
+  "component.DashboardMeetingStudent.meetingRedirection": {
+    "description": "Message when meeting is started and redirection should be triggered.",
+    "message": "You should be redirected to the meeting."
+  },
   "component.DashboardVideoPaneDownloadOption.allowDownload": {
     "description": "",
     "message": "Allow video download"
@@ -183,21 +291,17 @@
     "description": "DashboardVideoLive jitsi title.",
     "message": "Webinar"
   },
-  "components.DashboardVideoLive.liveCreating": {
-    "description": "Helptext explainig to wait until the live is created.",
-    "message": "Live streaming is being created. You will be able to start it in a few seconds"
-  },
   "components.DashboardVideoLive.liveStarting": {
     "description": "Helptext explainig to wait until the live is ready.",
-    "message": "Live streaming is starting. Wait before starting your stream."
+    "message": "Live streaming is starting. This can take a few minutes."
   },
   "components.DashboardVideoLive.liveStopped": {
     "description": "Helptext explaining that the live is ended and the live to VOD process has started.",
     "message": "Live streaming is ended. The process to transform the live to VOD has started. You can close the window and come back later."
   },
   "components.DashboardVideoLive.liveStopping": {
-    "description": "Helptext explaining that the live is ending and the live to VOD process will start.",
-    "message": "Live streaming is ending. The process to transform the live to VOD will begin soon. You can close the window and come back later."
+    "description": "Helptext explaining that the live is stopping and will be paused in few moments.",
+    "message": "Pause live streaming, please wait a few moments to be able to resume it."
   },
   "components.DashboardVideoLive.raw": {
     "description": "DashboardVideoLive main title.",
@@ -206,6 +310,14 @@
   "components.DashboardVideoLive.url": {
     "description": "Video url streaming.",
     "message": "url"
+  },
+  "components.DashboardVideoLiveEndButton.confirmEndLive": {
+    "description": "Confirmation to end the video streaming.",
+    "message": "Are you sure you want to end the video streaming ? This action is definitive"
+  },
+  "components.DashboardVideoLiveEndButton.endLive": {
+    "description": "End a video streaming.",
+    "message": "End live"
   },
   "components.DashboardVideoLiveInfo.copied": {
     "description": "Message displayed when endpoints info are copied.",
@@ -247,13 +359,21 @@
     "description": "button to redirect use to video player.",
     "message": "show live"
   },
+  "components.DashboardVideoLiveStartButton.confirmResumeLive": {
+    "description": "Confirmation to resume a video streaming.",
+    "message": "Are you sure you want to resume a video streaming ?"
+  },
   "components.DashboardVideoLiveStartButton.confirmStartLive": {
     "description": "Confirmation to start a video streaming.",
     "message": "Are you sure you want to start a video streaming ?"
   },
+  "components.DashboardVideoLiveStartButton.resumeLive": {
+    "description": "Resume a video streaming.",
+    "message": "Resume streaming"
+  },
   "components.DashboardVideoLiveStartButton.startLive": {
     "description": "Start a video streaming.",
-    "message": "start streaming"
+    "message": "Start streaming"
   },
   "components.DashboardVideoLiveStartButton.startLiveHelper": {
     "description": "Helper message explaining why the start live button is disabled",
@@ -261,11 +381,11 @@
   },
   "components.DashboardVideoLiveStopButton.confirmStopLive": {
     "description": "Confirmation to stop the video streaming.",
-    "message": "Are you sure you want to stop the video streaming ?"
+    "message": "Are you sure you want to pause the video streaming ?"
   },
   "components.DashboardVideoLiveStopButton.startLive": {
     "description": "Stop a video streaming.",
-    "message": "stop streaming"
+    "message": "pause ⏸"
   },
   "components.DashboardVideoPane.helpTextDeleted": {
     "description": "Dashboard helptext for when the video is in DELETED state",
@@ -431,10 +551,6 @@
     "description": "Title for the Instructor View. Describes the area appearing right above, which is a preview\n      of what the student will see there.",
     "message": "Preview"
   },
-  "components.ObjectStatusPicker.CREATING": {
-    "description": "Live video in creation status",
-    "message": "Creating"
-  },
   "components.ObjectStatusPicker.DELETED": {
     "description": "Status information for a video/audio/timed text track",
     "message": "Deleted"
@@ -454,6 +570,10 @@
   "components.ObjectStatusPicker.IDLE": {
     "description": "The video is in live state and ready to be start",
     "message": "Ready to start live"
+  },
+  "components.ObjectStatusPicker.PAUSED": {
+    "description": "The video is in live state and is paused",
+    "message": "Live is paused"
   },
   "components.ObjectStatusPicker.PENDING": {
     "description": "Status information for a video/audio/timed text track",
@@ -539,6 +659,78 @@
     "description": "Title for the list of videos in the playlist view.",
     "message": "Videos"
   },
+  "components.PublicPausedLive.message": {
+    "description": "Message for the public when live is paused",
+    "message": "The webinar is paused. When resumed, the video will start again."
+  },
+  "components.PublicPausedLive.pausedSince": {
+    "description": "Information about the time since which the webinar is paused.",
+    "message": "The webinar is paused since"
+  },
+  "components.PublicPausedLive.title": {
+    "description": "Title for the public paused live component",
+    "message": "Webinar is paused"
+  },
+  "components.ScheduledVideo.form.date": {
+    "description": "Label of the input field to add/update the scheduled date and time of the webinar",
+    "message": "Starting date and time"
+  },
+  "components.ScheduledVideo.form.description": {
+    "description": "Label of the input field to add/update the description of the webinar",
+    "message": "Description"
+  },
+  "components.ScheduledVideo.form.error": {
+    "description": "Error message while saving the form",
+    "message": "An error occured while updating the scheduled webinar, please try again."
+  },
+  "components.ScheduledVideo.form.error.starting_at": {
+    "description": "Error message while saving the form, date is not defined or in the past",
+    "message": "Scheduled date must be in the future and have a date and hour defined."
+  },
+  "components.ScheduledVideo.form.error.starting_at_already_past": {
+    "description": "Error message while saving the form, initial scheduled date of this webinar is already past, invit user to create a new webinar or to start this one.",
+    "message": "This webinar has an initial date that is already past, it can't be updated in the future. Please, create a new webinar or start this one."
+  },
+  "components.ScheduledVideo.form.error.title": {
+    "description": "Error on field title, this one cannot be empty",
+    "message": "Title must be defined."
+  },
+  "components.ScheduledVideo.form.intro": {
+    "description": "Title of the form to create or update the scheduled webinar",
+    "message": "Schedule a webinar"
+  },
+  "components.ScheduledVideo.form.placeholder.description": {
+    "description": "Placeholder of the description field in the form",
+    "message": "Description"
+  },
+  "components.ScheduledVideo.form.placeholder.title": {
+    "description": "Placeholder of the title field in the form",
+    "message": "Title"
+  },
+  "components.ScheduledVideo.form.success": {
+    "description": "message to confirm webinar has been updated",
+    "message": "Your webinar has been updated"
+  },
+  "components.ScheduledVideo.form.success.openregistration": {
+    "description": "message to confirm users can now register to the webinar",
+    "message": "Your can now ask users to register to your webinar"
+  },
+  "components.ScheduledVideo.form.title": {
+    "description": "Label of the input field to add/update the title to the webinar",
+    "message": "Title"
+  },
+  "components.ScheduledVideo.infoScheduledEvent": {
+    "description": "Message informing webinar is scheduled and giving the current date.",
+    "message": "Webinar is scheduled at {date}."
+  },
+  "components.ScheduledVideo.infoWasScheduledEvent": {
+    "description": "Message informing webinar was scheduled and giving the initial scheduled date.",
+    "message": "Webinar was scheduled at {date}."
+  },
+  "components.ScheduledVideo.infoWasScheduledEventDescription": {
+    "description": "Message informing that scheduled date is past and telling the user he can either start it or create a new one.",
+    "message": "Date is past, please, create a new webinar or start this one"
+  },
   "components.SelectContent.addDocument": {
     "description": "Text displayed on a button to add a new document.",
     "message": "Add a document"
@@ -598,6 +790,42 @@
   "components.SiteHeader.logInBtn": {
     "description": "Text for the login button in the header of the marsha site",
     "message": "Log in"
+  },
+  "components.SubscribScheduledVideo.daysLeft": {
+    "description": "Text message to inform on number of days left before the event starts",
+    "message": "Days left {daysLeft,number} {daysLeft, plural, =0 {day} one {day} other {days}}"
+  },
+  "components.SubscribScheduledVideo.register": {
+    "description": "Title message to register to this event",
+    "message": "Register to this event starting on {date}"
+  },
+  "components.SubscribScheduledVideoEmail.form.email": {
+    "description": "Label of the input field to add an email to subscribe to the event",
+    "message": "Type your email to subscribe"
+  },
+  "components.SubscribScheduledVideoEmail.form.email.default.error": {
+    "description": "Error message to warn the user that his email registration did not work. Ask user to check his email adress otherwise to contact us or to try later.",
+    "message": "Impossible to register your email {email} for this event. Make sure your email is valid otherwise, please try again later or contact us."
+  },
+  "components.SubscribScheduledVideoEmail.form.email.existing.error": {
+    "description": "Error message to warn the user that his email registration did not work because this email is already registered.",
+    "message": "Impossible to register, {email} is already registered for this event with another account."
+  },
+  "components.SubscribScheduledVideoEmail.form.email.invalid.error": {
+    "description": "Error message to warn the user that his email registration did not work because this email is not valid.",
+    "message": "Impossible to register, {email} is not valid."
+  },
+  "components.SubscribScheduledVideoEmail.form.labelRegisterSubmitButton": {
+    "description": "Label of the input to register to the event",
+    "message": "Register"
+  },
+  "components.SubscribScheduledVideoEmail.form.success": {
+    "description": "message display when the email is successfully registered for this event",
+    "message": "Email {email} successfully registered for this event"
+  },
+  "components.SubscribScheduledVideoEmail.waitingMessage": {
+    "description": "Message reminding the user, he has already registered and giving back the starting at date.",
+    "message": "You are registered for this event. Live will start at {date}."
   },
   "components.TimedTextCreationForm.addTrackBtn": {
     "description": "Text for the button in the dashboard to go upload a new timed text file.",
@@ -858,5 +1086,8 @@
   "message.key": {
     "description": "",
     "message": "Our title"
+  },
+  "zgxKi7": {
+    "message": "{pausedDays} {pausedDays, plural, one {day} other {days}}"
   }
 }

--- a/src/frontend/i18n/fr_FR.json
+++ b/src/frontend/i18n/fr_FR.json
@@ -1,4 +1,112 @@
 {
+  "apps.bbb.SelectContent.addMeeting": {
+    "description": "Text displayed on a button to add a new meeting.",
+    "message": "Ajouter une classe virtuelle"
+  },
+  "apps.bbb.SelectContent.loadingMeetings": {
+    "description": "Accessible message for the spinner while loading the meetings in lti select view.",
+    "message": "Chargement des classes virtuelles..."
+  },
+  "apps.bbb.SelectContent.newMeeting": {
+    "description": "Default LTI consumer title for a new meeting.",
+    "message": "Nouvelle classe virtuelle"
+  },
+  "apps.bbb.SelectContent.notStarted": {
+    "description": "Text helper displayed if a meeting is not started.",
+    "message": "Non démarrée"
+  },
+  "apps.bbb.SelectContent.select": {
+    "description": "Accessible message for selecting a meeting.",
+    "message": "Sélectionner {title}"
+  },
+  "apps.bbb.SelectContent.started": {
+    "description": "Text helper displayed if a meeting is started.",
+    "message": "Démarrée"
+  },
+  "component.DashboardMeeting.loadingMeeting": {
+    "description": "Accessible message for the spinner while loading the meeting in dashboard view.",
+    "message": "Chargement de la classe virtuelle..."
+  },
+  "component.DashboardMeeting.startMeetingFail": {
+    "description": "Message when meeting start failed.",
+    "message": "La classe virtuelle n'a pas commencé!"
+  },
+  "component.DashboardMeeting.startMeetingSuccess": {
+    "description": "Message when meeting start is successful.",
+    "message": "Classe virtuelle démarrée."
+  },
+  "component.DashboardMeetingAskUsername.cancel": {
+    "description": "Button label for discarding ask username form in meeting dashboard view.",
+    "message": "Annuler"
+  },
+  "component.DashboardMeetingAskUsername.join": {
+    "description": "Button label for setting username and joining the meeting in meeting dashboard view.",
+    "message": "Rejoindre"
+  },
+  "component.DashboardMeetingAskUsername.label": {
+    "description": "Label for asking username to join the meeting.",
+    "message": "Veuillez saisir votre nom pour rejoindre la classe virtuelle"
+  },
+  "component.DashboardMeetingForm.createMeetingFail": {
+    "description": "Message when meeting creation failed.",
+    "message": "Classe virtuelle non créée !"
+  },
+  "component.DashboardMeetingForm.createMeetingLabel": {
+    "description": "Label for confirm button in meeting creation form.",
+    "message": "Créer une classe virtuelle BBB"
+  },
+  "component.DashboardMeetingForm.titleLabel": {
+    "description": "Label for title in meeting creation form.",
+    "message": "Titre"
+  },
+  "component.DashboardMeetingForm.welcomeTextLabel": {
+    "description": "Label for welcome text in meeting creation form.",
+    "message": "Texte de bienvenue"
+  },
+  "component.DashboardMeetingInfos.listeners": {
+    "description": "Role name for listeners in dashboard meeting info view.",
+    "message": "Auditeurs"
+  },
+  "component.DashboardMeetingInfos.moderators": {
+    "description": "Role name for moderators in dashboard meeting info view.",
+    "message": "Modérateurs"
+  },
+  "component.DashboardMeetingInfos.participants": {
+    "description": "Role name for participants in dashboard meeting info view.",
+    "message": "Participants"
+  },
+  "component.DashboardMeetingInstructor.createMeetingFail": {
+    "description": "Message when meeting creation failed.",
+    "message": "Classe virtuelle non créée !"
+  },
+  "component.DashboardMeetingInstructor.endMeetingLabel": {
+    "description": "Label for ending meeting in instructor dashboard.",
+    "message": "Mettre fin à la classe virtuelle"
+  },
+  "component.DashboardMeetingInstructor.endingMeetingPending": {
+    "description": "Message when ending meeting is pending.",
+    "message": "Fin de classe virtuelle en cours…"
+  },
+  "component.DashboardMeetingInstructor.joinMeetingLabel": {
+    "description": "Label for joining meeting in instructor dashboard.",
+    "message": "Rejoindre la classe virtuelle"
+  },
+  "component.DashboardMeetingJoin.blockedPopups": {
+    "description": "Message when browser is blocking popups.",
+    "message": "Votre navigateur bloque les popups."
+  },
+  "component.DashboardMeetingJoin.joinLinkLabel": {
+    "description": "Label for link used to join a meeting.",
+    "message": "Cliquez ici pour accéder à la classe virtuelle."
+  },
+  "component.DashboardMeetingStudent.meetingNotStarted": {
+    "description": "Message when meeting is not started.",
+    "message": "La classe virtuelle n'a pas encore commencé."
+  },
+  "component.DashboardMeetingStudent.meetingRedirection": {
+    "description": "Message when meeting is started and redirection should be triggered.",
+    "message": "Vous allez être redirigé vers la classe virtuelle."
+  },
   "component.DashboardVideoPaneDownloadOption.allowDownload": {
     "description": "",
     "message": "Autoriser le téléchargement de la vidéo"
@@ -183,21 +291,17 @@
     "description": "DashboardVideoLive jitsi title.",
     "message": "Webinaire"
   },
-  "components.DashboardVideoLive.liveCreating": {
-    "description": "Helptext explainig to wait until the live is created.",
-    "message": "Le direct est cours de création. Vous allez pouvoir le démarrer dans quelques instants"
-  },
   "components.DashboardVideoLive.liveStarting": {
     "description": "Helptext explainig to wait until the live is ready.",
-    "message": "La diffusion en direct démarre. Attendez avant de commencer votre stream."
+    "message": "Le direct est en cours de démarrage. Cela peut prendre quelques minutes."
   },
   "components.DashboardVideoLive.liveStopped": {
     "description": "Helptext explaining that the live is ended and the live to VOD process has started.",
     "message": "Le direct est terminé. Le processus de conversion du direct en VOD a débuté. Vous pouvez fermer cette fenêtre et revenir plus tard."
   },
   "components.DashboardVideoLive.liveStopping": {
-    "description": "Helptext explaining that the live is ending and the live to VOD process will start.",
-    "message": "Arrêt du direct. Le processus de conversion du direct en VOD va bientôt commencer. Vous pouvez fermer la fenêtre et revenir plus tard."
+    "description": "Helptext explaining that the live is stopping and will be paused in few moments.",
+    "message": "Mise en pause du direct. Veuillez attendre l'arrêt total avant de pouvoir le redémarrer."
   },
   "components.DashboardVideoLive.raw": {
     "description": "DashboardVideoLive main title.",
@@ -206,6 +310,14 @@
   "components.DashboardVideoLive.url": {
     "description": "Video url streaming.",
     "message": "url"
+  },
+  "components.DashboardVideoLiveEndButton.confirmEndLive": {
+    "description": "Confirmation to end the video streaming.",
+    "message": "Êtes-vous certain de vouloir arrêter le direct ? Cette action est définitive"
+  },
+  "components.DashboardVideoLiveEndButton.endLive": {
+    "description": "End a video streaming.",
+    "message": "Terminer le direct"
   },
   "components.DashboardVideoLiveInfo.copied": {
     "description": "Message displayed when endpoints info are copied.",
@@ -247,13 +359,21 @@
     "description": "button to redirect use to video player.",
     "message": "afficher le direct"
   },
+  "components.DashboardVideoLiveStartButton.confirmResumeLive": {
+    "description": "Confirmation to resume a video streaming.",
+    "message": "Êtes-vous certain de vouloir redémarrer le direct ?"
+  },
   "components.DashboardVideoLiveStartButton.confirmStartLive": {
     "description": "Confirmation to start a video streaming.",
     "message": "Êtes-vous certain de vouloir démarrer un direct ?"
   },
+  "components.DashboardVideoLiveStartButton.resumeLive": {
+    "description": "Resume a video streaming.",
+    "message": "Reprendre le direct"
+  },
   "components.DashboardVideoLiveStartButton.startLive": {
     "description": "Start a video streaming.",
-    "message": "démarrer le direct"
+    "message": "Démarrer le direct"
   },
   "components.DashboardVideoLiveStartButton.startLiveHelper": {
     "description": "Helper message explaining why the start live button is disabled",
@@ -261,11 +381,11 @@
   },
   "components.DashboardVideoLiveStopButton.confirmStopLive": {
     "description": "Confirmation to stop the video streaming.",
-    "message": "Êtes-vous certain de vouloir arrêter le direct ?"
+    "message": "Êtes-vous certain de vouloir mettre en pause le direct ?"
   },
   "components.DashboardVideoLiveStopButton.startLive": {
     "description": "Stop a video streaming.",
-    "message": "arrêter le streaming"
+    "message": "pause ⏸"
   },
   "components.DashboardVideoPane.helpTextDeleted": {
     "description": "Dashboard helptext for when the video is in DELETED state",
@@ -431,10 +551,6 @@
     "description": "Title for the Instructor View. Describes the area appearing right above, which is a preview\n      of what the student will see there.",
     "message": "Prévisualiser"
   },
-  "components.ObjectStatusPicker.CREATING": {
-    "description": "Live video in creation status",
-    "message": "Création en cours"
-  },
   "components.ObjectStatusPicker.DELETED": {
     "description": "Status information for a video/audio/timed text track",
     "message": "Supprimé"
@@ -454,6 +570,10 @@
   "components.ObjectStatusPicker.IDLE": {
     "description": "The video is in live state and ready to be start",
     "message": "Prêt à démarrer le direct"
+  },
+  "components.ObjectStatusPicker.PAUSED": {
+    "description": "The video is in live state and is paused",
+    "message": "Le direct est en pause"
   },
   "components.ObjectStatusPicker.PENDING": {
     "description": "Status information for a video/audio/timed text track",
@@ -539,6 +659,78 @@
     "description": "Title for the list of videos in the playlist view.",
     "message": "Vidéos"
   },
+  "components.PublicPausedLive.message": {
+    "description": "Message for the public when live is paused",
+    "message": "Le webinaire est mis en pause. Une fois relancé, la vidéo redémarre."
+  },
+  "components.PublicPausedLive.pausedSince": {
+    "description": "Information about the time since which the webinar is paused.",
+    "message": "Le webinaire est en pause depuis"
+  },
+  "components.PublicPausedLive.title": {
+    "description": "Title for the public paused live component",
+    "message": "Le webinaire est en pause"
+  },
+  "components.ScheduledVideo.form.date": {
+    "description": "Label of the input field to add/update the scheduled date and time of the webinar",
+    "message": "Date et heure de début"
+  },
+  "components.ScheduledVideo.form.description": {
+    "description": "Label of the input field to add/update the description of the webinar",
+    "message": "Description"
+  },
+  "components.ScheduledVideo.form.error": {
+    "description": "Error message while saving the form",
+    "message": "Une erreur est survenue durant la mise à jour, merci de réessayer."
+  },
+  "components.ScheduledVideo.form.error.starting_at": {
+    "description": "Error message while saving the form, date is not defined or in the past",
+    "message": "La date de programmation doit être postérieure à la date actuelle. Vous devez définir une date et une heure."
+  },
+  "components.ScheduledVideo.form.error.starting_at_already_past": {
+    "description": "Error message while saving the form, initial scheduled date of this webinar is already past, invit user to create a new webinar or to start this one.",
+    "message": "La date de programmation de ce webinaire est déjà passée. Vous ne pouvez plus modifier sa date. Merci de créer un nouveau webinaire ou bien démarrez celui-ci."
+  },
+  "components.ScheduledVideo.form.error.title": {
+    "description": "Error on field title, this one cannot be empty",
+    "message": "Merci de renseigner un titre."
+  },
+  "components.ScheduledVideo.form.intro": {
+    "description": "Title of the form to create or update the scheduled webinar",
+    "message": "Programmer un webinaire"
+  },
+  "components.ScheduledVideo.form.placeholder.description": {
+    "description": "Placeholder of the description field in the form",
+    "message": "Description"
+  },
+  "components.ScheduledVideo.form.placeholder.title": {
+    "description": "Placeholder of the title field in the form",
+    "message": "Titre"
+  },
+  "components.ScheduledVideo.form.success": {
+    "description": "message to confirm webinar has been updated",
+    "message": "Votre webinaire a été mis à jour"
+  },
+  "components.ScheduledVideo.form.success.openregistration": {
+    "description": "message to confirm users can now register to the webinar",
+    "message": "Des utilisateurs peuvent désormais s'inscrire à ce webinaire"
+  },
+  "components.ScheduledVideo.form.title": {
+    "description": "Label of the input field to add/update the title to the webinar",
+    "message": "Titre"
+  },
+  "components.ScheduledVideo.infoScheduledEvent": {
+    "description": "Message informing webinar is scheduled and giving the current date.",
+    "message": "Le webinaire est programmé le {date}."
+  },
+  "components.ScheduledVideo.infoWasScheduledEvent": {
+    "description": "Message informing webinar was scheduled and giving the initial scheduled date.",
+    "message": "Le webinaire était programmé pour le {date}."
+  },
+  "components.ScheduledVideo.infoWasScheduledEventDescription": {
+    "description": "Message informing that scheduled date is past and telling the user he can either start it or create a new one.",
+    "message": "La date est passée, vous pouvez soit créer un nouveau webinaire soit démarrer celui-ci"
+  },
   "components.SelectContent.addDocument": {
     "description": "Text displayed on a button to add a new document.",
     "message": "Ajouter un document"
@@ -598,6 +790,42 @@
   "components.SiteHeader.logInBtn": {
     "description": "Text for the login button in the header of the marsha site",
     "message": "Se connecter"
+  },
+  "components.SubscribScheduledVideo.daysLeft": {
+    "description": "Text message to inform on number of days left before the event starts",
+    "message": "Jours restants {daysLeft,number} {daysLeft, plural, =0 {jour} one {jour} other {jours}}"
+  },
+  "components.SubscribScheduledVideo.register": {
+    "description": "Title message to register to this event",
+    "message": "S'enregistrer à ce webinaire débutant le {date}"
+  },
+  "components.SubscribScheduledVideoEmail.form.email": {
+    "description": "Label of the input field to add an email to subscribe to the event",
+    "message": "Saisissez votre mail pour vous inscrire"
+  },
+  "components.SubscribScheduledVideoEmail.form.email.default.error": {
+    "description": "Error message to warn the user that his email registration did not work. Ask user to check his email adress otherwise to contact us or to try later.",
+    "message": "Impossible d'enregistrer votre e-mail {email} pour ce webinaire. Assurez-vous que votre adresse e-mail est valide autrement, veuillez réessayer plus tard ou nous contacter."
+  },
+  "components.SubscribScheduledVideoEmail.form.email.existing.error": {
+    "description": "Error message to warn the user that his email registration did not work because this email is already registered.",
+    "message": "Impossible de s'enregistrer, {email} est déjà enregistré pour ce webinaire avec un autre compte."
+  },
+  "components.SubscribScheduledVideoEmail.form.email.invalid.error": {
+    "description": "Error message to warn the user that his email registration did not work because this email is not valid.",
+    "message": "Impossible de s'enregistrer, {email} n'est pas valide."
+  },
+  "components.SubscribScheduledVideoEmail.form.labelRegisterSubmitButton": {
+    "description": "Label of the input to register to the event",
+    "message": "S'enregistrer"
+  },
+  "components.SubscribScheduledVideoEmail.form.success": {
+    "description": "message display when the email is successfully registered for this event",
+    "message": "E-mail {email} enregistré avec succès pour ce webinaire"
+  },
+  "components.SubscribScheduledVideoEmail.waitingMessage": {
+    "description": "Message reminding the user, he has already registered and giving back the starting at date.",
+    "message": "Vous êtes enregistré pour ce webinaire. Il débutera le {date}."
   },
   "components.TimedTextCreationForm.addTrackBtn": {
     "description": "Text for the button in the dashboard to go upload a new timed text file.",
@@ -858,5 +1086,8 @@
   "message.key": {
     "description": "",
     "message": "Titre"
+  },
+  "zgxKi7": {
+    "message": "{pausedDays} {pausedDays, plural, one {jour} other {jours}}"
   }
 }

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marsha",
-  "version": "3.26.0",
+  "version": "3.27.0",
   "description": "🐠 a FUN LTI video provider",
   "main": "front/index.tsx",
   "scripts": {


### PR DESCRIPTION
### Added

- Prepare backend to manage apps
- Prepare frontend to manage apps
- Add BBB backend app
- Add BBB frontend app
- Add configuration to filter app with feature flags
- Start and stop a live
- Add a form to create a scheduled video on the Dashboard
- Add frontend components to register an email for scheduled webinars
- Add API endpoints to pair an external device to Jitsi live videos
- Add a store in the frontend to control live layout
- Add frontend components to pair an external device to Jitsi live videos
- Add public availability to video api
### Changed
- Postpone AWS creation stack to the first live start action
- Scheduled videos have a live_state set to IDLE
- Allow access to videos with a scheduled date past

### Fixed

- Users with empty email in their token can register to scheduled webinars
- Users with wrong email in token is properly detected as registered
- Users waiting on the registration page are redirected if video is started 
  earlier
- Update store in the WaitingLiveVideo component 
- Set specific timeout to 30 seconds in pollForLive to update the store

### Removed

- check_live_idle management command
- Remove validate_date_is_future validator on Video model
