### PR TITLE
🎨(make) change help task to better display self documenting makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ include env.d/development
 
 BOLD := \033[1m
 RESET := \033[0m
+GREEN := \033[1;32m
 
 # -- Docker
 COMPOSE              = docker-compose
@@ -43,7 +44,7 @@ YARN                 = $(COMPOSE_RUN_NODE) yarn
 # ==============================================================================
 # RULES
 
-default: help
+default: h
 
 # -- Project
 
@@ -423,8 +424,14 @@ env.d/development:
 env.d/lambda:
 	cp env.d/lambda.dist env.d/lambda
 
-help:  ## Show this help
+h: # short default help task
 	@echo "$(BOLD)Marsha Makefile$(RESET)"
 	@echo "Please use 'make $(BOLD)target$(RESET)' where $(BOLD)target$(RESET) is one of:"
-	@grep -h ':\s\+##' Makefile | column -tn -s# | awk -F ":" '{ print "  $(BOLD)" $$1 "$(RESET)" $$2 }'
+	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(firstword $(MAKEFILE_LIST)) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "$(GREEN)%-50s$(RESET) %s\n", $$1, $$2}'
+.PHONY: h
+
+help:  ## Show a more readable help on multiple lines
+	@echo "$(BOLD)Marsha Makefile$(RESET)"
+	@echo "Please use 'make $(BOLD)target$(RESET)' where $(BOLD)target$(RESET) is one of:"
+	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(firstword $(MAKEFILE_LIST)) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "$(GREEN)%s$(RESET)\n    %s\n\n", $$1, $$2}'
 .PHONY: help


### PR DESCRIPTION
## Purpose

The help task was self documenting the makefile as expected. It should
display first the name task and then its documentation suffixed by ## in
the makefile. This is the same help task used in other openfun projects
but the usage of MAKEFILE_LIST is modified because we include other
files in our makefile and this variable will contains all file name
included. So we have to use only the first word and not all.

## Proposal

- [x] change help task to better display self documenting makefile

