### PR TITLE
Manage access to shared live media with cloudfront

### DIFF
--- a/src/aws/cloudfront.tf
+++ b/src/aws/cloudfront.tf
@@ -108,6 +108,29 @@ resource "aws_cloudfront_distribution" "marsha_cloudfront_distribution" {
     viewer_protocol_policy = "redirect-to-https"
   }
 
+  ordered_cache_behavior {
+    path_pattern     = "*/sharedlivemedia/*"
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = local.s3_destination_origin_id
+    trusted_signers  = [var.cloudfront_trusted_signer_id]
+
+    forwarded_values {
+      query_string = true
+      headers = ["Access-Control-Request-Headers", "Access-Control-Request-Method", "Origin"]
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+    compress               = true
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
   # Destination bucket: access to timed text tracks is restricted to signed urls/cookies
   ordered_cache_behavior {
     path_pattern     = "*/timedtext/*"

--- a/src/aws/lambda-convert/src/convertSharedLiveMedia.js
+++ b/src/aws/lambda-convert/src/convertSharedLiveMedia.js
@@ -43,5 +43,15 @@ module.exports = async (objectKey, sourceBucket) => {
         })
         .promise();
     })
-  ).then(() => ({ nbPages, extension }));
+  )
+    .then(() => {
+      return s3
+        .copyObject({
+          Bucket: destinationBucket,
+          Key: `${videoId}/sharedlivemedia/${sharedliveMediaId}/${parts[3]}`,
+          CopySource: `${sourceBucket}/${objectKey}`,
+        })
+        .promise();
+    })
+    .then(() => ({ nbPages, extension }));
 };

--- a/src/aws/lambda-convert/src/convertSharedLiveMedia.spec.js
+++ b/src/aws/lambda-convert/src/convertSharedLiveMedia.spec.js
@@ -13,11 +13,13 @@ const svgFiles = [
 // Don't pollute tests with logs intended for CloudWatch
 jest.spyOn(console, "log");
 
-// Mock the AWS SDK calls used in encodeTimedTextTrack
+// Mock the AWS SDK calls used in convertSharedLiveMedia
 const mockGetObject = jest.fn();
 const mockPutObject = jest.fn();
+const mockCopyObject = jest.fn();
 jest.mock("aws-sdk", () => ({
   S3: function () {
+    this.copyObject = mockCopyObject;
     this.getObject = mockGetObject;
     this.putObject = mockPutObject;
   },
@@ -38,10 +40,13 @@ describe("lambda-convert/src/convertSharedLiveMedia", () => {
     mockPutObject.mockReturnValue({
       promise: () => new Promise((resolve) => resolve()),
     });
+    mockCopyObject.mockReturnValue({
+      promise: () => new Promise((resolve) => resolve()),
+    });
 
     const { nbPages, extension } = await convertSharedLiveMedia(
       "ed08da34-7447-4141-96ff-5740315d7b99/sharedlivemedia/c5cad053-111a-4e0e-8f78-fe43dec11512/1638403200.pdf",
-      "source bucket"
+      "source_bucket"
     );
 
     expect(nbPages).toBe(3);
@@ -61,6 +66,12 @@ describe("lambda-convert/src/convertSharedLiveMedia", () => {
       Body: fs.readFileSync(svgFiles[2]),
       Key: "ed08da34-7447-4141-96ff-5740315d7b99/sharedlivemedia/c5cad053-111a-4e0e-8f78-fe43dec11512/1638403200_3.svg",
       Bucket: "destination_bucket",
+    });
+    expect(mockCopyObject).toHaveBeenCalledWith({
+      Bucket: "destination_bucket",
+      Key: "ed08da34-7447-4141-96ff-5740315d7b99/sharedlivemedia/c5cad053-111a-4e0e-8f78-fe43dec11512/1638403200.pdf",
+      CopySource:
+        "source_bucket/ed08da34-7447-4141-96ff-5740315d7b99/sharedlivemedia/c5cad053-111a-4e0e-8f78-fe43dec11512/1638403200.pdf",
     });
   });
 });

--- a/src/backend/marsha/core/serializers/shared_live_media.py
+++ b/src/backend/marsha/core/serializers/shared_live_media.py
@@ -127,7 +127,7 @@ class SharedLiveMediaSerializer(
         if (self.context.get("is_admin") or obj.show_download) and cloudfront_signer:
             extension = f".{obj.extension}" if obj.extension else ""
             urls["media"] = cloudfront_signer.generate_presigned_url(
-                f"{base}/{stamp}/{stamp}{extension}?response-content-disposition="
+                f"{base}{extension}?response-content-disposition="
                 f"{quote_plus('attachment; filename=' + self.get_filename(obj))}",
                 date_less_than=date_less_than,
             )

--- a/src/backend/marsha/core/tests/test_api_shared_live_media.py
+++ b/src/backend/marsha/core/tests/test_api_shared_live_media.py
@@ -430,15 +430,15 @@ class SharedLiveMediaAPITest(TestCase):
                 "urls": {
                     "media": (
                         "https://abc.cloudfront.net/d9d7049c-5a3f-4070-a494-e6bf0bd8b9fb/"
-                        "sharedlivemedia/7520c16b-5846-41ca-822b-52b446a96809/1638230400/"
-                        "1638230400/1638230400.pdf?response-content-disposition=attachment"
-                        "%3B+filename%3Dpython-structures.pdf&Expires=1638237600&Signature="
-                        "PkRRV0~r3xUyzh9KiemFgRypYCh7fFQDzUlrnFSH0qi57lzvAmGjkteT1it7kjgEK"
-                        "jYFMYy-0aB7bTTu0RMUXQlhiHvFUasieJF66f2jMmhaSYTqXwDpSo4bbrThUp4LkI"
-                        "Jwn0C-KcBwBSxsBAo~72G8fsAQRR52TXL~Ya3~~RVAyMX6D3QbFE-dtdwZHcrH1uC"
-                        "89DGPq~~lXwBZv2MBwvNXwUMs6P4SwEPX96xYV8NUGOlf4tr2024JPtZz0RfKteIv"
-                        "-JutS0o5cyTxABx3pkPgDG~F018w2vrLCHHmsgNoiMEcASTLkBwWVJyivsKoOpQo-"
-                        "tb4VS0c07PimdClUw__&Key-Pair-Id=cloudfront-access-key-id"
+                        "sharedlivemedia/7520c16b-5846-41ca-822b-52b446a96809/1638230400."
+                        "pdf?response-content-disposition=attachment%3B+filename%3Dpython"
+                        "-structures.pdf&Expires=1638237600&Signature=Sm8I4Mnuc6e8sn9mxYY"
+                        "Vt53G6wpBeGEBQCKdkpXpd2Keyq9U-Vcm7pkYVjoHpqyeUcfpFBfkYXb1iwQAZvJ"
+                        "SxIP0-4wtO~118oDd11SzjkoQWXA8~ksCK13YR0WqrBH78SaUmwx3mCkE4IAHqZA"
+                        "R46o2ATZ7YTo9rA4qme9wYoKEj1dOgc~FNVv~ROuc-~xFzh~te39ngxoTw4E2ZRe"
+                        "8zLOvwfAri1yzaBk4EjZlCI90lp-Kyv~sLjpO47uIZ2k1g-llTFwscyH8rRpQSDv"
+                        "Rn1yzlrlrGa3yhdieH-hElr1iaHZUAQx-FdH11HXBSwe1eUeRrk1iOoxowEKS9rP"
+                        "DWA__&Key-Pair-Id=cloudfront-access-key-id"
                     ),
                     "pages": {
                         "1": (
@@ -714,16 +714,15 @@ class SharedLiveMediaAPITest(TestCase):
                 "urls": {
                     "media": (
                         "https://abc.cloudfront.net/d9d7049c-5a3f-4070-a494-e6bf0bd8b9fb/"
-                        "sharedlivemedia/7520c16b-5846-41ca-822b-52b446a96809/1638230400"
-                        "/1638230400/1638230400.pdf?response-content-disposition="
-                        "attachment%3B+filename%3Dpython-compound-statements.pdf&Expires="
-                        "1638237600&Signature=EvCA76D7FQYvvY7bjw~40M7Z2h8GfRkc-mczxiVDT52w"
-                        "YTo97PbLNWtR2F0Gipp1uNfcqrGLl-PhH4YUN8AoDM7j8Mz1lXDo0tF6R3FEZAAvA"
-                        "WILQusIlWQ24hgkN9PEAFax8icz5PM~bcTpQkWqbQroX~7krph92yj3E6YurChkYd"
-                        "KmOM8IGdwFU7p3ymFOMMrdLy01~O4ofg~mqDf7GjdTQYrk~6bIWmMWhFBxb9JqsE5"
-                        "gcuo5i8hl2nOhySZEzs7VUhN3R3zgRALMsWojPcoU3DILwkhkxq5u3Sf41jY5M~Ax"
-                        "IX9TJP4mrNAxdx0Ae~8bP2Up3lLRxH7DJO0LHw__"
-                        "&Key-Pair-Id=cloudfront-access-key-id"
+                        "sharedlivemedia/7520c16b-5846-41ca-822b-52b446a96809/1638230400."
+                        "pdf?response-content-disposition=attachment%3B+filename%3Dpython"
+                        "-compound-statements.pdf&Expires=1638237600&Signature=FfdLhpZUfM"
+                        "Iu5NtKTZFCcu7GmrlmwL356YwnFAO4nW8hSQ6KxiZfsOoo47vWhtztMFOhPKQHTn"
+                        "ayQvM574G-usHhfyih9Anw22mziKALfAh5l6sDgoRTSZNA1vt7C1wC-k~pJoIYBD"
+                        "2FOohrJnFXHhipHDIzlCYu3d6u5Dgs~QHmLufbNBYth6SsE9AI7kMt1bXhSZTGf6"
+                        "UqWRkQvmfUVNgSE1VQAQgRIBgcB8xLbxMdPcXkld~qkyyxqw7k7ZJbbTabqhzsno"
+                        "wBRH6L44pird2l0r5rWtCT088ecXSOQEUvDpUpgLVoGt0Dzj-~pjc9gQOJcps2l5"
+                        "MUl0ufvjGspA__&Key-Pair-Id=cloudfront-access-key-id"
                     ),
                     "pages": {
                         "1": (
@@ -1188,16 +1187,15 @@ class SharedLiveMediaAPITest(TestCase):
                         "urls": {
                             "media": (
                                 "https://abc.cloudfront.net/d9d7049c-5a3f-4070-a494-e6bf0bd8b9fb/"
-                                "sharedlivemedia/7520c16b-5846-41ca-822b-52b446a96809/1638230400"
-                                "/1638230400/1638230400.pdf?response-content-disposition="
-                                "attachment%3B+filename%3Dpython-expressions.pdf&Expires="
-                                "1638237600&Signature=Ss-CtLdmMVkAV-Wjfikpo0jebecQE~mgOcJSBEZFXUX"
-                                "qcz3IGhOu-nK-7pbCVLP7GQB3f-FF4OJfxOeCS0IgjXfhbzffBo8~Z6E9MUzTF8GT"
-                                "82B9cb4C9CwXYpSui~altLJyvnMRGoCQVMYqApj050KRBOc4zHa6fTysdbUmkFP1Q"
-                                "ZZPbb0gqT4R4M-xZZ8YTkKTa2fYrgUPDMdbTEovEi-wTaz8C4qTLhxAI9VI4gdv6A"
-                                "s55c8P~RxbQudk3W~GI4vZhQhj1xfJxI45cagJcQch8U1tAjhSbditodllgGb7LXA"
-                                "yJKAZConUMHJCrXCwaFULgIWsJHPwUP3NiO8Iqg__"
-                                "&Key-Pair-Id=cloudfront-access-key-id"
+                                "sharedlivemedia/7520c16b-5846-41ca-822b-52b446a96809/1638230400."
+                                "pdf?response-content-disposition=attachment%3B+filename%3Dpython"
+                                "-expressions.pdf&Expires=1638237600&Signature=FrElaE~yVca9D~Phjo"
+                                "cqk2FOGPXqWe7Aq3Jga74i9A~RxjA3qjXy436X6Mu0RMV~iYRqrOUYNlPYq7rYX9"
+                                "zsXwGeiJ9K12PIs~KsbjnOG5cv9aJrO0vn3JOrgNtjnK-L6ggrNbb8eAmQrdcdKb"
+                                "jjrAa1r2b0g8-vuR0XCztIGOQCfVDjA-7qdL9WPKiCCILrCV2qOkSmA41ENW1wrd"
+                                "F6~19Yn3YLvlJ3edBqI1Uvoo-5nY5ry8vLmh0TXUz2Mn7RjEmNb-j0UHkNlf93Fs"
+                                "a3oXZiL97KiilZkWD7MlPMMTH0Mv9~QuQsR~8fqJNFMyD7FE2yJaKckNGNp2YVOa"
+                                "vU7A__&Key-Pair-Id=cloudfront-access-key-id"
                             ),
                             "pages": {
                                 "1": (

--- a/src/backend/marsha/core/tests/test_api_video.py
+++ b/src/backend/marsha/core/tests/test_api_video.py
@@ -548,15 +548,15 @@ class VideoAPITest(TestCase):
                         "urls": {
                             "media": (
                                 "https://abc.cloudfront.net/d9d7049c-5a3f-4070-a494-e6bf0bd8b9fb/"
-                                "sharedlivemedia/f16dc536-8cba-473c-a85d-0eb88f64d8f9/1638230400/"
-                                "1638230400/1638230400.pdf?response-content-disposition=attachment"
-                                "%3B+filename%3Dpython-expressions.pdf&Expires=1638237600&Signatur"
-                                "e=O3B-Zc9XN1xmS~c05JvXdvHV~yfo1Exf~9vK3xLwlufMUASfLkngGKg4O7ut5di"
-                                "Pa7uyTbpU2lfroX0gl3ichbSWvBjPOLK5EZE8QRrp7U2vOE5Z74V1397IvcMMq7kT"
-                                "CYP3pH9IDSYhheVO3AurBN4kh6zVm1fjiQWxjqZwF5gBgue-G13OsCldfZBTXDoFe"
-                                "ZkY9HCEsZV9jXKkcDAsDLJaGcEodS2RMBi~ZjlmY2CrCipHZ3zOMKJ38bLHo2G1wb"
-                                "PbGt8vloPM30kytiMrsK3zTciyhGDreSSvqsgDMuE3MpxeGWM4LWkdLF7CcPPKP6A"
-                                "OpCzIp3tnp7M9nT~D8w__&Key-Pair-Id=cloudfront-access-key-id"
+                                "sharedlivemedia/f16dc536-8cba-473c-a85d-0eb88f64d8f9/1638230400."
+                                "pdf?response-content-disposition=attachment%3B+filename%3Dpython"
+                                "-expressions.pdf&Expires=1638237600&Signature=KJeU8~a7gmBi9tOgPk"
+                                "3WuLzSpO0vn6F1Mxk7XTp7MkmjOW5zZN96aRP3TixixWLY58vsHNH6atGD22MBl7"
+                                "gQiVdaW5Aehjb0t23fZZRavIo~A3d5P4zJsw1xjJxULSxZMj~4Pirs61Tnx5DShz"
+                                "bHH3iXlACFvjYxjbknzSwuWnrk9XvgEXCcrtNArMNrAYWySdy69YkEp5MkBu83r2"
+                                "XAUP0Uli6KlqcOacMJNXq-HOSiWboTecPNkxaNIEvxrwu6fhCrimfXeA2YPg0wQv"
+                                "4YZ0vY8aGuUmKUcrABa2DLGjaCo3s1lyeDfXftb2DAe5ifgOOdsVJ8nq2ar8wRrr"
+                                "vo-A__&Key-Pair-Id=cloudfront-access-key-id"
                             ),
                             "pages": {
                                 "1": (


### PR DESCRIPTION
## Purpose

Some feature are missing to correctly use shared live media feature. First the source file was not copied to the destination bucket and we need it to download it in the video dashboard. Then, the generated url to access it was not accurate with the choosen S3 key and finally there was no rule in the cloudfront distribution to access it.

## Proposal

- [x] copy the media file from the source to the destination bucket
- [x] fix the cloud front url to access it
- [x] create an ordered rule in the cloudfront distribution to expose all shared live media files.

