### PR TITLE
Upgrade to Django 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Improvement of emails templates for scheduled webinars
 - Use websocket in the VOD dashboard and stop polling resources
 - Display chat and viewers list in the tabs panel
+- Upgrade to Django 4
 
 ### Removed
 

--- a/renovate.json
+++ b/renovate.json
@@ -21,16 +21,6 @@
         "node-fetch",
         "react-router-dom"
       ]
-    },
-    {
-      "groupName": "allowed django versions",
-      "matchManagers": [
-        "setup-cfg"
-      ],
-      "matchPackageNames": [
-        "django"
-      ],
-      "allowedVersions": "<4"
     }
   ]
 }

--- a/src/backend/marsha/core/tests/test_api_document.py
+++ b/src/backend/marsha/core/tests/test_api_document.py
@@ -6,7 +6,6 @@ from unittest import mock
 
 from django.test import TestCase, override_settings
 
-import pytz
 from rest_framework_simplejwt.tokens import AccessToken
 
 from ..api import timezone
@@ -57,7 +56,7 @@ class DocumentAPITest(TestCase):
         """An instructor should be able to fetch a document."""
         document = DocumentFactory(
             pk="4c51f469-f91e-4998-b438-e31ee3bd3ea6",
-            uploaded_on=datetime(2018, 8, 8, tzinfo=pytz.utc),
+            uploaded_on=datetime(2018, 8, 8, tzinfo=timezone.utc),
             upload_state="ready",
             extension="pdf",
             playlist__title="foo",
@@ -353,7 +352,7 @@ class DocumentAPITest(TestCase):
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
         jwt_token.payload["permissions"] = {"can_update": True}
 
-        now = datetime(2018, 8, 8, tzinfo=pytz.utc)
+        now = datetime(2018, 8, 8, tzinfo=timezone.utc)
         with mock.patch.object(timezone, "now", return_value=now), mock.patch(
             "datetime.datetime"
         ) as mock_dt:
@@ -408,7 +407,7 @@ class DocumentAPITest(TestCase):
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
         jwt_token.payload["permissions"] = {"can_update": True}
 
-        now = datetime(2018, 8, 8, tzinfo=pytz.utc)
+        now = datetime(2018, 8, 8, tzinfo=timezone.utc)
         with mock.patch.object(timezone, "now", return_value=now), mock.patch(
             "datetime.datetime"
         ) as mock_dt:
@@ -463,7 +462,7 @@ class DocumentAPITest(TestCase):
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
         jwt_token.payload["permissions"] = {"can_update": True}
 
-        now = datetime(2018, 8, 8, tzinfo=pytz.utc)
+        now = datetime(2018, 8, 8, tzinfo=timezone.utc)
         with mock.patch.object(timezone, "now", return_value=now), mock.patch(
             "datetime.datetime"
         ) as mock_dt:

--- a/src/backend/marsha/core/tests/test_api_shared_live_media.py
+++ b/src/backend/marsha/core/tests/test_api_shared_live_media.py
@@ -6,7 +6,6 @@ from unittest import mock
 
 from django.test import TestCase, override_settings
 
-import pytz
 from rest_framework_simplejwt.tokens import AccessToken
 
 from .. import defaults
@@ -331,7 +330,7 @@ class SharedLiveMediaAPITest(TestCase):
             extension="pdf",
             title="python structures",
             upload_state=defaults.PENDING,
-            uploaded_on=datetime(2021, 11, 30, tzinfo=pytz.utc),
+            uploaded_on=datetime(2021, 11, 30, tzinfo=timezone.utc),
             nb_pages=3,
             video__id="d9d7049c-5a3f-4070-a494-e6bf0bd8b9fb",
         )
@@ -395,7 +394,7 @@ class SharedLiveMediaAPITest(TestCase):
             extension="pdf",
             title="python structures",
             upload_state=defaults.READY,
-            uploaded_on=datetime(2021, 11, 30, tzinfo=pytz.utc),
+            uploaded_on=datetime(2021, 11, 30, tzinfo=timezone.utc),
             nb_pages=3,
             video__id="d9d7049c-5a3f-4070-a494-e6bf0bd8b9fb",
         )
@@ -405,7 +404,7 @@ class SharedLiveMediaAPITest(TestCase):
         jwt_token.payload["roles"] = ["student"]
 
         # fix the time so that the url signature is deterministic and can be checked
-        now = datetime(2021, 11, 30, tzinfo=pytz.utc)
+        now = datetime(2021, 11, 30, tzinfo=timezone.utc)
         with mock.patch.object(timezone, "now", return_value=now), mock.patch(
             "builtins.open", new_callable=mock.mock_open, read_data=RSA_KEY_MOCK
         ):
@@ -498,7 +497,7 @@ class SharedLiveMediaAPITest(TestCase):
             show_download=False,
             title="python structures",
             upload_state=defaults.READY,
-            uploaded_on=datetime(2021, 11, 30, tzinfo=pytz.utc),
+            uploaded_on=datetime(2021, 11, 30, tzinfo=timezone.utc),
             nb_pages=3,
             video__id="d9d7049c-5a3f-4070-a494-e6bf0bd8b9fb",
         )
@@ -508,7 +507,7 @@ class SharedLiveMediaAPITest(TestCase):
         jwt_token.payload["roles"] = ["student"]
 
         # fix the time so that the url signature is deterministic and can be checked
-        now = datetime(2021, 11, 30, tzinfo=pytz.utc)
+        now = datetime(2021, 11, 30, tzinfo=timezone.utc)
         with mock.patch.object(timezone, "now", return_value=now), mock.patch(
             "builtins.open", new_callable=mock.mock_open, read_data=RSA_KEY_MOCK
         ):
@@ -615,7 +614,7 @@ class SharedLiveMediaAPITest(TestCase):
             extension="pdf",
             title="python compound statements",
             upload_state=defaults.PENDING,
-            uploaded_on=datetime(2021, 11, 30, tzinfo=pytz.utc),
+            uploaded_on=datetime(2021, 11, 30, tzinfo=timezone.utc),
             nb_pages=3,
             video__id="d9d7049c-5a3f-4070-a494-e6bf0bd8b9fb",
         )
@@ -679,7 +678,7 @@ class SharedLiveMediaAPITest(TestCase):
             extension="pdf",
             title="python compound statements",
             upload_state=defaults.PENDING,
-            uploaded_on=datetime(2021, 11, 30, tzinfo=pytz.utc),
+            uploaded_on=datetime(2021, 11, 30, tzinfo=timezone.utc),
             nb_pages=3,
             video__id="d9d7049c-5a3f-4070-a494-e6bf0bd8b9fb",
         )
@@ -689,7 +688,7 @@ class SharedLiveMediaAPITest(TestCase):
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
 
         # fix the time so that the url signature is deterministic and can be checked
-        now = datetime(2021, 11, 30, tzinfo=pytz.utc)
+        now = datetime(2021, 11, 30, tzinfo=timezone.utc)
         with mock.patch.object(timezone, "now", return_value=now), mock.patch(
             "builtins.open", new_callable=mock.mock_open, read_data=RSA_KEY_MOCK
         ):
@@ -965,14 +964,14 @@ class SharedLiveMediaAPITest(TestCase):
         )
         SharedLiveMediaFactory(
             upload_state=defaults.READY,
-            uploaded_on=datetime(2021, 11, 30, tzinfo=pytz.utc),
+            uploaded_on=datetime(2021, 11, 30, tzinfo=timezone.utc),
             nb_pages=5,
             video=video,
         )
         # This shared_live_media belongs to an other video
         SharedLiveMediaFactory(
             upload_state=defaults.READY,
-            uploaded_on=datetime(2021, 11, 30, tzinfo=pytz.utc),
+            uploaded_on=datetime(2021, 11, 30, tzinfo=timezone.utc),
             nb_pages=3,
         )
 
@@ -997,7 +996,7 @@ class SharedLiveMediaAPITest(TestCase):
             extension="pdf",
             title="python expressions",
             upload_state=defaults.READY,
-            uploaded_on=datetime(2021, 11, 30, tzinfo=pytz.utc),
+            uploaded_on=datetime(2021, 11, 30, tzinfo=timezone.utc),
             nb_pages=3,
             video=video,
         )
@@ -1006,7 +1005,7 @@ class SharedLiveMediaAPITest(TestCase):
         # payload response
         SharedLiveMediaFactory(
             upload_state=defaults.READY,
-            uploaded_on=datetime(2021, 11, 30, tzinfo=pytz.utc),
+            uploaded_on=datetime(2021, 11, 30, tzinfo=timezone.utc),
             nb_pages=3,
         )
 
@@ -1084,7 +1083,7 @@ class SharedLiveMediaAPITest(TestCase):
         )
         SharedLiveMediaFactory(
             upload_state=defaults.READY,
-            uploaded_on=datetime(2021, 11, 30, tzinfo=pytz.utc),
+            uploaded_on=datetime(2021, 11, 30, tzinfo=timezone.utc),
             nb_pages=3,
             video=video,
         )
@@ -1094,7 +1093,7 @@ class SharedLiveMediaAPITest(TestCase):
         other_video = VideoFactory()
         SharedLiveMediaFactory(
             upload_state=defaults.READY,
-            uploaded_on=datetime(2021, 11, 30, tzinfo=pytz.utc),
+            uploaded_on=datetime(2021, 11, 30, tzinfo=timezone.utc),
             nb_pages=3,
             video=other_video,
         )
@@ -1136,7 +1135,7 @@ class SharedLiveMediaAPITest(TestCase):
             extension="pdf",
             title="python expressions",
             upload_state=defaults.READY,
-            uploaded_on=datetime(2021, 11, 30, tzinfo=pytz.utc),
+            uploaded_on=datetime(2021, 11, 30, tzinfo=timezone.utc),
             nb_pages=3,
             video=video,
         )
@@ -1148,7 +1147,7 @@ class SharedLiveMediaAPITest(TestCase):
         # payload response
         SharedLiveMediaFactory(
             upload_state=defaults.READY,
-            uploaded_on=datetime(2021, 11, 30, tzinfo=pytz.utc),
+            uploaded_on=datetime(2021, 11, 30, tzinfo=timezone.utc),
             nb_pages=3,
         )
 
@@ -1158,7 +1157,7 @@ class SharedLiveMediaAPITest(TestCase):
         jwt_token.payload["permissions"] = {"can_update": True}
 
         # fix the time so that the url signature is deterministic and can be checked
-        now = datetime(2021, 11, 30, tzinfo=pytz.utc)
+        now = datetime(2021, 11, 30, tzinfo=timezone.utc)
         with mock.patch.object(timezone, "now", return_value=now), mock.patch(
             "builtins.open", new_callable=mock.mock_open, read_data=RSA_KEY_MOCK
         ):
@@ -1326,7 +1325,7 @@ class SharedLiveMediaAPITest(TestCase):
             extension="pdf",
             title="python extensions",
             upload_state=defaults.READY,
-            uploaded_on=datetime(2021, 11, 30, tzinfo=pytz.utc),
+            uploaded_on=datetime(2021, 11, 30, tzinfo=timezone.utc),
             nb_pages=3,
             video=video,
         )
@@ -1335,7 +1334,7 @@ class SharedLiveMediaAPITest(TestCase):
         # payload response
         SharedLiveMediaFactory(
             upload_state=defaults.READY,
-            uploaded_on=datetime(2021, 11, 30, tzinfo=pytz.utc),
+            uploaded_on=datetime(2021, 11, 30, tzinfo=timezone.utc),
             nb_pages=5,
         )
         PlaylistAccessFactory(user=user, playlist=playlist, role=ADMINISTRATOR)
@@ -1417,7 +1416,7 @@ class SharedLiveMediaAPITest(TestCase):
         )
         SharedLiveMediaFactory(
             upload_state=defaults.READY,
-            uploaded_on=datetime(2021, 11, 30, tzinfo=pytz.utc),
+            uploaded_on=datetime(2021, 11, 30, tzinfo=timezone.utc),
             nb_pages=3,
             video=video,
         )
@@ -1427,7 +1426,7 @@ class SharedLiveMediaAPITest(TestCase):
         other_video = VideoFactory()
         SharedLiveMediaFactory(
             upload_state=defaults.READY,
-            uploaded_on=datetime(2021, 11, 30, tzinfo=pytz.utc),
+            uploaded_on=datetime(2021, 11, 30, tzinfo=timezone.utc),
             nb_pages=5,
         )
         PlaylistAccessFactory(user=user, playlist=playlist, role=ADMINISTRATOR)
@@ -1488,7 +1487,7 @@ class SharedLiveMediaAPITest(TestCase):
             extension="pdf",
             title="python extensions",
             upload_state=defaults.READY,
-            uploaded_on=datetime(2021, 11, 30, tzinfo=pytz.utc),
+            uploaded_on=datetime(2021, 11, 30, tzinfo=timezone.utc),
             nb_pages=3,
             video=video,
         )
@@ -1500,7 +1499,7 @@ class SharedLiveMediaAPITest(TestCase):
         # payload response
         SharedLiveMediaFactory(
             upload_state=defaults.READY,
-            uploaded_on=datetime(2021, 11, 30, tzinfo=pytz.utc),
+            uploaded_on=datetime(2021, 11, 30, tzinfo=timezone.utc),
             nb_pages=5,
         )
 
@@ -1582,7 +1581,7 @@ class SharedLiveMediaAPITest(TestCase):
         )
         SharedLiveMediaFactory(
             upload_state=defaults.READY,
-            uploaded_on=datetime(2021, 11, 30, tzinfo=pytz.utc),
+            uploaded_on=datetime(2021, 11, 30, tzinfo=timezone.utc),
             nb_pages=3,
             video=video,
         )
@@ -1595,7 +1594,7 @@ class SharedLiveMediaAPITest(TestCase):
         other_video = VideoFactory()
         SharedLiveMediaFactory(
             upload_state=defaults.READY,
-            uploaded_on=datetime(2021, 11, 30, tzinfo=pytz.utc),
+            uploaded_on=datetime(2021, 11, 30, tzinfo=timezone.utc),
             nb_pages=5,
             video=other_video,
         )
@@ -2140,7 +2139,7 @@ class SharedLiveMediaAPITest(TestCase):
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
         jwt_token.payload["permissions"] = {"can_update": True}
 
-        now = datetime(2021, 12, 2, tzinfo=pytz.utc)
+        now = datetime(2021, 12, 2, tzinfo=timezone.utc)
         with mock.patch.object(timezone, "now", return_value=now), mock.patch(
             "datetime.datetime"
         ) as mock_dt:
@@ -2201,7 +2200,7 @@ class SharedLiveMediaAPITest(TestCase):
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
         jwt_token.payload["permissions"] = {"can_update": True}
 
-        now = datetime(2021, 12, 2, tzinfo=pytz.utc)
+        now = datetime(2021, 12, 2, tzinfo=timezone.utc)
         with mock.patch.object(timezone, "now", return_value=now), mock.patch(
             "datetime.datetime"
         ) as mock_dt:
@@ -2262,7 +2261,7 @@ class SharedLiveMediaAPITest(TestCase):
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
         jwt_token.payload["permissions"] = {"can_update": True}
 
-        now = datetime(2021, 12, 2, tzinfo=pytz.utc)
+        now = datetime(2021, 12, 2, tzinfo=timezone.utc)
         with mock.patch.object(timezone, "now", return_value=now), mock.patch(
             "datetime.datetime"
         ) as mock_dt:
@@ -2294,7 +2293,7 @@ class SharedLiveMediaAPITest(TestCase):
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
         jwt_token.payload["permissions"] = {"can_update": True}
 
-        now = datetime(2021, 12, 2, tzinfo=pytz.utc)
+        now = datetime(2021, 12, 2, tzinfo=timezone.utc)
         with mock.patch.object(timezone, "now", return_value=now), mock.patch(
             "datetime.datetime"
         ) as mock_dt:
@@ -2406,7 +2405,7 @@ class SharedLiveMediaAPITest(TestCase):
         jwt_token.payload["resource_id"] = str(user.id)
         jwt_token.payload["user"] = {"id": str(user.id)}
 
-        now = datetime(2021, 12, 2, tzinfo=pytz.utc)
+        now = datetime(2021, 12, 2, tzinfo=timezone.utc)
         with mock.patch.object(timezone, "now", return_value=now), mock.patch(
             "datetime.datetime"
         ) as mock_dt:
@@ -2516,7 +2515,7 @@ class SharedLiveMediaAPITest(TestCase):
         jwt_token.payload["resource_id"] = str(user.id)
         jwt_token.payload["user"] = {"id": str(user.id)}
 
-        now = datetime(2021, 12, 2, tzinfo=pytz.utc)
+        now = datetime(2021, 12, 2, tzinfo=timezone.utc)
         with mock.patch.object(timezone, "now", return_value=now), mock.patch(
             "datetime.datetime"
         ) as mock_dt:

--- a/src/backend/marsha/core/tests/test_api_thumbnail.py
+++ b/src/backend/marsha/core/tests/test_api_thumbnail.py
@@ -6,7 +6,6 @@ from unittest import mock
 
 from django.test import TestCase, override_settings
 
-import pytz
 from rest_framework_simplejwt.tokens import AccessToken
 
 from ..api import timezone
@@ -70,7 +69,7 @@ class ThumbnailApiTest(TestCase):
     def test_api_thumbnail_read_detail_token_user(self):
         """Instructors should be able to read details of thumbnail assotiated to their video."""
         video = VideoFactory(
-            uploaded_on=datetime(2018, 8, 8, tzinfo=pytz.utc), upload_state="ready"
+            uploaded_on=datetime(2018, 8, 8, tzinfo=timezone.utc), upload_state="ready"
         )
         thumbnail = ThumbnailFactory(video=video, upload_state="pending")
 
@@ -119,7 +118,7 @@ class ThumbnailApiTest(TestCase):
     def test_api_thumbnail_read_detail_admin_user(self):
         """Admin should be able to read details of thumbnail assotiated to their video."""
         video = VideoFactory(
-            uploaded_on=datetime(2018, 8, 8, tzinfo=pytz.utc), upload_state="ready"
+            uploaded_on=datetime(2018, 8, 8, tzinfo=timezone.utc), upload_state="ready"
         )
         thumbnail = ThumbnailFactory(video=video, upload_state="pending")
 
@@ -152,12 +151,12 @@ class ThumbnailApiTest(TestCase):
         """A ready thumbnail should have computed urls."""
         video = VideoFactory(
             pk="78338c1c-356e-4156-bd95-5bed71ffb655",
-            uploaded_on=datetime(2018, 8, 8, tzinfo=pytz.utc),
+            uploaded_on=datetime(2018, 8, 8, tzinfo=timezone.utc),
             upload_state="ready",
         )
         thumbnail = ThumbnailFactory(
             video=video,
-            uploaded_on=datetime(2018, 8, 8, tzinfo=pytz.utc),
+            uploaded_on=datetime(2018, 8, 8, tzinfo=timezone.utc),
             upload_state="ready",
         )
 
@@ -390,7 +389,7 @@ class ThumbnailApiTest(TestCase):
 
         # Get the upload policy for this thumbnail
         # It should generate a key file with the Unix timestamp of the present time
-        now = datetime(2018, 8, 8, tzinfo=pytz.utc)
+        now = datetime(2018, 8, 8, tzinfo=timezone.utc)
         with mock.patch.object(timezone, "now", return_value=now), mock.patch(
             "datetime.datetime"
         ) as mock_dt:

--- a/src/backend/marsha/core/tests/test_api_timed_text_track.py
+++ b/src/backend/marsha/core/tests/test_api_timed_text_track.py
@@ -6,7 +6,6 @@ from unittest import mock
 
 from django.test import TestCase, override_settings
 
-import pytz
 from rest_framework_simplejwt.tokens import AccessToken
 
 from .. import factories, models
@@ -149,7 +148,7 @@ class TimedTextTrackAPITest(TestCase):
             video__playlist__title="foo",
             mode="cc",
             language="fr",
-            uploaded_on=datetime(2018, 8, 8, tzinfo=pytz.utc),
+            uploaded_on=datetime(2018, 8, 8, tzinfo=timezone.utc),
             upload_state="ready",
             extension="srt",
         )
@@ -209,7 +208,7 @@ class TimedTextTrackAPITest(TestCase):
             video__playlist__title="foo",
             mode="cc",
             language="fr",
-            uploaded_on=datetime(2018, 8, 8, tzinfo=pytz.utc),
+            uploaded_on=datetime(2018, 8, 8, tzinfo=timezone.utc),
             upload_state="ready",
         )
 
@@ -264,7 +263,7 @@ class TimedTextTrackAPITest(TestCase):
             video__playlist__title="foo",
             mode="cc",
             language="fr",
-            uploaded_on=datetime(2018, 8, 8, tzinfo=pytz.utc),
+            uploaded_on=datetime(2018, 8, 8, tzinfo=timezone.utc),
             upload_state="ready",
             extension="srt",
         )
@@ -386,7 +385,7 @@ class TimedTextTrackAPITest(TestCase):
             video__playlist__title="foo",
             mode="cc",
             language="fr",
-            uploaded_on=datetime(2018, 8, 8, tzinfo=pytz.utc),
+            uploaded_on=datetime(2018, 8, 8, tzinfo=timezone.utc),
             upload_state="ready",
             extension="srt",
         )
@@ -397,7 +396,7 @@ class TimedTextTrackAPITest(TestCase):
 
         # Get the timed_text_track via the API using the JWT token
         # fix the time so that the url signature is deterministic and can be checked
-        now = datetime(2018, 8, 8, tzinfo=pytz.utc)
+        now = datetime(2018, 8, 8, tzinfo=timezone.utc)
         with mock.patch.object(timezone, "now", return_value=now):
             response = self.client.get(
                 f"/api/timedtexttracks/{timed_text_track.id}/",
@@ -1922,7 +1921,7 @@ class TimedTextTrackAPITest(TestCase):
 
         # Get the upload policy for this timed text track
         # It should generate a key file with the Unix timestamp of the present time
-        now = datetime(2018, 8, 8, tzinfo=pytz.utc)
+        now = datetime(2018, 8, 8, tzinfo=timezone.utc)
         with mock.patch.object(timezone, "now", return_value=now), mock.patch(
             "datetime.datetime"
         ) as mock_dt:
@@ -2038,7 +2037,7 @@ class TimedTextTrackAPITest(TestCase):
         jwt_token.payload["resource_id"] = str(user.id)
         jwt_token.payload["user"] = {"id": str(user.id)}
 
-        now = datetime(2018, 8, 8, tzinfo=pytz.utc)
+        now = datetime(2018, 8, 8, tzinfo=timezone.utc)
         with mock.patch.object(timezone, "now", return_value=now), mock.patch(
             "datetime.datetime"
         ) as mock_dt:
@@ -2077,7 +2076,7 @@ class TimedTextTrackAPITest(TestCase):
         jwt_token.payload["resource_id"] = str(user.id)
         jwt_token.payload["user"] = {"id": str(user.id)}
 
-        now = datetime(2018, 8, 8, tzinfo=pytz.utc)
+        now = datetime(2018, 8, 8, tzinfo=timezone.utc)
         with mock.patch.object(timezone, "now", return_value=now), mock.patch(
             "datetime.datetime"
         ) as mock_dt:
@@ -2118,7 +2117,7 @@ class TimedTextTrackAPITest(TestCase):
 
         # Get the upload policy for this timed text track
         # It should generate a key file with the Unix timestamp of the present time
-        now = datetime(2018, 8, 8, tzinfo=pytz.utc)
+        now = datetime(2018, 8, 8, tzinfo=timezone.utc)
         with mock.patch.object(timezone, "now", return_value=now), mock.patch(
             "datetime.datetime"
         ) as mock_dt:
@@ -2189,7 +2188,7 @@ class TimedTextTrackAPITest(TestCase):
         jwt_token.payload["resource_id"] = str(user.id)
         jwt_token.payload["user"] = {"id": str(user.id)}
 
-        now = datetime(2018, 8, 8, tzinfo=pytz.utc)
+        now = datetime(2018, 8, 8, tzinfo=timezone.utc)
         with mock.patch.object(timezone, "now", return_value=now), mock.patch(
             "datetime.datetime"
         ) as mock_dt:
@@ -2231,7 +2230,7 @@ class TimedTextTrackAPITest(TestCase):
 
         # Get the upload policy for this timed text track
         # It should generate a key file with the Unix timestamp of the present time
-        now = datetime(2018, 8, 8, tzinfo=pytz.utc)
+        now = datetime(2018, 8, 8, tzinfo=timezone.utc)
         with mock.patch.object(timezone, "now", return_value=now), mock.patch(
             "datetime.datetime"
         ) as mock_dt:

--- a/src/backend/marsha/core/tests/test_api_update_state.py
+++ b/src/backend/marsha/core/tests/test_api_update_state.py
@@ -1,5 +1,5 @@
 """Tests for the upload & processing state update API of the Marsha project."""
-from datetime import datetime
+from datetime import datetime, timezone
 import json
 import random
 from unittest import mock
@@ -8,7 +8,6 @@ from django.test import TestCase, override_settings
 
 from asgiref.sync import async_to_sync
 from channels.layers import get_channel_layer
-import pytz
 
 from marsha.websocket.defaults import VIDEO_ADMIN_ROOM_NAME, VIDEO_ROOM_NAME
 from marsha.websocket.utils import channel_layers_utils
@@ -59,7 +58,7 @@ class UpdateStateAPITest(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(json.loads(response.content), {"success": True})
-        self.assertEqual(video.uploaded_on, datetime(2018, 8, 8, tzinfo=pytz.utc))
+        self.assertEqual(video.uploaded_on, datetime(2018, 8, 8, tzinfo=timezone.utc))
         self.assertEqual(video.upload_state, "ready")
         self.assertEqual(video.resolutions, [144, 240, 480])
         message = async_to_sync(channel_layer.receive)("test_channel")
@@ -155,7 +154,7 @@ class UpdateStateAPITest(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(json.loads(response.content), {"success": True})
-        self.assertEqual(video.uploaded_on, datetime(2018, 8, 8, tzinfo=pytz.utc))
+        self.assertEqual(video.uploaded_on, datetime(2018, 8, 8, tzinfo=timezone.utc))
         self.assertEqual(video.upload_state, HARVESTED)
         self.assertEqual(video.resolutions, [240, 480, 720])
         self.assertIsNone(video.live_state)
@@ -240,7 +239,7 @@ class UpdateStateAPITest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(json.loads(response.content), {"success": True})
         self.assertEqual(
-            timed_text_track.uploaded_on, datetime(2018, 8, 8, tzinfo=pytz.utc)
+            timed_text_track.uploaded_on, datetime(2018, 8, 8, tzinfo=timezone.utc)
         )
         self.assertEqual(timed_text_track.upload_state, "ready")
 
@@ -352,7 +351,9 @@ class UpdateStateAPITest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(document.upload_state, "ready")
         self.assertEqual(document.extension, "pdf")
-        self.assertEqual(document.uploaded_on, datetime(2018, 8, 8, tzinfo=pytz.utc))
+        self.assertEqual(
+            document.uploaded_on, datetime(2018, 8, 8, tzinfo=timezone.utc)
+        )
 
     @override_settings(UPDATE_STATE_SHARED_SECRETS=["shared secret"])
     def test_api_update_state_document_without_extension(self):
@@ -383,7 +384,9 @@ class UpdateStateAPITest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(document.upload_state, "ready")
         self.assertEqual(document.extension, None)
-        self.assertEqual(document.uploaded_on, datetime(2018, 8, 8, tzinfo=pytz.utc))
+        self.assertEqual(
+            document.uploaded_on, datetime(2018, 8, 8, tzinfo=timezone.utc)
+        )
 
     @override_settings(UPDATE_STATE_SHARED_SECRETS=["shared secret"])
     def test_api_update_state_thumbnail(self):
@@ -417,7 +420,9 @@ class UpdateStateAPITest(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(thumbnail.upload_state, "ready")
-        self.assertEqual(thumbnail.uploaded_on, datetime(2018, 8, 8, tzinfo=pytz.utc))
+        self.assertEqual(
+            thumbnail.uploaded_on, datetime(2018, 8, 8, tzinfo=timezone.utc)
+        )
 
     @override_settings(UPDATE_STATE_SHARED_SECRETS=["shared secret"])
     def test_api_update_state_shared_live_media(self):
@@ -450,7 +455,7 @@ class UpdateStateAPITest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(shared_live_media.upload_state, "ready")
         self.assertEqual(
-            shared_live_media.uploaded_on, datetime(2018, 8, 8, tzinfo=pytz.utc)
+            shared_live_media.uploaded_on, datetime(2018, 8, 8, tzinfo=timezone.utc)
         )
         self.assertEqual(shared_live_media.nb_pages, 3)
         self.assertEqual(shared_live_media.extension, "pdf")

--- a/src/backend/marsha/core/tests/test_api_video.py
+++ b/src/backend/marsha/core/tests/test_api_video.py
@@ -7,7 +7,6 @@ import uuid
 
 from django.test import TestCase, override_settings
 
-import pytz
 from rest_framework_simplejwt.tokens import AccessToken
 
 from .. import api, factories, models
@@ -173,7 +172,7 @@ class VideoAPITest(TestCase):
         resolutions = [144, 240, 480, 720, 1080]
         video = factories.VideoFactory(
             pk="a2f27fde-973a-4e89-8dca-cc59e01d255c",
-            uploaded_on=datetime(2018, 8, 8, tzinfo=pytz.utc),
+            uploaded_on=datetime(2018, 8, 8, tzinfo=timezone.utc),
             upload_state="ready",
             resolutions=resolutions,
             playlist__title="foo bar",
@@ -183,7 +182,7 @@ class VideoAPITest(TestCase):
             video=video,
             mode="cc",
             language="fr",
-            uploaded_on=datetime(2018, 8, 8, tzinfo=pytz.utc),
+            uploaded_on=datetime(2018, 8, 8, tzinfo=timezone.utc),
             upload_state="ready",
             extension="srt",
         )
@@ -192,7 +191,7 @@ class VideoAPITest(TestCase):
             extension="pdf",
             title="python structures",
             upload_state=READY,
-            uploaded_on=datetime(2021, 11, 30, tzinfo=pytz.utc),
+            uploaded_on=datetime(2021, 11, 30, tzinfo=timezone.utc),
             nb_pages=3,
         )
         shared_live_media_2 = factories.SharedLiveMediaFactory(
@@ -368,7 +367,7 @@ class VideoAPITest(TestCase):
         resolutions = [144, 240, 480, 720, 1080]
         video = factories.VideoFactory(
             id="d9d7049c-5a3f-4070-a494-e6bf0bd8b9fb",
-            uploaded_on=datetime(2018, 8, 8, tzinfo=pytz.utc),
+            uploaded_on=datetime(2018, 8, 8, tzinfo=timezone.utc),
             upload_state="ready",
             resolutions=resolutions,
             playlist__title="foo bar",
@@ -380,7 +379,7 @@ class VideoAPITest(TestCase):
             show_download=False,
             title="python expressions",
             upload_state=READY,
-            uploaded_on=datetime(2021, 11, 30, tzinfo=pytz.utc),
+            uploaded_on=datetime(2021, 11, 30, tzinfo=timezone.utc),
             nb_pages=3,
             video=video,
         )
@@ -396,7 +395,7 @@ class VideoAPITest(TestCase):
         jwt_token.payload["permissions"] = {"can_update": True}
 
         # fix the time so that the url signature is deterministic and can be checked
-        now = datetime(2021, 11, 30, tzinfo=pytz.utc)
+        now = datetime(2021, 11, 30, tzinfo=timezone.utc)
         with mock.patch.object(timezone, "now", return_value=now), mock.patch(
             "builtins.open", new_callable=mock.mock_open, read_data=RSA_KEY_MOCK
         ):
@@ -621,7 +620,7 @@ class VideoAPITest(TestCase):
         resolutions = [144, 240, 480, 720, 1080]
         video = factories.VideoFactory(
             id="d9d7049c-5a3f-4070-a494-e6bf0bd8b9fb",
-            uploaded_on=datetime(2018, 8, 8, tzinfo=pytz.utc),
+            uploaded_on=datetime(2018, 8, 8, tzinfo=timezone.utc),
             upload_state="ready",
             resolutions=resolutions,
             playlist__title="foo bar",
@@ -633,7 +632,7 @@ class VideoAPITest(TestCase):
             show_download=False,
             title="python expressions",
             upload_state=READY,
-            uploaded_on=datetime(2021, 11, 30, tzinfo=pytz.utc),
+            uploaded_on=datetime(2021, 11, 30, tzinfo=timezone.utc),
             nb_pages=3,
             video=video,
         )
@@ -649,7 +648,7 @@ class VideoAPITest(TestCase):
         jwt_token.payload["permissions"] = {"can_update": False}
 
         # fix the time so that the url signature is deterministic and can be checked
-        now = datetime(2021, 11, 30, tzinfo=pytz.utc)
+        now = datetime(2021, 11, 30, tzinfo=timezone.utc)
         with mock.patch.object(timezone, "now", return_value=now), mock.patch(
             "builtins.open", new_callable=mock.mock_open, read_data=RSA_KEY_MOCK
         ):
@@ -992,7 +991,7 @@ class VideoAPITest(TestCase):
         """Activating signed urls should add Cloudfront query string authentication parameters."""
         video = factories.VideoFactory(
             pk="a2f27fde-973a-4e89-8dca-cc59e01d255c",
-            uploaded_on=datetime(2018, 8, 8, tzinfo=pytz.utc),
+            uploaded_on=datetime(2018, 8, 8, tzinfo=timezone.utc),
             upload_state="ready",
             resolutions=[144],
             playlist__title="foo",
@@ -1004,7 +1003,7 @@ class VideoAPITest(TestCase):
 
         # Get the video linked to the JWT token
         # fix the time so that the url signature is deterministic and can be checked
-        now = datetime(2018, 8, 8, tzinfo=pytz.utc)
+        now = datetime(2018, 8, 8, tzinfo=timezone.utc)
         with mock.patch.object(timezone, "now", return_value=now):
             response = self.client.get(
                 f"/api/videos/{video.id}/",
@@ -1851,13 +1850,13 @@ class VideoAPITest(TestCase):
         """A video with a custom thumbnail should have it in its payload."""
         video = factories.VideoFactory(
             pk="38a91911-9aee-41e2-94dd-573abda6f48f",
-            uploaded_on=datetime(2018, 8, 8, tzinfo=pytz.utc),
+            uploaded_on=datetime(2018, 8, 8, tzinfo=timezone.utc),
             upload_state="ready",
             resolutions=[144, 240, 480, 720, 1080],
         )
         thumbnail = factories.ThumbnailFactory(
             video=video,
-            uploaded_on=datetime(2018, 8, 8, tzinfo=pytz.utc),
+            uploaded_on=datetime(2018, 8, 8, tzinfo=timezone.utc),
             upload_state="ready",
         )
 
@@ -3599,7 +3598,7 @@ class VideoAPITest(TestCase):
 
         # Get the upload policy for this video
         # It should generate a key file with the Unix timestamp of the present time
-        now = datetime(2018, 8, 8, tzinfo=pytz.utc)
+        now = datetime(2018, 8, 8, tzinfo=timezone.utc)
         with mock.patch.object(timezone, "now", return_value=now), mock.patch(
             "datetime.datetime"
         ) as mock_dt:
@@ -3695,7 +3694,7 @@ class VideoAPITest(TestCase):
 
         # Get the upload policy for this video
         # It should generate a key file with the Unix timestamp of the present time
-        now = datetime(2018, 8, 8, tzinfo=pytz.utc)
+        now = datetime(2018, 8, 8, tzinfo=timezone.utc)
         with mock.patch.object(timezone, "now", return_value=now), mock.patch(
             "datetime.datetime"
         ) as mock_dt:
@@ -3737,7 +3736,7 @@ class VideoAPITest(TestCase):
 
         # Get the upload policy for this video
         # It should generate a key file with the Unix timestamp of the present time
-        now = datetime(2018, 8, 8, tzinfo=pytz.utc)
+        now = datetime(2018, 8, 8, tzinfo=timezone.utc)
         with mock.patch.object(timezone, "now", return_value=now), mock.patch(
             "datetime.datetime"
         ) as mock_dt:
@@ -3804,7 +3803,7 @@ class VideoAPITest(TestCase):
 
         # Get the upload policy for this video
         # It should generate a key file with the Unix timestamp of the present time
-        now = datetime(2018, 8, 8, tzinfo=pytz.utc)
+        now = datetime(2018, 8, 8, tzinfo=timezone.utc)
         with mock.patch.object(timezone, "now", return_value=now), mock.patch(
             "datetime.datetime"
         ) as mock_dt:
@@ -3844,7 +3843,7 @@ class VideoAPITest(TestCase):
         }
         # Get the upload policy for this video
         # It should generate a key file with the Unix timestamp of the present time
-        now = datetime(2018, 8, 8, tzinfo=pytz.utc)
+        now = datetime(2018, 8, 8, tzinfo=timezone.utc)
         with mock.patch.object(timezone, "now", return_value=now), mock.patch(
             "datetime.datetime"
         ) as mock_dt:
@@ -4482,7 +4481,7 @@ class VideoAPITest(TestCase):
         jwt_token.payload["permissions"] = {"can_update": True}
 
         # stop a live video,
-        now = datetime(2021, 11, 16, tzinfo=pytz.utc)
+        now = datetime(2021, 11, 16, tzinfo=timezone.utc)
         with mock.patch.object(timezone, "now", return_value=now), mock.patch.object(
             api.video, "stop_live_channel"
         ), mock.patch(
@@ -5017,7 +5016,7 @@ class VideoAPITest(TestCase):
             "state": "running",
         }
         signature = generate_hash("shared secret", json.dumps(data).encode("utf-8"))
-        now = datetime(2018, 8, 8, tzinfo=pytz.utc)
+        now = datetime(2018, 8, 8, tzinfo=timezone.utc)
         with mock.patch.object(timezone, "now", return_value=now), mock.patch(
             "marsha.websocket.utils.channel_layers_utils.dispatch_video_to_groups"
         ) as mock_dispatch_video_to_groups:
@@ -5110,7 +5109,7 @@ class VideoAPITest(TestCase):
         }
         signature = generate_hash("shared secret", json.dumps(data).encode("utf-8"))
 
-        now = datetime(2018, 8, 8, tzinfo=pytz.utc)
+        now = datetime(2018, 8, 8, tzinfo=timezone.utc)
         with mock.patch.object(timezone, "now", return_value=now), mock.patch(
             "marsha.websocket.utils.channel_layers_utils.dispatch_video_to_groups"
         ) as mock_dispatch_video_to_groups:
@@ -5337,7 +5336,7 @@ class VideoAPITest(TestCase):
             "state": "stopped",
         }
         signature = generate_hash("shared secret", json.dumps(data).encode("utf-8"))
-        now = datetime(2018, 8, 8, tzinfo=pytz.utc)
+        now = datetime(2018, 8, 8, tzinfo=timezone.utc)
         with mock.patch.object(timezone, "now", return_value=now), mock.patch(
             "marsha.websocket.utils.channel_layers_utils.dispatch_video_to_groups"
         ) as mock_dispatch_video_to_groups:

--- a/src/backend/marsha/core/tests/test_api_video_shared_live_media.py
+++ b/src/backend/marsha/core/tests/test_api_video_shared_live_media.py
@@ -1,12 +1,11 @@
 """Tests for the Video API for SharedLiveMedia navigation of the Marsha project."""
-from datetime import datetime
+from datetime import datetime, timezone
 import json
 import random
 from unittest import mock
 
 from django.test import TestCase, override_settings
 
-import pytz
 from rest_framework_simplejwt.tokens import AccessToken
 
 from ..api.video import channel_layers_utils
@@ -212,7 +211,7 @@ class TestVideoSharedLiveMedia(TestCase):
             extension="pdf",
             title="slides",
             upload_state=READY,
-            uploaded_on=datetime(2021, 11, 30, tzinfo=pytz.utc),
+            uploaded_on=datetime(2021, 11, 30, tzinfo=timezone.utc),
             nb_pages=3,
             video=video,
         )
@@ -414,7 +413,7 @@ class TestVideoSharedLiveMedia(TestCase):
                 title="slides",
                 # upload_state=random.choice([s[0] for s in STATE_CHOICES if s[0] != READY]),
                 upload_state=state,
-                uploaded_on=datetime(2021, 11, 30, tzinfo=pytz.utc),
+                uploaded_on=datetime(2021, 11, 30, tzinfo=timezone.utc),
                 nb_pages=3,
                 video=video,
             )

--- a/src/backend/marsha/core/tests/test_command_check_live_state.py
+++ b/src/backend/marsha/core/tests/test_command_check_live_state.py
@@ -1,5 +1,5 @@
 """Tests for check_live_state command."""
-from datetime import datetime
+from datetime import datetime, timezone
 from io import StringIO
 from unittest import mock
 
@@ -7,7 +7,6 @@ from django.core.management import call_command
 from django.test import TestCase
 
 from botocore.stub import Stubber
-import pytz
 
 from ..defaults import RAW, RUNNING
 from ..factories import VideoFactory
@@ -34,7 +33,7 @@ class CheckLiveStateTest(TestCase):
         """A live is running and stream is on-going, the command should not stop it."""
         VideoFactory(
             id="0b791906-ccb3-4450-97cb-7b66fd9ad419",
-            created_on=datetime(2020, 8, 25, 0, 0, 0, tzinfo=pytz.utc),
+            created_on=datetime(2020, 8, 25, 0, 0, 0, tzinfo=timezone.utc),
             live_state=RUNNING,
             live_info={
                 "cloudwatch": {"logGroupName": "/aws/lambda/dev-test-marsha-medialive"},
@@ -129,7 +128,7 @@ class CheckLiveStateTest(TestCase):
         """Live is ended and the delay is not expired."""
         VideoFactory(
             id="0b791906-ccb3-4450-97cb-7b66fd9ad419",
-            created_on=datetime(2020, 8, 25, 0, 0, 0, tzinfo=pytz.utc),
+            created_on=datetime(2020, 8, 25, 0, 0, 0, tzinfo=timezone.utc),
             live_state=RUNNING,
             live_info={
                 "cloudwatch": {"logGroupName": "/aws/lambda/dev-test-marsha-medialive"},
@@ -196,7 +195,7 @@ class CheckLiveStateTest(TestCase):
                 },
             )
             generate_expired_date_mock.return_value = datetime(
-                2020, 8, 25, 12, 0, 0, tzinfo=pytz.utc
+                2020, 8, 25, 12, 0, 0, tzinfo=timezone.utc
             )
             call_command("check_live_state", stdout=out)
             logs_client_stubber.assert_no_pending_responses()
@@ -213,7 +212,7 @@ class CheckLiveStateTest(TestCase):
         """Live is ended and the delay is expired. The channel must be stopped."""
         VideoFactory(
             id="0b791906-ccb3-4450-97cb-7b66fd9ad419",
-            created_on=datetime(2020, 8, 25, 0, 0, 0, tzinfo=pytz.utc),
+            created_on=datetime(2020, 8, 25, 0, 0, 0, tzinfo=timezone.utc),
             live_state=RUNNING,
             live_info={
                 "cloudwatch": {"logGroupName": "/aws/lambda/dev-test-marsha-medialive"},
@@ -281,7 +280,7 @@ class CheckLiveStateTest(TestCase):
             )
 
             generate_expired_date_mock.return_value = datetime(
-                2020, 8, 25, 12, 30, 0, tzinfo=pytz.utc
+                2020, 8, 25, 12, 30, 0, tzinfo=timezone.utc
             )
             call_command("check_live_state", stdout=out)
             logs_client_stubber.assert_no_pending_responses()

--- a/src/backend/marsha/core/tests/test_command_send_reminders.py
+++ b/src/backend/marsha/core/tests/test_command_send_reminders.py
@@ -11,8 +11,6 @@ from django.core.management import call_command
 from django.test import TestCase
 from django.utils import timezone
 
-import pytz
-
 from marsha.core.management.commands import send_reminders
 
 from ..defaults import IDLE, RAW, RUNNING
@@ -738,7 +736,7 @@ class SendRemindersTest(TestCase):
         """Subscribe to a webinar and mock the time to show all three steps
         reminders are sent."""
 
-        now_past = datetime(2020, 8, 8, tzinfo=pytz.utc)
+        now_past = datetime(2020, 8, 8, tzinfo=timezone.utc)
         with mock.patch.object(timezone, "now", return_value=now_past):
             video = VideoFactory(
                 live_state=IDLE,

--- a/src/backend/marsha/core/tests/test_models_video.py
+++ b/src/backend/marsha/core/tests/test_models_video.py
@@ -8,7 +8,6 @@ from django.db.utils import IntegrityError
 from django.test import TestCase
 from django.utils import timezone
 
-import pytz
 from safedelete.models import SOFT_DELETE_CASCADE
 
 from ..defaults import (
@@ -74,7 +73,7 @@ class VideoModelsTestCase(TestCase):
         for state_choice in STATE_CHOICES:
             video = VideoFactory(
                 upload_state=state_choice[0],
-                uploaded_on=datetime(2018, 8, 8, tzinfo=pytz.utc),
+                uploaded_on=datetime(2018, 8, 8, tzinfo=timezone.utc),
             )
 
             self.assertEqual(

--- a/src/backend/marsha/core/tests/test_serializers_update_state.py
+++ b/src/backend/marsha/core/tests/test_serializers_update_state.py
@@ -4,8 +4,7 @@ import random
 from uuid import uuid4
 
 from django.test import TestCase
-
-import pytz
+from django.utils import timezone
 
 from ..models.video import TimedTextTrack
 from ..serializers import UpdateStateSerializer
@@ -119,7 +118,7 @@ class UpdateStateSerializerTest(TestCase):
                 "model_name": "video",
                 "object_id": str(object_id),
                 "stamp": "1533686400",
-                "uploaded_on": datetime(2018, 8, 8, tzinfo=pytz.utc),
+                "uploaded_on": datetime(2018, 8, 8, tzinfo=timezone.utc),
             },
         )
 
@@ -141,6 +140,6 @@ class UpdateStateSerializerTest(TestCase):
                 "model_name": "document",
                 "object_id": str(object_id),
                 "stamp": "1533686400",
-                "uploaded_on": datetime(2018, 8, 8, tzinfo=pytz.utc),
+                "uploaded_on": datetime(2018, 8, 8, tzinfo=timezone.utc),
             },
         )

--- a/src/backend/marsha/core/tests/test_utils_time_utils.py
+++ b/src/backend/marsha/core/tests/test_utils_time_utils.py
@@ -2,8 +2,7 @@
 from datetime import datetime
 
 from django.test import TestCase
-
-import pytz
+from django.utils import timezone
 
 from ..utils import time_utils
 
@@ -13,7 +12,7 @@ class TimeUtilsTestCase(TestCase):
 
     def test_utils_time_utils_to_timestamp(self):
         """Test computing a Unix timestamp from a datetime value."""
-        value = datetime(2018, 8, 8, tzinfo=pytz.utc)
+        value = datetime(2018, 8, 8, tzinfo=timezone.utc)
         self.assertEqual(time_utils.to_timestamp(value), "1533686400")
 
     def test_utils_time_utils_to_timestamp_none(self):
@@ -23,7 +22,8 @@ class TimeUtilsTestCase(TestCase):
     def test_utils_time_utils_to_datetime(self):
         """Test computing a timeaware datetime from a Unix timestamp."""
         self.assertEqual(
-            time_utils.to_datetime(1533686400), datetime(2018, 8, 8, tzinfo=pytz.utc)
+            time_utils.to_datetime(1533686400),
+            datetime(2018, 8, 8, tzinfo=timezone.utc),
         )
 
     def test_utils_time_utils_to_datetime_none(self):

--- a/src/backend/marsha/core/utils/time_utils.py
+++ b/src/backend/marsha/core/utils/time_utils.py
@@ -3,8 +3,7 @@ import calendar
 from datetime import datetime
 
 from django.core.exceptions import ValidationError
-
-import pytz
+from django.utils import timezone
 
 
 def to_timestamp(value):
@@ -49,6 +48,6 @@ def to_datetime(value):
     if value is None:
         return None
     try:
-        return datetime.utcfromtimestamp(int(value)).replace(tzinfo=pytz.utc)
+        return datetime.utcfromtimestamp(int(value)).replace(tzinfo=timezone.utc)
     except (ValueError, TypeError):
         raise ValidationError("{:s} is not a valid Unix timestamp.".format(value))

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -494,7 +494,7 @@ class Build(Base):
     settings.
     """
 
-    ALLOWED_HOSTS = None
+    ALLOWED_HOSTS = []
     AWS_ACCESS_KEY_ID = values.Value("")
     AWS_SECRET_ACCESS_KEY = values.Value("")
     AWS_BASE_NAME = values.Value("")

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     chardet==4.0.0
     coreapi==2.3.3
     cryptography==36.0.1
-    django<4
+    django==4.0.1
     dj-database-url==0.5.0
     django-configurations==2.3.2
     django-cors-headers==3.11.0

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -43,7 +43,7 @@ install_requires =
     django-safedelete==1.1.2
     django-storages==1.12.3
     django-waffle==2.3.0
-    dockerflow==2021.7.0
+    dockerflow==2022.1.0
     gunicorn==20.1.0
     logging-ldp==0.0.6
     oauthlib==3.2.0


### PR DESCRIPTION
## Purpose

We can upgrade Django to version 4. We only need to upgrade dockerflow first and then we choose to remove usage of pytz.

## Proposal

Description...

- [x] upgrade dockerflow to version 2022.1.0
- [x] upgrade to django 4
- [x]  remove usage of pytz

