### PR TITLE
🐛(docker) Preserve marsha package structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Remove cancel button in student meeting join form
 - Replace automatic meeting joining by a button
 - Allow generated links in Django admin for objects in other applications
+- Do not install the `marsha` Python package in `site-packages`
 
 ## [4.0.0-beta.1] - 2022-02-15
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ RUN pip install --upgrade pip
 
 WORKDIR /builder
 
-COPY src/backend/marsha src/backend/setup.* /builder/
+# Only copy the setup files for dependencies install
+COPY src/backend/setup.* /builder/
 
 RUN mkdir /install && \
     pip install --prefix=/install .

--- a/docker/images/dev/Dockerfile
+++ b/docker/images/dev/Dockerfile
@@ -17,4 +17,6 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install development dependencies
-RUN pip install .[dev]
+# and forcibly remove the marsha package
+RUN pip install .[dev] && \
+    pip uninstall marsha

--- a/docker/images/e2e/Dockerfile
+++ b/docker/images/e2e/Dockerfile
@@ -6,6 +6,11 @@ COPY --from=marsha /app /app
 COPY src/backend/setup.cfg /app/src/backend/
 
 WORKDIR /app/src/backend
-RUN pip install .[dev,e2e]
+
+# Install development dependencies
+# and forcibly remove the marsha package
+RUN pip install .[dev,e2e] && \
+    pip uninstall marsha
+
 RUN playwright install-deps
 RUN playwright install


### PR DESCRIPTION
## Purpose

Files of the marsha Python package where copied directly into the
`/builder/` directory making the `setup.cfg` at the same level as the
Django applications' module, resulting in a wrong interpretation of the
package structure: each Django application was considered as a Python
package (thanks to the `find:` automatic attribute).
The issue raised on my side was the `markdown` application overwritting
the `markdown` original package... For instance, the bug was visible in
the `back-builder` image, were the `bbb` application was directly inside
the `/install/lib/python3.10/site-packages/bbb/` folder and so on.

## Proposal

Replace the inline file copy, to a different one to properly copy files into a `/builder/marsha/` directory to generate a `marsha` package.

## Remaining questions

- Why do we install the `marsha` package here? The marsha folder is copied (and used later) with `COPY . /app/`, we therefore don't need to install it through pip. Since this fix works, we may consider this question in a second time.

