### PR TITLE
🐛(frontend) fix converse initialisation

### DIFF
--- a/src/frontend/components/Chat/index.spec.tsx
+++ b/src/frontend/components/Chat/index.spec.tsx
@@ -1,14 +1,10 @@
 import React from 'react';
-import { act, render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 import { Chat } from 'components/Chat';
-import { getDecodedJwt } from 'data/appData';
-import { useLiveSession } from 'data/stores/useLiveSession';
-import { DecodedJwt } from 'types/jwt';
 import { liveState } from 'types/tracks';
 import { PersistentStore } from 'types/XMPP';
-import { converseMounter } from 'utils/conversejs/converse';
-import { liveSessionFactory, videoMockFactory } from 'utils/tests/factories';
+import { videoMockFactory } from 'utils/tests/factories';
 import { wrapInIntlProvider } from 'utils/tests/intl';
 
 const mockVideo = videoMockFactory({
@@ -31,79 +27,16 @@ jest.mock('data/appData', () => ({
   getDecodedJwt: jest.fn(),
 }));
 
-jest.mock('utils/conversejs/converse', () => ({
-  converseMounter: jest.fn(() => jest.fn()),
-}));
-
-const mockConverseMounter = converseMounter as jest.MockedFunction<
-  typeof converseMounter
->;
-
-const mockGetDecodedJwt = getDecodedJwt as jest.MockedFunction<
-  typeof getDecodedJwt
->;
-
 describe('<Chat />', () => {
-  afterEach(() => {
-    mockGetDecodedJwt.mockReset();
-  });
-  it('does not initialize converse without liveSession if user can not access dashboard', async () => {
-    mockGetDecodedJwt.mockReturnValue({
-      permissions: {
-        can_access_dashboard: false,
-        can_update: false,
-      },
-    } as DecodedJwt);
-    const liveSession = liveSessionFactory();
-    render(wrapInIntlProvider(<Chat video={mockVideo} />));
-    // mockConverseMounter returns itself a mock. We want to inspect this mock to be sure that
-    // is was called with the container name and the xmpp object
-    expect(mockConverseMounter.mock.results[0].value).not.toHaveBeenCalled();
+  it('renders the Chat component', () => {
+    render(wrapInIntlProvider(<Chat />));
 
-    act(() => {
-      useLiveSession.getState().setLiveSession(liveSession);
-    });
-    expect(mockConverseMounter.mock.results[0].value).toHaveBeenCalledWith(
-      mockVideo.xmpp,
-      null,
-    );
-  });
-  it('initializes converse with the displayname', () => {
-    mockGetDecodedJwt.mockReturnValue({
-      permissions: {
-        can_access_dashboard: false,
-        can_update: false,
-      },
-    } as DecodedJwt);
-    mockConverseMounter.mock.results[0].value.mockReset();
-    const liveSession = liveSessionFactory({ display_name: 'john' });
-    render(wrapInIntlProvider(<Chat video={mockVideo} />));
-    // mockConverseMounter returns itself a mock. We want to inspect this mock to be sure that
-    // is was called with the container name and the xmpp object
-    expect(mockConverseMounter.mock.results[0].value).not.toHaveBeenCalled();
-
-    act(() => {
-      useLiveSession.getState().setLiveSession(liveSession);
-    });
-    expect(mockConverseMounter.mock.results[0].value).toHaveBeenCalledWith(
-      mockVideo.xmpp,
-      'john',
-    );
+    screen.getByRole('button', { name: 'Join the chat' });
   });
 
-  it('initializes converse wihtout wiating live registration when you can access dashboard', () => {
-    mockGetDecodedJwt.mockReturnValue({
-      permissions: {
-        can_access_dashboard: true,
-        can_update: false,
-      },
-    } as DecodedJwt);
-    mockConverseMounter.mock.results[0].value.mockReset();
-    render(wrapInIntlProvider(<Chat video={mockVideo} />));
-    // mockConverseMounter returns itself a mock. We want to inspect this mock to be sure that
-    // is was called with the container name and the xmpp object
-    expect(mockConverseMounter.mock.results[0].value).toHaveBeenCalledWith(
-      mockVideo.xmpp,
-    );
+  it('renders the Chat component as standalone', () => {
+    render(wrapInIntlProvider(<Chat standalone />));
+
+    screen.getByRole('button', { name: 'Join the chat' });
   });
 });

--- a/src/frontend/components/Chat/index.tsx
+++ b/src/frontend/components/Chat/index.tsx
@@ -1,39 +1,13 @@
 import { Box, BoxExtendedProps } from 'grommet';
-import React, { useEffect } from 'react';
+import React from 'react';
 
-import { getDecodedJwt } from 'data/appData';
-import { useLiveSession } from 'data/stores/useLiveSession';
-import { useVideo } from 'data/stores/useVideo';
-import { liveState, Video } from 'types/tracks';
-import { converseMounter } from 'utils/conversejs/converse';
 import { ChatLayout } from './ChatLayout';
+
 interface ChatProps {
-  video: Video;
   standalone?: boolean;
 }
 
-const initConverse = converseMounter();
-
-export const Chat = ({ video: baseVideo, standalone }: ChatProps) => {
-  const video = useVideo((state) => state.getVideo(baseVideo));
-  const liveSession = useLiveSession((state) => state.liveSession);
-
-  useEffect(() => {
-    const isAdmin = getDecodedJwt().permissions.can_access_dashboard;
-    if (
-      !isAdmin &&
-      liveSession &&
-      video.live_state &&
-      video.live_state !== liveState.IDLE
-    ) {
-      initConverse(video.xmpp!, liveSession.display_name);
-    }
-
-    if (isAdmin && video.live_state && video.live_state !== liveState.IDLE) {
-      initConverse(video.xmpp!);
-    }
-  }, [video, liveSession]);
-
+export const Chat = ({ standalone }: ChatProps) => {
   const conditionalProps: Partial<BoxExtendedProps> = {};
   if (standalone) {
     conditionalProps.height = 'large';

--- a/src/frontend/components/Chat/route.ts
+++ b/src/frontend/components/Chat/route.ts
@@ -1,6 +1,0 @@
-/**
- * Route for the `<Chat />` component.
- */
-export const CHAT_ROUTE = () => {
-  return `/chat`;
-};

--- a/src/frontend/components/ConverseInitializer/index.spec.tsx
+++ b/src/frontend/components/ConverseInitializer/index.spec.tsx
@@ -1,0 +1,312 @@
+import { act, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { getDecodedJwt } from 'data/appData';
+import { useLiveSession } from 'data/stores/useLiveSession';
+import { DecodedJwt } from 'types/jwt';
+import { liveState } from 'types/tracks';
+import { PersistentStore } from 'types/XMPP';
+import { liveSessionFactory, videoMockFactory } from 'utils/tests/factories';
+
+import { ConverseInitializer } from '.';
+
+let mockConverse: any;
+jest.mock('utils/window', () => ({
+  get converse() {
+    return mockConverse;
+  },
+}));
+
+jest.mock('data/appData', () => ({
+  appData: {
+    video: mockVideo,
+  },
+  getDecodedJwt: jest.fn(),
+}));
+const mockGetDecodedJwt = getDecodedJwt as jest.MockedFunction<
+  typeof getDecodedJwt
+>;
+
+const mockInitConverse = jest.fn();
+jest.mock('utils/conversejs/converse', () => ({
+  converseMounter: () => mockInitConverse,
+}));
+
+const mockVideo = videoMockFactory();
+
+describe('<ConverseInitializer />', () => {
+  beforeEach(() => {
+    mockConverse = undefined;
+    jest.resetAllMocks();
+  });
+
+  it('does not initialize converse without liveRegistration if user can not access dashboard', async () => {
+    mockGetDecodedJwt.mockReturnValue({
+      permissions: {
+        can_access_dashboard: false,
+        can_update: false,
+      },
+    } as DecodedJwt);
+    const video = {
+      ...mockVideo,
+      live_state: liveState.RUNNING,
+      xmpp: {
+        bosh_url: 'https://xmpp-server.com/http-bind',
+        converse_persistent_store: PersistentStore.LOCALSTORAGE,
+        websocket_url: null,
+        conference_url:
+          '870c467b-d66e-4949-8ee5-fcf460c72e88@conference.xmpp-server.com',
+        prebind_url: 'https://xmpp-server.com/http-pre-bind',
+        jid: 'xmpp-server.com',
+      },
+    };
+    mockConverse = {};
+
+    render(<ConverseInitializer video={video} />);
+    // mockConverseMounter returns itself a mock. We want to inspect this mock to be sure that
+    // is was called with the container name and the xmpp object
+    expect(mockInitConverse).not.toHaveBeenCalled();
+
+    const liveSession = liveSessionFactory();
+    act(() => {
+      useLiveSession.getState().setLiveSession(liveSession);
+    });
+
+    expect(mockInitConverse).toHaveBeenCalled();
+    expect(mockInitConverse).toHaveBeenCalledWith(
+      {
+        bosh_url: 'https://xmpp-server.com/http-bind',
+        converse_persistent_store: PersistentStore.LOCALSTORAGE,
+        websocket_url: null,
+        conference_url:
+          '870c467b-d66e-4949-8ee5-fcf460c72e88@conference.xmpp-server.com',
+        prebind_url: 'https://xmpp-server.com/http-pre-bind',
+        jid: 'xmpp-server.com',
+      },
+      null,
+    );
+  });
+
+  it('does not initialize converse for a video without xmpp', () => {
+    mockGetDecodedJwt.mockReturnValue({
+      permissions: {
+        can_access_dashboard: false,
+        can_update: false,
+      },
+    } as DecodedJwt);
+    const video = {
+      ...mockVideo,
+      live_state: liveState.RUNNING,
+    };
+    mockConverse = {};
+
+    render(<ConverseInitializer video={video} />);
+    // mockConverseMounter returns itself a mock. We want to inspect this mock to be sure that
+    // is was called with the container name and the xmpp object
+    expect(mockInitConverse).not.toHaveBeenCalled();
+  });
+
+  it('does not initialize converse for a video without live state', () => {
+    mockGetDecodedJwt.mockReturnValue({
+      permissions: {
+        can_access_dashboard: false,
+        can_update: false,
+      },
+    } as DecodedJwt);
+    const video = {
+      ...mockVideo,
+      xmpp: {
+        bosh_url: 'https://xmpp-server.com/http-bind',
+        converse_persistent_store: PersistentStore.LOCALSTORAGE,
+        websocket_url: null,
+        conference_url:
+          '870c467b-d66e-4949-8ee5-fcf460c72e88@conference.xmpp-server.com',
+        prebind_url: 'https://xmpp-server.com/http-pre-bind',
+        jid: 'xmpp-server.com',
+      },
+    };
+    mockConverse = {};
+
+    render(<ConverseInitializer video={video} />);
+    // mockConverseMounter returns itself a mock. We want to inspect this mock to be sure that
+    // is was called with the container name and the xmpp object
+    expect(mockInitConverse).not.toHaveBeenCalled();
+  });
+
+  it('does not initialize converse for a video with a live state idle', () => {
+    mockGetDecodedJwt.mockReturnValue({
+      permissions: {
+        can_access_dashboard: false,
+        can_update: false,
+      },
+    } as DecodedJwt);
+    const video = {
+      ...mockVideo,
+      live_state: liveState.IDLE,
+      xmpp: {
+        bosh_url: 'https://xmpp-server.com/http-bind',
+        converse_persistent_store: PersistentStore.LOCALSTORAGE,
+        websocket_url: null,
+        conference_url:
+          '870c467b-d66e-4949-8ee5-fcf460c72e88@conference.xmpp-server.com',
+        prebind_url: 'https://xmpp-server.com/http-pre-bind',
+        jid: 'xmpp-server.com',
+      },
+    };
+    mockConverse = {};
+
+    render(<ConverseInitializer video={video} />);
+    // mockConverseMounter returns itself a mock. We want to inspect this mock to be sure that
+    // is was called with the container name and the xmpp object
+    expect(mockInitConverse).not.toHaveBeenCalled();
+  });
+
+  it('initializes converse with the displayname', () => {
+    mockGetDecodedJwt.mockReturnValue({
+      permissions: {
+        can_access_dashboard: false,
+        can_update: false,
+      },
+    } as DecodedJwt);
+    const video = {
+      ...mockVideo,
+      live_state: liveState.RUNNING,
+      xmpp: {
+        bosh_url: 'https://xmpp-server.com/http-bind',
+        converse_persistent_store: PersistentStore.LOCALSTORAGE,
+        websocket_url: null,
+        conference_url:
+          '870c467b-d66e-4949-8ee5-fcf460c72e88@conference.xmpp-server.com',
+        prebind_url: 'https://xmpp-server.com/http-pre-bind',
+        jid: 'xmpp-server.com',
+      },
+    };
+    mockConverse = {};
+
+    render(<ConverseInitializer video={video} />);
+    // mockConverseMounter returns itself a mock. We want to inspect this mock to be sure that
+    // is was called with the container name and the xmpp object
+    expect(mockInitConverse).not.toHaveBeenCalled();
+
+    const liveRegistration = liveSessionFactory({ display_name: 'john' });
+    act(() => {
+      useLiveSession.getState().setLiveSession(liveRegistration);
+    });
+
+    expect(mockInitConverse).toHaveBeenCalled();
+    expect(mockInitConverse).toHaveBeenCalledWith(
+      {
+        bosh_url: 'https://xmpp-server.com/http-bind',
+        converse_persistent_store: PersistentStore.LOCALSTORAGE,
+        websocket_url: null,
+        conference_url:
+          '870c467b-d66e-4949-8ee5-fcf460c72e88@conference.xmpp-server.com',
+        prebind_url: 'https://xmpp-server.com/http-pre-bind',
+        jid: 'xmpp-server.com',
+      },
+      'john',
+    );
+  });
+
+  it('renders children if converse is initialized in the window', () => {
+    mockGetDecodedJwt.mockReturnValue({
+      permissions: {
+        can_access_dashboard: false,
+        can_update: false,
+      },
+    } as DecodedJwt);
+    mockConverse = {};
+
+    render(
+      <ConverseInitializer video={mockVideo}>
+        <span>loaded</span>
+      </ConverseInitializer>,
+    );
+
+    screen.getByText('loaded');
+    expect(screen.queryByTestId('loader-id')).not.toBeInTheDocument();
+  });
+
+  it('initializes converse in the window if not define yet', async () => {
+    mockGetDecodedJwt.mockReturnValue({
+      permissions: {
+        can_access_dashboard: false,
+        can_update: false,
+      },
+    } as DecodedJwt);
+    const liveSession = liveSessionFactory();
+    useLiveSession.getState().setLiveSession(liveSession);
+
+    render(
+      <ConverseInitializer video={mockVideo}>
+        <span>loaded</span>
+      </ConverseInitializer>,
+    );
+
+    screen.getByTestId('loader-id');
+    expect(screen.queryByText('loaded')).not.toBeInTheDocument();
+
+    act(() => {
+      window.dispatchEvent(new Event('converse-loaded'));
+    });
+
+    await screen.findByText('loaded');
+    expect(screen.queryByTestId('loader-id')).not.toBeInTheDocument();
+
+    expect(mockInitConverse).not.toHaveBeenCalled();
+  });
+
+  it('initializes converse plugins if video has xmpp and live_state not idle', async () => {
+    mockGetDecodedJwt.mockReturnValue({
+      permissions: {
+        can_access_dashboard: false,
+        can_update: false,
+      },
+    } as DecodedJwt);
+    const video = {
+      ...mockVideo,
+      live_state: liveState.RUNNING,
+      xmpp: {
+        bosh_url: 'https://xmpp-server.com/http-bind',
+        converse_persistent_store: PersistentStore.LOCALSTORAGE,
+        websocket_url: null,
+        conference_url:
+          '870c467b-d66e-4949-8ee5-fcf460c72e88@conference.xmpp-server.com',
+        prebind_url: 'https://xmpp-server.com/http-pre-bind',
+        jid: 'xmpp-server.com',
+      },
+    };
+    const liveSession = liveSessionFactory();
+    useLiveSession.getState().setLiveSession(liveSession);
+
+    render(
+      <ConverseInitializer video={video}>
+        <span>loaded</span>
+      </ConverseInitializer>,
+    );
+
+    screen.getByTestId('loader-id');
+    expect(screen.queryByText('loaded')).not.toBeInTheDocument();
+
+    act(() => {
+      window.dispatchEvent(new Event('converse-loaded'));
+    });
+
+    await screen.findByText('loaded');
+    expect(screen.queryByTestId('loader-id')).not.toBeInTheDocument();
+
+    expect(mockInitConverse).toHaveBeenCalledTimes(1);
+    expect(mockInitConverse).toHaveBeenCalledWith(
+      {
+        bosh_url: 'https://xmpp-server.com/http-bind',
+        converse_persistent_store: PersistentStore.LOCALSTORAGE,
+        websocket_url: null,
+        conference_url:
+          '870c467b-d66e-4949-8ee5-fcf460c72e88@conference.xmpp-server.com',
+        prebind_url: 'https://xmpp-server.com/http-pre-bind',
+        jid: 'xmpp-server.com',
+      },
+      null,
+    );
+  });
+});

--- a/src/frontend/components/ConverseInitializer/index.tsx
+++ b/src/frontend/components/ConverseInitializer/index.tsx
@@ -1,0 +1,77 @@
+import { Box, Spinner } from 'grommet';
+import React, {
+  Fragment,
+  PropsWithChildren,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+
+import { getDecodedJwt } from 'data/appData';
+import { useLiveSession } from 'data/stores/useLiveSession';
+import { liveState, Video } from 'types/tracks';
+import { converseMounter } from 'utils/conversejs/converse';
+import { converse } from 'utils/window';
+
+interface ConverseMonterProps {
+  video: Video;
+}
+
+export const ConverseInitializer = ({
+  children,
+  video,
+}: PropsWithChildren<ConverseMonterProps>) => {
+  const initConverse = useMemo(() => {
+    return converseMounter();
+  }, [converseMounter]);
+  const [isConverseLoaded, setIsConverseLoaded] = useState(
+    converse !== undefined,
+  );
+  const liveSession = useLiveSession((state) => state.liveSession);
+
+  useEffect(() => {
+    const eventHandler = () => {
+      setIsConverseLoaded(true);
+    };
+    if (!isConverseLoaded) {
+      window.addEventListener('converse-loaded', eventHandler);
+    }
+    return () => {
+      window.removeEventListener('converse-loaded', eventHandler);
+    };
+  }, [isConverseLoaded]);
+
+  useEffect(() => {
+    if (!isConverseLoaded) {
+      //  converse is not loaded yet in the window
+      //  wait for initialization
+      return;
+    }
+
+    if (
+      !video.live_state ||
+      video.live_state === liveState.IDLE ||
+      !video.xmpp
+    ) {
+      //  video state is not ready to use XMPP and converse
+      return;
+    }
+
+    const isAdmin = getDecodedJwt().permissions.can_access_dashboard;
+    if (!isAdmin && liveSession) {
+      initConverse(video.xmpp, liveSession.display_name);
+    } else if (isAdmin) {
+      initConverse(video.xmpp);
+    }
+  }, [initConverse, isConverseLoaded, liveSession, video]);
+
+  if (!isConverseLoaded) {
+    return (
+      <Box fill>
+        <Spinner margin="auto" data-testid="loader-id" />
+      </Box>
+    );
+  }
+
+  return <Fragment>{children}</Fragment>;
+};

--- a/src/frontend/components/DashboardVideoLive/index.spec.tsx
+++ b/src/frontend/components/DashboardVideoLive/index.spec.tsx
@@ -13,6 +13,12 @@ import { DashboardVideoLive } from '.';
 jest.mock('jwt-decode', () => jest.fn());
 jest.mock('data/appData', () => ({
   appData: { jwt: 'cool_token_m8' },
+  getDecodedJwt: () => ({
+    permissions: {
+      can_access_dashboard: false,
+      can_update: false,
+    },
+  }),
 }));
 jest.mock(
   'components/DashboardVideoLiveRaw',

--- a/src/frontend/components/DashboardVideoLive/index.tsx
+++ b/src/frontend/components/DashboardVideoLive/index.tsx
@@ -1,6 +1,7 @@
 import { Box } from 'grommet';
 import React, { Fragment, useEffect, useState } from 'react';
 
+import { ConverseInitializer } from 'components/ConverseInitializer';
 import { DashboardVideoLivePairing } from 'components/DashboardVideoLivePairing';
 import { DashboardVideoLiveRunning } from 'components/DashboardVideoLiveRunning';
 import { LiveVideoLayout } from 'components/LiveVideoLayout';
@@ -53,56 +54,58 @@ export const DashboardVideoLive = ({ video }: DashboardVideoLiveProps) => {
     video.live_state !== undefined && video.live_state !== liveState.IDLE;
 
   return (
-    <LiveFeedbackProvider value={false}>
-      <StopLiveConfirmationProvider value={false}>
-        <Box>
-          <LiveVideoLayout
-            actionsElement={
-              <Fragment>
-                {isLiveStarted && <TeacherLiveControlBar video={video} />}
-                <TeacherLiveLifecycleControls
-                  canStartStreaming={canShowStartButton}
-                  hasRightToStart={canStartLive}
+    <ConverseInitializer video={video}>
+      <LiveFeedbackProvider value={false}>
+        <StopLiveConfirmationProvider value={false}>
+          <Box>
+            <LiveVideoLayout
+              actionsElement={
+                <Fragment>
+                  {isLiveStarted && <TeacherLiveControlBar video={video} />}
+                  <TeacherLiveLifecycleControls
+                    canStartStreaming={canShowStartButton}
+                    hasRightToStart={canStartLive}
+                    video={video}
+                  />
+                </Fragment>
+              }
+              displayActionsElement
+              isPanelOpen={isPanelVisible}
+              liveTitleElement={
+                <TeacherLiveInfoBar title={video.title} startDate={null} />
+              }
+              mainElement={
+                <TeacherLiveContent
+                  setCanShowStartButton={setCanShowStartButton}
+                  setCanStartLive={setCanStartLive}
                   video={video}
                 />
-              </Fragment>
-            }
-            displayActionsElement
-            isPanelOpen={isPanelVisible}
-            liveTitleElement={
-              <TeacherLiveInfoBar title={video.title} startDate={null} />
-            }
-            mainElement={
-              <TeacherLiveContent
-                setCanShowStartButton={setCanShowStartButton}
-                setCanStartLive={setCanStartLive}
-                video={video}
-              />
-            }
-            sideElement={<LiveVideoPanel video={video} />}
-          />
+              }
+              sideElement={<LiveVideoPanel video={video} />}
+            />
 
-          <Box direction={'row'} justify={'center'} margin={'small'}>
-            {appData.flags?.live_raw &&
-              video.live_state &&
-              [liveState.IDLE, liveState.PAUSED].includes(video.live_state) && (
-                <TeacherLiveTypeSwitch video={video} />
+            <Box direction={'row'} justify={'center'} margin={'small'}>
+              {appData.flags?.live_raw &&
+                video.live_state &&
+                [liveState.IDLE, liveState.PAUSED].includes(
+                  video.live_state,
+                ) && <TeacherLiveTypeSwitch video={video} />}
+              {video.live_state === liveState.RUNNING && (
+                <DashboardVideoLiveRunning video={video} />
               )}
-            {video.live_state === liveState.RUNNING && (
-              <DashboardVideoLiveRunning video={video} />
+            </Box>
+
+            {video.live_state !== liveState.STOPPED && (
+              <Box direction={'row'} justify={'center'} margin={'small'}>
+                <DashboardVideoLivePairing video={video} />
+              </Box>
+            )}
+            {video.live_state === liveState.IDLE && (
+              <ScheduledVideoForm video={video} />
             )}
           </Box>
-
-          {video.live_state !== liveState.STOPPED && (
-            <Box direction={'row'} justify={'center'} margin={'small'}>
-              <DashboardVideoLivePairing video={video} />
-            </Box>
-          )}
-          {video.live_state === liveState.IDLE && (
-            <ScheduledVideoForm video={video} />
-          )}
-        </Box>
-      </StopLiveConfirmationProvider>
-    </LiveFeedbackProvider>
+        </StopLiveConfirmationProvider>
+      </LiveFeedbackProvider>
+    </ConverseInitializer>
   );
 };

--- a/src/frontend/components/LTIRoutes/index.tsx
+++ b/src/frontend/components/LTIRoutes/index.tsx
@@ -3,8 +3,6 @@ import { MemoryRouter, Redirect, Route, Switch } from 'react-router-dom';
 
 import { appData } from 'data/appData';
 import { modelName } from 'types/models';
-import { Chat } from 'components/Chat';
-import { CHAT_ROUTE } from 'components/Chat/route';
 import { DASHBOARD_ROUTE } from 'components/Dashboard/route';
 import { FullScreenError } from 'components/ErrorComponents';
 import { FULL_SCREEN_ERROR_ROUTE } from 'components/ErrorComponents/route';
@@ -100,21 +98,6 @@ export const Routes = () => (
               lti_select_form_data={appData.lti_select_form_data!}
             />
           )}
-        />
-        <Route
-          exact
-          path={CHAT_ROUTE()}
-          render={() => {
-            if (appData.modelName === modelName.VIDEOS && appData.video?.xmpp) {
-              return (
-                <InstructorWrapper resource={appData.video}>
-                  <Chat video={appData.video} standalone={true} />
-                </InstructorWrapper>
-              );
-            }
-
-            return <Redirect push to={FULL_SCREEN_ERROR_ROUTE('notFound')} />;
-          }}
         />
         <Route
           exact

--- a/src/frontend/components/LiveVideoPanel/index.spec.tsx
+++ b/src/frontend/components/LiveVideoPanel/index.spec.tsx
@@ -5,29 +5,22 @@ import {
   LivePanelItem,
   useLivePanelState,
 } from 'data/stores/useLivePanelState';
-import { PersistentStore } from 'types/XMPP';
 import { videoMockFactory } from 'utils/tests/factories';
 import { renderImageSnapshot } from 'utils/tests/imageSnapshot';
 import { wrapInIntlProvider } from 'utils/tests/intl';
 
 import { LiveVideoPanel } from '.';
 
-const mockVideo = videoMockFactory({
-  xmpp: {
-    bosh_url: 'https://xmpp-server.com/http-bind',
-    converse_persistent_store: PersistentStore.LOCALSTORAGE,
-    websocket_url: null,
-    conference_url:
-      '870c467b-d66e-4949-8ee5-fcf460c72e88@conference.xmpp-server.com',
-    prebind_url: 'https://xmpp-server.com/http-pre-bind',
-    jid: 'xmpp-server.com',
-  },
-});
 jest.mock('data/appData', () => ({
-  appData: {
-    video: mockVideo,
-  },
+  getDecodedJwt: () => ({
+    permissions: {
+      can_access_dashboard: false,
+      can_update: false,
+    },
+  }),
 }));
+
+const video = videoMockFactory();
 
 describe('<LiveVideoPanel />', () => {
   it('closes the panel if no item is selected', () => {
@@ -43,7 +36,7 @@ describe('<LiveVideoPanel />', () => {
     });
 
     const { container } = render(
-      wrapInIntlProvider(<LiveVideoPanel video={mockVideo} />),
+      wrapInIntlProvider(<LiveVideoPanel video={video} />),
     );
 
     expect(mockSetPanelVisibility).toBeCalled();
@@ -63,7 +56,7 @@ describe('<LiveVideoPanel />', () => {
       ],
     });
 
-    render(wrapInIntlProvider(<LiveVideoPanel video={mockVideo} />));
+    render(wrapInIntlProvider(<LiveVideoPanel video={video} />));
 
     screen.getByRole('tablist');
     screen.getByRole('tab', { name: 'application' });
@@ -79,7 +72,7 @@ describe('<LiveVideoPanel />', () => {
       availableItems: [LivePanelItem.APPLICATION],
     });
 
-    render(wrapInIntlProvider(<LiveVideoPanel video={mockVideo} />));
+    render(wrapInIntlProvider(<LiveVideoPanel video={video} />));
 
     expect(screen.queryByRole('tablist')).not.toBeInTheDocument();
     expect(
@@ -103,7 +96,7 @@ describe('<LiveVideoPanel />', () => {
       ],
     });
 
-    await renderImageSnapshot(<LiveVideoPanel video={mockVideo} />);
+    await renderImageSnapshot(<LiveVideoPanel video={video} />);
   });
 
   it('renders with appropriate style on small screen', async () => {
@@ -116,6 +109,6 @@ describe('<LiveVideoPanel />', () => {
       ],
     });
 
-    await renderImageSnapshot(<LiveVideoPanel video={mockVideo} />, 300, 300);
+    await renderImageSnapshot(<LiveVideoPanel video={video} />, 300, 300);
   });
 });

--- a/src/frontend/components/LiveVideoPanel/index.tsx
+++ b/src/frontend/components/LiveVideoPanel/index.tsx
@@ -11,6 +11,7 @@ import {
 import { Video } from 'types/tracks';
 import { ShouldNotHappen } from 'utils/errors/exception';
 import { theme } from 'utils/theme/theme';
+
 import { LiveVideoTabPanel } from './LiveVideoTabPanel';
 
 const StyledGrommet = styled(Grommet)`
@@ -77,7 +78,7 @@ export const LiveVideoPanel = ({ video }: LiveVideoPanelProps) => {
   let content;
   switch (currentItem) {
     case LivePanelItem.CHAT:
-      content = <Chat video={video} />;
+      content = <Chat />;
       break;
     case LivePanelItem.APPLICATION:
       //  TODO : implement this item

--- a/src/frontend/components/PublicVideoDashboard/index.spec.tsx
+++ b/src/frontend/components/PublicVideoDashboard/index.spec.tsx
@@ -23,8 +23,6 @@ import { wrapInRouter } from 'utils/tests/router';
 
 import PublicVideoDashboard from '.';
 
-window.HTMLElement.prototype.scrollTo = jest.fn();
-
 jest.mock('Player/createPlayer', () => ({
   createPlayer: jest.fn(),
 }));
@@ -55,6 +53,12 @@ jest.mock('video.js', () => ({
   },
 }));
 
+jest.mock('components/ConverseInitializer', () => ({
+  ConverseInitializer: ({ children }: { children: React.ReactNode }) => {
+    return children;
+  },
+}));
+
 const mockCreatePlayer = createPlayer as jest.MockedFunction<
   typeof createPlayer
 >;
@@ -82,10 +86,6 @@ jest.mock('data/appData', () => ({
       can_update: mockCanUpdate,
     },
   }),
-}));
-
-jest.mock('utils/conversejs/converse', () => ({
-  converseMounter: jest.fn(() => jest.fn()),
 }));
 
 window.HTMLElement.prototype.scrollTo = jest.fn();

--- a/src/frontend/components/PublicVideoLiveJitsi/index.spec.tsx
+++ b/src/frontend/components/PublicVideoLiveJitsi/index.spec.tsx
@@ -56,8 +56,10 @@ jest.mock('data/appData', () => ({
   },
 }));
 
-jest.mock('utils/conversejs/converse', () => ({
-  converseMounter: jest.fn(() => jest.fn()),
+jest.mock('components/ConverseInitializer', () => ({
+  ConverseInitializer: ({ children }: { children: React.ReactNode }) => {
+    return children;
+  },
 }));
 
 const mockExecuteCommand = jest.fn();

--- a/src/frontend/components/StudentLiveWrapper/index.spec.tsx
+++ b/src/frontend/components/StudentLiveWrapper/index.spec.tsx
@@ -55,8 +55,10 @@ jest.mock('video.js', () => ({
   },
 }));
 
-jest.mock('utils/conversejs/converse', () => ({
-  converseMounter: jest.fn(() => jest.fn()),
+jest.mock('components/ConverseInitializer', () => ({
+  ConverseInitializer: ({ children }: { children: React.ReactNode }) => {
+    return children;
+  },
 }));
 
 const mockCreatePlayer = createPlayer as jest.MockedFunction<

--- a/src/frontend/components/StudentLiveWrapper/index.tsx
+++ b/src/frontend/components/StudentLiveWrapper/index.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
 
+import { ConverseInitializer } from 'components/ConverseInitializer';
 import DashboardVideoLiveJitsi from 'components/DashboardVideoLiveJitsi';
 import { LiveVideoLayout } from 'components/LiveVideoLayout';
 import { LiveVideoPanel } from 'components/LiveVideoPanel';
@@ -62,29 +63,31 @@ export const LiveVideoWrapper: React.FC<LiveVideoWrapperProps> = ({
   }, [video, configPanel, isStarted]);
 
   return (
-    <LiveVideoLayout
-      actionsElement={<StudentLiveControlBar video={video} />}
-      displayActionsElement={
-        configuration.type === LiveType.ON_STAGE || isStarted
-      }
-      isPanelOpen={isPanelVisible}
-      liveTitleElement={
-        <StudentLiveInfoBar title={video.title} startDate={null} />
-      }
-      mainElement={
-        <React.Fragment>
-          {configuration.type === LiveType.ON_STAGE && (
-            <DashboardVideoLiveJitsi video={video} />
-          )}
-          {configuration.type === LiveType.VIEWER && (
-            <StudentLiveViewerWrapper
-              video={video}
-              playerType={configuration.playerType}
-            />
-          )}
-        </React.Fragment>
-      }
-      sideElement={<LiveVideoPanel video={video} />}
-    />
+    <ConverseInitializer video={video}>
+      <LiveVideoLayout
+        actionsElement={<StudentLiveControlBar video={video} />}
+        displayActionsElement={
+          configuration.type === LiveType.ON_STAGE || isStarted
+        }
+        isPanelOpen={isPanelVisible}
+        liveTitleElement={
+          <StudentLiveInfoBar title={video.title} startDate={null} />
+        }
+        mainElement={
+          <React.Fragment>
+            {configuration.type === LiveType.ON_STAGE && (
+              <DashboardVideoLiveJitsi video={video} />
+            )}
+            {configuration.type === LiveType.VIEWER && (
+              <StudentLiveViewerWrapper
+                video={video}
+                playerType={configuration.playerType}
+              />
+            )}
+          </React.Fragment>
+        }
+        sideElement={<LiveVideoPanel video={video} />}
+      />
+    </ConverseInitializer>
   );
 };

--- a/src/frontend/utils/conversejs/converse.ts
+++ b/src/frontend/utils/conversejs/converse.ts
@@ -10,9 +10,8 @@ import { marshaJoinDiscussionPlugin } from './converse-plugins/marshaJoinDiscuss
 import { nicknameManagementPlugin } from './converse-plugins/nicknameManagementPlugin';
 import { participantsTrackingPlugin } from './converse-plugins/participantsTrackingPlugin';
 
+let isChatInitialized = false;
 export const converseMounter = () => {
-  let isChatInitialized = false;
-
   return (xmpp: XMPP, displayName?: Nullable<string>) => {
     if (!isChatInitialized) {
       chatPlugin.addPlugin(xmpp);


### PR DESCRIPTION
## Purpose

Converse is initialize when 'components/Chat/index.tsx' file is loaded but we
can have scripts using converse from window even if converse has not been
initialized yet.
Especially, current implementation works only because we are importing Chat file
in base routeur for the application.

## Proposal

To fix this issue, a new component is created to be responsible for the
initialization of converse and mount component using converse only when this is
done.
