### PR TITLE
🩹(front) fix 'Could not load .map files' warnings

### DIFF
--- a/src/frontend/webpack.config.js
+++ b/src/frontend/webpack.config.js
@@ -67,7 +67,6 @@ const config = {
       {
         enforce: 'pre',
         test: /\.js$/,
-        exclude: [path.join(__dirname, './node_modules/file-selector')],
         loader: 'source-map-loader',
       },
     ],


### PR DESCRIPTION
When loading sources map, ones related to file-selector module were raising an
error (indeed, /src folder where sources map files were pointed at were missing
in file-selector module in v0.2.2), and the file was so excluded. But doing
this way a warning was still present in dev-tools. With the actual version of
file-selector, /src folder where pointed at files were, was added in the
package, so there is no need anymore to exclude this module.
