### PR TITLE
✨(front) manage anonymous_id with websocket

### DIFF
--- a/src/frontend/components/DashboardThumbnail/index.spec.tsx
+++ b/src/frontend/components/DashboardThumbnail/index.spec.tsx
@@ -24,6 +24,24 @@ jest.mock('data/appData', () => ({
   appData: {
     jwt: 'some token',
   },
+  getDecodedJwt: () => ({
+    context_id: 'course-v1:ufr+mathematics+0001',
+    consumer_site: '112cf553-b8c3-4b98-9d47-d0793284b9b3',
+    locale: 'en_US',
+    maintenance: false,
+    permissions: {
+      can_access_dashboard: false,
+      can_update: false,
+    },
+    resource_id: '26debfee-8c3b-4c23-b08f-67f223de9832',
+    roles: ['student'],
+    session_id: '6bbb8d1d-442d-4575-a0ad-d1e34f37cae3',
+    user: {
+      email: 'sarah@test-mooc.fr',
+      id: 'aaace992-49e3-4e01-b809-7a84b1b55b72',
+      username: null,
+    },
+  }),
 }));
 
 const video = videoMockFactory();

--- a/src/frontend/components/DashboardTimedTextPane/index.spec.tsx
+++ b/src/frontend/components/DashboardTimedTextPane/index.spec.tsx
@@ -22,6 +22,24 @@ jest.mock('data/appData', () => ({
   appData: {
     jwt: 'foo',
   },
+  getDecodedJwt: () => ({
+    context_id: 'course-v1:ufr+mathematics+0001',
+    consumer_site: '112cf553-b8c3-4b98-9d47-d0793284b9b3',
+    locale: 'en_US',
+    maintenance: false,
+    permissions: {
+      can_access_dashboard: false,
+      can_update: false,
+    },
+    resource_id: '26debfee-8c3b-4c23-b08f-67f223de9832',
+    roles: ['student'],
+    session_id: '6bbb8d1d-442d-4575-a0ad-d1e34f37cae3',
+    user: {
+      email: 'sarah@test-mooc.fr',
+      id: 'aaace992-49e3-4e01-b809-7a84b1b55b72',
+      username: null,
+    },
+  }),
 }));
 
 jest.mock('utils/errors/report', () => ({

--- a/src/frontend/data/websocket.spec.ts
+++ b/src/frontend/data/websocket.spec.ts
@@ -1,15 +1,65 @@
 import { waitFor } from '@testing-library/react';
 import WS from 'jest-websocket-mock';
+import { v4 as uuidv4 } from 'uuid';
 
 import { modelName } from 'types/models';
+import { getOrInitAnonymousId } from 'utils/getOrInitAnonymousId';
 import { videoMockFactory } from 'utils/tests/factories';
+import { getDecodedJwt } from './appData';
 import { useVideo } from './stores/useVideo';
 
-jest.mock('data/appData', () => ({
+jest.mock('./appData', () => ({
   appData: { jwt: 'cool_token_m8' },
+  getDecodedJwt: jest.fn(),
 }));
 
+jest.mock('utils/getOrInitAnonymousId', () => ({
+  getOrInitAnonymousId: jest.fn(),
+}));
+
+const mockGetDecodedJwt = getDecodedJwt as jest.MockedFunction<
+  typeof getDecodedJwt
+>;
+const mockGetOrInitAnonymousId = getOrInitAnonymousId as jest.MockedFunction<
+  typeof getOrInitAnonymousId
+>;
+
+const publicToken = {
+  locale: 'en',
+  maintenance: false,
+  permissions: {
+    can_access_dashboard: false,
+    can_update: false,
+  },
+  resource_id: '26debfee-8c3b-4c23-b08f-67f223de9832',
+  roles: ['none'],
+  session_id: '6bbb8d1d-442d-4575-a0ad-d1e34f37cae3',
+};
+
+const ltiToken = {
+  context_id: 'course-v1:ufr+mathematics+0001',
+  consumer_site: '112cf553-b8c3-4b98-9d47-d0793284b9b3',
+  locale: 'en_US',
+  maintenance: false,
+  permissions: {
+    can_access_dashboard: false,
+    can_update: false,
+  },
+  resource_id: '26debfee-8c3b-4c23-b08f-67f223de9832',
+  roles: ['student'],
+  session_id: '6bbb8d1d-442d-4575-a0ad-d1e34f37cae3',
+  user: {
+    email: 'sarah@test-mooc.fr',
+    id: 'aaace992-49e3-4e01-b809-7a84b1b55b72',
+    username: null,
+  },
+};
+
 describe('initVideoWebsocket', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
   it('connects to the websocket and updates video zustand store when message is received', async () => {
     let initVideoWebsocket: any;
     jest.isolateModules(() => {
@@ -18,6 +68,8 @@ describe('initVideoWebsocket', () => {
     const video = videoMockFactory();
     useVideo.getState().addResource(video);
     const server = new WS(`ws://localhost:1234/ws/video/${video.id}/`);
+
+    mockGetDecodedJwt.mockReturnValue(ltiToken);
 
     global.window = Object.create(window);
     Object.defineProperty(window, 'location', {
@@ -31,6 +83,55 @@ describe('initVideoWebsocket', () => {
 
     initVideoWebsocket!(video);
     await server.connected;
+
+    expect(mockGetOrInitAnonymousId).not.toHaveBeenCalled();
+
+    const updatedVideo = {
+      ...video,
+      title: 'updated title',
+    };
+
+    server.send(
+      JSON.stringify({
+        type: modelName.VIDEOS,
+        resource: updatedVideo,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(useVideo.getState().getVideo(video)).toEqual(updatedVideo);
+    });
+
+    server.close();
+    WS.clean();
+  });
+
+  it('connects to the websocket using an anonymous id', async () => {
+    let initVideoWebsocket: any;
+    jest.isolateModules(() => {
+      initVideoWebsocket = require('./websocket').initVideoWebsocket;
+    });
+    const video = videoMockFactory();
+    useVideo.getState().addResource(video);
+    const server = new WS(`ws://localhost:1234/ws/video/${video.id}/`);
+
+    mockGetDecodedJwt.mockReturnValue(publicToken);
+    mockGetOrInitAnonymousId.mockReturnValue(uuidv4());
+
+    global.window = Object.create(window);
+    Object.defineProperty(window, 'location', {
+      value: {
+        href: 'http://localhost:1234/',
+        host: 'localhost:1234',
+        protocol: 'http',
+      },
+      writable: true,
+    });
+
+    initVideoWebsocket!(video);
+    await server.connected;
+
+    expect(mockGetOrInitAnonymousId).toHaveBeenCalled();
 
     const updatedVideo = {
       ...video,
@@ -61,6 +162,8 @@ describe('initVideoWebsocket', () => {
     useVideo.getState().addResource(video);
     const server = new WS(`wss://localhost:4321/ws/video/${video.id}/`);
 
+    mockGetDecodedJwt.mockReturnValue(ltiToken);
+
     global.window = Object.create(window);
     Object.defineProperty(window, 'location', {
       value: {
@@ -73,6 +176,8 @@ describe('initVideoWebsocket', () => {
 
     initVideoWebsocket!(video);
     await server.connected;
+
+    expect(mockGetOrInitAnonymousId).not.toHaveBeenCalled();
 
     const updatedVideo = {
       ...video,

--- a/src/frontend/utils/getOrInitAnonymousId.spec.ts
+++ b/src/frontend/utils/getOrInitAnonymousId.spec.ts
@@ -1,0 +1,93 @@
+import { v4 as uuidv4 } from 'uuid';
+
+import { getDecodedJwt } from 'data/appData';
+import { getOrInitAnonymousId } from './getOrInitAnonymousId';
+import { getAnonymousId, setAnonymousId } from './localstorage';
+
+jest.mock('data/appData', () => ({
+  getDecodedJwt: jest.fn(),
+}));
+jest.mock('./localstorage', () => ({
+  getAnonymousId: jest.fn(),
+  setAnonymousId: jest.fn(),
+}));
+
+const mockGetDecodedJwt = getDecodedJwt as jest.MockedFunction<
+  typeof getDecodedJwt
+>;
+const mockGetAnonymousId = getAnonymousId as jest.MockedFunction<
+  typeof getAnonymousId
+>;
+const mockSetAnonymousId = setAnonymousId as jest.MockedFunction<
+  typeof setAnonymousId
+>;
+
+const publicToken = {
+  locale: 'en',
+  maintenance: false,
+  permissions: {
+    can_access_dashboard: false,
+    can_update: false,
+  },
+  resource_id: '26debfee-8c3b-4c23-b08f-67f223de9832',
+  roles: ['none'],
+  session_id: '6bbb8d1d-442d-4575-a0ad-d1e34f37cae3',
+};
+
+const ltiToken = {
+  context_id: 'course-v1:ufr+mathematics+0001',
+  consumer_site: '112cf553-b8c3-4b98-9d47-d0793284b9b3',
+  locale: 'en_US',
+  maintenance: false,
+  permissions: {
+    can_access_dashboard: false,
+    can_update: false,
+  },
+  resource_id: '26debfee-8c3b-4c23-b08f-67f223de9832',
+  roles: ['student'],
+  session_id: '6bbb8d1d-442d-4575-a0ad-d1e34f37cae3',
+  user: {
+    email: 'sarah@test-mooc.fr',
+    id: 'aaace992-49e3-4e01-b809-7a84b1b55b72',
+    username: null,
+  },
+};
+
+describe('initAnonymousId', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('set the anonymous_is when present in the token and return it', () => {
+    const anonymousId = uuidv4();
+    mockGetDecodedJwt.mockReturnValue({
+      ...publicToken,
+      user: {
+        anonymous_id: anonymousId,
+        email: null,
+      },
+    });
+
+    expect(getOrInitAnonymousId()).toEqual(anonymousId);
+    expect(mockSetAnonymousId).toHaveBeenCalledWith(anonymousId);
+    expect(mockGetAnonymousId).not.toHaveBeenCalled();
+  });
+
+  it('generates a new anonymous_id when the public token does not contains one', () => {
+    const anonynousId = uuidv4();
+    mockGetDecodedJwt.mockReturnValue(publicToken);
+    mockGetAnonymousId.mockReturnValue(anonynousId);
+
+    expect(getOrInitAnonymousId()).toEqual(anonynousId);
+    expect(mockSetAnonymousId).not.toHaveBeenCalled();
+    expect(mockGetAnonymousId).toHaveBeenCalled();
+  });
+
+  it('does nothing when the token is not a public one', () => {
+    mockGetDecodedJwt.mockReturnValue(ltiToken);
+
+    expect(getOrInitAnonymousId()).toBeUndefined();
+    expect(mockSetAnonymousId).not.toHaveBeenCalled();
+    expect(mockGetAnonymousId).not.toHaveBeenCalled();
+  });
+});

--- a/src/frontend/utils/getOrInitAnonymousId.ts
+++ b/src/frontend/utils/getOrInitAnonymousId.ts
@@ -1,0 +1,15 @@
+import { getDecodedJwt } from 'data/appData';
+import { checkLtiToken } from './checkLtiToken';
+import { getAnonymousId, setAnonymousId } from './localstorage';
+
+export const getOrInitAnonymousId = () => {
+  const decodedJwt = getDecodedJwt();
+  let anonymousId = decodedJwt.user?.anonymous_id;
+  if (anonymousId) {
+    setAnonymousId(anonymousId);
+  } else if (!checkLtiToken(decodedJwt)) {
+    anonymousId = getAnonymousId();
+  }
+
+  return anonymousId;
+};

--- a/src/frontend/utils/initWebinarContext.ts
+++ b/src/frontend/utils/initWebinarContext.ts
@@ -1,10 +1,8 @@
-import { getDecodedJwt } from 'data/appData';
 import { getLiveSessions } from 'data/sideEffects/getLiveSessions';
 import { pushAttendance } from 'data/sideEffects/pushAttendance';
 import { useLiveSession } from 'data/stores/useLiveSession';
 import { Video } from 'types/tracks';
-import { checkLtiToken } from './checkLtiToken';
-import { getAnonymousId, setAnonymousId } from './localstorage';
+import { getOrInitAnonymousId } from './getOrInitAnonymousId';
 
 export const initWebinarContext = async (video: Video) => {
   // if not a live, stop it.
@@ -12,13 +10,8 @@ export const initWebinarContext = async (video: Video) => {
 
   // If live registration already present, stop it.
   if (useLiveSession.getState().liveSession) return;
-  const decodedJwt = getDecodedJwt();
-  let anonymousId = decodedJwt.user?.anonymous_id;
-  if (anonymousId) {
-    setAnonymousId(anonymousId);
-  } else if (!checkLtiToken(decodedJwt)) {
-    anonymousId = getAnonymousId();
-  }
+
+  const anonymousId = getOrInitAnonymousId();
 
   // check if registered
   const results = await getLiveSessions(anonymousId);


### PR DESCRIPTION
## Purpose

To connect to a websocket, we need to add the anonymous_id in the query
string when the current token in a public one.

## Proposal

- [x] manage anonymous_id with websocket

