### PR TITLE
🐛(front) Fix registration to scheduled events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,7 @@ the video to the ViewersList in the right panel
   earlier
 - Update store in the WaitingLiveVideo component
 - Set specific timeout to 30 seconds in pollForLive to update the store
+- Fix registration to scheduled events 
 
 ### Removed
 

--- a/src/frontend/components/PublicVideoDashboard/index.spec.tsx
+++ b/src/frontend/components/PublicVideoDashboard/index.spec.tsx
@@ -570,7 +570,7 @@ describe('PublicVideoDashboard', () => {
     screen.getByText('Error Component: liveStopped');
   });
 
-  it('redirects to the dashboard when user has update permission and live state is stopped', () => {
+  it('redirects to the dashboard when user has update permission and live state is stopped', async () => {
     mockCanUpdate = true;
     const video = videoMockFactory({
       live_state: liveState.STOPPED,
@@ -596,7 +596,6 @@ describe('PublicVideoDashboard', () => {
         ),
       ),
     );
-
     screen.getByText('dashboard videos');
   });
 
@@ -615,14 +614,13 @@ describe('PublicVideoDashboard', () => {
         ),
       ),
     );
-
-    screen.getByRole('heading', {
-      name: 'Live is starting',
+    await waitFor(() => {
+      expect(mockInitWebinarContext).toHaveBeenCalled();
     });
-    expect(mockInitWebinarContext).not.toHaveBeenCalled();
+    screen.getByRole('heading', { name: 'Live is starting' });
   });
 
-  it('displays the WaitingLiveVideo component when live_state is IDLE and video is not scheduled', () => {
+  it('displays the WaitingLiveVideo component when live_state is IDLE and video is not scheduled', async () => {
     const video = videoMockFactory({
       live_state: liveState.IDLE,
       is_scheduled: false,
@@ -639,10 +637,8 @@ describe('PublicVideoDashboard', () => {
       ),
     );
 
-    screen.getByRole('heading', {
-      name: 'Live is starting',
-    });
-    expect(mockInitWebinarContext).not.toHaveBeenCalled();
+    await screen.findByRole('heading', { name: 'Live is starting' });
+    expect(mockInitWebinarContext).toHaveBeenCalled();
   });
 
   it('displays the SubscribeScheduledVideo component when live_state is IDLE and video is scheduled', async () => {
@@ -671,11 +667,10 @@ describe('PublicVideoDashboard', () => {
         ),
       ),
     );
-
     await screen.findByRole('button', { name: /register/i });
     screen.getByRole('heading', {
       name: /Live will start in 2 days at 11:00 AM/i,
     });
-    expect(mockInitWebinarContext).not.toHaveBeenCalled();
+    expect(mockInitWebinarContext).toHaveBeenCalled();
   });
 });

--- a/src/frontend/components/PublicVideoDashboard/index.tsx
+++ b/src/frontend/components/PublicVideoDashboard/index.tsx
@@ -1,10 +1,11 @@
 import { Box } from 'grommet';
-import React from 'react';
+import React, { useState } from 'react';
 import { Redirect } from 'react-router-dom';
 
 import { DASHBOARD_ROUTE } from 'components/Dashboard/route';
 import { DownloadVideo } from 'components/DownloadVideo';
 import { FULL_SCREEN_ERROR_ROUTE } from 'components/ErrorComponents/route';
+import { Loader } from 'components/Loader';
 import { LiveVideoWrapper } from 'components/StudentLiveWrapper';
 import { Transcripts } from 'components/Transcripts';
 import VideoPlayer from 'components/VideoPlayer';
@@ -36,10 +37,13 @@ const PublicVideoDashboard = ({
   const timedTextTracks = useTimedTextTrack((state) =>
     state.getTimedTextTracks(),
   );
+  const [isReadyLive, setIsReadyLive] = useState(false);
 
   useAsyncEffect(async () => {
-    if (video.live_state && video.live_state !== liveState.IDLE) {
+    if (video.live_state && video.live_state !== liveState.STOPPED) {
       await initWebinarContext(video);
+      initVideoWebsocket(video);
+      setIsReadyLive(true);
     }
   }, [video.live_state]);
 
@@ -53,9 +57,11 @@ const PublicVideoDashboard = ({
       // otherwise the user can only see a message
       return <Redirect push to={FULL_SCREEN_ERROR_ROUTE('liveStopped')} />;
     }
-
-    initVideoWebsocket(video);
-    return <LiveVideoWrapper video={video} playerType={playerType} />;
+    return isReadyLive ? (
+      <LiveVideoWrapper video={video} playerType={playerType} />
+    ) : (
+      <Loader />
+    );
   }
 
   const transcripts = timedTextTracks


### PR DESCRIPTION


## Purpose

LiveVideoWrapper component could be loaded without
the initialization of the LiveSession. This resulted
in not being able to register, as two LiveSessions
were created simultaneously.

## Proposal

Force the creation of the LiveSession before loading LiveVideoWrapper component 

