### PR TITLE
🩹(back) add consumer_site in JWT token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Add model and API endpoints to manage a shared live media
 - Add component to display chat, viewers and apps during a live in a panel
+- Add `consumer_site` in JWT token
 
 ### Changed
 

--- a/src/backend/marsha/core/tests/test_views_lti_video.py
+++ b/src/backend/marsha/core/tests/test_views_lti_video.py
@@ -80,6 +80,9 @@ class VideoLTIViewTestCase(TestCase):
         jwt_token = AccessToken(context.get("jwt"))
         self.assertEqual(jwt_token.payload["resource_id"], str(video.id))
         self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
+        self.assertEqual(
+            jwt_token.payload["consumer_site"], str(passport.consumer_site.id)
+        )
         self.assertEqual(jwt_token.payload["roles"], [data["roles"]])
         self.assertEqual(jwt_token.payload["locale"], "fr_FR")
         self.assertEqual(
@@ -212,6 +215,9 @@ class VideoLTIViewTestCase(TestCase):
             },
         )
         self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
+        self.assertEqual(
+            jwt_token.payload["consumer_site"], str(passport.consumer_site.id)
+        )
         self.assertEqual(jwt_token.payload["roles"], [data["roles"]])
         self.assertEqual(jwt_token.payload["locale"], "fr_FR")
         self.assertEqual(
@@ -362,6 +368,9 @@ class VideoLTIViewTestCase(TestCase):
             },
         )
         self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
+        self.assertEqual(
+            jwt_token.payload["consumer_site"], str(passport.consumer_site.id)
+        )
         self.assertEqual(jwt_token.payload["roles"], [data["roles"]])
         self.assertEqual(jwt_token.payload["locale"], "fr_FR")
         self.assertEqual(
@@ -504,6 +513,9 @@ class VideoLTIViewTestCase(TestCase):
             },
         )
         self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
+        self.assertEqual(
+            jwt_token.payload["consumer_site"], str(passport.consumer_site.id)
+        )
         self.assertEqual(jwt_token.payload["roles"], [data["roles"]])
         self.assertEqual(jwt_token.payload["locale"], "fr_FR")
         self.assertEqual(
@@ -632,6 +644,9 @@ class VideoLTIViewTestCase(TestCase):
             },
         )
         self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
+        self.assertEqual(
+            jwt_token.payload["consumer_site"], str(passport.consumer_site.id)
+        )
         self.assertEqual(jwt_token.payload["roles"], [data["roles"]])
         self.assertEqual(jwt_token.payload["locale"], "fr_FR")
         self.assertEqual(
@@ -841,6 +856,9 @@ class VideoLTIViewTestCase(TestCase):
             },
         )
         self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
+        self.assertEqual(
+            jwt_token.payload["consumer_site"], str(passport.consumer_site.id)
+        )
         self.assertEqual(jwt_token.payload["roles"], [data["roles"]])
         self.assertEqual(jwt_token.payload["locale"], "en_US")
         self.assertEqual(
@@ -958,6 +976,9 @@ class VideoLTIViewTestCase(TestCase):
             },
         )
         self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
+        self.assertEqual(
+            jwt_token.payload["consumer_site"], str(passport.consumer_site.id)
+        )
         self.assertEqual(jwt_token.payload["roles"], [data["roles"]])
         self.assertEqual(jwt_token.payload["locale"], "en_US")
         self.assertEqual(
@@ -1077,6 +1098,9 @@ class VideoLTIViewTestCase(TestCase):
             },
         )
         self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
+        self.assertEqual(
+            jwt_token.payload["consumer_site"], str(passport.consumer_site.id)
+        )
         self.assertEqual(jwt_token.payload["roles"], [data["roles"]])
         self.assertEqual(jwt_token.payload["locale"], "en_US")
         self.assertEqual(
@@ -1191,6 +1215,9 @@ class VideoLTIViewTestCase(TestCase):
         jwt_token = AccessToken(context.get("jwt"))
         self.assertEqual(jwt_token.payload["resource_id"], str(video.id))
         self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
+        self.assertEqual(
+            jwt_token.payload["consumer_site"], str(passport.consumer_site.id)
+        )
         self.assertEqual(jwt_token.payload["roles"], [data["roles"]])
         self.assertEqual(jwt_token.payload["locale"], "en_US")
         self.assertEqual(
@@ -1320,6 +1347,9 @@ class VideoLTIViewTestCase(TestCase):
         jwt_token = AccessToken(context.get("jwt"))
         self.assertEqual(jwt_token.payload["resource_id"], str(video.id))
         self.assertEqual(jwt_token.payload["context_id"], data["context_id"])
+        self.assertEqual(
+            jwt_token.payload["consumer_site"], str(passport.consumer_site.id)
+        )
         self.assertEqual(jwt_token.payload["roles"], [data["roles"]])
         self.assertEqual(jwt_token.payload["locale"], "en_US")
         self.assertEqual(

--- a/src/backend/marsha/core/tests/test_views_public_document.py
+++ b/src/backend/marsha/core/tests/test_views_public_document.py
@@ -77,6 +77,7 @@ class DocumentPublicViewTestCase(TestCase):
         )
         self.assertEqual(context.get("modelName"), "documents")
         self.assertIsNone(context.get("context_id"))
+        self.assertIsNone(context.get("consumer_site"))
 
     def test_document_not_publicly_accessible(self):
         """Validate it is impossible to access to a non public document."""

--- a/src/backend/marsha/core/tests/test_views_public_video.py
+++ b/src/backend/marsha/core/tests/test_views_public_video.py
@@ -124,6 +124,7 @@ class VideoPublicViewTestCase(TestCase):
         self.assertEqual(context.get("state"), "success")
         self.assertEqual(context.get("modelName"), "videos")
         self.assertIsNone(context.get("context_id"))
+        self.assertIsNone(context.get("consumer_site"))
 
     def test_video_not_publicly_accessible(self):
         """Validate it is impossible to access to a non public video."""

--- a/src/backend/marsha/core/tests/test_views_site.py
+++ b/src/backend/marsha/core/tests/test_views_site.py
@@ -54,6 +54,7 @@ class SiteViewTestCase(TestCase):
             {"svg": {"icons": "/static/svg/icons.svg"}},
         )
         self.assertIsNone(context.get("context_id"))
+        self.assertIsNone(context.get("consumer_site"))
 
     @override_switch("site", active=False)
     def test_site_not_accessible(self):

--- a/src/backend/marsha/core/views.py
+++ b/src/backend/marsha/core/views.py
@@ -144,6 +144,7 @@ def build_jwt_token(
 
     if lti:
         jwt_token.payload["context_id"] = lti.context_id
+        jwt_token.payload["consumer_site"] = str(lti.get_consumer_site().id)
 
     if playlist_id:
         jwt_token.payload["playlist_id"] = playlist_id

--- a/src/frontend/types/jwt.ts
+++ b/src/frontend/types/jwt.ts
@@ -2,17 +2,18 @@ import { Nullable } from '../utils/types';
 
 export interface DecodedJwt {
   context_id?: string;
+  consumer_site?: string;
   email: string;
-  roles: string[];
-  session_id: string;
-  resource_id: string;
   locale: string;
+  maintenance: boolean;
   permissions: {
     can_access_dashboard: boolean;
     can_update: boolean;
   };
   playlist_id?: string;
-  maintenance: boolean;
+  resource_id: string;
+  roles: string[];
+  session_id: string;
   user?: {
     email: Nullable<string>;
     id: string;


### PR DESCRIPTION


## Purpose

The consumer site is sent during the LTI connexion. Models in Marsha
due to LTI’s protocol and video’s portability are sometimes complex.
For instance, a playlist with a context_id can have multiple
consumer_site. It makes it hard to link a user with his consumer
site. We've decided to simplify access to this information by adding
it directly in the JWT token.
## Proposal

Description...

- add consumer_site in JWT token

