### PR TITLE
(front) update live session on register when one already exists

### DIFF
--- a/src/frontend/components/PublicVideoDashboard/index.spec.tsx
+++ b/src/frontend/components/PublicVideoDashboard/index.spec.tsx
@@ -650,7 +650,7 @@ describe('PublicVideoDashboard', () => {
     startingAt.setFullYear(startingAt.getFullYear() + 10);
     const anonymousId = uuidv4();
     mockGetAnonymousId.mockReturnValue(anonymousId);
-    fetchMock.mock(`/api/livesessions/?anonymous_id=${anonymousId}&limit=999`, {
+    fetchMock.mock(`/api/livesessions/?anonymous_id=${anonymousId}`, {
       count: 0,
       results: [],
     });

--- a/src/frontend/components/StudentLiveAdvertising/StudentLiveRegistration/RegistrationForm/index.spec.tsx
+++ b/src/frontend/components/StudentLiveAdvertising/StudentLiveRegistration/RegistrationForm/index.spec.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 
 import { getDecodedJwt } from 'data/appData';
 import { createLiveSession } from 'data/sideEffects/createLiveSession';
+import { updateLiveSession } from 'data/sideEffects/updateLiveSession';
 import { liveSessionFactory } from 'utils/tests/factories';
 import { wrapInIntlProvider } from 'utils/tests/intl';
 
@@ -26,6 +27,13 @@ jest.mock('data/sideEffects/createLiveSession', () => ({
 }));
 const mockCreateLiveSession = createLiveSession as jest.MockedFunction<
   typeof createLiveSession
+>;
+
+jest.mock('data/sideEffects/updateLiveSession', () => ({
+  updateLiveSession: jest.fn(),
+}));
+const mockUpdateLiveSession = updateLiveSession as jest.MockedFunction<
+  typeof updateLiveSession
 >;
 
 describe('<RegistrationForm />', () => {
@@ -61,6 +69,7 @@ describe('<RegistrationForm />', () => {
     render(
       wrapInIntlProvider(
         <RegistrationForm
+          liveSession={undefined}
           setRegistrationCompleted={setRegistrationCompleted}
         />,
       ),
@@ -84,6 +93,7 @@ describe('<RegistrationForm />', () => {
       wrapInIntlProvider(
         <RegistrationForm
           defaultEmail="some.email@openfun.fr"
+          liveSession={undefined}
           setRegistrationCompleted={setRegistrationCompleted}
         />,
       ),
@@ -123,6 +133,7 @@ describe('<RegistrationForm />', () => {
       wrapInIntlProvider(
         <RegistrationForm
           defaultEmail="some.email@openfun.fr"
+          liveSession={undefined}
           setRegistrationCompleted={setRegistrationCompleted}
         />,
       ),
@@ -177,6 +188,7 @@ describe('<RegistrationForm />', () => {
       wrapInIntlProvider(
         <RegistrationForm
           defaultEmail="some.email@openfun.com"
+          liveSession={undefined}
           setRegistrationCompleted={setRegistrationCompleted}
         />,
       ),
@@ -196,6 +208,7 @@ describe('<RegistrationForm />', () => {
       wrapInIntlProvider(
         <RegistrationForm
           defaultEmail="some.invalid.email@openfun."
+          liveSession={undefined}
           setRegistrationCompleted={setRegistrationCompleted}
         />,
       ),
@@ -219,6 +232,7 @@ describe('<RegistrationForm />', () => {
       wrapInIntlProvider(
         <RegistrationForm
           defaultEmail="some.email@openfun.fr"
+          liveSession={undefined}
           setRegistrationCompleted={setRegistrationCompleted}
         />,
       ),
@@ -235,5 +249,35 @@ describe('<RegistrationForm />', () => {
     await screen.findByText(
       'Impossible to register your email some.email@openfun.fr for this event. Make sure your email is valid otherwise, please try again later or contact us.',
     );
+  });
+  it('updates the live session when this one is set in the props', async () => {
+    const existingLiveSession = liveSessionFactory({
+      is_registered: false,
+      email: 'to_update@fun-test.fr',
+    });
+
+    render(
+      wrapInIntlProvider(
+        <RegistrationForm
+          liveSession={existingLiveSession}
+          setRegistrationCompleted={setRegistrationCompleted}
+        />,
+      ),
+    );
+    const updatedEmail = 'updatedEmail@fun-test.fr';
+    const textbox = screen.getByRole('textbox', { name: 'Email address' });
+
+    userEvent.type(textbox, updatedEmail);
+
+    userEvent.click(screen.getByRole('button', { name: 'Register' }));
+
+    await waitFor(() => {
+      expect(mockUpdateLiveSession).toHaveBeenCalledWith(
+        existingLiveSession,
+        updatedEmail,
+        true,
+        expect.anything(),
+      );
+    });
   });
 });

--- a/src/frontend/components/StudentLiveAdvertising/StudentLiveRegistration/RegistrationForm/index.tsx
+++ b/src/frontend/components/StudentLiveAdvertising/StudentLiveRegistration/RegistrationForm/index.tsx
@@ -10,6 +10,8 @@ import { checkLtiToken } from 'utils/checkLtiToken';
 import { getAnonymousId } from 'utils/localstorage';
 import { theme } from 'utils/theme/theme';
 import { Maybe } from 'utils/types';
+import { LiveSession } from 'types/tracks';
+import { updateLiveSession } from 'data/sideEffects/updateLiveSession';
 
 const formTheme = deepMerge(theme, {
   global: {
@@ -125,11 +127,13 @@ const messages = defineMessages({
 
 interface RegistrationFormProps {
   defaultEmail?: string;
-  setRegistrationCompleted: () => void;
+  liveSession: Maybe<LiveSession>;
+  setRegistrationCompleted: (liveSession: LiveSession) => void;
 }
 
 export const RegistrationForm = ({
   defaultEmail = '',
+  liveSession,
   setRegistrationCompleted,
 }: RegistrationFormProps) => {
   const trimedEmail = defaultEmail && defaultEmail.trim();
@@ -158,9 +162,23 @@ export const RegistrationForm = ({
           if (!isLtiToken) {
             anonymousId = getAnonymousId();
           }
-          await createLiveSession(value.email, anonymousId);
+          let updatedLiveSession: LiveSession;
+          if (!liveSession) {
+            updatedLiveSession = await createLiveSession(
+              value.email,
+              anonymousId,
+            );
+          } else {
+            updatedLiveSession = await updateLiveSession(
+              liveSession,
+              value.email,
+              true,
+              anonymousId,
+            );
+          }
+
           setLtiUserError(undefined);
-          setRegistrationCompleted();
+          setRegistrationCompleted(updatedLiveSession);
         }}
         onSubmitError={(value, error) => {
           if (!value.email) {

--- a/src/frontend/components/StudentLiveAdvertising/index.spec.tsx
+++ b/src/frontend/components/StudentLiveAdvertising/index.spec.tsx
@@ -43,8 +43,11 @@ jest.mock('data/appData', () => ({
   }),
 }));
 
-jest.mock('data/queries/fetchList', () => ({
-  fetchList: async () => [],
+jest.mock('data/sideEffects/getLiveSessions', () => ({
+  getLiveSessions: async () => ({
+    count: 0,
+    results: [],
+  }),
 }));
 
 describe('<StudentLiveAdvertising />', () => {

--- a/src/frontend/data/sideEffects/updateLiveSession/index.spec.ts
+++ b/src/frontend/data/sideEffects/updateLiveSession/index.spec.ts
@@ -1,0 +1,111 @@
+import fetchMock from 'fetch-mock';
+import { v4 as uuidv4 } from 'uuid';
+
+import { liveSessionFactory } from 'utils/tests/factories';
+import { updateLiveSession } from '.';
+
+jest.mock('data/appData', () => ({
+  appData: {
+    jwt: 'token',
+  },
+}));
+
+describe('updateLiveSession', () => {
+  afterEach(() => fetchMock.restore());
+
+  it('updates a live session and returns it', async () => {
+    const liveSession = liveSessionFactory({
+      email: 'john@fun-test.fr',
+      is_registered: false,
+    });
+
+    fetchMock.mock(
+      {
+        url: `/api/livesessions/${liveSession.id}/`,
+        body: {
+          email: 'updated@fun-test.fr',
+          is_registered: true,
+        },
+        method: 'PATCH',
+      },
+      {
+        ...liveSession,
+        email: 'updated@fun-test.fr',
+        is_registered: true,
+      },
+    );
+
+    const updatedLiveSession = await updateLiveSession(
+      liveSession,
+      'updated@fun-test.fr',
+      true,
+    );
+
+    expect(updatedLiveSession.email).toEqual('updated@fun-test.fr');
+    expect(updatedLiveSession.is_registered).toEqual(true);
+  });
+
+  it('updates a live session using an anonymoud_id and returns it', async () => {
+    const anonymousId = uuidv4();
+    const liveSession = liveSessionFactory({
+      anonymous_id: anonymousId,
+      email: 'john@fun-test.fr',
+      is_registered: false,
+    });
+
+    fetchMock.mock(
+      {
+        url: `/api/livesessions/${liveSession.id}/?anonymous_id=${anonymousId}`,
+        body: {
+          email: 'updated@fun-test.fr',
+          is_registered: true,
+        },
+        method: 'PATCH',
+      },
+      {
+        ...liveSession,
+        email: 'updated@fun-test.fr',
+        is_registered: true,
+      },
+    );
+
+    const updatedLiveSession = await updateLiveSession(
+      liveSession,
+      'updated@fun-test.fr',
+      true,
+      anonymousId,
+    );
+
+    expect(updatedLiveSession.email).toEqual('updated@fun-test.fr');
+    expect(updatedLiveSession.is_registered).toEqual(true);
+  });
+
+  it('throws when it fails to update a live session and returns a json Error', async () => {
+    const anonymousId = uuidv4();
+    const liveSession = liveSessionFactory({
+      anonymous_id: anonymousId,
+      email: 'john@fun-test.fr',
+      is_registered: false,
+    });
+    fetchMock.mock(
+      `/api/livesessions/${liveSession.id}/?anonymous_id=${anonymousId}`,
+      {
+        body: JSON.stringify({ email: 'Invalid email!' }),
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      },
+    );
+
+    let thrownError;
+    try {
+      await updateLiveSession(liveSession, 'wrong email', true, anonymousId);
+    } catch (error) {
+      thrownError = error;
+    }
+
+    expect(thrownError).toEqual({
+      code: 'invalid',
+      email: 'Invalid email!',
+    });
+  });
+});

--- a/src/frontend/data/sideEffects/updateLiveSession/index.ts
+++ b/src/frontend/data/sideEffects/updateLiveSession/index.ts
@@ -1,0 +1,34 @@
+import { appData } from 'data/appData';
+import { API_ENDPOINT } from 'settings';
+import { LiveSession } from 'types/tracks';
+
+export const updateLiveSession = async (
+  liveSession: LiveSession,
+  email?: string,
+  isRegistered?: boolean,
+  anonymousId?: string,
+): Promise<LiveSession> => {
+  const body = {
+    email,
+    is_registered: isRegistered,
+  };
+
+  let endpoint = `${API_ENDPOINT}/livesessions/${liveSession.id}/`;
+  if (anonymousId) {
+    endpoint = `${endpoint}?anonymous_id=${anonymousId}`;
+  }
+
+  const response = await fetch(endpoint, {
+    body: JSON.stringify(body),
+    headers: {
+      Authorization: `Bearer ${appData.jwt}`,
+      'Content-Type': 'application/json',
+    },
+    method: 'PATCH',
+  });
+
+  if (!response.ok) {
+    throw { code: 'invalid', ...(await response.json()) };
+  }
+  return response.json();
+};


### PR DESCRIPTION
## Purpose

A live session can already exists when a user wants to register to the
live. Instead of creating one, we update this one by settings
is_registered to true and the choosen email.

## Proposal

- [x] add side effect to update a live session
- [x] update live session on register when one already exists

