### PR TITLE
👷(circle) increase jest worker to 2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -501,7 +501,7 @@ jobs:
               xdg-utils
       - run:
           name: Run tests
-          command: yarn test -w 1
+          command: yarn test -w 2
       - store_artifacts:
           path: ~/marsha/src/frontend/__diff_output__
 


### PR DESCRIPTION
## Purpose

In test-front job we can increase the number of worker to 2 in order to
speed execution.

## Proposal

- [x] increase jest worker to 2

