### PR TITLE
speed up docker build by activating DOCKER_BUILDKIT

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,7 +159,6 @@ jobs:
       - run: 
           name: Build production image
           command: |
-            export DOCKER_BUILDKIT=1
             ./bin/lambda build ${CIRCLE_SHA1}
 
       - run:
@@ -169,7 +168,6 @@ jobs:
       - run:
           name: Build lambda development image
           command: |
-            export DOCKER_BUILDKIT=1
             ./bin/lambda build "development-${CIRCLE_SHA1}" development
 
       - run:
@@ -1051,7 +1049,6 @@ jobs:
       - run:
           name: Build production image
           command: |
-            export DOCKER_BUILDKIT=1
             ./bin/lambda build ${CIRCLE_SHA1}
       # Tag docker images with the same pattern used in Git (Semantic Versioning)
       #

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,13 +122,14 @@ jobs:
       - <<: *generate-version-file
       # Activate docker-in-docker
       - setup_remote_docker:
-          version: 20.10.7
+          version: 20.10.11
       - *docker_login
       # Each image is tagged with the current git commit sha1 to avoid
       # collisions in parallel builds.
       - run:
           name: Build production image
           command: |
+            export DOCKER_BUILDKIT=1
             docker build \
               -t marsha:${CIRCLE_SHA1} \
               .
@@ -157,7 +158,9 @@ jobs:
           command: make env.d/lambda
       - run: 
           name: Build production image
-          command: ./bin/lambda build ${CIRCLE_SHA1}
+          command: |
+            export DOCKER_BUILDKIT=1
+            ./bin/lambda build ${CIRCLE_SHA1}
 
       - run:
           name: Check built image availability
@@ -165,7 +168,9 @@ jobs:
 
       - run:
           name: Build lambda development image
-          command: ./bin/lambda build "development-${CIRCLE_SHA1}" development
+          command: |
+            export DOCKER_BUILDKIT=1
+            ./bin/lambda build "development-${CIRCLE_SHA1}" development
 
       - run:
           name: Run convert lambda tests
@@ -183,13 +188,14 @@ jobs:
       - checkout
       # Activate docker-in-docker
       - setup_remote_docker:
-          version: 20.10.7
+          version: 20.10.11
       - *docker_login
       # Each image is tagged with the current git commit sha1 to avoid
       # collisions in parallel builds.
       - run:
           name: Build production image
           command: |
+            export DOCKER_BUILDKIT=1
             docker build \
               -t marsha-ffmpeg-transmux:${CIRCLE_SHA1} \
               src/aws/ffmpeg-transmux-live-image/
@@ -916,11 +922,12 @@ jobs:
       - <<: *generate-version-file
       # Activate docker-in-docker
       - setup_remote_docker:
-          version: 20.10.7
+          version: 20.10.11
       - *docker_login
       - run:
           name: Build production image (using cached layers)
           command: |
+            export DOCKER_BUILDKIT=1
             docker build \
               -t marsha:${CIRCLE_SHA1} \
               .      
@@ -980,13 +987,14 @@ jobs:
       - <<: *generate-version-file
       # Activate docker-in-docker
       - setup_remote_docker:
-          version: 20.10.7
+          version: 20.10.11
       - *docker_login
       # Each image is tagged with the current git commit sha1 to avoid
       # collisions in parallel builds.
       - run:
           name: Build production image
           command: |
+            export DOCKER_BUILDKIT=1
             docker build \
               -t marsha-ffmpeg-transmux:${CIRCLE_SHA1} \
               src/aws/ffmpeg-transmux-live-image/
@@ -1042,7 +1050,9 @@ jobs:
       - *docker_login
       - run:
           name: Build production image
-          command: ./bin/lambda build ${CIRCLE_SHA1}
+          command: |
+            export DOCKER_BUILDKIT=1
+            ./bin/lambda build ${CIRCLE_SHA1}
       # Tag docker images with the same pattern used in Git (Semantic Versioning)
       #
       # Git tag: v1.0.1

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ GREEN := \033[1;32m
 
 # -- Docker
 COMPOSE              = docker-compose
+COMPOSE_BUILD        = COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 $(COMPOSE) build
 COMPOSE_RUN          = $(COMPOSE) run --rm
 COMPOSE_RUN_APP      = $(COMPOSE_RUN) app
 COMPOSE_RUN_CROWDIN  = $(COMPOSE_RUN) crowdin crowdin
@@ -65,9 +66,9 @@ bootstrap: \
 # -- Docker/compose
 
 build: ## build the app container
-	@$(COMPOSE) build base;
-	@$(COMPOSE) build app;
-	@$(COMPOSE) build e2e;
+	@$(COMPOSE_BUILD) base;
+	@$(COMPOSE_BUILD) app;
+	@$(COMPOSE_BUILD) e2e;
 .PHONY: build
 
 build-lambda-dev: ## build all aws lambda
@@ -207,7 +208,7 @@ test:  ## Run django tests for the marsha project.
 .PHONY: test
 
 build-e2e: ## build the e2e container
-	@$(COMPOSE) build e2e;
+	@$(COMPOSE_BUILD) e2e;
 .PHONY: build-e2e
 
 e2e:  ## Run e2e tests for the marsha project.

--- a/bin/lambda
+++ b/bin/lambda
@@ -58,7 +58,7 @@ TAG: optional tag used for the marsha/lambda image (default: production)
 
   tag="${1:-production}"
   target="${2:-production}"
-  docker build \
+  DOCKER_BUILDKIT=1 docker build \
     --build-arg POPPLER_VERSION="${POPPLER_VERSION:-21.12.0}" \
     --build-arg POPPLER_DATA_VERSION="${POPPLER_DATA_VERSION:-0.4.11}" \
     --build-arg OPENJPEG_VERSION="${OPENJPEG_VERSION:-2.4.0}" \


### PR DESCRIPTION
## Purpose

Since docker 18.09 docker introduces a new backend builder image called
buildkit. This new builder improves build performance and should speed
the build. We activate it on circleci by using a newer version of
docker.

## Proposal

- [x] speed up docker build by activating DOCKER_BUILDKIT
- [x] enable it with docker-compose
