### PR TITLE
🔥(back) remove user id in prosody JWT token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Converse.js UI is not used anymore, react components are used instead
 - Add anonymous_id parameter to register a user to a scheduled webinar
 
+### Removed
+
+- Remove user id in prosody JWT token
+
 ## [3.27.0] - 2021-12-07
 
 ### Added

--- a/src/backend/marsha/core/serializers/video.py
+++ b/src/backend/marsha/core/serializers/video.py
@@ -243,13 +243,9 @@ class VideoSerializer(VideoBaseSerializer):
         Dictionnary
             A dictionary containing all info needed to manage a connection to a xmpp server.
         """
-        user_id = self.context.get("user", {}).get("id") or self.context.get(
-            "session_id"
-        )
-        if settings.LIVE_CHAT_ENABLED and user_id and obj.live_state is not None:
+        if settings.LIVE_CHAT_ENABLED and obj.live_state is not None:
             token = xmpp_utils.generate_jwt(
                 str(obj.id),
-                user_id,
                 "owner" if self.context.get("is_admin") else "member",
                 timezone.now() + timedelta(days=1),
             )

--- a/src/backend/marsha/core/tests/test_utils_xmpp_utils.py
+++ b/src/backend/marsha/core/tests/test_utils_xmpp_utils.py
@@ -16,13 +16,12 @@ class XmppUtilsTestCase(TestCase):
     def test_generate_jwt(self):
         """Test generating a JWT token."""
         with mock.patch.object(xmpp_utils.jwt, "encode") as jwt_encode_mock:
-            xmpp_utils.generate_jwt("room_name", "user_id", "affiliation", 1617889150)
+            xmpp_utils.generate_jwt("room_name", "affiliation", 1617889150)
 
             jwt_encode_mock.assert_called_once_with(
-                {
+                payload={
                     "context": {
                         "user": {
-                            "id": "user_id",
                             "affiliation": "affiliation",
                         },
                     },
@@ -32,7 +31,7 @@ class XmppUtilsTestCase(TestCase):
                     "room": "room_name",
                     "exp": 1617889150,
                 },
-                "thisIsASecret",
+                key="thisIsASecret",
             )
 
     def test_add_jwt_token_to_url(self):

--- a/src/backend/marsha/core/utils/xmpp_utils.py
+++ b/src/backend/marsha/core/utils/xmpp_utils.py
@@ -181,16 +181,13 @@ def close_room(room_name):
     )
 
 
-def generate_jwt(room_name, user_id, affiliation, expires_at):
+def generate_jwt(room_name, affiliation, expires_at):
     """Generate the JWT token used by xmpp server.
 
     Parameters
     ----------
     room_name: string
         The name of the room the token is associated with
-
-    user_id: string
-        User's id who try to access to the XMPP conference
 
     affiliations: string
         User affiliation (owner or member)
@@ -199,10 +196,9 @@ def generate_jwt(room_name, user_id, affiliation, expires_at):
         Expiration time in timestamp format
     """
     return jwt.encode(
-        {
+        payload={
             "context": {
                 "user": {
-                    "id": user_id,
                     "affiliation": affiliation,
                 },
             },
@@ -212,7 +208,7 @@ def generate_jwt(room_name, user_id, affiliation, expires_at):
             "room": room_name,
             "exp": expires_at,
         },
-        settings.XMPP_JWT_SHARED_SECRET,
+        key=settings.XMPP_JWT_SHARED_SECRET,
     )
 
 


### PR DESCRIPTION
## Purpose

The provided user_id to generate the prosody JWT token is useless and
not used. We can remove it, it will be easier to generate this token in
a non request context.

## Proposal

- [x] remove user id in prosody JWT token

