### PR TITLE
🐛(back) dispatch video in the websocket when start/stop recording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ the video to the ViewersList in the right panel
   live
 - Expose XMPP info for a live once this one started
 - Continue stopping live even if input waiter fails
+- Dispatch video in the websocket when start/stop recording
 
 ### Removed
 

--- a/src/backend/marsha/core/api/video.py
+++ b/src/backend/marsha/core/api/video.py
@@ -857,6 +857,9 @@ class VideoViewSet(ObjectPkMixin, viewsets.ModelViewSet):
             start_recording(video)
         except VideoRecordingError as error:
             return Response({"detail": str(error)}, status=400)
+
+        channel_layers_utils.dispatch_video_to_groups(video)
+
         serializer = self.get_serializer(video)
         return Response(serializer.data)
 
@@ -894,5 +897,8 @@ class VideoViewSet(ObjectPkMixin, viewsets.ModelViewSet):
             stop_recording(video)
         except VideoRecordingError as error:
             return Response({"detail": str(error)}, status=400)
+
+        channel_layers_utils.dispatch_video_to_groups(video)
+
         serializer = self.get_serializer(video)
         return Response(serializer.data)


### PR DESCRIPTION
## Purpose

When the recording is started or stopped, the video is not dispatched in
the websocket. No other participant are aware that the video is
recording.
Fixes #1476

## Proposal

- [x] Dispatch video in the websocket when start/stop recording
