### PR TITLE
🩹(front) fix stream stanza raising an error

### DIFF
--- a/src/frontend/utils/conversejs/converse-plugins/chatPlugin.ts
+++ b/src/frontend/utils/conversejs/converse-plugins/chatPlugin.ts
@@ -134,13 +134,6 @@ const addChatPlugin = (xmpp: XMPP) =>
                     .setHasReceivedMessageHistory(true);
                 }
                 break;
-
-              default:
-                report(
-                  new Error(
-                    `Unable to recognize the following received xml stanza : \n ${stanza.outerHTML}`,
-                  ),
-                );
             }
 
             return true;


### PR DESCRIPTION
When using websockets to establish a connection with the prosody server (
instead of bosh), server is sending stream stanzas (which consists of a stanza
beginning by a 'a' or 'r' tag'. These stanzas are unrecognized by the front and
an error is raised. This current commit introduces a condition to ignore these
stanzas when they are received, and so prevent errors to be raised.