### PR TITLE
🔖(major) bump release to 4.0.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.0.0-beta.1] - 2022-02-15
+
 ### Added
 
 - Add model and API endpoints to manage a shared live media
@@ -1009,7 +1011,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Minor fixes and improvements on features and tests
 
-[unreleased]: https://github.com/openfun/marsha/compare/v3.27.0...master
+[unreleased]: https://github.com/openfun/marsha/compare/v4.0.0-beta.1...master
+[4.0.0-beta.1]: https://github.com/openfun/marsha/compare/v3.27.0...v4.0.0-beta.1
 [3.27.0]: https://github.com/openfun/marsha/compare/v3.26.0...v3.27.0
 [3.26.0]: https://github.com/openfun/marsha/compare/v3.25.0...v3.26.0
 [3.25.0]: https://github.com/openfun/marsha/compare/v3.24.1...v3.25.0

--- a/src/aws/lambda-complete/package.json
+++ b/src/aws/lambda-complete/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-complete",
-  "version": "3.27.0",
+  "version": "4.0.0-beta.1",
   "engines": {
     "node": "14"
   },

--- a/src/aws/lambda-configure/package.json
+++ b/src/aws/lambda-configure/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-configure",
-  "version": "3.27.0",
+  "version": "4.0.0-beta.1",
   "engines": {
     "node": "14"
   },

--- a/src/aws/lambda-convert/package.json
+++ b/src/aws/lambda-convert/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-convert",
-  "version": "3.27.0",
+  "version": "4.0.0-beta.1",
   "engines": {
     "node": "14"
   },

--- a/src/aws/lambda-elemental-routing/package.json
+++ b/src/aws/lambda-elemental-routing/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-elemental-routing",
-  "version": "3.27.0",
+  "version": "4.0.0-beta.1",
   "engines": {
     "node": "14"
   },

--- a/src/aws/lambda-medialive/package.json
+++ b/src/aws/lambda-medialive/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-medialive",
-  "version": "3.27.0",
+  "version": "4.0.0-beta.1",
   "engines": {
     "node": "14"
   },

--- a/src/aws/lambda-mediapackage/package.json
+++ b/src/aws/lambda-mediapackage/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-mediapackage",
-  "version": "3.27.0",
+  "version": "4.0.0-beta.1",
   "engines": {
     "node": "14"
   },

--- a/src/aws/lambda-migrate/package.json
+++ b/src/aws/lambda-migrate/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-migrate",
-  "version": "3.27.0",
+  "version": "4.0.0-beta.1",
   "engines": {
     "node": "14"
   },

--- a/src/aws/utils/update-state/package.json
+++ b/src/aws/utils/update-state/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-update-state",
-  "version": "3.27.0",
+  "version": "4.0.0-beta.1",
   "engines": {
     "node": "14"
   },

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = marsha
 description = A FUN video provider for Open edX
-version = 3.27.0
+version = 4.0.0-beta.1
 author = Open FUN (France Universite Numerique)
 author_email = fun.dev@fun-mooc.fr
 license = MIT
@@ -11,10 +11,10 @@ classifiers =
     Intended Audience :: Developers
     License :: OSI Approved :: MIT License
     Framework :: Django
-    Framework :: Django :: 2.0
+    Framework :: Django :: 4.0
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3 :: Only
 keywords =
     video
@@ -22,7 +22,7 @@ keywords =
     accessibility
     a11y
 url = https://github.com/openfun/marsha
-requires-python = >=3.6
+requires-python = >=3.9
 
 [options]
 install_requires =

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marsha",
-  "version": "3.27.0",
+  "version": "4.0.0-beta.1",
   "description": "🐠 a FUN LTI video provider",
   "main": "front/index.tsx",
   "scripts": {


### PR DESCRIPTION
### Added

- Add model and API endpoints to manage a shared live media
- Add component to display chat, viewers and apps during a live in a panel
- Add `consumer_site` in JWT token
- Allow CORS headers configuration
- Extract SVG pages from PDF files for shared live media in lambda-convert
- Add fields `is_registered`,`live_attendance`,`username` for liveRegistration
- Add DRF endpoint to start attendance monitoring using liveRegistration model
- Add a new chat, using react components and design complying with the mockup
- Add anonymous_id and display_name in LiveRegistration model
- Add new endpoint to set display_name
- Add API endpoints to start, navigate and end a live media sharing
- Add fields `allow_recording`, `estimated_duration`, `has_chat` and
  `has_live_media` for Video model and API
- Manage websocket using django channels
- New video consumer able to send serialized video to all clients connected
  to the websocket when a video is updated through the API
- Add email settings and configure `mailcatcher` in docker-compose stack
- Transform `mjml` files (email's template files) to html and plaintext
- Add a participants tab, listing all users connected to the chat
- Add an authentificatin pop-up in the chat
- Add a default config file for the chat
- Add 'joined' and 'left' labels in the chat for users arrivals and departures
- Send updated video to clients connected to the websocket for all
  events related to the live workflow (start, pause, end, shared live medias)
- Send email when registering for a scheduled webinar
- Management command sending reminders for scheduled webinars
- Implement a way to address prosody controls on the nickname entered in the
  chat
- settings DEFAULT_LTI_LAUNCH_PRESENTATION_LOCALE as fallback value when
  launch_presentation_locale missing in the LTI request
- allow to configure CSRF_TRUSTED_ORIGINS django setting

### Changed

- docker image use python 3.10
- Rename lambda-encode to lambda-convert
- Registrations of a scheduled video from LTI are now based on
  `lti_user_id`, `consumer_site`, and `context_id`
- Converse.js UI is not used anymore, react components are used instead
- Add anonymous_id parameter to register a user to a scheduled webinar
- Update live layout for students
- Use websocket to update video resource instead of polling the API
- Improvement of emails templates for scheduled webinars
- Use websocket in the VOD dashboard and stop polling resources
- Display chat and viewers list in the tabs panel
- Upgrade to Django 4
- Integrate live advertisement in live layout
- Disable jitsi deeplinking

### Removed

- Remove user id in prosody JWT token


