### PR TITLE
🚧(front) remove imageSnapshot generation to test time with CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -501,7 +501,7 @@ jobs:
               xdg-utils
       - run:
           name: Run tests
-          command: yarn test -w 1
+          command: yarn test -w 2
       - store_artifacts:
           path: ~/marsha/src/frontend/__diff_output__
 


### PR DESCRIPTION
## Purpose

Front tests are slow. We are finding where we are loosing time.

## Proposal

Description...

- [ ] item 1...
- [ ] item 2...

