### PR TITLE
🔨(command) add a development command to simulate emails

### DIFF
--- a/src/backend/marsha/core/management/commands/dev_simulate_reminders.py
+++ b/src/backend/marsha/core/management/commands/dev_simulate_reminders.py
@@ -1,0 +1,155 @@
+"""Send reminders mails with simulated data to test the actual rendering."""
+from datetime import timedelta
+import uuid
+
+from django.conf import settings
+from django.core.management import CommandError, call_command
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+from marsha.core.defaults import IDLE, RAW, RUNNING
+from marsha.core.factories import LiveRegistrationFactory, VideoFactory
+
+
+class Command(BaseCommand):
+    """Send reminders for scheduled webinar."""
+
+    help = "Send samples of reminder mails for scheduled webinar."
+
+    def handle(self, *args, **options):
+        """Execute management command."""
+
+        if not settings.DEBUG:
+            raise CommandError(
+                "This command can only be executed when settings.DEBUG is True."
+            )
+
+        self.get_data_five_minutes_before()
+        self.get_data_three_hours_before()
+        self.get_data_three_days_before()
+        self.get_data_already_started()
+        call_command("send_reminders")
+        self.stdout.write("Command was executed in DEBUG mode.")
+
+    def get_data_five_minutes_before(self):
+        """Data to simulate the reminder sent 5 minutes before the live starts."""
+        video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(minutes=4),
+        )
+
+        # registration has been created 4 hours ago
+        LiveRegistrationFactory(
+            anonymous_id=uuid.uuid4(),
+            created_on=timezone.now() - timedelta(hours=4),
+            email="sarah@test-fun-mooc.fr",
+            is_registered=True,
+            should_send_reminders=True,
+            video=video,
+        )
+
+        # LTI registration with other reminders sent
+        LiveRegistrationFactory(
+            consumer_site=video.playlist.consumer_site,
+            created_on=timezone.now() - timedelta(hours=10),
+            email="chantal@test-fun-mooc.fr",
+            is_registered=True,
+            should_send_reminders=True,
+            lti_id="Maths",
+            lti_user_id="56255f3807599c377bf0e5bf072359fd",
+            reminders=[settings.REMINDER_2, settings.REMINDER_3],
+            username="Mummy",
+            video=video,
+        )
+
+    def get_data_three_hours_before(self):
+        """Data to simulate the reminder sent 3 hours before the live starts."""
+        video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(hours=2),
+        )
+
+        # registration has been created 26 hours ago (>1day)
+        LiveRegistrationFactory(
+            anonymous_id=uuid.uuid4(),
+            created_on=timezone.now() - timedelta(hours=26),
+            email="sarah@test-fun-mooc.fr",
+            is_registered=True,
+            should_send_reminders=True,
+            video=video,
+        )
+
+        # LTI registration with reminder 3 sent
+        LiveRegistrationFactory(
+            consumer_site=video.playlist.consumer_site,
+            created_on=timezone.now() - timedelta(hours=26),
+            email="chantal@test-fun-mooc.fr",
+            is_registered=True,
+            should_send_reminders=True,
+            lti_id="Maths",
+            lti_user_id="56255f3807599c377bf0e5bf072359fd",
+            reminders=[settings.REMINDER_3],
+            username="Chantal",
+            video=video,
+        )
+
+    def get_data_three_days_before(self):
+        """Data to simulate the reminder sent 3 days before the live starts"""
+        video = VideoFactory(
+            live_state=IDLE,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=2),
+        )
+
+        # registration has been created 32 days agp (>30 days)
+        LiveRegistrationFactory(
+            anonymous_id=uuid.uuid4(),
+            created_on=timezone.now() - timedelta(days=32),
+            email="sarah@test-fun-mooc.fr",
+            is_registered=True,
+            should_send_reminders=True,
+            video=video,
+        )
+
+        # LTI registration
+        LiveRegistrationFactory(
+            consumer_site=video.playlist.consumer_site,
+            created_on=timezone.now() - timedelta(days=32),
+            email="chantal@test-fun-mooc.fr",
+            is_registered=True,
+            should_send_reminders=True,
+            lti_id="Maths",
+            lti_user_id="56255f3807599c377bf0e5bf072359fd",
+            username="Super Chantal",
+            video=video,
+        )
+
+    def get_data_already_started(self):
+        """Data to simulate reminder sent when live is already started."""
+        video = VideoFactory(
+            live_state=RUNNING,
+            live_type=RAW,
+            starting_at=timezone.now() + timedelta(days=10),
+        )
+        LiveRegistrationFactory(
+            anonymous_id=uuid.uuid4(),
+            email="sarah@test-fun-mooc.fr",
+            is_registered=True,
+            should_send_reminders=True,
+            video=video,
+        )
+
+        # LTI registration with other reminders sent
+        LiveRegistrationFactory(
+            consumer_site=video.playlist.consumer_site,
+            email="chantal@test-fun-mooc.fr",
+            is_registered=True,
+            should_send_reminders=True,
+            lti_id="Maths",
+            lti_user_id="56255f3807599c377bf0e5bf072359fd",
+            reminders=[settings.REMINDER_1, settings.REMINDER_2, settings.REMINDER_3],
+            username="Mysterious Chantal",
+            video=video,
+        )

--- a/src/backend/marsha/core/tests/test_command_dev_simulate_reminders.py
+++ b/src/backend/marsha/core/tests/test_command_dev_simulate_reminders.py
@@ -1,0 +1,33 @@
+"""Tests for dev_simulate_reminders command."""
+from io import StringIO
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import TestCase, override_settings
+
+
+class DevSimulateRemindersTest(TestCase):
+    """Test dev_simulate_reminders command."""
+
+    @override_settings(DEBUG=False)
+    def test_dev_simulate_send_reminders_not_on_dev(self):
+        """Command should do nothing if we are not in the Debug mode."""
+
+        with self.assertRaises(CommandError) as context:
+            call_command("dev_simulate_reminders")
+
+        self.assertEqual(
+            str(context.exception),
+            "This command can only be executed when settings.DEBUG is True.",
+        )
+
+    @override_settings(DEBUG=True)
+    def test_dev_simulate_send_reminders_we_are_on_dev(self):
+        """Command should be executed if we are in the Debug mode."""
+        out = StringIO()
+        call_command("dev_simulate_reminders", stdout=out)
+        self.assertEqual(
+            "Command was executed in DEBUG mode.\n",
+            out.getvalue(),
+        )
+        out.close()

--- a/src/backend/marsha/core/tests/test_command_send_reminders.py
+++ b/src/backend/marsha/core/tests/test_command_send_reminders.py
@@ -1,4 +1,4 @@
-"""Tests for check_live_state command."""
+"""Tests for send_reminders command."""
 from datetime import datetime, timedelta
 from io import StringIO
 import smtplib


### PR DESCRIPTION


## Purpose

Changing emails templates and checking the results without any
tool is complicated. To simplify this task, we create a command
that can only be used in the development environment and that
sends a simple of the four distinct reminders mails. This way
we can easily check the final layout of each mail.

## Proposal

Create a command that creates data and execute send_reminders command, make sure it can only be executed on the development environment.

