### PR TITLE
🔧(front) update converse initialization settings

### DIFF
--- a/src/frontend/types/libs/converse/index.d.ts
+++ b/src/frontend/types/libs/converse/index.d.ts
@@ -34,40 +34,28 @@ declare namespace converse {
   }
 
   interface Options {
-    allow_contact_requests?: boolean;
-    allow_logout?: boolean;
-    allow_message_corrections?: 'all' | 'last';
-    allow_message_retraction?: 'all' | 'moderator' | 'own';
-    allow_muc_invitations?: boolean;
-    allow_registration?: boolean;
-    authentication?: 'anonymous' | 'external' | 'login' | 'prebind';
-    auto_login?: boolean;
-    auto_join_rooms?: sintrg[];
-    bosh_service_url?: Nullable<string>;
-    clear_cache_on_logout?: boolean;
-    discover_connection_methods?: boolean;
-    enable_smacks?: boolean;
-    hide_muc_participants?: boolean;
-    jid?: string;
-    loglevel?: string;
+    authentication: 'anonymous' | 'external' | 'login' | 'prebind';
+    auto_login: boolean;
+    auto_join_rooms: string[];
+    bosh_service_url: Nullable<string>;
+    clear_cache_on_logout: boolean;
+    discover_connection_methods: boolean;
+    enable_smacks: boolean;
+    idle_presence_timeout: number;
+    i18n: string;
+    jid: string;
+    loglevel: 'debug' | 'info' | 'warn' | 'error' | 'fatal';
     muc_history_max_stanzas: number;
-    modtools_disable_assign?: boolean;
-    muc_instant_rooms?: boolean;
-    muc_nickname_from_jid?: boolean;
-    muc_show_join_leave?: boolean;
-    nickname?: Nullable<string>;
-    root?: Nullable<Element>;
-    show_client_info?: boolean;
-    singleton?: boolean;
-    theme?: 'concord' | 'default';
-    view_mode?: 'embedded' | 'fullscreen' | 'mobile' | 'overlayed';
-    visible_toolbar_buttons?: {
-      call?: boolean;
-      emoji?: boolean;
-      spoiler?: boolean;
-      toggle_occupants?: boolean;
-    };
-    websocket_url?: Nullable<string>;
-    whitelisted_plugins?: string[];
+    muc_instant_rooms: boolean;
+    nickname: string;
+    persistent_store?:
+      | 'localStorage'
+      | 'IndexedDB'
+      | 'sessionStorage'
+      | 'BrowserExtLocal'
+      | 'BrowserExtSync';
+    ping_interval: number;
+    websocket_url: Nullable<string>;
+    whitelisted_plugins: string[];
   }
 }

--- a/src/frontend/utils/conversejs/converse.spec.ts
+++ b/src/frontend/utils/conversejs/converse.spec.ts
@@ -64,12 +64,6 @@ describe('initConverse', () => {
 
     expect(mockWindow.converse.initialize).toHaveBeenCalledTimes(1);
     expect(mockWindow.converse.initialize).toHaveBeenCalledWith({
-      allow_contact_requests: false,
-      allow_logout: false,
-      allow_message_corrections: 'last',
-      allow_message_retraction: 'all',
-      allow_muc_invitations: false,
-      allow_registration: false,
       authentication: 'anonymous',
       auto_login: true,
       auto_join_rooms: [
@@ -79,18 +73,14 @@ describe('initConverse', () => {
       clear_cache_on_logout: true,
       discover_connection_methods: false,
       enable_smacks: true,
-      hide_muc_participants: true,
+      idle_presence_timeout: 0,
+      i18n: 'en',
       jid: 'xmpp-server.com',
-      modtools_disable_assign: true,
+      loglevel: 'error',
       muc_history_max_stanzas: 0,
       muc_instant_rooms: false,
-      muc_show_join_leave: false,
       nickname: 'Anonymous-generated_id',
-      root: null,
-      show_client_info: false,
-      singleton: true,
-      theme: 'concord',
-      view_mode: 'embedded',
+      ping_interval: 20,
       websocket_url: 'wss://xmpp-server.com/xmpp-websocket',
       whitelisted_plugins: [
         chatPlugin.name,

--- a/src/frontend/utils/conversejs/converse.ts
+++ b/src/frontend/utils/conversejs/converse.ts
@@ -20,14 +20,9 @@ export const converseMounter = () => {
       nicknameManagementPlugin.addPlugin(xmpp);
       participantsTrackingPlugin.addPlugin();
 
+      const anonymousNickname = generateAnonymousNickname();
       // Converse Initialization
       converse.initialize({
-        allow_contact_requests: false,
-        allow_logout: false,
-        allow_message_corrections: 'last',
-        allow_message_retraction: 'all',
-        allow_muc_invitations: false,
-        allow_registration: false,
         authentication: 'anonymous',
         auto_login: true,
         auto_join_rooms: [xmpp.conference_url],
@@ -35,19 +30,14 @@ export const converseMounter = () => {
         clear_cache_on_logout: true,
         discover_connection_methods: false,
         enable_smacks: !!xmpp.websocket_url,
-        hide_muc_participants: true,
+        idle_presence_timeout: 0,
+        i18n: 'en',
         jid: xmpp.jid,
-        // loglevel: 'debug',
-        modtools_disable_assign: true,
+        loglevel: 'error',
         muc_history_max_stanzas: 0,
         muc_instant_rooms: false,
-        muc_show_join_leave: false,
-        nickname: generateAnonymousNickname(),
-        root: null,
-        show_client_info: false,
-        singleton: true,
-        theme: 'concord',
-        view_mode: 'embedded',
+        nickname: anonymousNickname,
+        ping_interval: 20,
         websocket_url: xmpp.websocket_url,
         whitelisted_plugins: [
           chatPlugin.name,
@@ -57,6 +47,7 @@ export const converseMounter = () => {
           participantsTrackingPlugin.name,
         ],
       });
+
       isChatInitialized = true;
     }
   };


### PR DESCRIPTION
Using only @converse/headless package and not the UI part, there are 
some settings which are not useful anymore. On another hand, some new 
settings are added : 
- idle_presence_timout : set to 0, in order to disable this feature, 
and prevent inactive users to be disconnected
- 18n :  set to 'en' which is the language loaded by default. It preventsconverse 
from displaying an error when trying to load missing localized files (which are 
not needed anyway, because converse UI part is not used)
- ping_interval : reducing ping_interval (default 60) make disconnection 
noticing faster