### PR TITLE
🔨(dev) limit iframe width

### DIFF
--- a/src/backend/marsha/core/templates/core/lti_development.html
+++ b/src/backend/marsha/core/templates/core/lti_development.html
@@ -44,7 +44,7 @@
         max-width: 40rem;
       }
       section iframe {
-        width: 100%;
+        width: 900px;
         height: 100px; /* Explicitly set a bogus height to force iframe-resizer action */
         resize: both;
         overflow: auto;


### PR DESCRIPTION
## Purpose

To be more accurate with how Marsha is used in a LMS, we decided to
limit the iframe width where the LTI request is used in the development
template. Doing this, we don't have to integrate Marsha in LMS to detect
some bugs.

## Proposal

- [x] limit iframe width

