### PR TITLE
📌(front) pin @converse/headless to version 8.0.1

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,12 +10,12 @@
         "npm"
       ],
       "matchPackageNames": [
+        "@converse/headless",
         "@storybook/addon-a11y",
         "@storybook/addon-actions",
         "@storybook/addon-essentials",
         "@storybook/react",
         "@types/faker",
-        "converse.js",
         "faker",
         "node",
         "node-fetch",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -82,7 +82,7 @@
     "xhr-mock": "2.5.1"
   },
   "dependencies": {
-    "@converse/headless": "9.0.0",
+    "@converse/headless": "8.0.1",
     "@formatjs/intl-relativetimeformat": "9.5.1",
     "@sentry/browser": "6.17.3",
     "@types/intl": "1.2.0",

--- a/src/frontend/yarn.lock
+++ b/src/frontend/yarn.lock
@@ -2512,10 +2512,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@converse/headless@9.0.0":
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/@converse/headless/-/headless-9.0.0.tgz#c72908c7d43340fd2eb2285796aaee0b013a6f8d"
-  integrity sha512-4XkekCMSd0tCdPdkCZ17VaElJuAzFUMvPz3THrw/OXewQltGG5muop8vq0mDNrKkFdAgl4MT1qMcoDMI/UpQNQ==
+"@converse/headless@8.0.1":
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/@converse/headless/-/headless-8.0.1.tgz#a405864eeb444f08c9a40972605fd7b64cf12775"
+  integrity sha512-JqJIyPifANaZJOrsTPh1CuK4mm+udk3yeSHOMUllPta8+HWefjFKpl7UT5oxnAjRoPAUE0wbVb1SUvSDqjQAmQ==
   dependencies:
     "@converse/skeletor" "0.0.5"
     dayjs "1.10.6"


### PR DESCRIPTION
## Purpose

We switch from converse.js to @converse/headless package but we still
have to use version 8.0.1, version 9 is not usable for us. We pin this
new package to version 8.0.1 and we ignore new version in renovate.json
configuration.

## Proposal

- [x] pin @converse/headless to version 8.0.1

