### PR TITLE
Manage display_name to connect to the chat

### DIFF
--- a/src/backend/marsha/core/api/live_registration.py
+++ b/src/backend/marsha/core/api/live_registration.py
@@ -280,10 +280,7 @@ class LiveRegistrationViewSet(
                     defaults=update_fields,
                 )
             return Response(
-                {
-                    "display_name": liveregistration.display_name,
-                    "username": liveregistration.username,
-                }
+                self.get_serializer(liveregistration).data, status.HTTP_200_OK
             )
         except IntegrityError as error:
             if "liveregistration_unique_video_display_name" in error.args[0]:

--- a/src/backend/marsha/core/api/live_registration.py
+++ b/src/backend/marsha/core/api/live_registration.py
@@ -269,6 +269,11 @@ class LiveRegistrationViewSet(
                     defaults=update_fields,
                 )
             else:
+                if not serializer.validated_data.get("anonymous_id"):
+                    return Response(
+                        {"detail": "Invalid request."},
+                        status=status.HTTP_400_BAD_REQUEST,
+                    )
                 liveregistration, _ = LiveRegistration.objects.update_or_create(
                     anonymous_id=serializer.validated_data["anonymous_id"],
                     video=video,
@@ -283,7 +288,7 @@ class LiveRegistrationViewSet(
         except IntegrityError as error:
             if "liveregistration_unique_video_display_name" in error.args[0]:
                 return Response(
-                    {"display_name": "User with that username already exists!"},
+                    {"display_name": "User with that display_name already exists!"},
                     status=status.HTTP_409_CONFLICT,
                 )
 

--- a/src/backend/marsha/core/serializers/live_registration.py
+++ b/src/backend/marsha/core/serializers/live_registration.py
@@ -15,7 +15,6 @@ class LiveRegistrationDisplayUsernameSerializer(serializers.ModelSerializer):
         fields = ("anonymous_id", "display_name", "username")
         read_only_fields = ("username",)
         extra_kwargs = {
-            "anonymous_id": {"allow_null": False, "required": True},
             "display_name": {"allow_null": False, "required": True},
         }
 

--- a/src/backend/marsha/core/tests/test_api_liveregistration.py
+++ b/src/backend/marsha/core/tests/test_api_liveregistration.py
@@ -3667,7 +3667,20 @@ class LiveRegistrationApiTest(TestCase):
 
         self.assertEqual(
             response.json(),
-            {"display_name": "Antoine", "username": None},
+            {
+                "anonymous_id": str(anonymous_id),
+                "consumer_site": None,
+                "display_name": "Antoine",
+                "email": liveregistration.email,
+                "id": str(liveregistration.id),
+                "is_registered": False,
+                "live_attendance": None,
+                "lti_id": None,
+                "lti_user_id": None,
+                "should_send_reminders": True,
+                "username": None,
+                "video": str(video.id),
+            },
         )
         self.assertEqual(liveregistration.display_name, "Antoine")
 
@@ -3699,11 +3712,25 @@ class LiveRegistrationApiTest(TestCase):
 
         # a new record has been created
         self.assertEqual(LiveRegistration.objects.count(), 2)
+        created_liveregistration = LiveRegistration.objects.get(video=video)
         self.assertEqual(
             response.json(),
-            {"display_name": "Antoine", "username": None},
+            {
+                "anonymous_id": str(anonymous_id),
+                "consumer_site": None,
+                "display_name": "Antoine",
+                "email": None,
+                "id": str(created_liveregistration.id),
+                "is_registered": False,
+                "live_attendance": None,
+                "lti_id": None,
+                "lti_user_id": None,
+                "should_send_reminders": True,
+                "username": None,
+                "video": str(video.id),
+            },
         )
-        created_liveregistration = LiveRegistration.objects.get(video=video)
+
         self.assertEqual(created_liveregistration.display_name, "Antoine")
         self.assertEqual(created_liveregistration.username, None)
         self.assertEqual(created_liveregistration.anonymous_id, anonymous_id)
@@ -3728,12 +3755,25 @@ class LiveRegistrationApiTest(TestCase):
         self.assertEqual(response.status_code, 200)
         # new record
         self.assertEqual(LiveRegistration.objects.count(), 1)
-
+        created_liveregistration = LiveRegistration.objects.last()
         self.assertEqual(
             response.json(),
-            {"display_name": "Antoine", "username": None},
+            {
+                "anonymous_id": str(anonymous_id),
+                "consumer_site": None,
+                "display_name": "Antoine",
+                "email": None,
+                "id": str(created_liveregistration.id),
+                "is_registered": False,
+                "live_attendance": None,
+                "lti_id": None,
+                "lti_user_id": None,
+                "should_send_reminders": True,
+                "username": None,
+                "video": str(video.id),
+            },
         )
-        created_liveregistration = LiveRegistration.objects.last()
+
         self.assertEqual(created_liveregistration.display_name, "Antoine")
         self.assertEqual(created_liveregistration.username, None)
         self.assertEqual(created_liveregistration.anonymous_id, anonymous_id)
@@ -3817,7 +3857,7 @@ class LiveRegistrationApiTest(TestCase):
         }
         response = self.client.put(
             "/api/liveregistrations/display_name/",
-            {"anonymous_id": uuid.uuid4(), "display_name": "Antoine"},
+            {"display_name": "Antoine"},
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
@@ -3829,7 +3869,20 @@ class LiveRegistrationApiTest(TestCase):
         # username has been updated with current information in the token
         self.assertEqual(
             response.json(),
-            {"display_name": "Antoine", "username": "Token"},
+            {
+                "anonymous_id": None,
+                "consumer_site": str(video.playlist.consumer_site.id),
+                "display_name": "Antoine",
+                "email": "sabrina@fun-test.fr",
+                "id": str(liveregistration.id),
+                "is_registered": False,
+                "live_attendance": None,
+                "lti_id": "Maths",
+                "lti_user_id": "55555",
+                "should_send_reminders": True,
+                "username": "Token",
+                "video": str(video.id),
+            },
         )
         self.assertEqual(liveregistration.display_name, "Antoine")
         # username has been updated with current information in the token
@@ -3871,7 +3924,7 @@ class LiveRegistrationApiTest(TestCase):
         }
         response = self.client.put(
             "/api/liveregistrations/display_name/",
-            {"anonymous_id": uuid.uuid4(), "display_name": "Antoine"},
+            {"display_name": "Antoine"},
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
@@ -3879,11 +3932,25 @@ class LiveRegistrationApiTest(TestCase):
 
         # a new record has been created
         self.assertEqual(LiveRegistration.objects.count(), 2)
+        created_liveregistration = LiveRegistration.objects.get(video=video)
         self.assertEqual(
             response.json(),
-            {"display_name": "Antoine", "username": "Patou"},
+            {
+                "anonymous_id": None,
+                "consumer_site": str(video.playlist.consumer_site.id),
+                "display_name": "Antoine",
+                "email": "sabrina@fun-test.fr",
+                "id": str(created_liveregistration.id),
+                "is_registered": False,
+                "live_attendance": None,
+                "lti_id": "Maths",
+                "lti_user_id": "55555",
+                "should_send_reminders": True,
+                "username": "Patou",
+                "video": str(video.id),
+            },
         )
-        created_liveregistration = LiveRegistration.objects.get(video=video)
+
         self.assertEqual(created_liveregistration.display_name, "Antoine")
         self.assertEqual(created_liveregistration.username, "Patou")
 
@@ -3915,12 +3982,25 @@ class LiveRegistrationApiTest(TestCase):
         self.assertEqual(response.status_code, 200)
         # new record
         self.assertEqual(LiveRegistration.objects.count(), 1)
-
+        created_liveregistration = LiveRegistration.objects.get(video=video)
         self.assertEqual(
             response.json(),
-            {"display_name": "Antoine", "username": "Token"},
+            {
+                "anonymous_id": None,
+                "consumer_site": str(video.playlist.consumer_site.id),
+                "display_name": "Antoine",
+                "email": "sabrina@fun-test.fr",
+                "id": str(created_liveregistration.id),
+                "is_registered": False,
+                "live_attendance": None,
+                "lti_id": "Maths",
+                "lti_user_id": "55555",
+                "should_send_reminders": True,
+                "username": "Token",
+                "video": str(video.id),
+            },
         )
-        created_liveregistration = LiveRegistration.objects.get(video=video)
+
         self.assertEqual(created_liveregistration.display_name, "Antoine")
         self.assertEqual(created_liveregistration.username, "Token")
 

--- a/src/backend/marsha/core/tests/test_api_liveregistration.py
+++ b/src/backend/marsha/core/tests/test_api_liveregistration.py
@@ -3609,10 +3609,11 @@ class LiveRegistrationApiTest(TestCase):
     def test_api_liveregistration_put_username_public_no_anonymous(
         self,
     ):
-        """Field anonymous_id is mandatory."""
+        """Field anonymous_id is mandatory when the JWT token is a public one."""
         video = VideoFactory()
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(video.id)
+        jwt_token.payload["roles"] = [NONE]
         response = self.client.put(
             "/api/liveregistrations/display_name/",
             {"display_name": "Antoine"},
@@ -3622,13 +3623,14 @@ class LiveRegistrationApiTest(TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json(), {"detail": "Invalid request."})
 
-    def test_api_liveregistration_put_username_public_no_anonymous_no_displayname(
+    def test_api_liveregistration_put_username_public_no_displayname(
         self,
     ):
         """Field display_name is mandatory."""
         video = VideoFactory()
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(video.id)
+        jwt_token.payload["roles"] = [NONE]
         response = self.client.put(
             "/api/liveregistrations/display_name/",
             {"anonymous_id": uuid.uuid4()},
@@ -3651,6 +3653,7 @@ class LiveRegistrationApiTest(TestCase):
         self.assertEqual(LiveRegistration.objects.count(), 1)
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(video.id)
+        jwt_token.payload["roles"] = [NONE]
         response = self.client.put(
             "/api/liveregistrations/display_name/",
             {"anonymous_id": anonymous_id, "display_name": "Antoine"},
@@ -3685,6 +3688,7 @@ class LiveRegistrationApiTest(TestCase):
         self.assertEqual(LiveRegistration.objects.count(), 1)
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(video.id)
+        jwt_token.payload["roles"] = [NONE]
         response = self.client.put(
             "/api/liveregistrations/display_name/",
             {"anonymous_id": anonymous_id, "display_name": "Antoine"},
@@ -3714,6 +3718,7 @@ class LiveRegistrationApiTest(TestCase):
         self.assertEqual(LiveRegistration.objects.count(), 0)
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(video.id)
+        jwt_token.payload["roles"] = [NONE]
         response = self.client.put(
             "/api/liveregistrations/display_name/",
             {"anonymous_id": anonymous_id, "display_name": "Antoine"},
@@ -3744,6 +3749,7 @@ class LiveRegistrationApiTest(TestCase):
         self.assertEqual(LiveRegistration.objects.count(), 1)
         jwt_token = AccessToken()
         jwt_token.payload["resource_id"] = str(video.id)
+        jwt_token.payload["roles"] = [NONE]
         response = self.client.put(
             "/api/liveregistrations/display_name/",
             {"anonymous_id": uuid.uuid4(), "display_name": "Samuel"},
@@ -3753,36 +3759,10 @@ class LiveRegistrationApiTest(TestCase):
         self.assertEqual(response.status_code, 409)
         self.assertEqual(
             response.json(),
-            {"display_name": "User with that username already exists!"},
+            {"display_name": "User with that display_name already exists!"},
         )
 
-    def test_api_liveregistration_put_username_lti_no_anonymous(
-        self,
-    ):
-        """Field anonymous_id is mandatory."""
-        video = VideoFactory()
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(video.id)
-        jwt_token.payload["consumer_site"] = str(video.playlist.consumer_site.id)
-        jwt_token.payload["context_id"] = "Maths"
-        jwt_token.payload["roles"] = [
-            random.choice(["administrator", "instructor", "student", ""])
-        ]
-        jwt_token.payload["user"] = {
-            "email": "sabrina@fun-test.fr",
-            "id": "55555",
-            "username": "Token",
-        }
-        response = self.client.put(
-            "/api/liveregistrations/display_name/",
-            {"display_name": "Antoine"},
-            content_type="application/json",
-            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
-        )
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.json(), {"detail": "Invalid request."})
-
-    def test_api_liveregistration_put_username_lti_no_anonymous_no_displayname(
+    def test_api_liveregistration_put_username_lti_no_displayname(
         self,
     ):
         """Field display_name is mandatory."""
@@ -3974,5 +3954,5 @@ class LiveRegistrationApiTest(TestCase):
         self.assertEqual(response.status_code, 409)
         self.assertEqual(
             response.json(),
-            {"display_name": "User with that username already exists!"},
+            {"display_name": "User with that display_name already exists!"},
         )

--- a/src/frontend/components/Chat/ChatLayout/index.spec.tsx
+++ b/src/frontend/components/Chat/ChatLayout/index.spec.tsx
@@ -6,7 +6,7 @@ import { useChatItemState } from 'data/stores/useChatItemsStore';
 import { wrapInIntlProvider } from 'utils/tests/intl';
 import { Nullable } from 'utils/types';
 import { converse } from 'utils/window';
-import { StudentChat } from '.';
+import { ChatLayout } from '.';
 import { liveRegistrationFactory } from 'utils/tests/factories';
 import { useLiveRegistration } from 'data/stores/useLiveRegistration';
 
@@ -41,7 +41,7 @@ mockConverse.mockImplementation(
 
 describe('<StudentChat />', () => {
   it("doesn't receive history messages, no display_name and the join button is disabled.", async () => {
-    render(wrapInIntlProvider(<StudentChat />));
+    render(wrapInIntlProvider(<ChatLayout />));
     // If no set, hasReceivedMessageHistory default value is false
     expect(useChatItemState.getState().hasReceivedMessageHistory).toEqual(
       false,
@@ -57,7 +57,7 @@ describe('<StudentChat />', () => {
   });
 
   it('has received history message and has no display_name, the join button is not disabled anymore.', () => {
-    render(wrapInIntlProvider(<StudentChat />));
+    render(wrapInIntlProvider(<ChatLayout />));
     const joinChatButton = screen.getByRole('button', {
       name: 'Join the chat',
     });
@@ -70,7 +70,7 @@ describe('<StudentChat />', () => {
 
   it('clicks on the join button and the input display_name is mounted', () => {
     useChatItemState.getState().setHasReceivedMessageHistory(true);
-    render(wrapInIntlProvider(<StudentChat />));
+    render(wrapInIntlProvider(<ChatLayout />));
     const joinChatButton = screen.getByRole('button', {
       name: 'Join the chat',
     });
@@ -85,7 +85,7 @@ describe('<StudentChat />', () => {
     useChatItemState.getState().setHasReceivedMessageHistory(true);
     const liveRegistration = liveRegistrationFactory({ display_name: 'l33t' });
     useLiveRegistration.getState().setLiveRegistration(liveRegistration);
-    render(wrapInIntlProvider(<StudentChat />));
+    render(wrapInIntlProvider(<ChatLayout />));
     expect(
       screen.queryByRole('button', {
         name: 'Join the chat',

--- a/src/frontend/components/Chat/ChatLayout/index.spec.tsx
+++ b/src/frontend/components/Chat/ChatLayout/index.spec.tsx
@@ -3,12 +3,12 @@ import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { useChatItemState } from 'data/stores/useChatItemsStore';
+import { useLiveRegistration } from 'data/stores/useLiveRegistration';
+import { liveRegistrationFactory } from 'utils/tests/factories';
 import { wrapInIntlProvider } from 'utils/tests/intl';
 import { Nullable } from 'utils/types';
 import { converse } from 'utils/window';
 import { ChatLayout } from '.';
-import { liveRegistrationFactory } from 'utils/tests/factories';
-import { useLiveRegistration } from 'data/stores/useLiveRegistration';
 
 window.HTMLElement.prototype.scrollTo = jest.fn();
 jest.mock('data/appData', () => ({
@@ -94,43 +94,4 @@ describe('<StudentChat />', () => {
     screen.getByText('Message...');
     expect(screen.queryByText('Display name')).not.toBeInTheDocument();
   });
-
-  /*it('successfully connects an anonymous user and sends a message.', async () => {
-    render(wrapInIntlProvider(<StudentChat />));
-    const joinChatButton = screen.getByRole('button', {
-      name: 'Join the chat',
-    });
-    expect(joinChatButton).toBeDisabled();
-    act(() => {
-      useChatItemState.getState().setHasReceivedMessageHistory(true);
-    });
-
-    act(() => {
-      userEvent.click(joinChatButton);
-    });
-    const textBoxDisplayName = screen.getByRole('textbox');
-    const buttonSendDisplayName = screen.getByRole('button');
-    userEvent.type(textBoxDisplayName, 'John Doe');
-    act(() => {
-      userEvent.click(buttonSendDisplayName);
-    });
-    expect(converse.claimNewNicknameInChatRoom).toHaveBeenNthCalledWith(
-      1,
-      'John Doe',
-      expect.any(Function),
-      expect.any(Function),
-    );
-    expect(converse.claimNewNicknameInChatRoom).toHaveBeenCalledTimes(1);
-    const sendChatButton = screen.getByRole('button');
-    const textboxChatInput = screen.getByRole('textbox');
-    userEvent.type(textboxChatInput, 'This is an example message.');
-    act(() => {
-      userEvent.click(sendChatButton);
-    });
-    expect(converse.sendMessage).toHaveBeenNthCalledWith(
-      1,
-      'This is an example message.',
-    );
-    expect(converse.sendMessage).toHaveBeenCalledTimes(1);
-  });*/
 });

--- a/src/frontend/components/Chat/ChatLayout/index.tsx
+++ b/src/frontend/components/Chat/ChatLayout/index.tsx
@@ -10,7 +10,7 @@ import { useChatItemState } from 'data/stores/useChatItemsStore';
 import { converse } from 'utils/window';
 import { useLiveRegistration } from 'data/stores/useLiveRegistration';
 
-export const StudentChat = () => {
+export const ChatLayout = () => {
   const liveRegistration = useLiveRegistration(
     (state) => state.liveRegistration,
   );

--- a/src/frontend/components/Chat/SharedChatComponents/InputBar/index.spec.tsx
+++ b/src/frontend/components/Chat/SharedChatComponents/InputBar/index.spec.tsx
@@ -237,4 +237,16 @@ describe('<InputBar /> UI', () => {
     );
     screen.getByText(exampleTextPlaceholder);
   });
+  it('displays default value passed in props in the TextInput', () => {
+    render(
+      <InputBar
+        defaultValue="Foo"
+        handleUserInput={mockHandleUserInputSuccess}
+        isChatInput={false}
+        placeholderText={exampleTextPlaceholder}
+      />,
+    );
+
+    expect(screen.getByRole('textbox')).toHaveValue('Foo');
+  });
 });

--- a/src/frontend/components/Chat/SharedChatComponents/InputBar/index.tsx
+++ b/src/frontend/components/Chat/SharedChatComponents/InputBar/index.tsx
@@ -16,7 +16,7 @@ const StyledMiniSpinner = styled(Spinner)`
 `;
 
 interface InputBarProps {
-  handleUserInput: (inputText: string) => boolean;
+  handleUserInput: (inputText: string) => Promise<boolean>;
   isChatInput: boolean;
   isDisabled?: boolean;
   isWaiting?: boolean;
@@ -32,9 +32,9 @@ export const InputBar = ({
 }: InputBarProps) => {
   const [inputText, setInputText] = useState('');
 
-  const handleOnClick = () => {
+  const handleOnClick = async () => {
     if (inputText.length !== 0) {
-      if (handleUserInput(inputText)) {
+      if (await handleUserInput(inputText)) {
         setInputText('');
       }
     }

--- a/src/frontend/components/Chat/SharedChatComponents/InputBar/index.tsx
+++ b/src/frontend/components/Chat/SharedChatComponents/InputBar/index.tsx
@@ -16,6 +16,7 @@ const StyledMiniSpinner = styled(Spinner)`
 `;
 
 interface InputBarProps {
+  defaultValue?: string;
   handleUserInput: (inputText: string) => Promise<boolean>;
   isChatInput: boolean;
   isDisabled?: boolean;
@@ -24,16 +25,17 @@ interface InputBarProps {
 }
 
 export const InputBar = ({
+  defaultValue = '',
   handleUserInput,
   isChatInput,
   isDisabled,
   isWaiting,
   placeholderText,
 }: InputBarProps) => {
-  const [inputText, setInputText] = useState('');
+  const [inputText, setInputText] = useState(defaultValue);
 
   const handleOnClick = async () => {
-    if (inputText.length !== 0) {
+    if (inputText && inputText.length !== 0) {
       if (await handleUserInput(inputText)) {
         setInputText('');
       }

--- a/src/frontend/components/Chat/SharedChatComponents/InputDisplayNameOverlay/index.spec.tsx
+++ b/src/frontend/components/Chat/SharedChatComponents/InputDisplayNameOverlay/index.spec.tsx
@@ -1,13 +1,15 @@
-import React from 'react';
-import { act, render, screen } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import React from 'react';
 
-import { useChatItemState } from 'data/stores/useChatItemsStore';
+import { setLiveRegistrationDisplayName } from 'data/sideEffects/setLiveRegistrationDisplayName';
+import { useLiveRegistration } from 'data/stores/useLiveRegistration';
 import {
   ANONYMOUS_ID_PREFIX,
   NICKNAME_MAX_LENGTH,
   NICKNAME_MIN_LENGTH,
 } from 'default/chat';
+import { liveRegistrationFactory } from 'utils/tests/factories';
 import { renderImageSnapshot } from 'utils/tests/imageSnapshot';
 import { wrapInIntlProvider } from 'utils/tests/intl';
 import { Nullable } from 'utils/types';
@@ -22,9 +24,24 @@ jest.mock('utils/window', () => ({
   },
 }));
 
+jest.mock('data/sideEffects/setLiveRegistrationDisplayName', () => ({
+  setLiveRegistrationDisplayName: jest.fn(),
+}));
+jest.mock('utils/checkLtiToken', () => ({
+  checkLtiToken: jest.fn(),
+}));
+jest.mock('data/appData', () => ({
+  getDecodedJwt: jest.fn(),
+}));
+
 const mockConverse = converse.claimNewNicknameInChatRoom as jest.MockedFunction<
   typeof converse.claimNewNicknameInChatRoom
 >;
+
+const mockSetLiveRegistrationDisplayName =
+  setLiveRegistrationDisplayName as jest.MockedFunction<
+    typeof setLiveRegistrationDisplayName
+  >;
 
 describe('<InputDisplayNameOverlay />', () => {
   beforeEach(() => {
@@ -54,7 +71,6 @@ describe('<InputDisplayNameOverlay />', () => {
       screen.queryByText(`Max length is ${NICKNAME_MAX_LENGTH} characters.`),
     ).toBeNull();
     expect(inputTextbox).toHaveValue(`${ANONYMOUS_ID_PREFIX}-John`);
-    expect(useChatItemState.getState().displayName).toBeNull();
     expect(mockSetOverlay).not.toHaveBeenCalled();
   });
 
@@ -76,7 +92,6 @@ describe('<InputDisplayNameOverlay />', () => {
       screen.queryByText(`Max length is ${NICKNAME_MAX_LENGTH} characters.`),
     ).toBeNull();
     expect(inputTextbox).toHaveValue('JD');
-    expect(useChatItemState.getState().displayName).toBeNull();
     expect(mockSetOverlay).not.toHaveBeenCalled();
   });
 
@@ -98,7 +113,6 @@ describe('<InputDisplayNameOverlay />', () => {
       screen.queryByText(`Min length is ${NICKNAME_MIN_LENGTH} characters.`),
     ).toBeNull();
     expect(inputTextbox).toHaveValue('John Doe the legend');
-    expect(useChatItemState.getState().displayName).toBeNull();
     expect(mockSetOverlay).not.toHaveBeenCalled();
   });
 
@@ -113,6 +127,10 @@ describe('<InputDisplayNameOverlay />', () => {
         callbackError(null);
       },
     );
+    mockSetLiveRegistrationDisplayName.mockResolvedValue({
+      success: liveRegistrationFactory({ display_name: 'John_Doe' }),
+    });
+    expect(useLiveRegistration.getState().liveRegistration).toBeUndefined();
 
     render(
       wrapInIntlProvider(
@@ -124,6 +142,9 @@ describe('<InputDisplayNameOverlay />', () => {
     userEvent.type(inputTextbox, 'John_Doe');
     expect(validateButton.querySelector('svg')).toBeTruthy();
     act(() => userEvent.click(validateButton));
+    await waitFor(() =>
+      expect(mockSetLiveRegistrationDisplayName).toHaveBeenCalled(),
+    );
     expect(mockSetOverlay).toHaveBeenCalledTimes(0);
     expect(converse.claimNewNicknameInChatRoom).toHaveBeenCalledTimes(1);
     // When waiting prosody answer, svg button is replaced by a waiting spinner
@@ -133,7 +154,54 @@ describe('<InputDisplayNameOverlay />', () => {
     });
     expect(validateButton.querySelector('svg')).toBeTruthy();
     screen.getByText('The server took too long to respond. Please retry.');
-    expect(useChatItemState.getState().displayName).toEqual(null);
+  });
+
+  it('enters a valid nickname but it is already used by a live registration', async () => {
+    mockConverse.mockImplementation(
+      async (
+        _displayName: string,
+        _callbackSuccess: () => void,
+        callbackError: (stanza: Nullable<HTMLElement>) => void,
+      ) => {
+        await new Promise((r) => setTimeout(r, 2000));
+        const parser = new DOMParser();
+        callbackError(
+          parser.parseFromString(
+            '<error code="409" />',
+            'text/xml',
+          ) as any as HTMLElement,
+        );
+      },
+    );
+    mockSetLiveRegistrationDisplayName.mockResolvedValue({
+      error: 409,
+    });
+    expect(useLiveRegistration.getState().liveRegistration).toBeUndefined();
+    render(
+      wrapInIntlProvider(
+        <InputDisplayNameOverlay setOverlay={mockSetOverlay} />,
+      ),
+    );
+    const inputTextbox = screen.getByRole('textbox');
+    const validateButton = screen.getByRole('button');
+    userEvent.type(inputTextbox, 'John_Doe');
+    expect(validateButton.querySelector('svg')).toBeTruthy();
+    act(() => userEvent.click(validateButton));
+    // When waiting prosody answer, svg button is replaced by a waiting spinner
+    expect(validateButton.querySelector('svg')).toBeNull();
+    await waitFor(() =>
+      expect(mockSetLiveRegistrationDisplayName).toHaveBeenCalled(),
+    );
+    expect(mockSetOverlay).toHaveBeenCalledTimes(0);
+    expect(converse.claimNewNicknameInChatRoom).toHaveBeenCalledTimes(0);
+    await act(async () => {
+      jest.advanceTimersByTime(3000);
+    });
+    expect(validateButton.querySelector('svg')).toBeTruthy();
+    screen.getByText(
+      'Your nickname is already used in the chat. Please choose another one.',
+    );
+    expect(useLiveRegistration.getState().liveRegistration).toBeUndefined();
   });
 
   it('enters a valid nickname but it is already used in the chat', async () => {
@@ -153,7 +221,10 @@ describe('<InputDisplayNameOverlay />', () => {
         );
       },
     );
-
+    mockSetLiveRegistrationDisplayName.mockResolvedValue({
+      success: liveRegistrationFactory({ display_name: 'John_Doe' }),
+    });
+    expect(useLiveRegistration.getState().liveRegistration).toBeUndefined();
     render(
       wrapInIntlProvider(
         <InputDisplayNameOverlay setOverlay={mockSetOverlay} />,
@@ -164,6 +235,9 @@ describe('<InputDisplayNameOverlay />', () => {
     userEvent.type(inputTextbox, 'John_Doe');
     expect(validateButton.querySelector('svg')).toBeTruthy();
     act(() => userEvent.click(validateButton));
+    await waitFor(() =>
+      expect(mockSetLiveRegistrationDisplayName).toHaveBeenCalled(),
+    );
     expect(mockSetOverlay).toHaveBeenCalledTimes(0);
     expect(converse.claimNewNicknameInChatRoom).toHaveBeenCalledTimes(1);
     // When waiting prosody answer, svg button is replaced by a waiting spinner
@@ -175,7 +249,7 @@ describe('<InputDisplayNameOverlay />', () => {
     screen.getByText(
       'Your nickname is already used in the chat. Please choose another one.',
     );
-    expect(useChatItemState.getState().displayName).toEqual(null);
+    expect(useLiveRegistration.getState().liveRegistration).toBeUndefined();
   });
 
   it('enters a valid nickname but the server returns an unknown response', async () => {
@@ -195,6 +269,10 @@ describe('<InputDisplayNameOverlay />', () => {
         );
       },
     );
+    mockSetLiveRegistrationDisplayName.mockResolvedValue({
+      success: liveRegistrationFactory({ display_name: 'John_Doe' }),
+    });
+    expect(useLiveRegistration.getState().liveRegistration).toBeUndefined();
 
     render(
       wrapInIntlProvider(
@@ -206,6 +284,9 @@ describe('<InputDisplayNameOverlay />', () => {
     userEvent.type(inputTextbox, 'John_Doe');
     expect(validateButton.querySelector('svg')).toBeTruthy();
     act(() => userEvent.click(validateButton));
+    await waitFor(() =>
+      expect(mockSetLiveRegistrationDisplayName).toHaveBeenCalled(),
+    );
     expect(mockSetOverlay).toHaveBeenCalledTimes(0);
     expect(converse.claimNewNicknameInChatRoom).toHaveBeenCalledTimes(1);
     // When waiting prosody answer, svg button is replaced by a waiting spinner
@@ -215,10 +296,10 @@ describe('<InputDisplayNameOverlay />', () => {
     });
     expect(validateButton.querySelector('svg')).toBeTruthy();
     screen.getByText('Impossible to connect you to the chat. Please retry.');
-    expect(useChatItemState.getState().displayName).toEqual(null);
+    expect(useLiveRegistration.getState().liveRegistration).toBeUndefined();
   });
 
-  it('enters a valid nickname and validates it.', () => {
+  it('enters a valid nickname and validates it.', async () => {
     mockConverse.mockImplementation(
       async (
         _displayName: string,
@@ -228,6 +309,13 @@ describe('<InputDisplayNameOverlay />', () => {
         callbackSuccess();
       },
     );
+    const liveRegistration = liveRegistrationFactory({
+      display_name: 'John_Doe',
+    });
+    mockSetLiveRegistrationDisplayName.mockResolvedValue({
+      success: liveRegistration,
+    });
+    expect(useLiveRegistration.getState().liveRegistration).toBeUndefined();
 
     render(
       wrapInIntlProvider(
@@ -238,6 +326,9 @@ describe('<InputDisplayNameOverlay />', () => {
     const validateButton = screen.getByRole('button');
     userEvent.type(inputTextbox, 'John_Doe');
     act(() => userEvent.click(validateButton));
+    await waitFor(() =>
+      expect(mockSetLiveRegistrationDisplayName).toHaveBeenCalled(),
+    );
     expect(mockSetOverlay).toHaveBeenCalledTimes(1);
     expect(converse.claimNewNicknameInChatRoom).toHaveBeenNthCalledWith(
       1,
@@ -246,7 +337,9 @@ describe('<InputDisplayNameOverlay />', () => {
       expect.any(Function),
     );
     expect(converse.claimNewNicknameInChatRoom).toHaveBeenCalledTimes(1);
-    expect(useChatItemState.getState().displayName).toEqual('John_Doe');
+    expect(useLiveRegistration.getState().liveRegistration).toEqual(
+      liveRegistration,
+    );
   });
 
   it('closes the window.', () => {
@@ -259,9 +352,8 @@ describe('<InputDisplayNameOverlay />', () => {
       'Click this button to close the overlay.',
     );
     act(() => userEvent.click(closeButton));
-    expect(useChatItemState.getState().displayName).toBeNull();
     expect(mockSetOverlay).toHaveBeenCalledTimes(1);
-    expect(useChatItemState.getState().displayName).toBeNull();
+    expect(mockSetLiveRegistrationDisplayName).not.toHaveBeenCalled();
   });
 
   it('displays the component and compares it with previous render.', async () => {

--- a/src/frontend/components/Chat/SharedChatComponents/InputDisplayNameOverlay/index.spec.tsx
+++ b/src/frontend/components/Chat/SharedChatComponents/InputDisplayNameOverlay/index.spec.tsx
@@ -356,6 +356,17 @@ describe('<InputDisplayNameOverlay />', () => {
     expect(mockSetLiveRegistrationDisplayName).not.toHaveBeenCalled();
   });
 
+  it('displays the component and use liveragistration username as default value', () => {
+    const liveRegistration = liveRegistrationFactory({ username: 'Foo' });
+    useLiveRegistration.getState().setLiveRegistration(liveRegistration);
+    render(
+      wrapInIntlProvider(
+        <InputDisplayNameOverlay setOverlay={mockSetOverlay} />,
+      ),
+    );
+    expect(screen.getByRole('textbox')).toHaveValue('Foo');
+  });
+
   it('displays the component and compares it with previous render.', async () => {
     await renderImageSnapshot(
       <InputDisplayNameOverlay setOverlay={mockSetOverlay} />,

--- a/src/frontend/components/Chat/SharedChatComponents/InputDisplayNameOverlay/index.tsx
+++ b/src/frontend/components/Chat/SharedChatComponents/InputDisplayNameOverlay/index.tsx
@@ -91,8 +91,11 @@ export const InputDisplayNameOverlay = ({
   const intl = useIntl();
   const [alertsState, setAlertsState] = useState<string[]>([]);
   const [isWaiting, setIsWaiting] = useState(false);
-  const setLiveRegistration = useLiveRegistration(
-    (state) => state.setLiveRegistration,
+  const { liveRegistration, setLiveRegistration } = useLiveRegistration(
+    (state) => ({
+      liveRegistration: state.liveRegistration,
+      setLiveRegistration: state.setLiveRegistration,
+    }),
   );
   const processDisplayName = async (displayName: string) => {
     displayName = displayName.trim();
@@ -253,6 +256,7 @@ export const InputDisplayNameOverlay = ({
             </Box>
           </Box>
           <InputBar
+            defaultValue={liveRegistration?.username || ''}
             handleUserInput={processDisplayName}
             isChatInput={false}
             isWaiting={isWaiting}

--- a/src/frontend/components/Chat/StudentChat/index.tsx
+++ b/src/frontend/components/Chat/StudentChat/index.tsx
@@ -8,9 +8,12 @@ import { InputDisplayNameOverlay } from 'components/Chat/SharedChatComponents/In
 import { JoinChatButton } from 'components/Chat/SharedChatComponents/JoinChatButton';
 import { useChatItemState } from 'data/stores/useChatItemsStore';
 import { converse } from 'utils/window';
+import { useLiveRegistration } from 'data/stores/useLiveRegistration';
 
 export const StudentChat = () => {
-  const displayName = useChatItemState((state) => state.displayName);
+  const liveRegistration = useLiveRegistration(
+    (state) => state.liveRegistration,
+  );
   const hasReceivedMessageHistory = useChatItemState(
     (state) => state.hasReceivedMessageHistory,
   );
@@ -19,7 +22,7 @@ export const StudentChat = () => {
 
   const processChatMessage = (chatMsg: string) => {
     converse.sendMessage(chatMsg);
-    return true;
+    return Promise.resolve(true);
   };
 
   const messages = defineMessages({
@@ -49,7 +52,7 @@ export const StudentChat = () => {
             <ChatConversationDisplayer />
           )}
           <Box margin="10px">
-            {displayName ? (
+            {liveRegistration?.display_name ? (
               <InputBar
                 handleUserInput={processChatMessage}
                 isChatInput={true}

--- a/src/frontend/components/Chat/index.spec.tsx
+++ b/src/frontend/components/Chat/index.spec.tsx
@@ -1,11 +1,17 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 
 import { Chat } from 'components/Chat';
+import { getDecodedJwt } from 'data/appData';
+import { useLiveRegistration } from 'data/stores/useLiveRegistration';
+import { DecodedJwt } from 'types/jwt';
 import { liveState } from 'types/tracks';
 import { PersistentStore } from 'types/XMPP';
 import { converseMounter } from 'utils/conversejs/converse';
-import { videoMockFactory } from 'utils/tests/factories';
+import {
+  liveRegistrationFactory,
+  videoMockFactory,
+} from 'utils/tests/factories';
 import { wrapInIntlProvider } from 'utils/tests/intl';
 
 const mockVideo = videoMockFactory({
@@ -25,6 +31,7 @@ jest.mock('data/appData', () => ({
   appData: {
     video: mockVideo,
   },
+  getDecodedJwt: jest.fn(),
 }));
 
 jest.mock('utils/conversejs/converse', () => ({
@@ -35,12 +42,66 @@ const mockConverseMounter = converseMounter as jest.MockedFunction<
   typeof converseMounter
 >;
 
+const mockGetDecodedJwt = getDecodedJwt as jest.MockedFunction<
+  typeof getDecodedJwt
+>;
+
 describe('<Chat />', () => {
   afterEach(() => {
-    jest.resetAllMocks();
+    mockGetDecodedJwt.mockReset();
+  });
+  it('does not initialize converse without liveRegistration if user can not access dashboard', async () => {
+    mockGetDecodedJwt.mockReturnValue({
+      permissions: {
+        can_access_dashboard: false,
+        can_update: false,
+      },
+    } as DecodedJwt);
+    const liveRegistration = liveRegistrationFactory();
+    render(wrapInIntlProvider(<Chat video={mockVideo} />));
+    // mockConverseMounter returns itself a mock. We want to inspect this mock to be sure that
+    // is was called with the container name and the xmpp object
+    expect(mockConverseMounter.mock.results[0].value).not.toHaveBeenCalled();
+
+    act(() => {
+      useLiveRegistration.getState().setLiveRegistration(liveRegistration);
+    });
+    expect(mockConverseMounter.mock.results[0].value).toHaveBeenCalledWith(
+      mockVideo.xmpp,
+      null,
+    );
+  });
+  it('initializes converse with the displayname', () => {
+    mockGetDecodedJwt.mockReturnValue({
+      permissions: {
+        can_access_dashboard: false,
+        can_update: false,
+      },
+    } as DecodedJwt);
+    mockConverseMounter.mock.results[0].value.mockReset();
+    const liveRegistration = liveRegistrationFactory({ display_name: 'john' });
+    render(wrapInIntlProvider(<Chat video={mockVideo} />));
+    // mockConverseMounter returns itself a mock. We want to inspect this mock to be sure that
+    // is was called with the container name and the xmpp object
+    expect(mockConverseMounter.mock.results[0].value).not.toHaveBeenCalled();
+
+    act(() => {
+      useLiveRegistration.getState().setLiveRegistration(liveRegistration);
+    });
+    expect(mockConverseMounter.mock.results[0].value).toHaveBeenCalledWith(
+      mockVideo.xmpp,
+      'john',
+    );
   });
 
-  it('renders the Chat component', () => {
+  it('initializes converse wihtout wiating live registration when you can access dashboard', () => {
+    mockGetDecodedJwt.mockReturnValue({
+      permissions: {
+        can_access_dashboard: true,
+        can_update: false,
+      },
+    } as DecodedJwt);
+    mockConverseMounter.mock.results[0].value.mockReset();
     render(wrapInIntlProvider(<Chat video={mockVideo} />));
     // mockConverseMounter returns itself a mock. We want to inspect this mock to be sure that
     // is was called with the container name and the xmpp object

--- a/src/frontend/components/Chat/index.tsx
+++ b/src/frontend/components/Chat/index.tsx
@@ -1,11 +1,12 @@
 import { Box, BoxExtendedProps } from 'grommet';
 import React, { useEffect } from 'react';
 
+import { getDecodedJwt } from 'data/appData';
+import { useLiveRegistration } from 'data/stores/useLiveRegistration';
 import { useVideo } from 'data/stores/useVideo';
 import { liveState, Video } from 'types/tracks';
 import { converseMounter } from 'utils/conversejs/converse';
 import { StudentChat } from './StudentChat';
-
 interface ChatProps {
   video: Video;
   standalone?: boolean;
@@ -15,12 +16,25 @@ const initConverse = converseMounter();
 
 export const Chat = ({ video: baseVideo, standalone }: ChatProps) => {
   const video = useVideo((state) => state.getVideo(baseVideo));
+  const liveRegistration = useLiveRegistration(
+    (state) => state.liveRegistration,
+  );
 
   useEffect(() => {
-    if (video.live_state && video.live_state !== liveState.IDLE) {
+    const isAdmin = getDecodedJwt().permissions.can_access_dashboard;
+    if (
+      !isAdmin &&
+      liveRegistration &&
+      video.live_state &&
+      video.live_state !== liveState.IDLE
+    ) {
+      initConverse(video.xmpp!, liveRegistration.display_name);
+    }
+
+    if (isAdmin && video.live_state && video.live_state !== liveState.IDLE) {
       initConverse(video.xmpp!);
     }
-  }, [video.live_state]);
+  }, [video, liveRegistration]);
 
   const conditionalProps: Partial<BoxExtendedProps> = {};
   if (standalone) {

--- a/src/frontend/components/Chat/index.tsx
+++ b/src/frontend/components/Chat/index.tsx
@@ -6,7 +6,7 @@ import { useLiveRegistration } from 'data/stores/useLiveRegistration';
 import { useVideo } from 'data/stores/useVideo';
 import { liveState, Video } from 'types/tracks';
 import { converseMounter } from 'utils/conversejs/converse';
-import { StudentChat } from './StudentChat';
+import { ChatLayout } from './ChatLayout';
 interface ChatProps {
   video: Video;
   standalone?: boolean;
@@ -47,10 +47,10 @@ export const Chat = ({ video: baseVideo, standalone }: ChatProps) => {
     <Box {...conditionalProps}>
       {!!standalone ? (
         <div>
-          <StudentChat />
+          <ChatLayout />
         </div>
       ) : (
-        <StudentChat />
+        <ChatLayout />
       )}
     </Box>
   );

--- a/src/frontend/components/PublicVideoLiveJitsi/index.spec.tsx
+++ b/src/frontend/components/PublicVideoLiveJitsi/index.spec.tsx
@@ -43,6 +43,10 @@ const mockVideo = videoMockFactory({
 
 jest.mock('data/appData', () => ({
   getDecodedJwt: () => ({
+    permissions: {
+      can_access_dashboard: false,
+      can_update: false,
+    },
     user: {
       username: 'jane_doe',
     },

--- a/src/frontend/data/sideEffects/setLiveRegistrationDisplayName/index.spec.ts
+++ b/src/frontend/data/sideEffects/setLiveRegistrationDisplayName/index.spec.ts
@@ -1,0 +1,121 @@
+import * as faker from 'faker';
+import fetchMock from 'fetch-mock';
+import { v4 as uuidv4 } from 'uuid';
+
+import { liveRegistrationFactory } from 'utils/tests/factories';
+import { setLiveRegistrationDisplayName } from '.';
+
+jest.mock('data/appData', () => ({
+  appData: {
+    jwt: 'some token',
+  },
+}));
+
+describe('setLiveRegistrationDisplayName', () => {
+  afterEach(() => fetchMock.restore());
+
+  it('returns a liveRegistration without anonymous_id', async () => {
+    const liveRegistration = liveRegistrationFactory();
+    const displayName = faker.internet.userName();
+
+    fetchMock.mock(
+      {
+        body: { display_name: displayName },
+        headers: {
+          Authorization: 'Bearer some token',
+          'Content-Type': 'application/json',
+        },
+        method: 'PUT',
+        url: '/api/liveregistrations/display_name/',
+      },
+      {
+        ...liveRegistration,
+        display_name: displayName,
+      },
+    );
+
+    const response = await setLiveRegistrationDisplayName(displayName);
+
+    expect(response.success).toEqual({
+      ...liveRegistration,
+      display_name: displayName,
+    });
+  });
+
+  it('returns a liveRegistration with an anonymous_id', async () => {
+    const anonymousId = uuidv4();
+    const liveRegistration = liveRegistrationFactory({
+      anonymous_id: anonymousId,
+    });
+    const displayName = faker.internet.userName();
+
+    fetchMock.mock(
+      {
+        body: { display_name: displayName, anonymous_id: anonymousId },
+        headers: {
+          Authorization: 'Bearer some token',
+          'Content-Type': 'application/json',
+        },
+        method: 'PUT',
+        url: '/api/liveregistrations/display_name/',
+      },
+      {
+        ...liveRegistration,
+        display_name: displayName,
+      },
+    );
+
+    const response = await setLiveRegistrationDisplayName(
+      displayName,
+      anonymousId,
+    );
+
+    expect(response.success).toEqual({
+      ...liveRegistration,
+      display_name: displayName,
+    });
+  });
+
+  it('returns a 409 error when the display_name already exists', async () => {
+    const displayName = faker.internet.userName();
+    fetchMock.mock(
+      {
+        body: { display_name: displayName },
+        headers: {
+          Authorization: 'Bearer some token',
+          'Content-Type': 'application/json',
+        },
+        method: 'PUT',
+        url: '/api/liveregistrations/display_name/',
+      },
+      409,
+    );
+
+    const response = await setLiveRegistrationDisplayName(displayName);
+
+    expect(response).toEqual({ error: 409 });
+  });
+
+  it('returns any error when the request fails', async () => {
+    const displayName = faker.internet.userName();
+    fetchMock.mock(
+      {
+        body: { display_name: displayName },
+        headers: {
+          Authorization: 'Bearer some token',
+          'Content-Type': 'application/json',
+        },
+        method: 'PUT',
+        url: '/api/liveregistrations/display_name/',
+      },
+      {
+        body: { detail: 'Invalid request.' },
+        status: 400,
+      },
+    );
+
+    const response = await setLiveRegistrationDisplayName(displayName);
+
+    expect(response).toEqual({ error: { detail: 'Invalid request.' } });
+  });
+});

--- a/src/frontend/data/sideEffects/setLiveRegistrationDisplayName/index.ts
+++ b/src/frontend/data/sideEffects/setLiveRegistrationDisplayName/index.ts
@@ -1,0 +1,38 @@
+import { appData } from 'data/appData';
+import { API_ENDPOINT } from 'settings';
+import { LiveRegistration } from 'types/tracks';
+
+export const setLiveRegistrationDisplayName = async (
+  displayName: string,
+  anonymousId?: string,
+): Promise<{
+  error?: string | number;
+  success?: LiveRegistration;
+}> => {
+  const body = {
+    display_name: displayName,
+    anonymous_id: anonymousId,
+  };
+
+  const response = await fetch(
+    `${API_ENDPOINT}/liveregistrations/display_name/`,
+    {
+      body: JSON.stringify(body),
+      headers: {
+        Authorization: `Bearer ${appData.jwt}`,
+        'Content-Type': 'application/json',
+      },
+      method: 'PUT',
+    },
+  );
+
+  if (response.status === 409) {
+    return { error: 409 };
+  }
+
+  if (!response.ok) {
+    return { error: await response.json() };
+  }
+
+  return { success: await response.json() };
+};

--- a/src/frontend/data/stores/useChatItemsStore/index.ts
+++ b/src/frontend/data/stores/useChatItemsStore/index.ts
@@ -52,8 +52,6 @@ type State = {
   chatItems: ChatItem[];
   addMessage: (newMessage: ReceivedMessageType) => void;
   addPresence: (newPresence: ChatPresenceType) => void;
-  displayName: string | null;
-  setDisplayName: (displayName: string) => void;
 };
 
 export const useChatItemState = create<State>((set) => ({
@@ -107,6 +105,4 @@ export const useChatItemState = create<State>((set) => ({
         presenceData: presence,
       }),
     })),
-  displayName: null,
-  setDisplayName: (displayName) => set({ displayName }),
 }));

--- a/src/frontend/utils/conversejs/converse.ts
+++ b/src/frontend/utils/conversejs/converse.ts
@@ -2,6 +2,7 @@ import './entry.js';
 
 import { XMPP } from 'types/XMPP';
 import { generateAnonymousNickname } from 'utils/chat/chat';
+import { Nullable } from 'utils/types.js';
 import { converse } from 'utils/window';
 import { chatPlugin } from './converse-plugins/chatPlugin';
 import { logoutPlugin } from './converse-plugins/logoutPlugin';
@@ -12,7 +13,7 @@ import { participantsTrackingPlugin } from './converse-plugins/participantsTrack
 export const converseMounter = () => {
   let isChatInitialized = false;
 
-  return (xmpp: XMPP) => {
+  return (xmpp: XMPP, displayName?: Nullable<string>) => {
     if (!isChatInitialized) {
       chatPlugin.addPlugin(xmpp);
       logoutPlugin.addPlugin();
@@ -20,7 +21,7 @@ export const converseMounter = () => {
       nicknameManagementPlugin.addPlugin(xmpp);
       participantsTrackingPlugin.addPlugin();
 
-      const anonymousNickname = generateAnonymousNickname();
+      const nickname = displayName || generateAnonymousNickname();
       // Converse Initialization
       converse.initialize({
         authentication: 'anonymous',
@@ -36,7 +37,7 @@ export const converseMounter = () => {
         loglevel: 'error',
         muc_history_max_stanzas: 0,
         muc_instant_rooms: false,
-        nickname: anonymousNickname,
+        nickname,
         persistent_store: xmpp.converse_persistent_store,
         ping_interval: 20,
         websocket_url: xmpp.websocket_url,

--- a/src/frontend/utils/initWebinarContext.ts
+++ b/src/frontend/utils/initWebinarContext.ts
@@ -28,7 +28,8 @@ export const initWebinarContext = async (video: Video) => {
   } else {
     // push an empty attendance to create the live registration
     // and then register it in the store
-    const liveRegistration = await pushAttendance({}, anonymousId);
-    useLiveRegistration.getState().setLiveRegistration(liveRegistration);
+    useLiveRegistration
+      .getState()
+      .setLiveRegistration(await pushAttendance({}, anonymousId));
   }
 };


### PR DESCRIPTION
## Purpose

We want to have a unique display_name by user for a live streaming. We decided to save this display name in the liveRegistration record and use it every time the user connects to the live. This feature uses the `anonymous_id` if the user does not come from a LTI connection.

## Proposal

- [x] refactor back to manage anonymous_id on the set display_name endpoint
- [x] return the serialized live registration on the set display name endpoint
- [x] manage the display name in the front application
- [x] remove display_name from the useChatItemState store
- [x] rename the `StudentChat` component in `ChatLayout`

