### PR TITLE
🔖(beta) bump release to 4.0.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.0.0-beta.2] - 2022-04-13
+
 ### Added
 
 - Add a view to cancel reminder mails, link added in the footer of mails
@@ -1064,7 +1066,8 @@ the video to the ViewersList in the right panel
 
 - Minor fixes and improvements on features and tests
 
-[unreleased]: https://github.com/openfun/marsha/compare/v4.0.0-beta.1...master
+[unreleased]: https://github.com/openfun/marsha/compare/v4.0.0-beta.2...master
+[4.0.0-beta.2]: https://github.com/openfun/marsha/compare/v4.0.0-beta.1...v4.0.0-beta.2
 [4.0.0-beta.1]: https://github.com/openfun/marsha/compare/v3.27.0...v4.0.0-beta.1
 [3.27.0]: https://github.com/openfun/marsha/compare/v3.26.0...v3.27.0
 [3.26.0]: https://github.com/openfun/marsha/compare/v3.25.0...v3.26.0

--- a/src/aws/lambda-complete/package.json
+++ b/src/aws/lambda-complete/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-complete",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "engines": {
     "node": "14"
   },

--- a/src/aws/lambda-configure/package.json
+++ b/src/aws/lambda-configure/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-configure",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "engines": {
     "node": "14"
   },

--- a/src/aws/lambda-convert/package.json
+++ b/src/aws/lambda-convert/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-convert",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "engines": {
     "node": "14"
   },

--- a/src/aws/lambda-elemental-routing/package.json
+++ b/src/aws/lambda-elemental-routing/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-elemental-routing",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "engines": {
     "node": "14"
   },

--- a/src/aws/lambda-medialive/package.json
+++ b/src/aws/lambda-medialive/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-medialive",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "engines": {
     "node": "14"
   },

--- a/src/aws/lambda-mediapackage/package.json
+++ b/src/aws/lambda-mediapackage/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-mediapackage",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "engines": {
     "node": "14"
   },

--- a/src/aws/lambda-migrate/package.json
+++ b/src/aws/lambda-migrate/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-migrate",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "engines": {
     "node": "14"
   },

--- a/src/aws/utils/update-state/package.json
+++ b/src/aws/utils/update-state/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-update-state",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "engines": {
     "node": "14"
   },

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = marsha
 description = A FUN video provider for Open edX
-version = 4.0.0-beta.1
+version = 4.0.0-beta.2
 author = Open FUN (France Universite Numerique)
 author_email = fun.dev@fun-mooc.fr
 license = MIT

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marsha",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "description": "🐠 a FUN LTI video provider",
   "main": "front/index.tsx",
   "scripts": {


### PR DESCRIPTION
### Added

- Add a view to cancel reminder mails, link added in the footer of mails
- Prevent multiple join to BBB meetings
- Introduce anonymous_id mechanism
- Create a direct access to a video out of an LMS context for a public
  or LTI ressource, based on a liveregistration
- Auto-set in the localstorage anonymousId if it's set in the JWT token
- Persist live video participants
- Add a vertical slider on the live view, to resize the panel on the
right (and close / open it)
- Add PATCH endpoint to update a LiveSession
- Add start and stop live recording
- Generate a JWT token to connect to jitsi
- Save livesession registration date

### Changed

- rename LiveRegistration model in LiveSession
- Disable jitsi prejoin page
- Admin can access all LiveSession belonging to a video
- Move on-stage request functional (in Instructor view) from under
the video to the ViewersList in the right panel
- Prevent students from joining the discussion anonymously

### Fixed

- Allow to configure converse persistent store
- Show a specific message to students when BBB meeting ended
- Remove cancel button in student meeting join form
- Replace automatic meeting joining by a button
- Allow generated links in Django admin for objects in other applications
- Do not install the `marsha` Python package in `site-packages`
- Do not allow a lti user to change his email when he registers to a scheduled
  live
- Expose XMPP info for a live once this one started
- Continue stopping live even if input waiter fails
- Dispatch video in the websocket when start/stop recording
- Send registration email when livesession is updated and is_registered
  set to True
- Stop trying to start recording jitsi when this one is already live
- Live layout for teacher on smartphone
- Live recording actions visibility

### Removed

- Remove email when the webinar started earlier
- Remove video constraint video_unique_idx