### PR TITLE
✨(backend) send rtmp endpoints when pairing external devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Add 'joined' and 'left' labels in the chat for users arrivals and departures
 - Send updated video to clients connected to the websocket for all
   events related to the live workflow (start, pause, end, shared live medias)
+- Send rtmp urls on pairing challenge success
 
 ### Changed
 

--- a/src/backend/marsha/core/api/pairing_challenge.py
+++ b/src/backend/marsha/core/api/pairing_challenge.py
@@ -67,5 +67,8 @@ def pairing_challenge(request):
     Device.objects.get_or_create(id=request.data.get("box_id"))
 
     return Response(
-        {"jitsi_url": f"https://{settings.JITSI_DOMAIN}/{live_pairing.video.id}"}
+        {
+            "jitsi_url": f"https://{settings.JITSI_DOMAIN}/{live_pairing.video.id}",
+            "rtmp_urls": live_pairing.video.get_medialive_input().get("endpoints"),
+        }
     )

--- a/src/backend/marsha/core/tests/test_api_video_live_pairing.py
+++ b/src/backend/marsha/core/tests/test_api_video_live_pairing.py
@@ -290,7 +290,22 @@ class PairingDeviceAPITest(TestCase):
 
     def test_api_video_pairing_challenge_valid_secret_jitsi(self):
         """Request with valid secret payload should delete live pairing and return a jitsi url."""
-        video = factories.VideoFactory(live_state=IDLE, live_type=JITSI)
+        video = factories.VideoFactory(
+            live_state=IDLE,
+            live_type=JITSI,
+            live_info={
+                "medialive": {
+                    "input": {
+                        "id": "medialive_input_1",
+                        "endpoints": [
+                            "https://live_endpoint1",
+                            "https://live_endpoint2",
+                        ],
+                    },
+                    "channel": {"id": "medialive_channel_1"},
+                },
+            },
+        )
         live_pairing = LivePairingFactory(video=video)
 
         box_id = uuid.uuid4()
@@ -299,7 +314,13 @@ class PairingDeviceAPITest(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
-            {"jitsi_url": f"https://{settings.JITSI_DOMAIN}/{video.id}"},
+            {
+                "jitsi_url": f"https://{settings.JITSI_DOMAIN}/{video.id}",
+                "rtmp_urls": [
+                    "https://live_endpoint1",
+                    "https://live_endpoint2",
+                ],
+            },
             response.json(),
         )
         self.assertEqual(LivePairing.objects.count(), 0)
@@ -310,7 +331,22 @@ class PairingDeviceAPITest(TestCase):
 
     def test_api_video_pairing_challenge_valid_secret_jitsi_multiple_challenges(self):
         """Multiple successfull pairing should not fail."""
-        video = factories.VideoFactory(live_state=IDLE, live_type=JITSI)
+        video = factories.VideoFactory(
+            live_state=IDLE,
+            live_type=JITSI,
+            live_info={
+                "medialive": {
+                    "input": {
+                        "id": "medialive_input_1",
+                        "endpoints": [
+                            "https://live_endpoint1",
+                            "https://live_endpoint2",
+                        ],
+                    },
+                    "channel": {"id": "medialive_channel_1"},
+                },
+            },
+        )
         live_pairing = LivePairingFactory(video=video)
 
         box_id = uuid.uuid4()
@@ -321,7 +357,13 @@ class PairingDeviceAPITest(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
-            {"jitsi_url": f"https://{settings.JITSI_DOMAIN}/{video.id}"},
+            {
+                "jitsi_url": f"https://{settings.JITSI_DOMAIN}/{video.id}",
+                "rtmp_urls": [
+                    "https://live_endpoint1",
+                    "https://live_endpoint2",
+                ],
+            },
             response.json(),
         )
         self.assertEqual(LivePairing.objects.count(), 0)
@@ -329,7 +371,22 @@ class PairingDeviceAPITest(TestCase):
         device = Device.objects.first()
         self.assertEqual(device.id, box_id)
 
-        video = factories.VideoFactory(live_state=IDLE, live_type=JITSI)
+        video = factories.VideoFactory(
+            live_state=IDLE,
+            live_type=JITSI,
+            live_info={
+                "medialive": {
+                    "input": {
+                        "id": "medialive_input_1",
+                        "endpoints": [
+                            "https://live_endpoint1",
+                            "https://live_endpoint2",
+                        ],
+                    },
+                    "channel": {"id": "medialive_channel_1"},
+                },
+            },
+        )
         live_pairing = LivePairingFactory(video=video)
 
         payload = {"box_id": box_id, "secret": live_pairing.secret}
@@ -339,7 +396,13 @@ class PairingDeviceAPITest(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
-            {"jitsi_url": f"https://{settings.JITSI_DOMAIN}/{video.id}"},
+            {
+                "jitsi_url": f"https://{settings.JITSI_DOMAIN}/{video.id}",
+                "rtmp_urls": [
+                    "https://live_endpoint1",
+                    "https://live_endpoint2",
+                ],
+            },
             response.json(),
         )
         self.assertEqual(LivePairing.objects.count(), 0)


### PR DESCRIPTION
## Purpose

When a pairing challenge is successful, we want to allow rtmp stream to the live video.

## Proposal

Send medialive input endpoints on pairing challenge success.
