### PR TITLE
🐛(back) remove development views from init module

### DIFF
--- a/src/backend/marsha/development/__init__.py
+++ b/src/backend/marsha/development/__init__.py
@@ -1,4 +1,3 @@
 """Make all endpoints and views available from marsha.development."""
 # pylint: disable=wildcard-import,unused-wildcard-import
 from .api import *  # noqa isort:skip
-from .views import *  # noqa isort:skip


### PR DESCRIPTION
## Purpose

The development init module import all views. With this import, marsha
is not working in non development environment. This commit complete
commit 3e4a8ed1a0ce3d71ba5283613169e50c0bbc562d.

## Proposal

- [x] Remove development views from init module
