### PR TITLE
♻️(back) configure with settings the default lti locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Management command sending reminders for scheduled webinars
 - Implement a way to address prosody controls on the nickname entered in the 
   chat
+- settings DEFAULT_LTI_LAUNCH_PRESENTATION_LOCALE as fallback value when
+  launch_presentation_locale missing in the LTI request
 
 ### Changed
 

--- a/src/backend/marsha/core/lti/__init__.py
+++ b/src/backend/marsha/core/lti/__init__.py
@@ -307,10 +307,14 @@ class LTI:
         Returns
         -------
         string
-            The locale present in launch_presentation_locale or fallback to en
+            The locale present in launch_presentation_locale or fallback to the setting
+            DEFAULT_LTI_LAUNCH_PRESENTATION_LOCALE
 
         """
-        return self.request.POST.get("launch_presentation_locale", "en")
+        return self.request.POST.get(
+            "launch_presentation_locale",
+            settings.DEFAULT_LTI_LAUNCH_PRESENTATION_LOCALE,
+        )
 
     @property
     def username(self):

--- a/src/backend/marsha/core/tests/test_lti.py
+++ b/src/backend/marsha/core/tests/test_lti.py
@@ -476,6 +476,31 @@ class LTITestCase(TestCase):
         lti = LTI(request, resource_id)
         self.assertEqual(lti.launch_presentation_locale, "en")
 
+    @override_settings(DEFAULT_LTI_LAUNCH_PRESENTATION_LOCALE="fr")
+    def test_lti_launch_presentation_locale_fallback_settings(self):
+        """Fallback on defined DEFAULT_LTI_LAUNCH_PRESENTATION_LOCALE setting
+        if property is missing."""
+        ConsumerSiteLTIPassportFactory(
+            oauth_consumer_key="ABC123", consumer_site__domain="testserver"
+        )
+        data = {
+            "resource_link_id": "df7",
+            "context_id": "13245",
+            "roles": "Student",
+            "oauth_consumer_key": "ABC123",
+            "tool_consumer_instance_name": "ufr",
+            "context_title": "mathematics",
+        }
+        resource_id = uuid.uuid4()
+        request = self.factory.post(
+            f"/lti/videos/{resource_id}",
+            data,
+            HTTP_X_FORWARDED_PROTO="https",
+            HTTP_REFERER="http://testserver/lti-video/",
+        )
+        lti = LTI(request, resource_id)
+        self.assertEqual(lti.launch_presentation_locale, "fr")
+
     def test_lti_launch_presentation_locale(self):
         """Return value from launch_presentation_locale property when present."""
         ConsumerSiteLTIPassportFactory(

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -234,6 +234,7 @@ class Base(Configuration):
     USE_TZ = True
 
     REACT_LOCALES = values.ListValue(["en_US", "es_ES", "fr_FR", "fr_CA"])
+    DEFAULT_LTI_LAUNCH_PRESENTATION_LOCALE = values.Value("en")
 
     VIDEO_RESOLUTIONS = [144, 240, 480, 720, 1080]
     STORAGE_BACKEND = values.Value("marsha.core.storage.s3")


### PR DESCRIPTION
## Purpose

In a LTI request, the locale is defined using the property
launch_presentation_locale in the request. When this one is missing,
since now we were fallbacking with `en` value. We want to configure this
default value and we created a new settings for this named
DEFAULT_LTI_LAUNCH_PRESENTATION_LOCALE

## Proposal

- [x] configure with settings the default lti locale
