### PR TITLE
🐛(front) keep input register email display

### DIFF
--- a/src/frontend/components/StudentLiveAdvertising/StudentLiveRegistration/RegistrationForm/index.spec.tsx
+++ b/src/frontend/components/StudentLiveAdvertising/StudentLiveRegistration/RegistrationForm/index.spec.tsx
@@ -66,11 +66,17 @@ describe('<RegistrationForm />', () => {
       ),
     );
 
-    screen.getByRole('textbox', { name: 'Email address' });
+    const textbox = screen.getByRole('textbox', { name: 'Email address' });
     screen.getByRole('button', { name: 'Register' });
     expect(
       screen.queryByText('You have to submit a valid email to register.'),
     ).not.toBeInTheDocument();
+
+    const email = 'test_email@openfun.fr';
+    userEvent.type(textbox, email);
+
+    expect(textbox).toBeInTheDocument();
+    expect(textbox).toHaveValue(email);
   });
 
   it('renders the form with initial value', () => {

--- a/src/frontend/components/StudentLiveAdvertising/StudentLiveRegistration/RegistrationForm/index.tsx
+++ b/src/frontend/components/StudentLiveAdvertising/StudentLiveRegistration/RegistrationForm/index.tsx
@@ -129,7 +129,7 @@ interface RegistrationFormProps {
 }
 
 export const RegistrationForm = ({
-  defaultEmail,
+  defaultEmail = '',
   setRegistrationCompleted,
 }: RegistrationFormProps) => {
   const trimedEmail = defaultEmail && defaultEmail.trim();
@@ -141,11 +141,7 @@ export const RegistrationForm = ({
     return checkLtiToken(getDecodedJwt());
   }, [getDecodedJwt]);
 
-  const displayEmailInput = !(
-    isLtiToken &&
-    values.email &&
-    values.email !== ''
-  );
+  const displayEmailInput = !(isLtiToken && trimedEmail && trimedEmail !== '');
 
   return (
     <Grommet theme={formTheme}>


### PR DESCRIPTION
## Purpose

If the user has no email in its JWT token, he can enter one by using an
input. This input was removed after he enter a first caracter because we
were checking if the entered value was not empty to display this input
or not. We have to do this check on the initial email value and not the
one entered by the user.

## Proposal

- [x] keep input register email display
