### PR TITLE
🔧(ci) attach workspace in build-back-i18n job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -254,6 +254,8 @@ jobs:
     steps:
       - checkout:
           path: ~/marsha
+      - attach_workspace:
+          at: ~/marsha
       - restore_cache:
           keys:
             - v4-back-dependencies-{{ .Revision }}


### PR DESCRIPTION
## Purpose

The email templates are missing in the build-back-i18n job and so their
translations string too. This is because the marsha workspace is not
attached in this job. We attach it in this commit to resolve this
issue.

## Proposal

- [x] Attach workspace in build-back-i18n job

