### PR TITLE
🐛(back) load development urls only when DEBUG is true

### DIFF
--- a/src/backend/marsha/development/urls.py
+++ b/src/backend/marsha/development/urls.py
@@ -1,0 +1,12 @@
+"""Marsha Development app URLs configuration."""
+
+from django.urls import path
+
+from .views import DevelopmentLTIView
+
+
+app_name = "development"
+
+urlpatterns = [
+    path("development/", DevelopmentLTIView.as_view(), name="lti-development-view"),
+]

--- a/src/backend/marsha/development/views.py
+++ b/src/backend/marsha/development/views.py
@@ -81,7 +81,7 @@ class DevelopmentLTIView(TemplateView):
             "uuid": uuid.uuid4(),
             "select_context_id": playlist.lti_id,
             "select_content_item_return_url": self.request.build_absolute_uri(
-                reverse("lti-development-view")
+                reverse("development:lti-development-view")
             ),
             "oauth_dict": oauth_dict,
         }

--- a/src/backend/marsha/urls.py
+++ b/src/backend/marsha/urls.py
@@ -31,7 +31,6 @@ from marsha.core.views import (
     VideoView,
 )
 from marsha.development.api import local_document_upload, local_video_upload
-from marsha.development.views import DevelopmentLTIView
 
 
 router = DefaultRouter()
@@ -88,9 +87,7 @@ if settings.BBB_ENABLED:
     urlpatterns += [path("", include("marsha.bbb.urls"))]
 
 if settings.DEBUG:
-    urlpatterns += [
-        path("development/", DevelopmentLTIView.as_view(), name="lti-development-view"),
-    ]
+    urlpatterns += [path("", include("marsha.development.urls"))]
 
 if "dummy" in settings.STORAGE_BACKEND:
     urlpatterns += [


### PR DESCRIPTION
## Purpose

In the DevelopmentViewset we use packages required only in development
environment. But this module is imported in marsha.urls and we have a
ModuleNotFoundError in an environment have DEBUG set to False. To avoid
this error, an `urls` module is created in marsha.development and is
loaded in marsha.urls using django.urls.include only when DEBUG is True.

## Proposal

- [x]  load development urls only when DEBUG is true
