### PR TITLE
⚡️(frontend) display the student waiting screen only until live has started once

### DIFF
--- a/src/frontend/components/PublicVideoDashboard/index.spec.tsx
+++ b/src/frontend/components/PublicVideoDashboard/index.spec.tsx
@@ -418,6 +418,9 @@ describe('PublicVideoDashboard', () => {
         jid: 'xmpp-server.com',
       },
     });
+    useLiveStateStarted.setState({
+      isStarted: false,
+    });
 
     render(
       wrapInIntlProvider(
@@ -548,6 +551,10 @@ describe('PublicVideoDashboard', () => {
     const video = videoMockFactory({
       live_state: liveState.IDLE,
     });
+    useLiveStateStarted.setState({
+      isStarted: false,
+    });
+
     render(
       wrapInIntlProvider(
         wrapInRouter(
@@ -566,6 +573,10 @@ describe('PublicVideoDashboard', () => {
       live_state: liveState.IDLE,
       is_scheduled: false,
     });
+    useLiveStateStarted.setState({
+      isStarted: false,
+    });
+
     render(
       wrapInIntlProvider(
         wrapInRouter(
@@ -588,6 +599,10 @@ describe('PublicVideoDashboard', () => {
       starting_at: DateTime.fromJSDate(new Date(2022, 1, 29, 11, 0, 0)).toISO(),
       is_scheduled: true,
     });
+    useLiveStateStarted.setState({
+      isStarted: false,
+    });
+
     render(
       wrapInIntlProvider(
         wrapInRouter(

--- a/src/frontend/components/StudentLiveWrapper/StudentLiveViewerWrapper/index.tsx
+++ b/src/frontend/components/StudentLiveWrapper/StudentLiveViewerWrapper/index.tsx
@@ -46,11 +46,7 @@ export const StudentLiveViewerWrapper = ({
     };
   }, [video, isLiveStarted]);
 
-  if (
-    video.live_state === liveState.IDLE ||
-    video.live_state === liveState.STARTING ||
-    !isLiveStarted
-  ) {
+  if (!isLiveStarted) {
     return <StudentLiveAdvertising video={video} />;
   } else {
     return (


### PR DESCRIPTION
## Purpose

Currently, when a live is paused then resume, the student is presented with the
waiting screen as if the live has not started yet.

## Proposal

We now render the waiting screen only as long as the live has not started once
(aka until the manifest can be fetch). During a pause and when the live is
restarting after a pause, the student is advertise only with the pause screen.
