### PR TITLE
✨(back) allow to configure CORS headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Add model and API endpoints to manage a shared live media
 - Add component to display chat, viewers and apps during a live in a panel
 - Add `consumer_site` in JWT token
+- Allow CORS headers configuration
 
 ### Changed
 

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -13,6 +13,7 @@ import os
 from django.utils.translation import gettext_lazy as _
 
 from configurations import Configuration, values
+from corsheaders.defaults import default_headers
 import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
 
@@ -112,11 +113,13 @@ class Base(Configuration):
         "dockerflow.django",
         "waffle",
         "rest_framework",
+        "corsheaders",
         "marsha.core.apps.CoreConfig",
         "marsha.bbb.apps.BbbConfig",
     ]
 
     MIDDLEWARE = [
+        "corsheaders.middleware.CorsMiddleware",
         "django.middleware.security.SecurityMiddleware",
         "whitenoise.middleware.WhiteNoiseMiddleware",
         "django.contrib.sessions.middleware.SessionMiddleware",
@@ -306,6 +309,14 @@ class Base(Configuration):
 
     # SHARED LIVE MEDIA SETTINGS
     ALLOWED_SHARED_LIVE_MEDIA_MIME_TYPES = values.ListValue(["application/pdf"])
+
+    # Cors
+    CORS_ALLOW_ALL_ORIGINS = values.BooleanValue(False)
+    CORS_ALLOWED_ORIGINS = values.ListValue([])
+    CORS_ALLOWED_ORIGIN_REGEXES = values.ListValue([])
+    CORS_URLS_REGEX = values.Value(r"^/api/pairing-challenge$")
+    CORS_ALLOW_METHODS = values.ListValue(["POST", "OPTIONS"])
+    CORS_ALLOW_HEADERS = values.ListValue(list(default_headers))
 
     # pylint: disable=invalid-name
     @property

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -34,6 +34,7 @@ install_requires =
     django==3.2.10
     dj-database-url==0.5.0
     django-configurations==2.3.1
+    django-cors-headers==3.10.1
     django-extensions==3.1.5
     djangorestframework==3.12.4
     djangorestframework_simplejwt==5.0.0


### PR DESCRIPTION
## Purpose

The recently added `/api/pairing-challenge` url will be used in a
browser to a not recognized domain. This requests are rejected because
CORS headers are not activated in Marsha. We added the
django-cors-headers package responsible to manage them. The
configuration is not fully made to not block the strategy you want to
use. You have to decide on your marsha instance the strategy you want by
configuring one of the following setting `CORS_ALLOWED_ORIGINS`,
`CORS_ALLOWED_ORIGIN_REGEXES` and `CORS_ALLOW_ALL_ORIGINS`.
The full documentation is available here
https://github.com/adamchainz/django-cors-headers#configuration

## Proposal

- [x] Allow to configure CORS headers

