### PR TITLE
🐛(frontend) fix lti select view tabs

### DIFF
--- a/src/frontend/components/SelectContent/index.spec.tsx
+++ b/src/frontend/components/SelectContent/index.spec.tsx
@@ -51,12 +51,38 @@ jest.mock(
   },
 );
 
+const mockOtherCustomSelectContentTab = ({
+  selectContent,
+}: SelectContentTabProps) => (
+  <Tab title="Other custom app tab">
+    <p
+      onClick={() =>
+        selectContent(
+          'other-custom-select-content-url',
+          'Other custom select content title',
+        )
+      }
+    >
+      Other select app content
+    </p>
+  </Tab>
+);
+
+jest.mock(
+  '../../apps/other_custom_app/SelectContentTab',
+  () => mockOtherCustomSelectContentTab,
+  {
+    virtual: true,
+  },
+);
+
 /**
  * Mock available app type in the front to provide the app used in the test
  */
 jest.mock('types/AppData.ts', () => ({
   appNames: {
     custom_app: 'custom_app',
+    other_custom_app: 'other_custom_app',
   },
 }));
 
@@ -399,10 +425,20 @@ describe('<SelectContent />', () => {
       ),
     );
 
+    const otherCustomAppTab = await screen.findByRole('tab', {
+      name: 'Other custom app tab',
+    });
+    fireEvent.click(otherCustomAppTab);
+    screen.getByText('Other select app content');
+    expect(screen.queryByText('Select app content')).not.toBeInTheDocument();
+
     const customAppTab = await screen.findByRole('tab', {
       name: 'Custom app tab',
     });
     fireEvent.click(customAppTab);
+    expect(
+      screen.queryByText('Other select app content'),
+    ).not.toBeInTheDocument();
     fireEvent.click(screen.getByText('Select app content'));
 
     expect(window.HTMLFormElement.prototype.submit).toHaveBeenCalledTimes(1);

--- a/src/frontend/components/SelectContent/index.tsx
+++ b/src/frontend/components/SelectContent/index.tsx
@@ -406,11 +406,11 @@ export const SelectContent = ({
           />
         </Tab>
 
-        <Suspense fallback={<Loader />}>
-          {appTabs.map((LazyComponent, index) => (
-            <LazyComponent key={index} selectContent={selectContent} />
-          ))}
-        </Suspense>
+        {appTabs.map((LazyComponent, index) => (
+          <Suspense key={index} fallback={<Loader />}>
+            <LazyComponent selectContent={selectContent} />
+          </Suspense>
+        ))}
       </Tabs>
     </Box>
   );


### PR DESCRIPTION
## Purpose

When we add multiple custom apps, the loaded tabs in the lti select resource view weren't working.
Clicking on one of the custom tabs was always displaying the last one.

## Proposal

Wrap each lazy loaded tab in his own suspense component.

