### PR TITLE
📌(back) pin astroid to version 2.9.0

### DIFF
--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -73,6 +73,7 @@ console_scripts =
 
 [options.extras_require]
 dev =
+    astroid==2.9.0
     bandit==1.7.1
     black==21.10b0
     factory_boy==3.2.1


### PR DESCRIPTION
## Purpose

Astroid 2.9.1 is released since 2021/12/31 but pylint has multiple
errors with this new version. We have to pin to version 2.9.0 and wait
for a new release of pylint.

## Proposal

- [x] pin astroid to version 2.9.0

