### PR TITLE
Live student buttons responsive

### DIFF
--- a/src/backend/marsha/core/templates/core/resource.html
+++ b/src/backend/marsha/core/templates/core/resource.html
@@ -5,6 +5,7 @@
   <head>
     <link rel="stylesheet" type="text/css" href="{% static 'css/main.css' %}">
     <meta name="public-path" value="{{ static_base_url }}" />
+    <meta name="viewport" content="width=device-width,initial-scale=1.0">
   </head>
   <body>
     <div id="marsha-frontend-data" data-context="{{ app_data }}"></div>

--- a/src/frontend/components/Button/index.tsx
+++ b/src/frontend/components/Button/index.tsx
@@ -1,5 +1,5 @@
-import React, { useLayoutEffect, useState, useRef } from 'react';
-import { Box, Button as GrommetButton, Text } from 'grommet';
+import React, { useLayoutEffect, useState, useRef, useContext } from 'react';
+import { Box, Button as GrommetButton, ResponsiveContext, Text } from 'grommet';
 import { normalizeColor } from 'grommet/utils';
 import styled from 'styled-components';
 
@@ -12,21 +12,38 @@ const StyledGrommetButton = styled(GrommetButton)`
   padding: 0;
 `;
 
-const StyledBox = styled(Box)`
+interface ResponsiveProps {
+  size: string;
+}
+
+const IconBox = styled(Box)`
   display: flex;
-  flex: 1;
-  margin: 0 8px;
+  height: ${({ size }: ResponsiveProps) => (size === 'small' ? '60%' : '80%')};
+  margin: ${({ size }: ResponsiveProps) =>
+    size === 'small' ? '0 6px' : '0 8px'};
   margin-bottom: 6px;
   min-height: 0;
   position: relative;
   width: 100%;
 `;
 
+const TextBox = styled(Box)`
+  display: flex;
+  height: ${({ size }: ResponsiveProps) => (size === 'small' ? '40%' : '20%')};
+  text-align: center;
+  width: 100%;
+`;
+
 const StyledText = styled(Text)`
   font-family: Roboto-Regular;
   font-weight: normal;
-  letter-spacing: -0.13px;
-  white-space: nowrap;
+  font-size: ${({ size }: ResponsiveProps) =>
+    size === 'small' ? '0.7rem' : '0.9rem'};
+  letter-spacing: ${({ size }: ResponsiveProps) =>
+    size === 'small' ? '-0.3px' : '-0.13px'};
+  line-height: ${({ size }: ResponsiveProps) =>
+    size === 'small' ? '0.8rem' : '0.9rem'};
+  margin: auto;
 `;
 
 interface ButtonProps {
@@ -48,6 +65,7 @@ export const Button = ({
   reversed,
   title,
 }: ButtonProps) => {
+  const size = useContext(ResponsiveContext);
   const iconRef = useRef<Nullable<HTMLDivElement>>(null);
   const [iconWidth, setIconWidth] = useState(0);
 
@@ -121,22 +139,24 @@ export const Button = ({
         return (
           <Box align="center" fill>
             {Icon && (
-              <StyledBox role="icon_container" ref={iconRef}>
+              <IconBox role="icon_container" ref={iconRef} size={size}>
                 <Box role="icon_resizer" margin="auto">
                   <Icon containerStyle={containerStyle} iconColor={iconColor} />
                   {badge}
                 </Box>
-              </StyledBox>
+              </IconBox>
             )}
 
             {label && (
-              <StyledText
-                size=".8rem"
-                color={normalizeColor('blue-active', theme)}
-                role="button_title"
-              >
-                {label}
-              </StyledText>
+              <TextBox size={size}>
+                <StyledText
+                  color={normalizeColor('blue-active', theme)}
+                  role="button_title"
+                  size={size}
+                >
+                  {label}
+                </StyledText>
+              </TextBox>
             )}
           </Box>
         );

--- a/src/frontend/components/LiveVideoPanel/index.tsx
+++ b/src/frontend/components/LiveVideoPanel/index.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect } from 'react';
-import { Tabs, Box, Grommet } from 'grommet';
+import React, { useEffect, useContext } from 'react';
+import { Tabs, Box, Grommet, ResponsiveContext } from 'grommet';
 
 import { Chat } from 'components/Chat';
 import {
@@ -8,7 +8,7 @@ import {
 } from 'data/stores/useLivePanelState';
 import { Video } from 'types/tracks';
 import { ShouldNotHappen } from 'utils/errors/exception';
-import { breakpointSize, theme } from 'utils/theme/theme';
+import { theme } from 'utils/theme/theme';
 
 import { LiveVideoTabPanel } from './LiveVideoTabPanel';
 
@@ -17,6 +17,7 @@ interface LiveVideoPanelProps {
 }
 
 export const LiveVideoPanel = ({ video }: LiveVideoPanelProps) => {
+  const size = useContext(ResponsiveContext);
   const { currentItem, availableItems, setPanelVisibility } = useLivePanelState(
     (state) => ({
       currentItem: state.currentItem,
@@ -81,9 +82,7 @@ export const LiveVideoPanel = ({ video }: LiveVideoPanelProps) => {
             display: flex; \
             flex-wrap: nowrap;`,
           },
-          extend: `@media (max-width: ${breakpointSize.tablet}) { \
-            display: none; \
-          }`,
+          extend: `display: ${size === 'small' ? 'none' : 'flex'};`,
           gap: 'none',
         },
       }}

--- a/src/frontend/utils/theme/theme.ts
+++ b/src/frontend/utils/theme/theme.ts
@@ -2,16 +2,6 @@ import { TextProps } from 'grommet';
 import { ColorType } from 'grommet/utils';
 import { rgba } from 'polished';
 
-export const breakpointSize = {
-  mobileS: '320px',
-  mobileM: '375px',
-  mobileL: '425px',
-  tablet: '768px',
-  laptop: '1024px',
-  laptopL: '1440px',
-  desktop: '2560px',
-};
-
 const colorsGeneric = {
   'accent-1': 'brand',
   'accent-2': '#f72b2f',


### PR DESCRIPTION
## Purpose

Live button theme is slightly different when displayed on small screen to be properly responsive

## Proposal

Use the Responsive context from grommet to update button's style on small screens

Small layout:
<img width="475" alt="Capture d’écran 2022-01-04 à 14 58 42" src="https://user-images.githubusercontent.com/10722639/148070525-a3637970-e432-4413-941b-18018cb6515b.png">
Default layout:
<img width="116" alt="Capture d’écran 2022-01-04 à 14 59 05" src="https://user-images.githubusercontent.com/10722639/148070547-29b27fcd-b834-4f48-8dfb-29697c1f1b8c.png">
