### PR TITLE
🐛(back) allow to configure converse persistent store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Add a view to cancel reminder mails, link added in the footer of mails
 
+### Fixed
+
+- Allow to configure converse persistent store
+
 ## [4.0.0-beta.1] - 2022-02-15
 
 ### Added

--- a/src/backend/marsha/core/serializers/video.py
+++ b/src/backend/marsha/core/serializers/video.py
@@ -254,6 +254,7 @@ class VideoSerializer(VideoBaseSerializer):
                 "bosh_url": xmpp_utils.add_jwt_token_to_url(
                     settings.XMPP_BOSH_URL, token
                 ),
+                "converse_persistent_store": settings.XMPP_CONVERSE_PERSISTENT_STORE,
                 "websocket_url": xmpp_utils.add_jwt_token_to_url(
                     settings.XMPP_WEBSOCKET_URL, token
                 ),

--- a/src/backend/marsha/core/tests/test_api_video.py
+++ b/src/backend/marsha/core/tests/test_api_video.py
@@ -4201,6 +4201,7 @@ class VideoAPITest(TestCase):
                 "live_type": JITSI,
                 "xmpp": {
                     "bosh_url": "https://xmpp-server.com/http-bind?token=xmpp_jwt",
+                    "converse_persistent_store": "localStorage",
                     "websocket_url": None,
                     "conference_url": f"{video.id}@conference.xmpp-server.com",
                     "jid": "conference.xmpp-server.com",
@@ -4211,6 +4212,7 @@ class VideoAPITest(TestCase):
     @override_settings(LIVE_CHAT_ENABLED=True)
     @override_settings(XMPP_BOSH_URL="https://xmpp-server.com/http-bind")
     @override_settings(XMPP_CONFERENCE_DOMAIN="conference.xmpp-server.com")
+    @override_settings(XMPP_CONVERSE_PERSISTENT_STORE="IndexedDB")
     @override_settings(XMPP_DOMAIN="conference.xmpp-server.com")
     @override_settings(XMPP_JWT_SHARED_SECRET="xmpp_shared_secret")
     def test_api_instructor_start_already_created_live(self):
@@ -4331,6 +4333,7 @@ class VideoAPITest(TestCase):
                 "live_type": JITSI,
                 "xmpp": {
                     "bosh_url": "https://xmpp-server.com/http-bind?token=xmpp_jwt",
+                    "converse_persistent_store": "IndexedDB",
                     "websocket_url": None,
                     "conference_url": f"{video.id}@conference.xmpp-server.com",
                     "jid": "conference.xmpp-server.com",
@@ -4839,6 +4842,7 @@ class VideoAPITest(TestCase):
                 "xmpp": {
                     "bosh_url": "https://xmpp-server.com/http-bind?token=xmpp_jwt",
                     "conference_url": f"{video.id}@conference.xmpp-server.com",
+                    "converse_persistent_store": "localStorage",
                     "jid": "conference.xmpp-server.com",
                     "websocket_url": None,
                 },

--- a/src/backend/marsha/core/tests/test_api_video_shared_live_media.py
+++ b/src/backend/marsha/core/tests/test_api_video_shared_live_media.py
@@ -356,6 +356,7 @@ class TestVideoSharedLiveMedia(TestCase):
                     "live_type": JITSI,
                     "xmpp": {
                         "bosh_url": "https://xmpp-server.com/http-bind?token=xmpp_jwt",
+                        "converse_persistent_store": "localStorage",
                         "websocket_url": None,
                         "conference_url": f"{video.id}@conference.xmpp-server.com",
                         "jid": "conference.xmpp-server.com",
@@ -699,6 +700,7 @@ class TestVideoSharedLiveMedia(TestCase):
                     "live_type": JITSI,
                     "xmpp": {
                         "bosh_url": "https://xmpp-server.com/http-bind?token=xmpp_jwt",
+                        "converse_persistent_store": "localStorage",
                         "websocket_url": None,
                         "conference_url": f"{video.id}@conference.xmpp-server.com",
                         "jid": "conference.xmpp-server.com",
@@ -1088,6 +1090,7 @@ class TestVideoSharedLiveMedia(TestCase):
                     "live_type": JITSI,
                     "xmpp": {
                         "bosh_url": "https://xmpp-server.com/http-bind?token=xmpp_jwt",
+                        "converse_persistent_store": "localStorage",
                         "websocket_url": None,
                         "conference_url": f"{video.id}@conference.xmpp-server.com",
                         "jid": "conference.xmpp-server.com",

--- a/src/backend/marsha/core/tests/test_views_lti_video.py
+++ b/src/backend/marsha/core/tests/test_views_lti_video.py
@@ -456,6 +456,7 @@ class VideoLTIViewTestCase(TestCase):
                 "live_type": RAW,
                 "xmpp": {
                     "bosh_url": "https://xmpp-server.com/http-bind?token=xmpp_jwt",
+                    "converse_persistent_store": "localStorage",
                     "websocket_url": None,
                     "conference_url": f"{video.id}@conference.xmpp-server.com",
                     "jid": "conference.xmpp-server.com",

--- a/src/backend/marsha/core/tests/test_views_public_video.py
+++ b/src/backend/marsha/core/tests/test_views_public_video.py
@@ -281,6 +281,7 @@ class VideoPublicViewTestCase(TestCase):
                 "live_type": RAW,
                 "xmpp": {
                     "bosh_url": None,
+                    "converse_persistent_store": "localStorage",
                     "websocket_url": "ws://xmpp-server.com/xmpp-websocket?token=xmpp_jwt",
                     "conference_url": f"{video.id}@conference.xmpp-server.com",
                     "jid": "conference.xmpp-server.com",

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -307,6 +307,7 @@ class Base(Configuration):
     # XMPP Settings
     LIVE_CHAT_ENABLED = values.BooleanValue(False)
     XMPP_BOSH_URL = values.Value(None)
+    XMPP_CONVERSE_PERSISTENT_STORE = values.Value("localStorage")
     XMPP_WEBSOCKET_URL = values.Value(None)
     XMPP_CONFERENCE_DOMAIN = values.Value(None)
     XMPP_PRIVATE_ADMIN_JID = values.Value(None)

--- a/src/frontend/components/Chat/index.spec.tsx
+++ b/src/frontend/components/Chat/index.spec.tsx
@@ -3,6 +3,7 @@ import { render } from '@testing-library/react';
 
 import { Chat } from 'components/Chat';
 import { liveState } from 'types/tracks';
+import { PersistentStore } from 'types/XMPP';
 import { converseMounter } from 'utils/conversejs/converse';
 import { videoMockFactory } from 'utils/tests/factories';
 import { wrapInIntlProvider } from 'utils/tests/intl';
@@ -12,6 +13,7 @@ const mockVideo = videoMockFactory({
   live_state: liveState.RUNNING,
   xmpp: {
     bosh_url: 'https://xmpp-server.com/http-bind',
+    converse_persistent_store: PersistentStore.LOCALSTORAGE,
     websocket_url: null,
     conference_url:
       '870c467b-d66e-4949-8ee5-fcf460c72e88@conference.xmpp-server.com',

--- a/src/frontend/components/LiveVideoPanel/index.spec.tsx
+++ b/src/frontend/components/LiveVideoPanel/index.spec.tsx
@@ -5,6 +5,7 @@ import {
   LivePanelItem,
   useLivePanelState,
 } from 'data/stores/useLivePanelState';
+import { PersistentStore } from 'types/XMPP';
 import { videoMockFactory } from 'utils/tests/factories';
 import { renderImageSnapshot } from 'utils/tests/imageSnapshot';
 import { wrapInIntlProvider } from 'utils/tests/intl';
@@ -14,6 +15,7 @@ import { LiveVideoPanel } from '.';
 const mockVideo = videoMockFactory({
   xmpp: {
     bosh_url: 'https://xmpp-server.com/http-bind',
+    converse_persistent_store: PersistentStore.LOCALSTORAGE,
     websocket_url: null,
     conference_url:
       '870c467b-d66e-4949-8ee5-fcf460c72e88@conference.xmpp-server.com',

--- a/src/frontend/components/PublicVideoDashboard/index.spec.tsx
+++ b/src/frontend/components/PublicVideoDashboard/index.spec.tsx
@@ -13,6 +13,7 @@ import {
 import { useTimedTextTrack } from 'data/stores/useTimedTextTrack';
 import { createPlayer } from 'Player/createPlayer';
 import { liveState, timedTextMode } from 'types/tracks';
+import { PersistentStore } from 'types/XMPP';
 import { timedTextMockFactory, videoMockFactory } from 'utils/tests/factories';
 import { wrapInIntlProvider } from 'utils/tests/intl';
 import { wrapInRouter } from 'utils/tests/router';
@@ -309,6 +310,7 @@ describe('PublicVideoDashboard', () => {
       },
       xmpp: {
         bosh_url: 'https://xmpp-server.com/http-bind',
+        converse_persistent_store: PersistentStore.LOCALSTORAGE,
         websocket_url: null,
         conference_url:
           '870c467b-d66e-4949-8ee5-fcf460c72e88@conference.xmpp-server.com',
@@ -362,6 +364,7 @@ describe('PublicVideoDashboard', () => {
       },
       xmpp: {
         bosh_url: 'https://xmpp-server.com/http-bind',
+        converse_persistent_store: PersistentStore.LOCALSTORAGE,
         websocket_url: null,
         conference_url:
           '870c467b-d66e-4949-8ee5-fcf460c72e88@conference.xmpp-server.com',
@@ -411,6 +414,7 @@ describe('PublicVideoDashboard', () => {
       },
       xmpp: {
         bosh_url: 'https://xmpp-server.com/http-bind',
+        converse_persistent_store: PersistentStore.LOCALSTORAGE,
         websocket_url: null,
         conference_url:
           '870c467b-d66e-4949-8ee5-fcf460c72e88@conference.xmpp-server.com',
@@ -452,6 +456,7 @@ describe('PublicVideoDashboard', () => {
       },
       xmpp: {
         bosh_url: 'https://xmpp-server.com/http-bind',
+        converse_persistent_store: PersistentStore.LOCALSTORAGE,
         websocket_url: null,
         conference_url:
           '870c467b-d66e-4949-8ee5-fcf460c72e88@conference.xmpp-server.com',

--- a/src/frontend/components/PublicVideoLiveJitsi/index.spec.tsx
+++ b/src/frontend/components/PublicVideoLiveJitsi/index.spec.tsx
@@ -9,6 +9,7 @@ import {
 import { useLiveStateStarted } from 'data/stores/useLiveStateStarted';
 import { useParticipantWorkflow } from 'data/stores/useParticipantWorkflow';
 import { LiveModeType, liveState } from 'types/tracks';
+import { PersistentStore } from 'types/XMPP';
 import { videoMockFactory } from 'utils/tests/factories';
 import { wrapInIntlProvider } from 'utils/tests/intl';
 import { wrapInRouter } from 'utils/tests/router';
@@ -31,6 +32,7 @@ const mockVideo = videoMockFactory({
   live_type: LiveModeType.JITSI,
   xmpp: {
     bosh_url: 'https://xmpp-server.com/http-bind',
+    converse_persistent_store: PersistentStore.LOCALSTORAGE,
     websocket_url: null,
     conference_url:
       '870c467b-d66e-4949-8ee5-fcf460c72e88@conference.xmpp-server.com',

--- a/src/frontend/components/StudentLiveControlBar/index.spec.tsx
+++ b/src/frontend/components/StudentLiveControlBar/index.spec.tsx
@@ -6,6 +6,7 @@ import {
   useLivePanelState,
 } from 'data/stores/useLivePanelState';
 import { LiveModeType, liveState } from 'types/tracks';
+import { PersistentStore } from 'types/XMPP';
 import { videoMockFactory } from 'utils/tests/factories';
 import { wrapInIntlProvider } from 'utils/tests/intl';
 
@@ -144,6 +145,7 @@ describe('<StudentLiveControlBar /> leave/join discussion wrapper', () => {
       live_state: liveState.RUNNING,
       xmpp: {
         bosh_url: 'https://xmpp-server.com/http-bind',
+        converse_persistent_store: PersistentStore.LOCALSTORAGE,
         websocket_url: null,
         conference_url:
           '870c467b-d66e-4949-8ee5-fcf460c72e88@conference.xmpp-server.com',
@@ -179,6 +181,7 @@ describe('<StudentLiveControlBar /> leave/join discussion wrapper', () => {
       live_state: null,
       xmpp: {
         bosh_url: 'https://xmpp-server.com/http-bind',
+        converse_persistent_store: PersistentStore.LOCALSTORAGE,
         websocket_url: null,
         conference_url:
           '870c467b-d66e-4949-8ee5-fcf460c72e88@conference.xmpp-server.com',
@@ -214,6 +217,7 @@ describe('<StudentLiveControlBar /> leave/join discussion wrapper', () => {
       live_state: liveState.STOPPING,
       xmpp: {
         bosh_url: 'https://xmpp-server.com/http-bind',
+        converse_persistent_store: PersistentStore.LOCALSTORAGE,
         websocket_url: null,
         conference_url:
           '870c467b-d66e-4949-8ee5-fcf460c72e88@conference.xmpp-server.com',
@@ -249,6 +253,7 @@ describe('<StudentLiveControlBar /> leave/join discussion wrapper', () => {
       live_state: liveState.PAUSED,
       xmpp: {
         bosh_url: 'https://xmpp-server.com/http-bind',
+        converse_persistent_store: PersistentStore.LOCALSTORAGE,
         websocket_url: null,
         conference_url:
           '870c467b-d66e-4949-8ee5-fcf460c72e88@conference.xmpp-server.com',
@@ -284,6 +289,7 @@ describe('<StudentLiveControlBar /> leave/join discussion wrapper', () => {
       live_state: liveState.RUNNING,
       xmpp: {
         bosh_url: 'https://xmpp-server.com/http-bind',
+        converse_persistent_store: PersistentStore.LOCALSTORAGE,
         websocket_url: null,
         conference_url:
           '870c467b-d66e-4949-8ee5-fcf460c72e88@conference.xmpp-server.com',

--- a/src/frontend/components/StudentLiveWrapper/index.spec.tsx
+++ b/src/frontend/components/StudentLiveWrapper/index.spec.tsx
@@ -1,20 +1,21 @@
 import React from 'react';
 import fetchMock from 'fetch-mock';
 import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import {
   LivePanelItem,
   useLivePanelState,
 } from 'data/stores/useLivePanelState';
+import { useLiveStateStarted } from 'data/stores/useLiveStateStarted';
 import { LiveModeType, liveState } from 'types/tracks';
+import { PersistentStore } from 'types/XMPP';
 import { videoMockFactory } from 'utils/tests/factories';
-
-import { LiveType, LiveVideoWrapper } from '.';
 import { wrapInIntlProvider } from 'utils/tests/intl';
 import { wrapInRouter } from 'utils/tests/router';
 import { createPlayer } from 'Player/createPlayer';
-import { useLiveStateStarted } from 'data/stores/useLiveStateStarted';
-import userEvent from '@testing-library/user-event';
+
+import { LiveType, LiveVideoWrapper } from '.';
 
 const mockVideo = videoMockFactory();
 jest.mock('data/appData', () => ({
@@ -121,6 +122,7 @@ describe('<StudentLiveWrapper /> as a viewer', () => {
       },
       xmpp: {
         bosh_url: 'https://xmpp-server.com/http-bind',
+        converse_persistent_store: PersistentStore.LOCALSTORAGE,
         websocket_url: null,
         conference_url:
           '870c467b-d66e-4949-8ee5-fcf460c72e88@conference.xmpp-server.com',
@@ -186,6 +188,7 @@ describe('<StudentLiveWrapper /> as a viewer', () => {
       },
       xmpp: {
         bosh_url: 'https://xmpp-server.com/http-bind',
+        converse_persistent_store: PersistentStore.LOCALSTORAGE,
         websocket_url: null,
         conference_url:
           '870c467b-d66e-4949-8ee5-fcf460c72e88@conference.xmpp-server.com',
@@ -249,6 +252,7 @@ describe('<StudentLiveWrapper /> as a viewer', () => {
       },
       xmpp: {
         bosh_url: 'https://xmpp-server.com/http-bind',
+        converse_persistent_store: PersistentStore.LOCALSTORAGE,
         websocket_url: null,
         conference_url:
           '870c467b-d66e-4949-8ee5-fcf460c72e88@conference.xmpp-server.com',
@@ -368,6 +372,7 @@ describe('<StudentLiveWrapper /> as a viewer', () => {
       },
       xmpp: {
         bosh_url: 'https://xmpp-server.com/http-bind',
+        converse_persistent_store: PersistentStore.LOCALSTORAGE,
         websocket_url: null,
         conference_url:
           '870c467b-d66e-4949-8ee5-fcf460c72e88@conference.xmpp-server.com',
@@ -484,6 +489,7 @@ describe('<StudentLiveWrapper /> as a streamer', () => {
       live_type: LiveModeType.JITSI,
       xmpp: {
         bosh_url: 'https://xmpp-server.com/http-bind',
+        converse_persistent_store: PersistentStore.LOCALSTORAGE,
         websocket_url: null,
         conference_url:
           '870c467b-d66e-4949-8ee5-fcf460c72e88@conference.xmpp-server.com',
@@ -541,6 +547,7 @@ describe('<StudentLiveWrapper /> as a streamer', () => {
       live_type: LiveModeType.JITSI,
       xmpp: {
         bosh_url: 'https://xmpp-server.com/http-bind',
+        converse_persistent_store: PersistentStore.LOCALSTORAGE,
         websocket_url: null,
         conference_url:
           '870c467b-d66e-4949-8ee5-fcf460c72e88@conference.xmpp-server.com',
@@ -596,6 +603,7 @@ describe('<StudentLiveWrapper /> as a streamer', () => {
       live_type: LiveModeType.JITSI,
       xmpp: {
         bosh_url: 'https://xmpp-server.com/http-bind',
+        converse_persistent_store: PersistentStore.LOCALSTORAGE,
         websocket_url: null,
         conference_url:
           '870c467b-d66e-4949-8ee5-fcf460c72e88@conference.xmpp-server.com',
@@ -699,6 +707,7 @@ describe('<StudentLiveWrapper /> as a streamer', () => {
       live_type: LiveModeType.JITSI,
       xmpp: {
         bosh_url: 'https://xmpp-server.com/http-bind',
+        converse_persistent_store: PersistentStore.LOCALSTORAGE,
         websocket_url: null,
         conference_url:
           '870c467b-d66e-4949-8ee5-fcf460c72e88@conference.xmpp-server.com',

--- a/src/frontend/components/VideoPlayer/index.spec.tsx
+++ b/src/frontend/components/VideoPlayer/index.spec.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 
 import { createPlayer } from 'Player/createPlayer';
 import { liveState, timedTextMode, uploadState } from 'types/tracks';
+import { PersistentStore } from 'types/XMPP';
 import { timedTextMockFactory, videoMockFactory } from 'utils/tests/factories';
 import { wrapInIntlProvider } from 'utils/tests/intl';
 import VideoPlayer from './index';
@@ -176,6 +177,7 @@ describe('VideoPlayer', () => {
       },
       xmpp: {
         bosh_url: 'https://xmpp-server.com/http-bind',
+        converse_persistent_store: PersistentStore.LOCALSTORAGE,
         websocket_url: null,
         conference_url:
           '870c467b-d66e-4949-8ee5-fcf460c72e88@conference.xmpp-server.com',

--- a/src/frontend/types/XMPP.ts
+++ b/src/frontend/types/XMPP.ts
@@ -3,6 +3,7 @@ import { Nullable } from '../utils/types';
 /* XMPP representation */
 export interface XMPP {
   bosh_url: Nullable<string>;
+  converse_persistent_store: converse.Options['persistent_store'];
   conference_url: string;
   jid: string;
   prebind_url: string;
@@ -23,4 +24,12 @@ export enum EventType {
   PARTICIPANT_ASK_TO_JOIN = 'participantAskToJoin',
   REJECT = 'reject',
   REJECTED = 'rejected',
+}
+
+export enum PersistentStore {
+  BROWSEREXTLOCAL = 'BrowserExtLocal',
+  BROWSEREXTSYNC = 'BrowserExtSync',
+  LOCALSTORAGE = 'localStorage',
+  INDEXEDDB = 'IndexedDB',
+  SESSIONSTORAGE = 'sessionStorage',
 }

--- a/src/frontend/types/libs/converse/index.d.ts
+++ b/src/frontend/types/libs/converse/index.d.ts
@@ -1,6 +1,6 @@
 import { Participant } from 'types/Participant';
 import { Video } from 'types/tracks';
-import { XMPP } from 'types/XMPP';
+import { PersistentStore, XMPP } from 'types/XMPP';
 import { Nullable } from 'utils/types';
 
 export as namespace converse;
@@ -52,12 +52,7 @@ declare namespace converse {
     muc_history_max_stanzas: number;
     muc_instant_rooms: boolean;
     nickname: string;
-    persistent_store?:
-      | 'localStorage'
-      | 'IndexedDB'
-      | 'sessionStorage'
-      | 'BrowserExtLocal'
-      | 'BrowserExtSync';
+    persistent_store?: PersistentStore;
     ping_interval: number;
     websocket_url: Nullable<string>;
     whitelisted_plugins: string[];

--- a/src/frontend/utils/conversejs/converse.spec.ts
+++ b/src/frontend/utils/conversejs/converse.spec.ts
@@ -1,3 +1,4 @@
+import { PersistentStore } from 'types/XMPP';
 import { videoMockFactory } from 'utils/tests/factories';
 import * as mockWindow from 'utils/window';
 
@@ -47,6 +48,7 @@ describe('initConverse', () => {
 
     const xmpp = {
       bosh_url: 'https://xmpp-server.com/http-bind',
+      converse_persistent_store: PersistentStore.LOCALSTORAGE,
       websocket_url: 'wss://xmpp-server.com/xmpp-websocket',
       conference_url:
         '870c467b-d66e-4949-8ee5-fcf460c72e88@conference.xmpp-server.com',
@@ -80,6 +82,7 @@ describe('initConverse', () => {
       muc_history_max_stanzas: 0,
       muc_instant_rooms: false,
       nickname: 'Anonymous-generated_id',
+      persistent_store: 'localStorage',
       ping_interval: 20,
       websocket_url: 'wss://xmpp-server.com/xmpp-websocket',
       whitelisted_plugins: [

--- a/src/frontend/utils/conversejs/converse.ts
+++ b/src/frontend/utils/conversejs/converse.ts
@@ -37,6 +37,7 @@ export const converseMounter = () => {
         muc_history_max_stanzas: 0,
         muc_instant_rooms: false,
         nickname: anonymousNickname,
+        persistent_store: xmpp.converse_persistent_store,
         ping_interval: 20,
         websocket_url: xmpp.websocket_url,
         whitelisted_plugins: [


### PR DESCRIPTION
## Purpose

Converse allow to use multiple persistent store. By default the one used
is IndexedDB. This is a modern persistent store avaiable in browsers but
have some caveats. Browsers have more and more mechanisms to protect
user private life, like not allowing the usage of IndexedDB database
when the script using it is not on the same domain (cross domain). In
that specific case (private browsing or by default with Brave), converse
is not usable and does not fallback on an other storage. For this we
want to configure the persistent store used by converse and we can
configure it by changing the XMPP_CONVERSE_PERSISTENT_STORE setting.


## Proposal

- [x] allow to configure converse persistent store
