### PR TITLE
🐛(back) continue stopping live even if input waiter fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ right (and close / open it)
 - Do not allow a lti user to change his email when he registers to a scheduled 
   live
 - Expose XMPP info for a live once this one started
+- Continue stopping live even if input waiter fails
 
 ## [4.0.0-beta.1] - 2022-02-15
 

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -267,6 +267,8 @@ class Base(Configuration):
     AWS_UPLOAD_EXPIRATION_DELAY = values.Value(24 * 60 * 60)  # 24h
     AWS_MEDIALIVE_ROLE_ARN = values.SecretValue()
     AWS_MEDIAPACKAGE_HARVEST_JOB_ARN = values.SecretValue()
+    AWS_MEDIALIVE_INPUT_WAITER_DELAY = values.PositiveIntegerValue(5)
+    AWS_MEDIALIVE_INPUT_WAITER_MAX_ATTEMPTS = values.PositiveIntegerValue(84)
 
     # BBB
     BBB_ENABLED = values.BooleanValue(False)


### PR DESCRIPTION
## Purpose

The medialive input waiter can fails when we try to delete the aws
stack. If the max attempt is reached, a WaiterError is raised, the
endpoint return a 500 and then it is not possible any more to stop a
live. To fix this issue, the WaiterError exception is catch and sent to
sentry and the stop endpoint continues its job.

## Proposal

- [x] continue stopping live even if input waiter fails

