### PR TITLE
🐛(back) expose XMPP info for a live once this one started

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Do not install the `marsha` Python package in `site-packages`
 - Do not allow a lti user to change his email when he registers to a scheduled 
   live
+- Expose XMPP info for a live once this one started
 
 ## [4.0.0-beta.1] - 2022-02-15
 

--- a/src/backend/marsha/core/serializers/video.py
+++ b/src/backend/marsha/core/serializers/video.py
@@ -247,7 +247,11 @@ class VideoSerializer(VideoBaseSerializer):
         Dictionnary
             A dictionary containing all info needed to manage a connection to a xmpp server.
         """
-        if settings.LIVE_CHAT_ENABLED and obj.live_state is not None:
+        if (
+            settings.LIVE_CHAT_ENABLED
+            and obj.live_state
+            and obj.live_state not in [IDLE]
+        ):
             token = xmpp_utils.generate_jwt(
                 str(obj.id),
                 "owner" if self.context.get("is_admin") else "member",

--- a/src/backend/marsha/core/tests/test_views_lti_video.py
+++ b/src/backend/marsha/core/tests/test_views_lti_video.py
@@ -331,7 +331,7 @@ class VideoLTIViewTestCase(TestCase):
             playlist__lti_id="course-v1:ufr+mathematics+00001",
             playlist__title="foo bar",
             playlist__consumer_site=passport.consumer_site,
-            live_state=IDLE,
+            live_state=RUNNING,
             live_info={
                 "medialive": {
                     "input": {
@@ -450,7 +450,7 @@ class VideoLTIViewTestCase(TestCase):
                     "lti_id": "course-v1:ufr+mathematics+00001",
                 },
                 "shared_live_medias": [],
-                "live_state": IDLE,
+                "live_state": RUNNING,
                 "live_info": {
                     "medialive": {
                         "input": {


### PR DESCRIPTION
## Purpose

When a live is created, it has a IDLE live_state and the XMPP room is
not created at this time. Returning the XMPP info in the serializer is a
mistake and lets think that the XMPP room can be used by the front
application which is not the case.

## Proposal

- [x] expose XMPP info for a live once this one started

