### PR TITLE
🔧(renovate) enable django updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,14 +22,14 @@
       ]
     },
     {
-      "enabled": false,
-      "groupName": "ignored python dependencies",
+      "groupName": "allowed django versions",
       "matchManagers": [
         "setup-cfg"
       ],
       "matchPackageNames": [
         "django"
-      ]
+      ],
+      "allowedVersions": "<4"
     }
   ]
 }


### PR DESCRIPTION
## Purpose

As django is pinned as `<4` in setup.cfg, we want to allow updates for `3.2+` security releases.

## Proposal

Remove django from ignored renovate updates.