### PR TITLE
🐛(frontend) declare meeting attendees nullable

### DIFF
--- a/src/frontend/apps/bbb/DashboardMeeting/index.tsx
+++ b/src/frontend/apps/bbb/DashboardMeeting/index.tsx
@@ -9,6 +9,8 @@ import { Loader } from 'components/Loader';
 
 import { bbbAppData } from 'apps/bbb/data/bbbAppData';
 import { useJoinMeeting, useMeeting } from 'apps/bbb/data/queries';
+import { Attendee } from 'apps/bbb/types/models';
+import { Maybe } from 'utils/types';
 
 const DashboardMeetingStudent = lazy(
   () => import('apps/bbb/DashboardMeetingStudent'),
@@ -64,14 +66,17 @@ const DashboardMeeting = () => {
   }`;
 
   useEffect(() => {
-    const attendeeFound = meeting?.infos?.attendees.find((attendee) => {
-      return (
-        consumerSiteUserId === attendee.userID &&
-        (attendee.hasVideo === 'true' ||
-          attendee.hasJoinedVoice === 'true' ||
-          attendee.isListeningOnly === 'true')
-      );
-    });
+    let attendeeFound: Maybe<Attendee>;
+    if (meeting?.infos?.attendees) {
+      attendeeFound = meeting.infos.attendees?.find((attendee) => {
+        return (
+          consumerSiteUserId === attendee.userID &&
+          (attendee.hasVideo === 'true' ||
+            attendee.hasJoinedVoice === 'true' ||
+            attendee.isListeningOnly === 'true')
+        );
+      });
+    }
 
     if (attendeeFound) {
       setUserFullname(attendeeFound.fullName);

--- a/src/frontend/apps/bbb/types/models.ts
+++ b/src/frontend/apps/bbb/types/models.ts
@@ -1,4 +1,5 @@
 import { Playlist, Resource } from 'types/tracks';
+import { Nullable } from 'utils/types';
 
 export interface Meeting extends Resource {
   playlist: Playlist;
@@ -35,7 +36,7 @@ export interface MeetingInfos {
   videoCount: string;
   maxUsers: string;
   moderatorCount: string;
-  attendees: Attendee[];
+  attendees: Nullable<Attendee[]>;
   metadata: string;
   isBreakout: string;
 }

--- a/src/frontend/apps/bbb/utils/tests/factories.ts
+++ b/src/frontend/apps/bbb/utils/tests/factories.ts
@@ -45,7 +45,7 @@ export const meetingInfosMockFactory = (
     videoCount: faker.datatype.number().toString(),
     maxUsers: faker.datatype.number().toString(),
     moderatorCount: faker.datatype.number().toString(),
-    attendees: [],
+    attendees: null,
     metadata: faker.datatype.string(),
     isBreakout: 'false',
     ...meetingInfos,


### PR DESCRIPTION
## Purpose

When we start a meeting, no attendees can exists, so the MeetingInfo type must allow it.
Factory should not create an empty array by default.

## Proposal

Description...

- [x] declare meeting attendees type nullable
- [x] meeting factory creates attendees null

