### PR TITLE
♻️(front) move appairing component in a dashboard widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ control the live
 - Add a widget to modify live title and allow / disallow live recording
 - Add a widget to schedule live and modify description
 
+### Changed
+
+- Move appairing device component in the widget dashboard
 
 ## [4.0.0-beta.3] - 2022-04-22
 
@@ -25,9 +28,6 @@ control the live
 - Send emails in current livesession's language
 - Load livesession's language in the JWT token for direct access 
 from email
-- Add a control pane destined to contain widgets for the instructor to 
-control the live
-- Add a widget to modify live title and allow / disallow live recording
 
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ control the live
 - Send emails in current livesession's language
 - Load livesession's language in the JWT token for direct access 
 from email
+- Add a control pane destined to contain widgets for the instructor to 
+control the live
+- Add a widget to modify live title and allow / disallow live recording
+
 
 ### Fixed
 

--- a/src/frontend/components/Dashboard/DashboardVideoWrapper/index.spec.tsx
+++ b/src/frontend/components/Dashboard/DashboardVideoWrapper/index.spec.tsx
@@ -127,8 +127,6 @@ describe('<DashboardVideoWrapper />', () => {
     );
 
     expect(spiedInitVideoWebsocket).toHaveBeenCalled();
-
-    await screen.findByRole('button', { name: 'Pair an external device' });
   });
 
   it('renders the video layout when live_state is null', async () => {

--- a/src/frontend/components/DashboardVideoLive/index.spec.tsx
+++ b/src/frontend/components/DashboardVideoLive/index.spec.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import fetchMock from 'fetch-mock';
 import React, { Suspense, useEffect } from 'react';
@@ -46,12 +46,6 @@ jest.mock(
   'components/DashboardVideoLiveJitsi',
   () => mockDashboardVideoLiveJitsi,
 );
-
-jest.mock('components/DashboardVideoLivePairing', () => ({
-  DashboardVideoLivePairing: (props: { video: Video }) => (
-    <span title={`Pairing button for ${props.video.id}`} />
-  ),
-}));
 
 let queryClient: QueryClient;
 
@@ -253,30 +247,6 @@ describe('components/DashboardVideoLive', () => {
     );
     screen.getByRole('textbox', { name: 'Enter title of your live here' });
     screen.getByDisplayValue(/maths/i);
-  });
-
-  it('shows the pairing button when the status is not STOPPED', () => {
-    for (const state of Object.values(liveState)) {
-      const { getByTitle, queryByTitle } = render(
-        wrapInIntlProvider(
-          wrapInRouter(
-            <QueryClientProvider client={queryClient}>
-              <Suspense fallback="loading...">
-                <DashboardVideoLive video={{ ...video, live_state: state }} />
-              </Suspense>
-            </QueryClientProvider>,
-          ),
-        ),
-      );
-      if (state !== liveState.STOPPED) {
-        getByTitle(`Pairing button for ${video.id}`);
-      } else {
-        expect(
-          queryByTitle(`Pairing button for ${video.id}`),
-        ).not.toBeInTheDocument();
-      }
-      cleanup();
-    }
   });
 
   it('prompts display name form when trying to join the chat', async () => {

--- a/src/frontend/components/DashboardVideoLive/index.tsx
+++ b/src/frontend/components/DashboardVideoLive/index.tsx
@@ -83,7 +83,7 @@ export const DashboardVideoLive = ({ video }: DashboardVideoLiveProps) => {
               </Fragment>
             }
             additionalContent={
-              <Fragment>
+              <Box background="bg-marsha">
                 <Box direction={'row'} justify={'center'} margin={'small'}>
                   {appData.flags?.live_raw &&
                     video.live_state &&
@@ -98,7 +98,7 @@ export const DashboardVideoLive = ({ video }: DashboardVideoLiveProps) => {
                   </Box>
                 )}
                 <DashboardVideoLiveControlPane video={video} />
-              </Fragment>
+              </Box>
             }
             displayActionsElement
             isPanelOpen={isPanelVisible}

--- a/src/frontend/components/DashboardVideoLive/index.tsx
+++ b/src/frontend/components/DashboardVideoLive/index.tsx
@@ -3,7 +3,6 @@ import React, { Fragment, useEffect, useState } from 'react';
 
 import { ConverseInitializer } from 'components/ConverseInitializer';
 import { DashboardVideoLiveControlPane } from 'components/DashboardVideoLiveControlPane';
-import { DashboardVideoLivePairing } from 'components/DashboardVideoLivePairing';
 import { LiveVideoLayout } from 'components/LiveVideoLayout';
 import { LiveVideoPanel } from 'components/LiveVideoPanel';
 import { TeacherLiveContent } from 'components/TeacherLiveContent';
@@ -83,22 +82,18 @@ export const DashboardVideoLive = ({ video }: DashboardVideoLiveProps) => {
               </Fragment>
             }
             additionalContent={
-              <Box background="bg-marsha">
-                <Box direction={'row'} justify={'center'} margin={'small'}>
-                  {appData.flags?.live_raw &&
-                    video.live_state &&
-                    [liveState.IDLE, liveState.PAUSED].includes(
-                      video.live_state,
-                    ) && <TeacherLiveTypeSwitch video={video} />}
-                </Box>
-
-                {video.live_state !== liveState.STOPPED && (
-                  <Box direction={'row'} justify={'center'} margin={'small'}>
-                    <DashboardVideoLivePairing video={video} />
-                  </Box>
-                )}
+              <Fragment>
+                {appData.flags?.live_raw &&
+                  video.live_state &&
+                  [liveState.IDLE, liveState.PAUSED].includes(
+                    video.live_state,
+                  ) && (
+                    <Box direction={'row'} justify={'center'} margin={'small'}>
+                      <TeacherLiveTypeSwitch video={video} />
+                    </Box>
+                  )}
                 <DashboardVideoLiveControlPane video={video} />
-              </Box>
+              </Fragment>
             }
             displayActionsElement
             isPanelOpen={isPanelVisible}

--- a/src/frontend/components/DashboardVideoLiveControlPane/index.spec.tsx
+++ b/src/frontend/components/DashboardVideoLiveControlPane/index.spec.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { ResponsiveContext } from 'grommet';
 import { DateTime } from 'luxon';
 import React from 'react';
@@ -70,5 +71,14 @@ describe('<DashboardVideoLiveControlPane />', () => {
     });
     expect(textArea).toHaveValue('An example description');
     screen.getByPlaceholderText('Description...');
+
+    // DashboardVideoLiveWidgetLivePairing
+    const openButton = screen.getByRole('button', {
+      name: 'External broadcast sources',
+    });
+    userEvent.click(openButton);
+    screen.getByRole('button', {
+      name: /pair an external device/i,
+    });
   });
 });

--- a/src/frontend/components/DashboardVideoLiveControlPane/index.tsx
+++ b/src/frontend/components/DashboardVideoLiveControlPane/index.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { DashboardVideoLiveWidgetsContainer } from 'components/DashboardVideoLiveControlPane/widgets/DashboardVideoLiveWidgetsContainer';
 import { DashboardVideoLiveWidgetGeneralTitle } from 'components/DashboardVideoLiveControlPane/widgets/DashboardVideoLiveWidgetGeneralTitle';
 import { DashboardVideoLiveWidgetSchedulingAndDescription } from 'components/DashboardVideoLiveControlPane/widgets/DashboardVideoLiveWidgetSchedulingAndDescription';
+import { DashboardVideoLiveWidgetLivePairing } from './widgets/DashboardVideoLiveWidgetLivePairing';
 import { Video } from 'types/tracks';
 
 interface DashboardVideoLiveControlPaneProps {
@@ -16,6 +17,7 @@ export const DashboardVideoLiveControlPane = ({
     <DashboardVideoLiveWidgetsContainer>
       <DashboardVideoLiveWidgetGeneralTitle video={video} />
       <DashboardVideoLiveWidgetSchedulingAndDescription video={video} />
+      <DashboardVideoLiveWidgetLivePairing video={video} />
     </DashboardVideoLiveWidgetsContainer>
   );
 };

--- a/src/frontend/components/DashboardVideoLiveControlPane/widgets/DashboardVideoLiveWidgetLivePairing/index.spec.tsx
+++ b/src/frontend/components/DashboardVideoLiveControlPane/widgets/DashboardVideoLiveWidgetLivePairing/index.spec.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from 'react-query';
+
+import { liveState } from 'types/tracks';
+import { videoMockFactory } from 'utils/tests/factories';
+import { wrapInIntlProvider } from 'utils/tests/intl';
+import { DashboardVideoLiveWidgetLivePairing } from '.';
+
+jest.mock('data/appData', () => ({
+  appData: {
+    jwt: 'some token',
+  },
+}));
+
+describe('DashboardVideoLiveWidgetLivePairing', () => {
+  it('displays the appairing button', () => {
+    const video = videoMockFactory({
+      live_state: liveState.IDLE,
+    });
+    const queryClient = new QueryClient();
+
+    render(
+      wrapInIntlProvider(
+        <QueryClientProvider client={queryClient}>
+          <DashboardVideoLiveWidgetLivePairing video={video} />
+        </QueryClientProvider>,
+      ),
+    );
+
+    expect(
+      screen.queryByRole('button', {
+        name: /pair an external device/i,
+      }),
+    ).not.toBeInTheDocument();
+
+    // open the widget
+    const openButton = screen.getByRole('button', {
+      name: 'External broadcast sources',
+    });
+    userEvent.click(openButton);
+
+    screen.getByRole('button', {
+      name: /pair an external device/i,
+    });
+  });
+});

--- a/src/frontend/components/DashboardVideoLiveControlPane/widgets/DashboardVideoLiveWidgetLivePairing/index.tsx
+++ b/src/frontend/components/DashboardVideoLiveControlPane/widgets/DashboardVideoLiveWidgetLivePairing/index.tsx
@@ -1,0 +1,43 @@
+import { Box } from 'grommet';
+import React from 'react';
+import { defineMessages, useIntl } from 'react-intl';
+
+import { Video } from 'types/tracks';
+import { DashboardVideoLivePairing } from 'components/DashboardVideoLivePairing';
+import { DashboardVideoLiveWidgetTemplate } from 'components/DashboardVideoLiveControlPane/widgets/DashboardVideoLiveWidgetTemplate';
+
+const messages = defineMessages({
+  title: {
+    defaultMessage: 'External broadcast sources',
+    description: 'Title used in the external broadcast dashboard widget',
+    id: 'components.DashboardVideoLiveControlPane.widgets.DashboardVideoLiveWidgetLiePairing.title',
+  },
+  info: {
+    defaultMessage:
+      'The appairing button allows you to appair an external device and connect you to the current jitsi room.',
+    description:
+      'Helper explaining what contains the external sources widget and how to use the appairing button',
+    id: 'components.DashboardVideoLiveControlPane.widgets.DashboardVideoLiveWidgetLiePairing.info',
+  },
+});
+
+interface DashboardVideoLiveWidgetLivePairingProps {
+  video: Video;
+}
+
+export const DashboardVideoLiveWidgetLivePairing = ({
+  video,
+}: DashboardVideoLiveWidgetLivePairingProps) => {
+  const intl = useIntl();
+  return (
+    <DashboardVideoLiveWidgetTemplate
+      title={intl.formatMessage(messages.title)}
+      infoText={intl.formatMessage(messages.info)}
+      initialOpenValue={false}
+    >
+      <Box direction={'row'} justify={'center'}>
+        <DashboardVideoLivePairing video={video} />
+      </Box>
+    </DashboardVideoLiveWidgetTemplate>
+  );
+};

--- a/src/frontend/components/DashboardVideoLiveControlPane/widgets/DashboardVideoLiveWidgetTemplate/index.spec.tsx
+++ b/src/frontend/components/DashboardVideoLiveControlPane/widgets/DashboardVideoLiveWidgetTemplate/index.spec.tsx
@@ -1,7 +1,6 @@
 import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
-import { QueryClient, QueryClientProvider } from 'react-query';
 
 import { DashboardVideoLiveWidgetTemplate } from '.';
 
@@ -12,7 +11,6 @@ const genericInfoText = 'An example info text';
 
 describe('<DashboardVideoLiveWidgetTemplate />', () => {
   it('renders DashboardVideoLiveWidgetTemplate opened, with an info text ', () => {
-    const queryClient = new QueryClient();
     render(
       <DashboardVideoLiveWidgetTemplate
         initialOpenValue={true}
@@ -31,7 +29,6 @@ describe('<DashboardVideoLiveWidgetTemplate />', () => {
   });
 
   it('renders DashboardVideoLiveWidgetTemplate closed without info text and clicks on the title.', () => {
-    const queryClient = new QueryClient();
     render(
       <DashboardVideoLiveWidgetTemplate
         initialOpenValue={false}
@@ -52,8 +49,6 @@ describe('<DashboardVideoLiveWidgetTemplate />', () => {
   });
 
   it('renders DashboardVideoLiveWidgetTemplate closed with info text and clicks on info button', () => {
-    const queryClient = new QueryClient();
-
     render(
       <DashboardVideoLiveWidgetTemplate
         initialOpenValue={false}

--- a/src/frontend/components/DashboardVideoLiveControlPane/widgets/DashboardVideoLiveWidgetTemplate/index.spec.tsx
+++ b/src/frontend/components/DashboardVideoLiveControlPane/widgets/DashboardVideoLiveWidgetTemplate/index.spec.tsx
@@ -1,6 +1,7 @@
 import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
+import { QueryClient, QueryClientProvider } from 'react-query';
 
 import { DashboardVideoLiveWidgetTemplate } from '.';
 
@@ -11,6 +12,7 @@ const genericInfoText = 'An example info text';
 
 describe('<DashboardVideoLiveWidgetTemplate />', () => {
   it('renders DashboardVideoLiveWidgetTemplate opened, with an info text ', () => {
+    const queryClient = new QueryClient();
     render(
       <DashboardVideoLiveWidgetTemplate
         initialOpenValue={true}
@@ -29,6 +31,7 @@ describe('<DashboardVideoLiveWidgetTemplate />', () => {
   });
 
   it('renders DashboardVideoLiveWidgetTemplate closed without info text and clicks on the title.', () => {
+    const queryClient = new QueryClient();
     render(
       <DashboardVideoLiveWidgetTemplate
         initialOpenValue={false}
@@ -49,6 +52,8 @@ describe('<DashboardVideoLiveWidgetTemplate />', () => {
   });
 
   it('renders DashboardVideoLiveWidgetTemplate closed with info text and clicks on info button', () => {
+    const queryClient = new QueryClient();
+
     render(
       <DashboardVideoLiveWidgetTemplate
         initialOpenValue={false}

--- a/src/frontend/components/DashboardVideoLivePairing/index.spec.tsx
+++ b/src/frontend/components/DashboardVideoLivePairing/index.spec.tsx
@@ -3,6 +3,7 @@ import fetchMock from 'fetch-mock';
 import { Grommet } from 'grommet';
 import React from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
+import { liveState } from 'types/tracks';
 
 import { Deferred } from 'utils/tests/Deferred';
 import { videoMockFactory } from 'utils/tests/factories';
@@ -93,5 +94,28 @@ describe('<DashboardVideoLivePairing />', () => {
       'Pairing secret expired',
     );
     expect(pairingSecretExpiration).not.toBeInTheDocument();
+  });
+
+  it('disables the button when the live state is stopped', () => {
+    const video = videoMockFactory({
+      live_state: liveState.STOPPED,
+    });
+
+    const queryClient = new QueryClient();
+    render(
+      wrapInIntlProvider(
+        <Grommet>
+          <QueryClientProvider client={queryClient}>
+            <DashboardVideoLivePairing video={video} />
+          </QueryClientProvider>
+        </Grommet>,
+      ),
+    );
+
+    const pairButton = screen.getByRole('button', {
+      name: /pair an external device/i,
+    });
+
+    expect(pairButton).toBeDisabled();
   });
 });

--- a/src/frontend/components/DashboardVideoLivePairing/index.tsx
+++ b/src/frontend/components/DashboardVideoLivePairing/index.tsx
@@ -4,7 +4,7 @@ import { defineMessages, FormattedMessage } from 'react-intl';
 
 import { DashboardButton } from 'components/DashboardPaneButtons/DashboardButtons';
 import { usePairingVideo } from 'data/queries';
-import { Video } from 'types/tracks';
+import { liveState, Video } from 'types/tracks';
 
 const messages = defineMessages({
   pairingSecretLabel: {
@@ -135,6 +135,8 @@ export const DashboardVideoLivePairing = ({
       color={buttonColor}
       onClick={pairVideoAction}
       label={content}
+      style={{ margin: 0, maxWidth: '100%' }}
+      disabled={video.live_state === liveState.STOPPED}
     />
   );
 };


### PR DESCRIPTION
## Purpose

The appairing component was mounted alone in the top of the dashboard.
Now we have a dashboard decoupled in widgets. The appairing should live
now in a dedicated widget and remove it from the top.

## Proposal

- [x] move appairing component in a dashboard widget
