### PR TITLE
:bug:(backend) change model app in `link_field`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Show a specific message to students when BBB meeting ended
 - Remove cancel button in student meeting join form
 - Replace automatic meeting joining by a button
+- Allow generated links in Django admin for objects in other applications
 
 ## [4.0.0-beta.1] - 2022-02-15
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -17,6 +17,7 @@
 - [Vassili Rezvoy](https://github.com/RVassili) <vassili.rezvoy@polyconseil.fr>
 - [Raphael Fernandes](https://github.com/RaphaelFernandes92) <rfer92@gmail.com>
 - [Ronan Le Viennesse](https://github.com/roro-lv) <ronan.le-viennesse@polyconseil.fr>
+- [Quentin Bey](https://github.com/qbey) <quentin.bey@polyconseil.fr>
 
 - [Renovate Bot](https://renovatebot.com) <bot@renovateapp.com>
 - [Pyup Bot](https://pyup.io) <github-bot@pyup.io>

--- a/src/backend/marsha/core/admin.py
+++ b/src/backend/marsha/core/admin.py
@@ -43,7 +43,7 @@ def link_field(field_name):
     Returns
     -------
     function
-        The function that Django admin must call with the object as arguement to render the field
+        The function that Django admin must call with the object as argument to render the field
         as a link.
 
     """
@@ -65,10 +65,10 @@ def link_field(field_name):
             The html representing the link to the object admin change view.
 
         """
-        app_label = obj._meta.app_label
         linked_obj = getattr(obj, field_name)
         if linked_obj is None:
             return "-"
+        app_label = linked_obj._meta.app_label
         model_name = linked_obj._meta.model_name
         view_name = f"admin:{app_label}_{model_name}_change"
         link_url = reverse(view_name, args=[linked_obj.id])

--- a/src/backend/marsha/core/tests/test_admin.py
+++ b/src/backend/marsha/core/tests/test_admin.py
@@ -1,0 +1,62 @@
+"""Tests for the admin helpers in the ``core`` app of the Marsha project."""
+from django.db import models
+from django.test import TestCase
+from django.urls import NoReverseMatch
+
+from ..admin import link_field
+from ..factories import ConsumerSiteLTIPassportFactory, PlaylistLTIPassportFactory
+from ..models import BaseModel
+
+
+# We don't enforce arguments documentation in tests
+# pylint: disable=unused-argument
+
+
+class AdminLinkFieldTestCase(TestCase):
+    """Test the `link_field` helper works as expected."""
+
+    def test_link_field_no_linked_object(self):
+        """Assert `link_field` works properly when no instance is linked."""
+
+        lti_passport_no_playlist = ConsumerSiteLTIPassportFactory()
+        self.assertEqual(link_field("playlist")(lti_passport_no_playlist), "-")
+
+    def test_link_field_same_application(self):
+        """Assert `link_field` works properly for models inside the same application."""
+
+        # LTIPassport is in the same application as its linked playlist
+        lti_passport = PlaylistLTIPassportFactory()
+        playlist = lti_passport.playlist
+
+        self.assertEqual(
+            link_field("playlist")(lti_passport),
+            f'<a href="/admin/core/playlist/{playlist.pk}/change/">{str(playlist)}</a>',
+        )
+
+    def test_link_field_different_applications(self):
+        """Assert `link_field` works properly for models in two different applications.
+
+        Note: Can't easily mock Django URL resolver, so rely on the raised exception instead.
+        """
+
+        class AModel(BaseModel):  # pylint: disable=missing-class-docstring
+            class Meta:
+                app_label = "one_app"
+
+        class BModel(BaseModel):  # pylint: disable=missing-class-docstring
+            linked_object = models.ForeignKey(
+                to=AModel,
+                null=True,
+                blank=True,
+                on_delete=models.SET_NULL,
+            )
+
+            class Meta:
+                app_label = "another_app"
+
+        # Assert the admin URL for the AModel is properly reversed
+        instance_with_linked_object = BModel(linked_object=AModel())
+        with self.assertRaises(NoReverseMatch) as exc_context_mgr:
+            link_field("linked_object")(instance_with_linked_object)
+        reverse_exception = exc_context_mgr.exception
+        self.assertIn("one_app_amodel_change", str(reverse_exception))


### PR DESCRIPTION
## Purpose

The `link_field` helper to forge admin URL to the foreign key object was
using the local model's application name instead of the linked model's
application name, resulting in an error for the BBB admin display, as
the ``bbb.Meeting`` model has a foreign key to ``core.Playlist`` model
and the helper was trying to resolve a ``bbb.Playlist`` which doesn't
exist.

## Proposal

Use the linked model application name to reverse the URL properly.

