### PR TITLE
🔨(make) add reset task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,14 @@ down: ## Stop and remove containers, networks, images, and volumes
 	@$(COMPOSE) down
 .PHONY: down
 
+reset: ## Reset the project by destroying all containers, migrate the database and then recreate missing containers and finally create the prosody admin
+reset: \
+	down \
+	migrate \
+	run \
+	prosody-admin
+.PHONY: reset
+
 logs: ## display app logs (follow mode)
 	@$(COMPOSE) logs -f app
 .PHONY: logs


### PR DESCRIPTION
## Purpose

We have a task to down the docker-compose stack and one to run it. By
creating the reset stack we can now down the stack, recreate it, apply
the migration and create the prosody admin user.

## Proposal

- [x] add reset task to makefile

