### PR TITLE
♻️(i18n) emails must be generated before the i18n job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1272,6 +1272,7 @@ workflows:
       - build-back-i18n:
           requires:
             - build-back
+            - build-mails
           filters:
             tags:
               only: /.*/


### PR DESCRIPTION
## Purpose

For crowdin to detect the translations needed for emails,
the circle ci needs to run the i18n job after the job
that generates emails.

## Proposal

add build-mail as a dependance

