### PR TITLE
🎨(emails) mjml conversion to html and text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - patch video to publish it once harvested
+- mjml files format not to break `trans` instructions
 
 ## [4.0.0-beta.2] - 2022-04-13
 

--- a/src/backend/marsha/core/tests/test_api_livesession.py
+++ b/src/backend/marsha/core/tests/test_api_livesession.py
@@ -87,6 +87,10 @@ class LiveSessionApiTest(TestCase):
             email_content,
         )
 
+        # emails are generated from mjml format, test rendering of email doesn't
+        # contain any trans tag, it might happens if \n are generated
+        self.assertNotIn("trans", email_content)
+
     def test_api_livesession_read_anonymous(self):
         """Anonymous users should not be allowed to fetch a livesession."""
         video = VideoFactory()

--- a/src/backend/marsha/core/tests/test_command_send_reminders.py
+++ b/src/backend/marsha/core/tests/test_command_send_reminders.py
@@ -218,6 +218,8 @@ class SendRemindersTest(TestCase):
             mail.outbox[1].subject,
             "Live starts in less than 5 minutes",
         )
+        # check this kind of template is well formed
+        self.assertNotIn("trans", mail.outbox[0].body)
 
         self.assertIn(
             f"Access the event [//example.com/videos/{lti_livesession.video.pk}?lrpk="
@@ -430,6 +432,9 @@ class SendRemindersTest(TestCase):
             mail.outbox[1].subject,
             "Live starts in less than 3 hours",
         )
+        # check this kind of template is well formed
+        self.assertNotIn("trans", mail.outbox[0].body)
+
         self.assertIn(
             f"Access the event [//example.com/videos/{public_livesession.video.pk}?lrpk="
             f"{public_livesession.pk}&amp;key={public_livesession.get_generate_salted_hmac()}]",
@@ -651,6 +656,9 @@ class SendRemindersTest(TestCase):
             mail.outbox[1].subject,
             "Live starts in less than 3 days",
         )
+        # check this kind of template is well formed
+        self.assertNotIn("trans", mail.outbox[0].body)
+
         self.assertIn(
             f"Access the event [//example.com/videos/{lti_livesession.video.pk}?lrpk="
             f"{lti_livesession.pk}&amp;key={lti_livesession.get_generate_salted_hmac()}]",
@@ -1110,6 +1118,9 @@ class SendRemindersTest(TestCase):
             mail.outbox[1].subject,
             "Webinar has been updated.",
         )
+        # check this kind of template is well formed
+        self.assertNotIn("trans", mail.outbox[0].body)
+
         self.assertIn(
             f"Access the event [//example.com/videos/{lti_livesession.video.pk}?lrpk="
             f"{lti_livesession.pk}&amp;key={lti_livesession.get_generate_salted_hmac()}]",

--- a/src/mail/bin/html-to-plain-text
+++ b/src/mail/bin/html-to-plain-text
@@ -13,7 +13,7 @@ if [ ! -d "${DIR_MAILS}"html/ ]; then
 fi
 
 for file in "${DIR_MAILS}"html/*.html; 
-    do html-to-text < "$file" > "${file%.html}".txt; done; 
+    do html-to-text --wordwrap=600 < "$file" > "${file%.html}".txt; done; 
 
 if [ ! -d "${DIR_MAILS}"text/ ]; then
   mkdir -p "${DIR_MAILS}"text/;

--- a/src/mail/mjml/partial/footer.mjml
+++ b/src/mail/mjml/partial/footer.mjml
@@ -2,13 +2,13 @@
 
 <mj-section background-color="#000000" padding="15px">
   <mj-column vertical-align="top" width="100%">
-    <mj-text align="center" color="#FFFFFF" font-size="12px" padding="5px 25px">{% trans "This mail has been sent to" %} {{email}} {% trans "by Marsha"%}
+    <mj-text align="center" color="#FFFFFF" font-size="12px" padding="5px 25px">{%trans "This mail has been sent to" %} {{email}} {%trans "by Marsha"%}
     </mj-text>
   </mj-column>
   <mj-column padding="10px">
     <mj-text align="center" color="#9B9B9B" font-size="10px">
-      {% trans "Your email address is used because you have shown interest in this webinar. If you want to unsubscribe your email from these notifications, please follow the link : "%}
-      <a href="{{cancel_reminder_url}}" style="color: #ffffff">{% trans "unsubscribe" %}</a>.
+      {%trans "Your email address is used because you have shown interest in this webinar. If you want to unsubscribe your email from these notifications, please follow the link : "%}
+      <a href="{{cancel_reminder_url}}" style="color: #ffffff">{%trans "unsubscribe"%}</a>.
     </mj-text>
   </mj-column>
 </mj-section>

--- a/src/mail/mjml/partial/hello.mjml
+++ b/src/mail/mjml/partial/hello.mjml
@@ -1,4 +1,4 @@
 <mj-text align="center" font-size="18px" padding="20px 25px">
-  {% if username %} {% trans "Hello" %} {{username}}, {% else %} {% trans
-  "Hello," %} {% endif %}
+  {%if username%} {%trans "Hello"%} {{username}}, {%else%} 
+  {%trans "Hello,"%} {%endif%}
 </mj-text>

--- a/src/mail/mjml/partial/video_access_url.mjml
+++ b/src/mail/mjml/partial/video_access_url.mjml
@@ -1,7 +1,7 @@
 <mj-section>
   <mj-column width="100%">
     <mj-button background-color="#e51a2d" color="#FFFFFF" href="{{video_access_url}}" padding="20px 0 0 0" font-weight="bold" font-size="16px">
-      {% trans "Access the event" %}
+      {%trans "Access the event"%}
     </mj-button>
   </mj-column>
 </mj-section>
@@ -10,7 +10,7 @@
 <mj-section background-color="#F5f5f5">
   <mj-column width="100%" padding="20px">
     <mj-text align="center" color="#000000" font-size="13px" padding="4px 25px">
-      {% trans "Do not forward this email or share this link. It contains your personal code to access the event."%}
+      {%trans "Do not forward this email or share this link. It contains your personal code to access the event."%}
     </mj-text>
   </mj-column>
 </mj-section>

--- a/src/mail/mjml/register.mjml
+++ b/src/mail/mjml/register.mjml
@@ -5,7 +5,7 @@
       <mj-column background-color="#008000">
         <mj-text>{% load i18n %}</mj-text>
         <mj-text align="center" color="#FFFFFF" font-size="15px" padding="8px 8px">
-          {% trans "Registration validated!"%}
+          {%trans "Registration validated!"%}
         </mj-text>
       </mj-column>
     </mj-section>
@@ -14,8 +14,9 @@
       <mj-column width="100%">
         <mj-include path="./partial/hello.mjml" />
         <mj-text align="center" font-size="18px" padding="10px 50px">
-          {% trans "We have taken note of your interest in the event " %} "{{video.title}}".
-          {% trans "We'll meet you at " %}{{video.starting_at}} {{time_zone}} {% trans "for the start of the webinar." %}
+          {%trans "We have taken note of your interest in the event "%} "{{video.title}}".
+          {%trans "We'll meet you at "%}{{video.starting_at}} {{time_zone}} 
+          {%trans "for the start of the webinar."%}
         </mj-text>
       </mj-column>
     </mj-section>

--- a/src/mail/mjml/reminder.mjml
+++ b/src/mail/mjml/reminder.mjml
@@ -4,7 +4,7 @@
     <mj-section background-color="#2a5cab" padding="10px 0">
       <mj-column background-color="#e51a2d">
         <mj-text>{% load i18n %}</mj-text>
-        <mj-text align="center" color="#ffffff" font-size="15px" padding="8px 8px"><strong>{% trans "Get ready! The live is starting " %}{{reminder_timer_title}}</strong></mj-text>
+        <mj-text align="center" color="#ffffff" font-size="15px" padding="8px 8px"><strong>{%trans "Get ready! The live is starting in less than "%}{{reminder_timer_title}}</strong></mj-text>
       </mj-column>
     </mj-section>
     <mj-include path="./partial/video_description.mjml" />
@@ -12,9 +12,9 @@
       <mj-column width="100%">
         <mj-include path="./partial/hello.mjml" />
         <mj-text align="center" font-size="18px" padding="20px 50px">
-          {% trans "Our event" %} "{{video.title}}" {% trans "will start" %} {{reminder_timer_title}}.
+          {%trans "Our event"%} "{{video.title}}" {%trans "will start in less than "%}{{reminder_timer_title}}.
         </mj-text>
-        <mj-text align="center" font-size="18px" padding="10px 50px">{% trans "Get ready to join us."%}</mj-text>
+        <mj-text align="center" font-size="18px" padding="10px 50px">{%trans "Get ready to join us."%}</mj-text>
       </mj-column>
     </mj-section>
     <mj-include path="./partial/footer.mjml" />

--- a/src/mail/mjml/reminder_date_updated.mjml
+++ b/src/mail/mjml/reminder_date_updated.mjml
@@ -4,7 +4,7 @@
     <mj-section background-color="#2a5cab" padding="10px 0">
       <mj-column background-color="#e51a2d">
         <mj-text>{% load i18n %}</mj-text>
-        <mj-text align="center" color="#ffffff" font-size="15px" padding="8px 8px"><strong>{% trans "Our event has been updated, the date has changed!" %}</strong></mj-text>
+        <mj-text align="center" color="#ffffff" font-size="15px" padding="8px 8px"><strong>{%trans "Our event has been updated, the date has changed!"%}</strong></mj-text>
       </mj-column>
     </mj-section>
     <mj-include path="./partial/video_description.mjml" />
@@ -12,8 +12,8 @@
       <mj-column width="100%">
         <mj-include path="./partial/hello.mjml" />
         <mj-text align="center" font-size="18px" padding="20px 50px">
-          {% trans "Our event" %} "{{video.title}}" {% trans "had some updates." %}
-          {% trans "We'll meet you at " %}{{video.starting_at}} {{time_zone}} {% trans "for the start of the webinar." %}
+          {%trans "Our event" %} "{{video.title}}" {%trans "had some updates."%}
+          {%trans "We'll meet you at " %}{{video.starting_at}} {{time_zone}} {% trans "for the start of the webinar."%}
         </mj-text>
       </mj-column>
     </mj-section>


### PR DESCRIPTION


## Purpose

Previous commit 2c72a92a already indicated that mjml files were capricious.
New lines were inserted in html and text files and disrupted the
translation of the file. To be consistent, all the spaces before the `trans`
tags have been deleted. For text versions of emails, the word wrapping has
been set so that `trans` instructions don't get broken. In order to keep
the conversion of the mjml files into html and text reliable, tests have
been added to make sure, there are no `trans` tags that don't get properly
transformed.

## Proposal

format mjml files, test there is no tag trans in the mail content, stop wordwrapping with the conversion to text

NB: in the documentation of html-to-text it said that word wrapping can be canceled with the value Null or False, unfortunately, it doesn't give the right result, it's why it has been set to a large number

