### PR TITLE
🩹(front) fix avatar icon's crushed width in chat

### DIFF
--- a/src/frontend/components/Chat/SharedChatComponents/ChatMessageMetadatas/index.tsx
+++ b/src/frontend/components/Chat/SharedChatComponents/ChatMessageMetadatas/index.tsx
@@ -51,7 +51,9 @@ export const ChatMessageMetadatas = ({
         bottom: '9px',
       }}
     >
-      <ChatAvatar />
+      <Box>
+        <ChatAvatar />
+      </Box>
       <Box
         margin={{
           left: '10px',


### PR DESCRIPTION
The width of the user's avatar icon was crushed and was not making a square, as
it was supposed to do.