### PR TITLE
Install and configure redis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Add a new chat, using react components and design complying with the mockup
 - Add anonymous_id and display_name in LiveRegistration model
 - Add new endpoint to set display_name
+- Manage websocket using django channels
+- New video consumer able to send serialized video to all clients connected
+  to the websocket when a video is updated through the API
 
 ### Changed
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,8 +39,12 @@ services:
     depends_on:
       - "base"
       - "db"
+      - "redis"
     stdin_open: true
     tty: true
+
+  redis:
+    image: redis:5
 
   e2e:
     build:

--- a/src/backend/marsha/asgi.py
+++ b/src/backend/marsha/asgi.py
@@ -3,9 +3,12 @@
 from channels.routing import ProtocolTypeRouter
 from configurations.asgi import get_asgi_application
 
+from marsha.websocket.application import websocket_application
+
 
 application = ProtocolTypeRouter(
     {
         "http": get_asgi_application(),
+        "websocket": websocket_application,
     }
 )

--- a/src/backend/marsha/core/api/video.py
+++ b/src/backend/marsha/core/api/video.py
@@ -13,6 +13,7 @@ from rest_framework.response import Response
 from rest_framework_simplejwt.models import TokenUser
 
 from marsha.core.defaults import JITSI
+from marsha.websocket.utils import channel_layers_utils
 
 from .. import defaults, forms, permissions, serializers, storage
 from ..models import LivePairing, Video
@@ -98,6 +99,10 @@ class VideoViewSet(ObjectPkMixin, viewsets.ModelViewSet):
             )
 
         return context
+
+    def perform_update(self, serializer):
+        super().perform_update(serializer)
+        channel_layers_utils.dispatch_video_to_groups(serializer.instance)
 
     def create(self, request, *args, **kwargs):
         """Create one video based on the request payload."""

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -116,6 +116,7 @@ class Base(Configuration):
         "corsheaders",
         "marsha.core.apps.CoreConfig",
         "marsha.bbb.apps.BbbConfig",
+        "marsha.websocket.apps.WebsocketConfig",
         "channels",
     ]
 

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -171,7 +171,7 @@ class Base(Configuration):
     # }
     CHANNEL_LAYERS = {
         "default": {
-            "BACKEND": "channels_redis.core.RedisChannelLayer",
+            "BACKEND": "marsha.websocket.layers.JsonRedisChannelLayer",
             "CONFIG": {
                 "hosts": values.ListValue(
                     [("redis", 6379)], environ_name="REDIS_HOST", environ_prefix=None

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -155,8 +155,7 @@ class Base(Configuration):
     AUTH_USER_MODEL = "core.User"
 
     ASGI_APPLICATION = "marsha.asgi.application"
-    
-    
+
     # For sentinels:
     # CHANNEL_LAYERS = {
     #     'default': {
@@ -510,6 +509,9 @@ class Test(Base):
     # Enable it to speed up tests by stopping WhiteNoise from scanning your static files
     WHITENOISE_AUTOREFRESH = True
     LIVE_CHAT_ENABLED = False
+    CHANNEL_LAYERS = {
+        "default": {"BACKEND": "channels.layers.InMemoryChannelLayer"},
+    }
 
 
 class Production(Base):

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -154,6 +154,30 @@ class Base(Configuration):
     AUTH_USER_MODEL = "core.User"
 
     ASGI_APPLICATION = "marsha.asgi.application"
+    
+    
+    # For sentinels:
+    # CHANNEL_LAYERS = {
+    #     'default': {
+    #         'BACKEND': 'channels_redis.core.RedisChannelLayer',
+    #         'CONFIG': {
+    #             "hosts": [{
+    #                 "sentinels": [(SENTINEL_HOST, SENTINEL_PORT)]m
+    #                 "master_name": SENTINEL_MASTER,
+    #             }],
+    #         },
+    #     },
+    # }
+    CHANNEL_LAYERS = {
+        "default": {
+            "BACKEND": "channels_redis.core.RedisChannelLayer",
+            "CONFIG": {
+                "hosts": values.ListValue(
+                    [("redis", 6379)], environ_name="REDIS_HOST", environ_prefix=None
+                ),
+            },
+        },
+    }
 
     REST_FRAMEWORK = {
         "DEFAULT_AUTHENTICATION_CLASSES": (

--- a/src/backend/marsha/websocket/__init__.py
+++ b/src/backend/marsha/websocket/__init__.py
@@ -1,0 +1,1 @@
+"""The ``websocket`` app of the Marsha project."""

--- a/src/backend/marsha/websocket/application.py
+++ b/src/backend/marsha/websocket/application.py
@@ -1,0 +1,12 @@
+"""Module configuring the websocket application used in the asgi module."""
+
+from channels.routing import URLRouter
+from channels.security.websocket import AllowedHostsOriginValidator
+
+from marsha.websocket.middlewares import JWTMiddleware
+from marsha.websocket.routing import websocket_urlpatterns
+
+
+base_application = JWTMiddleware(URLRouter(websocket_urlpatterns))
+
+websocket_application = AllowedHostsOriginValidator(base_application)

--- a/src/backend/marsha/websocket/apps.py
+++ b/src/backend/marsha/websocket/apps.py
@@ -1,0 +1,11 @@
+"""Defines the django app config for the ``websocket`` app."""
+
+from django.apps import AppConfig
+from django.utils.translation import gettext_lazy as _
+
+
+class WebsocketConfig(AppConfig):
+    """Django app config for the ``websocket`` app."""
+
+    name = "marsha.websocket"
+    verbose_name = _("Marsha websockets")

--- a/src/backend/marsha/websocket/consumers/__init__.py
+++ b/src/backend/marsha/websocket/consumers/__init__.py
@@ -1,0 +1,3 @@
+"""Make all consumers available through marsha.websocket.consumers."""
+# pylint: disable=wildcard-import,unused-wildcard-import
+from .video import *  # noqa isort:skip

--- a/src/backend/marsha/websocket/consumers/video.py
+++ b/src/backend/marsha/websocket/consumers/video.py
@@ -1,0 +1,70 @@
+"""Video consumer module"""
+from channels.db import database_sync_to_async
+from channels.generic.websocket import AsyncJsonWebsocketConsumer
+
+from marsha.core.models import Video
+from marsha.core.permissions import IsTokenAdmin, IsTokenInstructor
+from marsha.websocket import defaults
+
+
+class VideoConsumer(AsyncJsonWebsocketConsumer):
+    """Video consumer."""
+
+    room_group_name = None
+
+    async def connect(self):
+        """Manage connection to this consumer."""
+        await self._validate_token()
+        await self._check_video_exists()
+        self.room_group_name = self._get_room_name()
+
+        # Join room group
+        await self.channel_layer.group_add(self.room_group_name, self.channel_name)
+
+        await self.accept()
+
+    async def _validate_token(self):
+        """Validate that the resource_id in the token match the video_id in the url."""
+        video_id = self.scope["url_route"]["kwargs"]["video_id"]
+        token = self.scope["token"]
+        if token.payload.get("resource_id") != video_id:
+            await self.close()
+
+    async def _check_video_exists(self):
+        """Close the room if the video does not exists."""
+        if not await self._video_exists():
+            await self.close()
+
+    @database_sync_to_async
+    def _video_exists(self):
+        """Return if a video exists in database or not."""
+        return Video.objects.filter(
+            pk=self.scope["url_route"]["kwargs"]["video_id"]
+        ).exists()
+
+    def _is_admin(self):
+        """Check if the connected user has admin persmissions."""
+        token = self.scope["token"]
+        return IsTokenInstructor().check_role(token) or IsTokenAdmin().check_role(token)
+
+    def _get_room_name(self):
+        """Generate the room name the user is connected on depending its permissions."""
+        if self._is_admin():
+            return defaults.VIDEO_ADMIN_ROOM_NAME.format(
+                video_id=self.scope["url_route"]["kwargs"]["video_id"]
+            )
+
+        return defaults.VIDEO_ROOM_NAME.format(
+            video_id=self.scope["url_route"]["kwargs"]["video_id"]
+        )
+
+    # pylint: disable=unused-argument
+    async def disconnect(self, code):
+        """Manage disconnection to this consumer."""
+        # Leave room group
+        await self.channel_layer.group_discard(self.room_group_name, self.channel_name)
+
+    # pylint: disable=unused-argument
+    async def video_updated(self, event):
+        """Listener for the video_updated event."""
+        await self.send_json(event["video"])

--- a/src/backend/marsha/websocket/defaults.py
+++ b/src/backend/marsha/websocket/defaults.py
@@ -1,0 +1,3 @@
+"""Default settings for the ``websocket`` app of the Marsha project."""
+VIDEO_ROOM_NAME = "video_{video_id:s}"
+VIDEO_ADMIN_ROOM_NAME = "video_admin_{video_id:s}"

--- a/src/backend/marsha/websocket/layers.py
+++ b/src/backend/marsha/websocket/layers.py
@@ -1,0 +1,36 @@
+"""Layers used by django channels"""
+import json
+import random
+
+from django.core.serializers.json import DjangoJSONEncoder
+
+from channels_redis.core import RedisChannelLayer
+
+
+class JsonRedisChannelLayer(RedisChannelLayer):
+    """Use json to serialize and deserialize messages."""
+
+    def serialize(self, message):
+        """
+        Serializes message in json.
+        """
+        value = bytes(json.dumps(message, cls=DjangoJSONEncoder), encoding="utf-8")
+        if self.crypter:
+            value = self.crypter.encrypt(value)
+
+        # As we use an sorted set to expire messages we need to guarantee uniqueness,
+        # with 12 bytes.
+        random_prefix = random.getrandbits(8 * 12).to_bytes(12, "big")
+        return random_prefix + value
+
+    def deserialize(self, message):
+        """
+        Deserializes from a byte string.
+        """
+        # Removes the random prefix
+        message = message[12:]
+        message = message.decode("utf-8")
+
+        if self.crypter:
+            message = self.crypter.decrypt(message, self.expiry + 10)
+        return json.loads(message)

--- a/src/backend/marsha/websocket/middlewares/__init__.py
+++ b/src/backend/marsha/websocket/middlewares/__init__.py
@@ -1,0 +1,3 @@
+"""Make all middlewares available through marsha.websocket.middlewares."""
+# pylint: disable=wildcard-import,unused-wildcard-import
+from .jwt import *  # noqa isort:skip

--- a/src/backend/marsha/websocket/middlewares/jwt.py
+++ b/src/backend/marsha/websocket/middlewares/jwt.py
@@ -1,0 +1,54 @@
+"""Middleware checking if the JWT is valid."""
+import logging
+from urllib.parse import parse_qs
+
+from channels.security.websocket import WebsocketDenier
+from rest_framework_simplejwt.exceptions import TokenError
+from rest_framework_simplejwt.tokens import AccessToken
+
+
+logger = logging.getLogger(__name__)
+
+
+class JWTMiddleware:
+    """Middleware checking if the JWT is valid."""
+
+    def __init__(self, application):
+        """Store the ASGI application we were passed."""
+        self.application = application
+
+    async def __call__(self, scope, receive, send):
+        # Make sure the scope is of type websocket
+        if scope["type"] != "websocket":
+            raise ValueError(
+                "You cannot use JWTMiddleware on a non-WebSocket connection"
+            )
+
+        try:
+            token = self.validate_jwt(scope)
+            scope["token"] = token
+            return await self.application(scope, receive, send)
+        except TokenError:
+            # Deny the connection
+            denier = WebsocketDenier()
+            return await denier(scope, receive, send)
+
+    def validate_jwt(self, scope):
+        """Validate the JWT token."""
+
+        query_string = parse_qs(scope["query_string"])
+
+        if b"jwt" not in query_string:
+            logger.info("jwt query string is missing")
+            raise ValueError("jwt query string is missing")
+
+        raw_token = query_string[b"jwt"]
+        if len(raw_token) != 1:
+            logger.info("More than one token present in the query string")
+            raise ValueError("jwt query string is missing")
+
+        try:
+            return AccessToken(token=raw_token[0])
+        except TokenError as err:
+            logger.debug("Invalid jwt token")
+            raise err

--- a/src/backend/marsha/websocket/routing.py
+++ b/src/backend/marsha/websocket/routing.py
@@ -1,0 +1,17 @@
+"""Routing for marsha consumers."""
+
+from django.urls import re_path
+
+from marsha.websocket.consumers import VideoConsumer
+
+
+UUID_REGEX = (
+    "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
+)
+
+websocket_urlpatterns = [
+    re_path(
+        f"ws/video/(?P<video_id>{UUID_REGEX:s})/$",
+        VideoConsumer.as_asgi(),
+    ),
+]

--- a/src/backend/marsha/websocket/tests/test_consumers_video.py
+++ b/src/backend/marsha/websocket/tests/test_consumers_video.py
@@ -1,0 +1,306 @@
+"""Test for video consumers."""
+import json
+import random
+from uuid import uuid4
+
+from django.test import TransactionTestCase
+
+from asgiref.sync import sync_to_async
+from channels.layers import get_channel_layer
+from channels.testing import WebsocketCommunicator
+from rest_framework_simplejwt.tokens import AccessToken
+
+from marsha.core.defaults import JITSI, RUNNING
+from marsha.core.factories import VideoFactory
+from marsha.core.serializers import VideoSerializer
+from marsha.websocket.application import base_application
+from marsha.websocket.defaults import VIDEO_ADMIN_ROOM_NAME, VIDEO_ROOM_NAME
+
+
+class VideoConsumerTest(TransactionTestCase):
+    """Test for the video consumer."""
+
+    maxDiff = None
+
+    @sync_to_async
+    def _get_video(self, **kwargs):
+        """Create a video using VideoFactory"""
+        return VideoFactory(**kwargs)
+
+    @sync_to_async
+    def _get_serializer_data(self, video, context):
+        serializer = VideoSerializer(video, context=context)
+        return serializer.data
+
+    async def test_connect_matching_video(self):
+        """A connection with url params matching jwt resource_id should succeed."""
+        video = await self._get_video()
+
+        jwt_token = AccessToken()
+        jwt_token.payload["resource_id"] = str(video.id)
+        jwt_token.payload["roles"] = ["student"]
+        jwt_token.payload["permissions"] = {"can_update": False}
+
+        communicator = WebsocketCommunicator(
+            base_application,
+            f"ws/video/{video.id}/?jwt={jwt_token}",
+        )
+
+        connected, _ = await communicator.connect()
+
+        self.assertTrue(connected)
+
+        await communicator.disconnect()
+
+    async def test_connect_no_matching_video(self):
+        """Try to connect with a video not matching the one in the token."""
+        video = await self._get_video()
+        other_video = await self._get_video()
+
+        jwt_token = AccessToken()
+        jwt_token.payload["resource_id"] = str(video.id)
+        jwt_token.payload["roles"] = ["student"]
+        jwt_token.payload["permissions"] = {"can_update": False}
+
+        communicator = WebsocketCommunicator(
+            base_application,
+            f"ws/video/{other_video.id}/?jwt={jwt_token}",
+        )
+
+        connected, _ = await communicator.connect()
+
+        self.assertFalse(connected)
+
+        await communicator.disconnect()
+
+    async def test_connect_video_not_existing(self):
+        """Connect on a not existing video should be refused."""
+        video_id = uuid4()
+        jwt_token = AccessToken()
+        jwt_token.payload["resource_id"] = str(video_id)
+        jwt_token.payload["roles"] = ["student"]
+        jwt_token.payload["permissions"] = {"can_update": False}
+
+        communicator = WebsocketCommunicator(
+            base_application,
+            f"ws/video/{video_id}/?jwt={jwt_token}",
+        )
+
+        connected, _ = await communicator.connect()
+
+        self.assertFalse(connected)
+
+        await communicator.disconnect()
+
+    async def test_video_update_channel_layer(self):
+        """Messages sent on the admin channel should not be received by a regular user."""
+        video = await self._get_video(
+            live_state=RUNNING,
+            live_type=JITSI,
+            live_info={
+                "medialive": {
+                    "input": {
+                        "id": "medialive_input_1",
+                        "endpoints": [
+                            "https://live_endpoint1",
+                            "https://live_endpoint2",
+                        ],
+                    },
+                    "channel": {"id": "medialive_channel_1"},
+                },
+                "mediapackage": {
+                    "id": "mediapackage_channel_1",
+                    "endpoints": {
+                        "hls": {
+                            "id": "endpoint1",
+                            "url": "https://channel_endpoint1/live.m3u8",
+                        },
+                    },
+                },
+            },
+        )
+
+        jwt_token = AccessToken()
+        jwt_token.payload["resource_id"] = str(video.id)
+
+        communicator = WebsocketCommunicator(
+            base_application,
+            f"ws/video/{video.id}/?jwt={jwt_token}",
+        )
+
+        connected, _ = await communicator.connect()
+
+        self.assertTrue(connected)
+
+        channel_layer = get_channel_layer()
+
+        await channel_layer.group_send(
+            VIDEO_ROOM_NAME.format(video_id=str(video.id)),
+            {
+                "type": "video_updated",
+                "video": await self._get_serializer_data(video, {"is_admin": False}),
+            },
+        )
+
+        response = await communicator.receive_from()
+        self.assertEqual(
+            json.loads(response),
+            {
+                "active_stamp": None,
+                "description": video.description,
+                "id": str(video.id),
+                "is_public": False,
+                "is_ready_to_show": True,
+                "is_scheduled": False,
+                "timed_text_tracks": [],
+                "thumbnail": None,
+                "title": video.title,
+                "upload_state": "pending",
+                "urls": {
+                    "manifests": {"hls": "https://channel_endpoint1/live.m3u8"},
+                    "mp4": {},
+                    "thumbnails": {},
+                },
+                "show_download": True,
+                "should_use_subtitle_as_transcript": False,
+                "starting_at": None,
+                "has_transcript": False,
+                "playlist": {
+                    "id": str(video.playlist.id),
+                    "title": video.playlist.title,
+                    "lti_id": video.playlist.lti_id,
+                },
+                "live_info": {},
+                "live_state": RUNNING,
+                "live_type": JITSI,
+                "xmpp": None,
+                "shared_live_medias": [],
+            },
+        )
+
+        await channel_layer.group_send(
+            VIDEO_ADMIN_ROOM_NAME.format(video_id=str(video.id)),
+            {
+                "type": "video_updated",
+                "video": await self._get_serializer_data(video, {"is_admin": True}),
+            },
+        )
+
+        self.assertTrue(await communicator.receive_nothing())
+
+        await communicator.disconnect()
+
+    async def test_video_update_instructor_channel_layer(self):
+        """Admin user should receive message only from the admin channel."""
+        video = await self._get_video(
+            live_state=RUNNING,
+            live_type=JITSI,
+            live_info={
+                "medialive": {
+                    "input": {
+                        "id": "medialive_input_1",
+                        "endpoints": [
+                            "https://live_endpoint1",
+                            "https://live_endpoint2",
+                        ],
+                    },
+                    "channel": {"id": "medialive_channel_1"},
+                },
+                "mediapackage": {
+                    "id": "mediapackage_channel_1",
+                    "endpoints": {
+                        "hls": {
+                            "id": "endpoint1",
+                            "url": "https://channel_endpoint1/live.m3u8",
+                        },
+                    },
+                },
+            },
+        )
+
+        jwt_token = AccessToken()
+        jwt_token.payload["resource_id"] = str(video.id)
+        jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
+        jwt_token.payload["permissions"] = {"can_update": True}
+
+        communicator = WebsocketCommunicator(
+            base_application,
+            f"ws/video/{video.id}/?jwt={jwt_token}",
+        )
+
+        connected, _ = await communicator.connect()
+
+        self.assertTrue(connected)
+
+        channel_layer = get_channel_layer()
+
+        await channel_layer.group_send(
+            VIDEO_ROOM_NAME.format(video_id=str(video.id)),
+            {
+                "type": "video_updated",
+                "video": await self._get_serializer_data(video, {"is_admin": False}),
+            },
+        )
+
+        self.assertTrue(await communicator.receive_nothing())
+
+        await channel_layer.group_send(
+            VIDEO_ADMIN_ROOM_NAME.format(video_id=str(video.id)),
+            {
+                "type": "video_updated",
+                "video": await self._get_serializer_data(video, {"is_admin": True}),
+            },
+        )
+
+        response = await communicator.receive_from()
+        self.assertEqual(
+            json.loads(response),
+            {
+                "active_stamp": None,
+                "description": video.description,
+                "id": str(video.id),
+                "is_public": False,
+                "is_ready_to_show": True,
+                "is_scheduled": False,
+                "timed_text_tracks": [],
+                "thumbnail": None,
+                "title": video.title,
+                "upload_state": "pending",
+                "urls": {
+                    "manifests": {"hls": "https://channel_endpoint1/live.m3u8"},
+                    "mp4": {},
+                    "thumbnails": {},
+                },
+                "show_download": True,
+                "should_use_subtitle_as_transcript": False,
+                "starting_at": None,
+                "has_transcript": False,
+                "playlist": {
+                    "id": str(video.playlist.id),
+                    "title": video.playlist.title,
+                    "lti_id": video.playlist.lti_id,
+                },
+                "live_info": {
+                    "jitsi": {
+                        "config_overwrite": {},
+                        "domain": "meet.jit.si",
+                        "external_api_url": "https://meet.jit.si/external_api.js",
+                        "interface_config_overwrite": {},
+                    },
+                    "medialive": {
+                        "input": {
+                            "endpoints": [
+                                "https://live_endpoint1",
+                                "https://live_endpoint2",
+                            ],
+                        },
+                    },
+                },
+                "live_state": RUNNING,
+                "live_type": JITSI,
+                "xmpp": None,
+                "shared_live_medias": [],
+            },
+        )
+
+        await communicator.disconnect()

--- a/src/backend/marsha/websocket/tests/test_layers.py
+++ b/src/backend/marsha/websocket/tests/test_layers.py
@@ -1,0 +1,31 @@
+"""Test marsha layers use by django channels."""
+from django.test import TestCase
+
+from marsha.websocket.layers import JsonRedisChannelLayer
+
+
+class JsonRedisChannelLayerTest(TestCase):
+    """Test serialize and deserialize."""
+
+    def test_serialize_message(self):
+        """
+        Test default serialization method
+        """
+        message = {"a": True, "b": None, "c": {"d": []}}
+        channel_layer = JsonRedisChannelLayer()
+        serialized = channel_layer.serialize(message)
+        self.assertIsInstance(serialized, bytes)
+        self.assertEqual(serialized[12:], b'{"a": true, "b": null, "c": {"d": []}}')
+
+    def test_deserialize_message(self):
+        """
+        Test default deserialization method
+        """
+        message = (
+            b'[\x85\xf8\xdeY\xe5\xa3}is\x0f3{"a": true, "b": null, "c": {"d": []}}'
+        )
+        channel_layer = JsonRedisChannelLayer()
+        deserialized = channel_layer.deserialize(message)
+
+        self.assertIsInstance(deserialized, dict)
+        self.assertEqual(deserialized, {"a": True, "b": None, "c": {"d": []}})

--- a/src/backend/marsha/websocket/tests/test_middleware_jwt.py
+++ b/src/backend/marsha/websocket/tests/test_middleware_jwt.py
@@ -1,0 +1,61 @@
+"""Test for the jwt middleware."""
+from datetime import timedelta
+
+from django.test import TestCase
+from django.utils import timezone
+
+from channels.generic.websocket import AsyncWebsocketConsumer
+from channels.testing import WebsocketCommunicator
+from rest_framework_simplejwt.tokens import AccessToken
+
+from marsha.websocket.middlewares import JWTMiddleware
+
+
+class JWTMiddlewareTest(TestCase):
+    """Test for the jwt middleware."""
+
+    maxDiff = None
+
+    async def test_missing_token(self):
+        """Without token in the query string the connection is refused."""
+        application = JWTMiddleware(AsyncWebsocketConsumer())
+        comminucator = WebsocketCommunicator(application, "/")
+
+        with self.assertRaises(ValueError):
+            connected, _ = await comminucator.connect()
+            self.assertFalse(connected)
+            await comminucator.disconnect()
+
+    async def test_invalid_token(self):
+        """With an invalid token the connection is refused."""
+        token = AccessToken()
+        token.set_exp(
+            from_time=timezone.now() - timedelta(minutes=30),
+            lifetime=timedelta(minutes=1),
+        )
+
+        application = JWTMiddleware(AsyncWebsocketConsumer())
+        comminucator = WebsocketCommunicator(application, f"/?jwt={token}")
+
+        connected, _ = await comminucator.connect()
+        self.assertFalse(connected)
+        await comminucator.disconnect()
+
+    async def test_valid_token(self):
+        """with a valid token the connection is accepted."""
+        token = AccessToken()
+        token.set_exp(lifetime=timedelta(minutes=20))
+
+        application = JWTMiddleware(AsyncWebsocketConsumer())
+        comminucator = WebsocketCommunicator(application, f"/?jwt={token}")
+
+        connected, _ = await comminucator.connect()
+        self.assertTrue(connected)
+        await comminucator.disconnect()
+
+    async def test_invalid_scope_type(self):
+        """Only websocket scope type is accepted."""
+
+        middleware = JWTMiddleware(AsyncWebsocketConsumer())
+        with self.assertRaises(ValueError):
+            await middleware({"type": "wrong-type"}, None, None)

--- a/src/backend/marsha/websocket/tests/test_utils_channel_layers.py
+++ b/src/backend/marsha/websocket/tests/test_utils_channel_layers.py
@@ -1,0 +1,54 @@
+"""Module testing utils channel_layers"""
+from django.test import TestCase
+
+from asgiref.sync import async_to_sync
+from channels.layers import get_channel_layer
+
+from marsha.core.factories import VideoFactory
+from marsha.core.serializers import VideoSerializer
+from marsha.websocket.defaults import VIDEO_ADMIN_ROOM_NAME, VIDEO_ROOM_NAME
+from marsha.websocket.utils import channel_layers_utils
+
+
+class ChannelLayersUtilsTest(TestCase):
+    """Test channel layers utils."""
+
+    maxDiff = None
+
+    def tearDown(self):
+        super().tearDown()
+        channel_layer = get_channel_layer()
+        async_to_sync(channel_layer.flush)()
+
+    def test_send_video_to_simple_user(self):
+        """A message containing serialized video is dispatched to the regular group."""
+        video = VideoFactory()
+
+        channel_layer = get_channel_layer()
+        async_to_sync(channel_layer.group_add)(
+            VIDEO_ROOM_NAME.format(video_id=str(video.id)), "test_channel"
+        )
+
+        channel_layers_utils.dispatch_video_to_simple_group(video)
+
+        message = async_to_sync(channel_layer.receive)("test_channel")
+        self.assertEqual(message["type"], "video_updated")
+        self.assertEqual(
+            message["video"], VideoSerializer(video, context={"is_admin": False}).data
+        )
+
+    def test_send_video_to_admin_user(self):
+        video = VideoFactory()
+
+        channel_layer = get_channel_layer()
+        async_to_sync(channel_layer.group_add)(
+            VIDEO_ADMIN_ROOM_NAME.format(video_id=str(video.id)), "test_channel"
+        )
+
+        channel_layers_utils.dispatch_video_to_admin_group(video)
+
+        message = async_to_sync(channel_layer.receive)("test_channel")
+        self.assertEqual(message["type"], "video_updated")
+        self.assertEqual(
+            message["video"], VideoSerializer(video, context={"is_admin": True}).data
+        )

--- a/src/backend/marsha/websocket/utils/__init__.py
+++ b/src/backend/marsha/websocket/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Module for marsha.websocket.utils."""

--- a/src/backend/marsha/websocket/utils/channel_layers_utils.py
+++ b/src/backend/marsha/websocket/utils/channel_layers_utils.py
@@ -1,0 +1,34 @@
+"""Marsha module working with django channels layers."""
+from asgiref.sync import async_to_sync
+from channels.layers import get_channel_layer
+
+from marsha.core.serializers import VideoSerializer
+from marsha.websocket.defaults import VIDEO_ADMIN_ROOM_NAME, VIDEO_ROOM_NAME
+
+
+def dispatch_video_to_groups(video):
+    """Send the video to both simple and admin user."""
+    dispatch_video_to_simple_group(video)
+    dispatch_video_to_admin_group(video)
+
+
+def dispatch_video_to_simple_group(video):
+    """Send the video to simple users connected to the video consumer."""
+    channel_layer = get_channel_layer()
+
+    serialized_video = VideoSerializer(video, context={"is_admin": False})
+    async_to_sync(channel_layer.group_send)(
+        VIDEO_ROOM_NAME.format(video_id=str(video.id)),
+        {"type": "video_updated", "video": serialized_video.data},
+    )
+
+
+def dispatch_video_to_admin_group(video):
+    """Send the video to admin users connected to the video consumer."""
+    channel_layer = get_channel_layer()
+
+    serialized_video = VideoSerializer(video, context={"is_admin": True})
+    async_to_sync(channel_layer.group_send)(
+        VIDEO_ADMIN_ROOM_NAME.format(video_id=str(video.id)),
+        {"type": "video_updated", "video": serialized_video.data},
+    )

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -29,6 +29,7 @@ install_requires =
     Brotli==1.0.9
     boto3==1.20.26
     channels==3.0.4
+    channels-redis==3.3.1
     chardet==4.0.0
     coreapi==2.3.3
     cryptography==36.0.1


### PR DESCRIPTION
## Purpose

We will use the [channel layers](https://channels.readthedocs.io/en/stable/topics/channel_layers.html) feature from django channels. For this we need to install `channels-redis` package, add a redis instance in our docker-compose file and then configure a default channel layer.

## Proposal

- [x] Install channel-redis
- [x] add a redis instance in docker-compose
- [x] configure a default channel layer

This PR is part of #1246 