### PR TITLE
♻️(back) only use is_admin in serializer context

### DIFF
--- a/src/backend/marsha/core/api/video.py
+++ b/src/backend/marsha/core/api/video.py
@@ -96,8 +96,6 @@ class VideoViewSet(ObjectPkMixin, viewsets.ModelViewSet):
     def get_serializer_context(self):
         """Extra context provided to the serializer class."""
         context = super().get_serializer_context()
-        # The API is only reachable by admin users.
-        context["can_return_live_info"] = True
 
         user = self.request.user
         if isinstance(user, TokenUser):

--- a/src/backend/marsha/core/views.py
+++ b/src/backend/marsha/core/views.py
@@ -336,13 +336,9 @@ class BaseLTIView(ABC, TemplateResponseMixin, View):
                     "resource": self.serializer_class(
                         resource,
                         context={
-                            "can_return_live_info": lti.is_admin or lti.is_instructor
-                            if lti
-                            else False,
                             "is_admin": lti.is_admin or lti.is_instructor
                             if lti
                             else False,
-                            "roles": lti.roles if lti else [],
                             "user_id": user_id,
                             "session_id": session_id,
                         },


### PR DESCRIPTION
## Purpose

Several ways were used to determine if the current user is an admin or
not in the serializers. To do that we injected `roles` and
`can_return_live_info` and look in the serializer for these  values. We
must remove of these keys in the serializer to keep only `is_admin` to
be less confusing and less error prone. `can_return_live_info` was
introduce in a first time to allow to return live_info for student when
they want to join a discussion. But finally we decided to inject these
informations from the front directly instead of the back application to
not disclose sensitive informations. We forget to change its name.

## Proposal

- [x] only use is_admin in serializer context
