### PR TITLE
✅(e2e) wait player initialization before playing it

### DIFF
--- a/src/backend/marsha/e2e/test_lti.py
+++ b/src/backend/marsha/e2e/test_lti.py
@@ -348,8 +348,14 @@ def test_lti_video_play(page: Page, live_server: LiveServer, mock_video_cloud_st
     ) as response_info:
         assert 200 == response_info.value.response().status
 
+    # Wait player initialization before playing it
+    with page.expect_request("**/xapi/video/") as request_info:
+        assert "initialized" == request_info.value.post_data_json.get("verb").get(
+            "display"
+        ).get("en-US")
+
     page.click('button:has-text("Play Video")')
-    for verb in ("initialized", "paused", "completed"):
+    for verb in ("played", "paused", "completed"):
         with page.expect_request("**/xapi/video/") as request_info:
             assert verb == request_info.value.post_data_json.get("verb").get(
                 "display"


### PR DESCRIPTION
## Purpose

In the test test_lti_video_play we wait first the XAPI initialized event
before clicking on the play button. Doing this we are sure the player is
ready and we must have a played event before the paused.
## Proposal

- [x]  wait player initialization before playing it

