### PR TITLE
🔧(back) allow to configure CSRF_TRUSTED_ORIGINS django setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   chat
 - settings DEFAULT_LTI_LAUNCH_PRESENTATION_LOCALE as fallback value when
   launch_presentation_locale missing in the LTI request
+- allow to configure CSRF_TRUSTED_ORIGINS django setting
 
 ### Changed
 

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -98,6 +98,7 @@ class Base(Configuration):
     X_FRAME_OPTIONS = "DENY"
     SECURE_REFERRER_POLICY = "same-origin"
     SILENCED_SYSTEM_CHECKS = values.ListValue([])
+    CSRF_TRUSTED_ORIGINS = values.ListValue([])
 
     # Application definition
 


### PR DESCRIPTION
## Purpose

The setting CSRF_TRUSTED_ORIGINS has evolved and we now must configure
it on each marsha instance to allow the usage of CSRF protection.

## Proposal

- [x] allow to configure CSRF_TRUSTED_ORIGINS django setting
