### PR TITLE
fix live schedule info 

### DIFF
--- a/src/frontend/components/PublicVideoDashboard/index.spec.tsx
+++ b/src/frontend/components/PublicVideoDashboard/index.spec.tsx
@@ -605,7 +605,7 @@ describe('PublicVideoDashboard', () => {
 
     await screen.findByRole('button', { name: /register/i });
     screen.getByRole('heading', {
-      name: /Live will starts tomorrow at 11:00 AM/i,
+      name: /Live will start in 2 days at 11:00 AM/i,
     });
   });
 });

--- a/src/frontend/components/StudentLiveAdvertising/StudentLiveScheduleInfo/index.spec.tsx
+++ b/src/frontend/components/StudentLiveAdvertising/StudentLiveScheduleInfo/index.spec.tsx
@@ -42,7 +42,7 @@ describe('<StudentLiveScheduleInfo />', () => {
     expect(mockSetTimeIsOver).toHaveBeenCalledTimes(1);
   });
 
-  it('renders waiting message and starting date when live should start', () => {
+  it('renders waiting message when live should start', () => {
     const startDate = DateTime.fromJSDate(new Date(2022, 2, 27, 13, 59, 59));
 
     render(
@@ -94,7 +94,32 @@ describe('<StudentLiveScheduleInfo />', () => {
     expect(mockSetTimeIsOver).toHaveBeenCalledTimes(1);
   });
 
-  it('renders info about event tomorrow and the date of the event', () => {
+  it('renders info about event tomorrow and the date of the event when scheduled date is in the next calendar day', () => {
+    const startDate = DateTime.fromJSDate(new Date(2022, 1, 28, 13, 0, 0));
+
+    render(
+      wrapInIntlProvider(
+        <StudentLiveScheduleInfo
+          isTimeOver={false}
+          setTimeIsOver={mockSetTimeIsOver}
+          startDate={startDate}
+        />,
+      ),
+    );
+
+    screen.getByRole('heading', {
+      name: `Live will starts tomorrow at ${startDate
+        .setLocale('en')
+        .toLocaleString(DateTime.TIME_SIMPLE)}`,
+    });
+    screen.getByText(
+      startDate.setLocale('en').toLocaleString(DateTime.DATE_MED_WITH_WEEKDAY),
+    );
+
+    expect(mockSetTimeIsOver).not.toHaveBeenCalled();
+  });
+
+  it('renders info about event tomorrow and the date of the event when scheduled date is in more than 24 hours', () => {
     const startDate = DateTime.fromJSDate(new Date(2022, 1, 28, 15, 0, 0));
 
     render(

--- a/src/frontend/components/StudentLiveAdvertising/StudentLiveScheduleInfo/index.spec.tsx
+++ b/src/frontend/components/StudentLiveAdvertising/StudentLiveScheduleInfo/index.spec.tsx
@@ -108,7 +108,7 @@ describe('<StudentLiveScheduleInfo />', () => {
     );
 
     screen.getByRole('heading', {
-      name: `Live will starts tomorrow at ${startDate
+      name: `Live will start tomorrow at ${startDate
         .setLocale('en')
         .toLocaleString(DateTime.TIME_SIMPLE)}`,
     });
@@ -133,7 +133,7 @@ describe('<StudentLiveScheduleInfo />', () => {
     );
 
     screen.getByRole('heading', {
-      name: `Live will starts tomorrow at ${startDate
+      name: `Live will start tomorrow at ${startDate
         .setLocale('en')
         .toLocaleString(DateTime.TIME_SIMPLE)}`,
     });

--- a/src/frontend/components/StudentLiveAdvertising/StudentLiveScheduleInfo/index.tsx
+++ b/src/frontend/components/StudentLiveAdvertising/StudentLiveScheduleInfo/index.tsx
@@ -29,18 +29,21 @@ const StyledClock = styled(Clock)`
   color: ${normalizeColor('blue-hover', theme)};
 `;
 
-function splitDay(dateTime: DateTime) {
-  // Using diff.toISO() would be better but Clock grommet component is not able to manage
-  // iso8601 period without hours.
-  const diff = dateTime
-    .diffNow(['days', 'hours', 'minutes', 'seconds'])
+function splitDay(scheduleDate: DateTime) {
+  const now = DateTime.now();
+  const startOfNow = now.startOf('day');
+  const startOfScheduleDate = scheduleDate.startOf('day');
+  const { days } = startOfScheduleDate.diff(startOfNow, ['days']).toObject();
+
+  const compareDate = days === 0 ? now : startOfNow;
+  const diff = scheduleDate
+    .diff(compareDate, ['hours', 'minutes', 'seconds'])
     .toObject();
 
   // We need to truncate values to simplify tests of checkDays
   const seconds = Math.trunc(Number(diff.seconds || 0));
-  const days = Math.trunc(Number(diff.days || 0));
   return {
-    days,
+    days: Math.trunc(Number(days || 0)),
     hours: diff.hours || 0,
     minutes: diff.minutes || 0,
     seconds,

--- a/src/frontend/components/StudentLiveAdvertising/StudentLiveScheduleInfo/index.tsx
+++ b/src/frontend/components/StudentLiveAdvertising/StudentLiveScheduleInfo/index.tsx
@@ -73,7 +73,7 @@ const messages = defineMessages({
     id: 'components.StudentLiveScheduleInfo.timeLeft',
   },
   dayLeft: {
-    defaultMessage: 'Live will starts tomorrow at {hour}',
+    defaultMessage: 'Live will start tomorrow at {hour}',
     description:
       'Text message to inform at what time the event will start tomorrow',
     id: 'components.StudentLiveScheduleInfo.dayLeft',

--- a/src/frontend/components/StudentLiveAdvertising/index.spec.tsx
+++ b/src/frontend/components/StudentLiveAdvertising/index.spec.tsx
@@ -100,7 +100,7 @@ describe('<StudentLiveAdvertising />', () => {
     screen.getByText('live description');
 
     screen.getByRole('heading', {
-      name: 'Live will starts tomorrow at 11:00 AM',
+      name: 'Live will start in 2 days at 11:00 AM',
     });
   });
 


### PR DESCRIPTION
## Purpose

Scheduled live delay from now calculation is bugged, it calculates absolute delta from two dates but does not refer to calendar interval.

## Proposal

Use start of days to calculate the number of days before schedule date.
