### PR TITLE
🐛(front) fix unscrollable chat messages in instructor view

### DIFF
--- a/src/frontend/components/Chat/index.tsx
+++ b/src/frontend/components/Chat/index.tsx
@@ -33,7 +33,6 @@ export const Chat = ({ video: baseVideo, standalone }: ChatProps) => {
     <Box {...conditionalProps}>
       {!!standalone ? (
         <div>
-          Instructor Chat
           <StudentChat />
         </div>
       ) : (

--- a/src/frontend/components/DashboardVideoLiveRunning/index.tsx
+++ b/src/frontend/components/DashboardVideoLiveRunning/index.tsx
@@ -63,7 +63,13 @@ export const DashboardVideoLiveRunning = ({
       {video.live_type === LiveModeType.JITSI && (
         <React.Fragment>
           <DashboardJoinDiscussion video={video} />
-          <Chat video={video} standalone={true} />
+          <Box
+            border={{ color: 'blue', size: 'xsmall' }}
+            height="large"
+            round="6px"
+          >
+            <Chat video={video} />
+          </Box>
         </React.Fragment>
       )}
     </Box>


### PR DESCRIPTION
The chat wasn't rendering as desired in the instructor view and messages were
overlapping 'Pair external device button'. Now the chat has a fixed set to 'large' and a nice blue border when rendered in instructor view.

This PR fixes issue #1355 

This is what is in place now, in the instructor view :

![image](https://user-images.githubusercontent.com/83247226/153017386-bd6b7973-d124-4572-9531-e52a25e121a6.png)
