### PR TITLE
🐛(front) better detect https protocol to connect to the websocket

### DIFF
--- a/src/frontend/data/websocket.spec.ts
+++ b/src/frontend/data/websocket.spec.ts
@@ -4,7 +4,6 @@ import WS from 'jest-websocket-mock';
 import { modelName } from 'types/models';
 import { videoMockFactory } from 'utils/tests/factories';
 import { useVideo } from './stores/useVideo';
-import { initVideoWebsocket } from './websocket';
 
 jest.mock('data/appData', () => ({
   appData: { jwt: 'cool_token_m8' },
@@ -12,6 +11,10 @@ jest.mock('data/appData', () => ({
 
 describe('initVideoWebsocket', () => {
   it('connects to the websocket and updates video zustand store when message is received', async () => {
+    let initVideoWebsocket: any;
+    jest.isolateModules(() => {
+      initVideoWebsocket = require('./websocket').initVideoWebsocket;
+    });
     const video = videoMockFactory();
     useVideo.getState().addResource(video);
     const server = new WS(`ws://localhost:1234/ws/video/${video.id}/`);
@@ -23,14 +26,57 @@ describe('initVideoWebsocket', () => {
         host: 'localhost:1234',
         protocol: 'http',
       },
+      writable: true,
     });
 
-    initVideoWebsocket(video);
+    initVideoWebsocket!(video);
     await server.connected;
 
     const updatedVideo = {
       ...video,
       title: 'updated title',
+    };
+
+    server.send(
+      JSON.stringify({
+        type: modelName.VIDEOS,
+        resource: updatedVideo,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(useVideo.getState().getVideo(video)).toEqual(updatedVideo);
+    });
+
+    server.close();
+    WS.clean();
+  });
+
+  it('connects to the websocket using https protocol', async () => {
+    let initVideoWebsocket: any;
+    jest.isolateModules(() => {
+      initVideoWebsocket = require('./websocket').initVideoWebsocket;
+    });
+    const video = videoMockFactory();
+    useVideo.getState().addResource(video);
+    const server = new WS(`wss://localhost:4321/ws/video/${video.id}/`);
+
+    global.window = Object.create(window);
+    Object.defineProperty(window, 'location', {
+      value: {
+        href: 'https://localhost:4321/',
+        host: 'localhost:4321',
+        protocol: 'https:',
+      },
+      writable: true,
+    });
+
+    initVideoWebsocket!(video);
+    await server.connected;
+
+    const updatedVideo = {
+      ...video,
+      title: 'updated title with https',
     };
 
     server.send(

--- a/src/frontend/data/websocket.ts
+++ b/src/frontend/data/websocket.ts
@@ -17,7 +17,7 @@ let videoWebsocket: RobustWebSocket;
 export const initVideoWebsocket = (video: Video) => {
   if (videoWebsocket) return;
   const location = window.location;
-  const wsProto = location.protocol === 'https' ? 'wss' : 'ws';
+  const wsProto = location.protocol.startsWith('https') ? 'wss' : 'ws';
   videoWebsocket = new RobustWebSocket(
     `${wsProto}://${location.host}${WS_ENPOINT}/video/${video.id}/?jwt=${appData.jwt}`,
   );


### PR DESCRIPTION
## Purpose

To know if we have to connect to the websocket using the ws or wss
protocol, we check the current protocol used to connect to the page,
this protocol is present in window.location.protocol. Depending the
browser implementation, the procotol can include the final `:`

## Proposal

 - [x] better detect https protocol to connect to the websocket

