### PR TITLE
patch video to publish it once harvested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- patch video to publish it once harvested
+
 ## [4.0.0-beta.2] - 2022-04-13
 
 ### Added

--- a/src/frontend/components/DashboardVideoHarvested/index.tsx
+++ b/src/frontend/components/DashboardVideoHarvested/index.tsx
@@ -6,14 +6,14 @@ import { Redirect } from 'react-router-dom';
 import {
   DashboardButton,
   DashboardButtonWithLink,
-} from '../DashboardPaneButtons/DashboardButtons';
-import { PLAYER_ROUTE } from '../routes';
-import { FULL_SCREEN_ERROR_ROUTE } from '../ErrorComponents/route';
-import { updateResource } from '../../data/sideEffects/updateResource';
-import { useVideo } from '../../data/stores/useVideo';
-import { modelName } from '../../types/models';
-import { Video, uploadState } from '../../types/tracks';
-import { report } from '../../utils/errors/report';
+} from 'components/DashboardPaneButtons/DashboardButtons';
+import { PLAYER_ROUTE } from 'components/routes';
+import { FULL_SCREEN_ERROR_ROUTE } from 'components/ErrorComponents/route';
+import { useVideo } from 'data/stores/useVideo';
+import { useUpdateVideo } from 'data/queries';
+import { modelName } from 'types/models';
+import { Video, uploadState } from 'types/tracks';
+import { report } from 'utils/errors/report';
 
 const messages = defineMessages({
   publish: {
@@ -40,19 +40,20 @@ export const DashboardVideoHarvested = ({
     updateVideo: state.addResource,
   }));
   const [error, setError] = useState<unknown>();
-
-  const onClick = async () => {
-    const updatedVideo = {
-      ...video,
-      upload_state: uploadState.READY,
-    };
-    try {
-      await updateResource(updatedVideo, modelName.VIDEOS);
+  const mutation = useUpdateVideo(video.id, {
+    onSuccess: (updatedVideo) => {
       updateVideo(updatedVideo);
-    } catch (err) {
+    },
+    onError: (err) => {
       report(err);
       setError(err);
-    }
+    },
+  });
+
+  const onClick = () => {
+    mutation.mutate({
+      upload_state: uploadState.READY,
+    });
   };
 
   if (error) {

--- a/src/frontend/components/DashboardVideoPane/index.spec.tsx
+++ b/src/frontend/components/DashboardVideoPane/index.spec.tsx
@@ -1,6 +1,7 @@
 import { cleanup, render, screen, act } from '@testing-library/react';
 import fetchMock from 'fetch-mock';
 import React from 'react';
+import { QueryClient, QueryClientProvider } from 'react-query';
 
 import { modelName } from 'types/models';
 import { uploadState, Video } from 'types/tracks';
@@ -234,15 +235,19 @@ describe('<DashboardVideoPane />', () => {
 
   it('shows the buttons only when the video is pending or ready', async () => {
     for (const state of Object.values(uploadState)) {
+      const queryClient = new QueryClient();
+
       const { getByText, queryByText } = render(
         wrapInIntlProvider(
           wrapInRouter(
-            <DashboardVideoPane
-              video={videoMockFactory({
-                is_ready_to_show: false,
-                upload_state: state,
-              })}
-            />,
+            <QueryClientProvider client={queryClient}>
+              <DashboardVideoPane
+                video={videoMockFactory({
+                  is_ready_to_show: false,
+                  upload_state: state,
+                })}
+              />
+            </QueryClientProvider>,
           ),
         ),
       );
@@ -268,15 +273,18 @@ describe('<DashboardVideoPane />', () => {
 
   it('shows the thumbnail only when the video is ready', async () => {
     for (const state of Object.values(uploadState)) {
+      const queryClient = new QueryClient();
       const { getByAltText, queryByAltText } = render(
         wrapInIntlProvider(
           wrapInRouter(
-            <DashboardVideoPane
-              video={videoMockFactory({
-                is_ready_to_show: false,
-                upload_state: state,
-              })}
-            />,
+            <QueryClientProvider client={queryClient}>
+              <DashboardVideoPane
+                video={videoMockFactory({
+                  is_ready_to_show: false,
+                  upload_state: state,
+                })}
+              />
+            </QueryClientProvider>,
           ),
         ),
       );
@@ -319,18 +327,21 @@ describe('<DashboardVideoPane />', () => {
 
   it('does not show the upload progress when the video is not uploading', () => {
     for (const state of Object.values(uploadState)) {
+      const queryClient = new QueryClient();
       render(
         <UploadManagerContext.Provider
           value={{ setUploadState: jest.fn(), uploadManagerState: {} }}
         >
           {wrapInIntlProvider(
             wrapInRouter(
-              <DashboardVideoPane
-                video={videoMockFactory({
-                  is_ready_to_show: false,
-                  upload_state: state,
-                })}
-              />,
+              <QueryClientProvider client={queryClient}>
+                <DashboardVideoPane
+                  video={videoMockFactory({
+                    is_ready_to_show: false,
+                    upload_state: state,
+                  })}
+                />
+              </QueryClientProvider>,
             ),
           )}
         </UploadManagerContext.Provider>,
@@ -344,9 +355,16 @@ describe('<DashboardVideoPane />', () => {
     const video = videoMockFactory({
       upload_state: uploadState.HARVESTED,
     });
+    const queryClient = new QueryClient();
 
     render(
-      wrapInIntlProvider(wrapInRouter(<DashboardVideoPane video={video} />)),
+      wrapInIntlProvider(
+        wrapInRouter(
+          <QueryClientProvider client={queryClient}>
+            <DashboardVideoPane video={video} />
+          </QueryClientProvider>,
+        ),
+      ),
     );
 
     screen.getByRole('button', { name: 'watch' });

--- a/src/frontend/data/queries/index.spec.tsx
+++ b/src/frontend/data/queries/index.spec.tsx
@@ -22,6 +22,7 @@ import {
   useThumbnail,
   useTimedTextTracks,
   useUpdatePlaylist,
+  useUpdateVideo,
   useVideo,
   useVideos,
 } from './index';
@@ -434,6 +435,62 @@ describe('queries', () => {
         body: JSON.stringify({
           playlist: video.playlist.id,
           title: video.title,
+        }),
+      });
+      expect(result.current.data).toEqual(undefined);
+      expect(result.current.status).toEqual('error');
+    });
+  });
+
+  describe('useUpdateVideo', () => {
+    it('updates the resource', async () => {
+      const video = videoMockFactory();
+      fetchMock.patch(`/api/videos/${video.id}/`, video);
+
+      const { result, waitFor } = renderHook(() => useUpdateVideo(video.id), {
+        wrapper: Wrapper,
+      });
+      result.current.mutate({
+        title: 'updated title',
+      });
+      await waitFor(() => result.current.isSuccess);
+
+      expect(fetchMock.lastCall()![0]).toEqual(`/api/videos/${video.id}/`);
+      expect(fetchMock.lastCall()![1]).toEqual({
+        headers: {
+          Authorization: 'Bearer some token',
+          'Content-Type': 'application/json',
+        },
+        method: 'PATCH',
+        body: JSON.stringify({
+          title: 'updated title',
+        }),
+      });
+      expect(result.current.data).toEqual(video);
+      expect(result.current.status).toEqual('success');
+    });
+
+    it('fails to update the resource', async () => {
+      const video = videoMockFactory();
+      fetchMock.patch(`/api/videos/${video.id}/`, 400);
+
+      const { result, waitFor } = renderHook(() => useUpdateVideo(video.id), {
+        wrapper: Wrapper,
+      });
+      result.current.mutate({
+        title: 'updated title',
+      });
+      await waitFor(() => result.current.isError);
+
+      expect(fetchMock.lastCall()![0]).toEqual(`/api/videos/${video.id}/`);
+      expect(fetchMock.lastCall()![1]).toEqual({
+        headers: {
+          Authorization: 'Bearer some token',
+          'Content-Type': 'application/json',
+        },
+        method: 'PATCH',
+        body: JSON.stringify({
+          title: 'updated title',
         }),
       });
       expect(result.current.data).toEqual(undefined);

--- a/src/frontend/data/queries/index.tsx
+++ b/src/frontend/data/queries/index.tsx
@@ -149,6 +149,40 @@ export const useCreateVideo = (options?: UseCreateVideoOptions) => {
   );
 };
 
+type UseUpdateVideoData = Partial<Video>;
+type UseUpdateVideoError =
+  | { code: 'exception' }
+  | {
+      code: 'invalid';
+      errors: { [key in keyof UseUpdateVideoData]?: string[] }[];
+    };
+type UseUpdateVideoOptions = UseMutationOptions<
+  Video,
+  UseUpdateVideoError,
+  UseUpdateVideoData
+>;
+export const useUpdateVideo = (id: string, options?: UseUpdateVideoOptions) => {
+  const queryClient = useQueryClient();
+  return useMutation<Video, UseUpdateVideoError, UseUpdateVideoData>(
+    (updatedVideo) => updateOne({ name: 'videos', id, object: updatedVideo }),
+    {
+      ...options,
+      onSuccess: (data, variables, context) => {
+        queryClient.invalidateQueries('videos');
+        if (options?.onSuccess) {
+          options.onSuccess(data, variables, context);
+        }
+      },
+      onError: (error, variables, context) => {
+        queryClient.invalidateQueries('videos');
+        if (options?.onError) {
+          options.onError(error, variables, context);
+        }
+      },
+    },
+  );
+};
+
 type VideosResponse = APIList<Video>;
 type UseVideosParams = {} | { organization: string };
 export const useVideos = (


### PR DESCRIPTION
## Purpose

Updating the video using a PUT request is not the better way to update a
video. The title is null when the video is created but we force it to
not be null when the user tries to update it. Using a PUT request, we
send the entire object and, sometimes, the title can be null. To fix
this issue, we decided to use a PATCH request and send only the needed
fields in the body.

## Proposal

- [x] implement `useUpdateVideo` with react-query
- [x] patch video to publish it once harvested