### PR TITLE
Ignore react router in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,12 @@
       ],
       "matchPackageNames": [
         "converse.js",
-        "node-fetch"
+        "node-fetch",
+        "@storybook/addon-a11y",
+        "@storybook/addon-actions",
+        "@storybook/addon-essentials",
+        "@storybook/react",
+        "react-router-dom"
       ]
     },
     {

--- a/renovate.json
+++ b/renovate.json
@@ -16,7 +16,8 @@
         "@storybook/addon-actions",
         "@storybook/addon-essentials",
         "@storybook/react",
-        "react-router-dom"
+        "react-router-dom",
+        "node"
       ]
     },
     {
@@ -27,18 +28,6 @@
       ],
       "matchPackageNames": [
         "django"
-      ]
-    },
-    {
-      "enabled": false,
-      "matchPaths": [
-        "src/aws/*"
-      ],
-      "matchDepTypes": [
-        "engines"
-      ],
-      "matchPackageNames": [
-        "node"
       ]
     }
   ]


### PR DESCRIPTION
## Purpose

We don't want to upgrade to react router v6 for now. It's a long process
to upgrade it. We decided to ignore this version for now and ignore all
packages depending on it like storybook.

## Proposal

- [x] ignore react router and packages depending on it
- [x] ignore node package
