### PR TITLE
🐛(front) fix unscrollable viewers list in tabs

### DIFF
--- a/src/frontend/components/StudentViewersList/index.tsx
+++ b/src/frontend/components/StudentViewersList/index.tsx
@@ -34,6 +34,7 @@ export const StudentViewersList = () => {
 
   return (
     <Box
+      fill
       gap="30px"
       overflow={{
         horizontal: 'hidden',


### PR DESCRIPTION
When there are a lot of viewers,  viewers list length exceeds tab height. The
user can now scroll throught this list.

![image](https://user-images.githubusercontent.com/83247226/153001294-16dd3efd-76ca-46e2-b6fc-bcad80b1156a.png)


This PR fixes the issue #1354