### PR TITLE
🐛(frontend) fix live actions button testId

### DIFF
--- a/src/frontend/components/Badge/index.spec.tsx
+++ b/src/frontend/components/Badge/index.spec.tsx
@@ -11,7 +11,7 @@ describe('<StudentShowChatButton />', () => {
 
     screen.getByText('24');
 
-    const badge = screen.getByRole('badge_container');
+    const badge = screen.getByTestId('badge_container');
     expect(badge).toHaveStyle('background-color: #ffffff;');
     expect(badge).toHaveStyle('border: 1px solid #031963;');
     expect(badge).toHaveStyle('border-radius: 6px;');

--- a/src/frontend/components/Badge/index.tsx
+++ b/src/frontend/components/Badge/index.tsx
@@ -23,7 +23,7 @@ interface BadgeProps {
 
 export const Badge = ({ value }: BadgeProps) => {
   return (
-    <StyledBadge role="badge_container">
+    <StyledBadge data-testid="badge_container">
       <Text size="0.6rem">{value}</Text>
     </StyledBadge>
   );

--- a/src/frontend/components/Button/index.spec.tsx
+++ b/src/frontend/components/Button/index.spec.tsx
@@ -7,10 +7,7 @@ describe('<Button />', () => {
   it('renders the Button component with its title only', () => {
     render(<Button label="Button" />);
 
-    screen.getByRole('button');
-    screen.getByRole('button_title');
-    expect(screen.queryByRole('icon_container')).not.toBeInTheDocument();
-    expect(screen.queryByRole('icon_resizer')).not.toBeInTheDocument();
+    screen.getByRole('button', { name: /Button/i });
   });
 
   it('calls onCLick when clicking the button', () => {
@@ -18,7 +15,7 @@ describe('<Button />', () => {
 
     render(<Button label="Button" onClick={onClick} />);
 
-    fireEvent.click(screen.getByRole('button'));
+    fireEvent.click(screen.getByRole('button', { name: /Button/i }));
 
     expect(onClick).toHaveBeenCalledTimes(1);
   });
@@ -28,10 +25,7 @@ describe('<Button />', () => {
 
     render(<Button label="Button" badge={<Badge />} />);
 
-    screen.getByRole('button');
-    screen.getByRole('button_title');
-    expect(screen.queryByRole('icon_container')).not.toBeInTheDocument();
-    expect(screen.queryByRole('icon_resizer')).not.toBeInTheDocument();
+    screen.getByRole('button', { name: /Button/i });
     expect(screen.queryByText('badge')).not.toBeInTheDocument();
   });
 
@@ -45,10 +39,7 @@ describe('<Button />', () => {
 
     render(<Button label="Button" Icon={Icon} badge={<Badge />} />);
 
-    screen.getByRole('button');
-    screen.getByRole('button_title');
-    screen.getByRole('icon_container');
-    screen.getByRole('icon_resizer');
+    screen.getByRole('button', { name: /Button/i });
 
     screen.getByText('icon');
     expect(Icon).toHaveBeenCalledTimes(1);
@@ -76,10 +67,7 @@ describe('<Button />', () => {
 
     render(<Button label="Button" Icon={Icon} badge={<Badge />} disabled />);
 
-    screen.getByRole('button');
-    screen.getByRole('button_title');
-    screen.getByRole('icon_container');
-    screen.getByRole('icon_resizer');
+    screen.getByRole('button', { name: /Button/i });
 
     screen.getByText('icon');
     expect(Icon).toHaveBeenCalledTimes(1);
@@ -107,12 +95,7 @@ describe('<Button />', () => {
 
     render(<Button label="Button" Icon={Icon} badge={<Badge />} />);
 
-    fireEvent.mouseEnter(screen.getByRole('button'));
-
-    screen.getByRole('button');
-    screen.getByRole('button_title');
-    screen.getByRole('icon_container');
-    screen.getByRole('icon_resizer');
+    fireEvent.mouseEnter(screen.getByRole('button', { name: /Button/i }));
 
     screen.getByText('icon');
     expect(Icon).toHaveBeenCalledTimes(2);
@@ -153,10 +136,7 @@ describe('<Button />', () => {
 
     render(<Button label="Button" Icon={Icon} badge={<Badge />} reversed />);
 
-    screen.getByRole('button');
-    screen.getByRole('button_title');
-    screen.getByRole('icon_container');
-    screen.getByRole('icon_resizer');
+    screen.getByRole('button', { name: /Button/i });
 
     screen.getByText('icon');
     expect(Icon).toHaveBeenCalledTimes(1);
@@ -187,10 +167,7 @@ describe('<Button />', () => {
       <Button label="Button" Icon={Icon} badge={<Badge />} disabled reversed />,
     );
 
-    screen.getByRole('button');
-    screen.getByRole('button_title');
-    screen.getByRole('icon_container');
-    screen.getByRole('icon_resizer');
+    screen.getByRole('button', { name: /Button/i });
 
     screen.getByText('icon');
     expect(Icon).toHaveBeenCalledTimes(1);
@@ -221,10 +198,7 @@ describe('<Button />', () => {
 
     fireEvent.mouseEnter(screen.getByRole('button'));
 
-    screen.getByRole('button');
-    screen.getByRole('button_title');
-    screen.getByRole('icon_container');
-    screen.getByRole('icon_resizer');
+    screen.getByRole('button', { name: /Button/i });
 
     screen.getByText('icon');
     expect(Icon).toHaveBeenCalledTimes(2);

--- a/src/frontend/components/Button/index.tsx
+++ b/src/frontend/components/Button/index.tsx
@@ -139,8 +139,8 @@ export const Button = ({
         return (
           <Box align="center" fill>
             {Icon && (
-              <IconBox role="icon_container" ref={iconRef} size={size}>
-                <Box role="icon_resizer" margin="auto">
+              <IconBox ref={iconRef} size={size}>
+                <Box margin="auto">
                   <Icon containerStyle={containerStyle} iconColor={iconColor} />
                   {badge}
                 </Box>
@@ -151,7 +151,6 @@ export const Button = ({
               <TextBox size={size}>
                 <StyledText
                   color={normalizeColor('blue-active', theme)}
-                  role="button_title"
                   size={size}
                 >
                   {label}


### PR DESCRIPTION
## Purpose

Live action button wrongly uses role.
HTML role attribute should conform to https://www.w3.org/TR/wai-aria/  specifications.

## Proposal

Use data-testid if this is really required, else use byRole or byText instead.

