### PR TITLE
Use cloudfront public keys management insterad of AWS root account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,12 +20,17 @@ students
 - Add a widget to make live publicly available and get the shareable url
 - New field deleted_by_cascade on all model inheriting from SafeDeleteModel
   Field added in django-safedelete version 1.2.0
-
-
+- CLOUDFRONT_SIGNED_PUBLIC_KEY_ID settings is added. It contains the 
+  public key id created on AWS cloudfront public keys
 
 ### Changed
 
 - Move appairing device component in the widget dashboard
+- Use cloudfront key groups to sign urls instead of using root AWS ssh key
+
+### Removed
+
+- CLOUDFRONT_ACCESS_KEY_ID settings is removed
 
 ## [4.0.0-beta.3] - 2022-04-22
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -7,6 +7,31 @@ not skip minor/major releases while upgrading (fix releases can be skipped).
 The format is inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.27.x to 4.0.x
+
+### Before deploying
+
+First you have to install `hashicorp/tls` provider by running `./bin/terraform init` in the `src/aws` directory.
+
+Then the new terraform plan must be applied:
+
+```bash
+$ cd src/aws
+$ make apply
+```
+
+Once done, a new ssh key pair has been generated. The public key is in the cloudfront management public keys and you have to use the corresponding ssh private key in your marsha installation. You have to retrieve it and replace your actual ssh private key by this one.
+
+```bash
+$ ./bin/terraform output cloudfront_ssh_private_key
+```
+
+You also have to remove the `DJANGO_CLOUDFRONT_ACCESS_KEY_ID` environment variable and add the new one `DJANGO_CLOUDFRONT_SIGNED_PUBLIC_KEY_ID`. It's value can be retrieve in the terraform output:
+
+```bash
+$ /bin/terraform output cloudfront_publick_key_id
+```
+
 ## 3.0.0 to 3.1.0
 
 ### After deploying

--- a/docs/env.md
+++ b/docs/env.md
@@ -247,11 +247,10 @@ versions of the app can run in parallel without interfering with each other.
 - Required: No
 - Default: `staticfiles.json`
 
-#### DJANGO_CLOUDFRONT_ACCESS_KEY_ID
+#### DJANGO_CLOUDFRONT_SIGNED_PUBLIC_KEY_ID
 
-The access key ID of the AWS master account (not its account id!) with which we want to sign urls (it is declared in the CloudFront distribution as a signing account).
-
-Note: Must be associated with a master account as IAM accounts cannot sign URLs.
+The public key id saved in AWS cloudfront public keys management. This public key is created by terraform and you can pick
+the id using `terraform output cloudfront_publick_key_id`
 
 - Type: string
 - Required:
@@ -259,9 +258,10 @@ Note: Must be associated with a master account as IAM accounts cannot sign URLs.
   - No otherwise.
 - Default: None;
 
-#### CLOUDFRONT_PRIVATE_KEY_PATH
+#### DJANGO_CLOUDFRONT_PRIVATE_KEY_PATH
 
-Path to a private key corresponding to the acess key ID in `DJANGO_CLOUDFRONT_ACCESS_KEY_ID`. Also used to sign Cloudfront URLs.
+Path to a private key corresponding to the public key ID in `DJANGO_CLOUDFRONT_SIGNED_PUBLIC_KEY_ID`. Also used to sign Cloudfront URLs.
+The private key can be retrieve from the terraform output `terraform output cloudfront_ssh_private_key`
 
 - Type: string
 - Required:

--- a/env.d/development.dist
+++ b/env.d/development.dist
@@ -34,7 +34,7 @@ DJANGO_CLOUDFRONT_SIGNED_URLS_ACTIVE=False
 DJANGO_CLOUDFRONT_DOMAIN=yourCloudfrontUrl
 # variable below should be uncommented if DJANGO_CLOUDFRONT_SIGNED_URLS_ACTIVE is set to True
 # DJANGO_CLOUDFRONT_PRIVATE_KEY_PATH=/path/to/cloudfront/ssh/private_key
-# DJANGO_CLOUDFRONT_ACCESS_KEY_ID=YourCloudfrontAccessKeyId
+# DJANGO_CLOUDFRONT_SIGNED_PUBLIC_KEY_ID=YourCloudfrontPublicKeyId
 
 # Medialive ARN role
 DJANGO_AWS_MEDIALIVE_ROLE_ARN=aws:medialive:arn:role

--- a/src/aws/.terraform.lock.hcl
+++ b/src/aws/.terraform.lock.hcl
@@ -19,3 +19,23 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:f5638a533cf9444f7d02b5527446cdbc3b2eab8bcc4ec4b0ca32035fe6f479d3",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version     = "3.3.0"
+  constraints = "3.3.0"
+  hashes = [
+    "h1:xx/b39Q9FVZSlDc97rlDmQ9dNaaxFFyVzP9kV+47z28=",
+    "zh:16140e8cc880f95b642b6bf6564f4e98760e9991864aacc8e21273423571e561",
+    "zh:16338b8457759c97fdd73153965d6063b037f2954fd512e569fcdc42b7fef743",
+    "zh:348bd44b7cd0c6d663bba36cecb474c17635a8f22b02187d034b8e57a8729c5a",
+    "zh:3832ac73c2335c0fac26138bacbd18160efaa3f06c562869acc129e814e27f86",
+    "zh:756d1e60690d0164eee9c93b498b4c8beabbfc1d8b7346cb6d2fa719055089d6",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:93b911bcddba8dadc5339edb004c8019c230ea67477c73c4f741c236dd9511b1",
+    "zh:c0c4e5742e8ac004c507540423db52af3f44b8ec04443aa8e14669340819344f",
+    "zh:c78296a1dff8ccd5d50203aac353422fc18d425072ba947c88cf5b46de7d32d2",
+    "zh:d7143f444e0f7e6cd67fcaf080398b4f1487cf05de3e0e79af6c14e22812e38b",
+    "zh:e600ac76b118816ad72132eee4c22ab5fc044f67c3babc54537e1fc1ad53d295",
+    "zh:fca07af5f591e12d2dc178a550da69a4847bdb34f8180a5b8e04fde6b528cf99",
+  ]
+}

--- a/src/aws/cloudfront.tf
+++ b/src/aws/cloudfront.tf
@@ -3,6 +3,23 @@ locals {
   static_origin_id = "marsha-static-origin"
 }
 
+resource "tls_private_key" "marsha_cloudfront_ssh_key" {
+  algorithm = "RSA"
+  rsa_bits  = 2048
+}
+
+resource "aws_cloudfront_public_key" "marsha_cloudfront_signer_public_key" {
+  comment     = "Public key signing cloudfront urls"
+  encoded_key = tls_private_key.marsha_cloudfront_ssh_key.public_key_pem
+  name        = "${terraform.workspace}-marsha_cloudfront_signer_public_key"
+}
+
+resource "aws_cloudfront_key_group" "marsha_cloudfront_signer_key_group" {
+  comment = "Key group containing public key signing cloudfront urls"
+  items   = [aws_cloudfront_public_key.marsha_cloudfront_signer_public_key.id]
+  name    = "${terraform.workspace}-marsha_cloudfront_signer_key_group"
+}
+
 # Create an origin access identity that will allow CloudFront to access S3
 # See bucket policies in s3.tf or documentation for more details:
 # https://www.terraform.io/docs/providers/aws/r/cloudfront_origin_access_identity.html
@@ -43,7 +60,8 @@ resource "aws_cloudfront_distribution" "marsha_cloudfront_distribution" {
     allowed_methods  = ["GET", "HEAD", "OPTIONS"]
     cached_methods   = ["GET", "HEAD", "OPTIONS"]
     target_origin_id = local.s3_destination_origin_id
-    trusted_signers  = [var.cloudfront_trusted_signer_id]
+    trusted_signers  = []
+    trusted_key_groups = [aws_cloudfront_key_group.marsha_cloudfront_signer_key_group.id]
 
     forwarded_values {
       query_string = false
@@ -67,7 +85,8 @@ resource "aws_cloudfront_distribution" "marsha_cloudfront_distribution" {
     allowed_methods  = ["GET", "HEAD", "OPTIONS"]
     cached_methods   = ["GET", "HEAD", "OPTIONS"]
     target_origin_id = local.s3_destination_origin_id
-    trusted_signers  = [var.cloudfront_trusted_signer_id]
+    trusted_signers  = []
+    trusted_key_groups = [aws_cloudfront_key_group.marsha_cloudfront_signer_key_group.id]
 
     forwarded_values {
       query_string = true
@@ -90,7 +109,8 @@ resource "aws_cloudfront_distribution" "marsha_cloudfront_distribution" {
     allowed_methods  = ["GET", "HEAD", "OPTIONS"]
     cached_methods   = ["GET", "HEAD", "OPTIONS"]
     target_origin_id = local.s3_destination_origin_id
-    trusted_signers  = [var.cloudfront_trusted_signer_id]
+    trusted_signers  = []
+    trusted_key_groups = [aws_cloudfront_key_group.marsha_cloudfront_signer_key_group.id]
 
     forwarded_values {
       query_string = true
@@ -113,7 +133,8 @@ resource "aws_cloudfront_distribution" "marsha_cloudfront_distribution" {
     allowed_methods  = ["GET", "HEAD", "OPTIONS"]
     cached_methods   = ["GET", "HEAD", "OPTIONS"]
     target_origin_id = local.s3_destination_origin_id
-    trusted_signers  = [var.cloudfront_trusted_signer_id]
+    trusted_signers  = []
+    trusted_key_groups = [aws_cloudfront_key_group.marsha_cloudfront_signer_key_group.id]
 
     forwarded_values {
       query_string = true
@@ -137,7 +158,8 @@ resource "aws_cloudfront_distribution" "marsha_cloudfront_distribution" {
     allowed_methods  = ["GET", "HEAD", "OPTIONS"]
     cached_methods   = ["GET", "HEAD", "OPTIONS"]
     target_origin_id = local.s3_destination_origin_id
-    trusted_signers  = [var.cloudfront_trusted_signer_id]
+    trusted_signers  = []
+    trusted_key_groups = [aws_cloudfront_key_group.marsha_cloudfront_signer_key_group.id]
 
     forwarded_values {
       query_string = true

--- a/src/aws/output.tf
+++ b/src/aws/output.tf
@@ -2,6 +2,15 @@ output "cloudfront_domain" {
   value = aws_cloudfront_distribution.marsha_cloudfront_distribution.domain_name
 }
 
+output "cloudfront_publick_key_id" {
+  value = aws_cloudfront_public_key.marsha_cloudfront_signer_public_key.id
+}
+
+output "cloudfront_ssh_private_key" {
+  value = tls_private_key.marsha_cloudfront_ssh_key.private_key_pem
+  sensitive = true
+}
+
 output "endpoint" {
   value = data.aws_lambda_invocation.configure_lambda_endpoint.result
 }

--- a/src/aws/provider.tf
+++ b/src/aws/provider.tf
@@ -4,5 +4,9 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 3.63"
     }
+    tls = {
+      source = "hashicorp/tls"
+      version = "3.3.0"
+    }
   }
 }

--- a/src/backend/marsha/core/serializers/file.py
+++ b/src/backend/marsha/core/serializers/file.py
@@ -118,7 +118,7 @@ class DocumentSerializer(
                 seconds=settings.CLOUDFRONT_SIGNED_URLS_VALIDITY
             )
             cloudfront_signer = CloudFrontSigner(
-                settings.CLOUDFRONT_ACCESS_KEY_ID, cloudfront_utils.rsa_signer
+                settings.CLOUDFRONT_SIGNED_PUBLIC_KEY_ID, cloudfront_utils.rsa_signer
             )
             url = cloudfront_signer.generate_presigned_url(
                 url, date_less_than=date_less_than

--- a/src/backend/marsha/core/serializers/shared_live_media.py
+++ b/src/backend/marsha/core/serializers/shared_live_media.py
@@ -109,7 +109,7 @@ class SharedLiveMediaSerializer(
                 seconds=settings.CLOUDFRONT_SIGNED_URLS_VALIDITY
             )
             cloudfront_signer = CloudFrontSigner(
-                settings.CLOUDFRONT_ACCESS_KEY_ID, cloudfront_utils.rsa_signer
+                settings.CLOUDFRONT_SIGNED_PUBLIC_KEY_ID, cloudfront_utils.rsa_signer
             )
 
         pages = {}

--- a/src/backend/marsha/core/serializers/timed_text_track.py
+++ b/src/backend/marsha/core/serializers/timed_text_track.py
@@ -98,7 +98,7 @@ class TimedTextTrackSerializer(serializers.ModelSerializer):
             seconds=settings.CLOUDFRONT_SIGNED_URLS_VALIDITY
         )
         cloudfront_signer = CloudFrontSigner(
-            settings.CLOUDFRONT_ACCESS_KEY_ID, cloudfront_utils.rsa_signer
+            settings.CLOUDFRONT_SIGNED_PUBLIC_KEY_ID, cloudfront_utils.rsa_signer
         )
         return cloudfront_signer.generate_presigned_url(
             url, date_less_than=date_less_than

--- a/src/backend/marsha/core/serializers/video.py
+++ b/src/backend/marsha/core/serializers/video.py
@@ -124,7 +124,8 @@ class VideoBaseSerializer(serializers.ModelSerializer):
             # Sign the urls of mp4 videos only if the functionality is activated
             if settings.CLOUDFRONT_SIGNED_URLS_ACTIVE:
                 cloudfront_signer = CloudFrontSigner(
-                    settings.CLOUDFRONT_ACCESS_KEY_ID, cloudfront_utils.rsa_signer
+                    settings.CLOUDFRONT_SIGNED_PUBLIC_KEY_ID,
+                    cloudfront_utils.rsa_signer,
                 )
                 mp4_url = cloudfront_signer.generate_presigned_url(
                     mp4_url, date_less_than=date_less_than

--- a/src/backend/marsha/core/tests/test_api_shared_live_media.py
+++ b/src/backend/marsha/core/tests/test_api_shared_live_media.py
@@ -383,7 +383,7 @@ class SharedLiveMediaAPITest(TestCase):
 
     @override_settings(
         CLOUDFRONT_SIGNED_URLS_ACTIVE=True,
-        CLOUDFRONT_ACCESS_KEY_ID="cloudfront-access-key-id",
+        CLOUDFRONT_SIGNED_PUBLIC_KEY_ID="cloudfront-access-key-id",
     )
     def test_api_shared_live_media_read_detail_student_ready_to_show_and_signed_url_active(
         self,
@@ -482,7 +482,7 @@ class SharedLiveMediaAPITest(TestCase):
 
     @override_settings(
         CLOUDFRONT_SIGNED_URLS_ACTIVE=True,
-        CLOUDFRONT_ACCESS_KEY_ID="cloudfront-access-key-id",
+        CLOUDFRONT_SIGNED_PUBLIC_KEY_ID="cloudfront-access-key-id",
     )
     def test_api_shared_live_media_read_detail_student_ready_to_show_and_show_download_off(
         self,
@@ -667,7 +667,7 @@ class SharedLiveMediaAPITest(TestCase):
 
     @override_settings(
         CLOUDFRONT_SIGNED_URLS_ACTIVE=True,
-        CLOUDFRONT_ACCESS_KEY_ID="cloudfront-access-key-id",
+        CLOUDFRONT_SIGNED_PUBLIC_KEY_ID="cloudfront-access-key-id",
     )
     def test_api_shared_live_media_read_detail_instructor_ready_to_show_and_signed_url_on(
         self,
@@ -1122,7 +1122,7 @@ class SharedLiveMediaAPITest(TestCase):
 
     @override_settings(
         CLOUDFRONT_SIGNED_URLS_ACTIVE=True,
-        CLOUDFRONT_ACCESS_KEY_ID="cloudfront-access-key-id",
+        CLOUDFRONT_SIGNED_PUBLIC_KEY_ID="cloudfront-access-key-id",
     )
     def test_api_shared_live_media_list_instructor_ready_to_show_and_signed_url_active(
         self,

--- a/src/backend/marsha/core/tests/test_api_timed_text_track.py
+++ b/src/backend/marsha/core/tests/test_api_timed_text_track.py
@@ -375,7 +375,7 @@ class TimedTextTrackAPITest(TestCase):
 
     @override_settings(
         CLOUDFRONT_SIGNED_URLS_ACTIVE=True,
-        CLOUDFRONT_ACCESS_KEY_ID="cloudfront-access-key-id",
+        CLOUDFRONT_SIGNED_PUBLIC_KEY_ID="cloudfront-access-key-id",
     )
     @mock.patch("builtins.open", new_callable=mock.mock_open, read_data=RSA_KEY_MOCK)
     def test_api_timed_text_track_read_detail_token_user_signed_urls(self, mock_open):

--- a/src/backend/marsha/core/tests/test_api_video.py
+++ b/src/backend/marsha/core/tests/test_api_video.py
@@ -361,7 +361,7 @@ class VideoAPITest(TestCase):
 
     @override_settings(
         CLOUDFRONT_SIGNED_URLS_ACTIVE=True,
-        CLOUDFRONT_ACCESS_KEY_ID="cloudfront-access-key-id",
+        CLOUDFRONT_SIGNED_PUBLIC_KEY_ID="cloudfront-access-key-id",
     )
     def test_api_video_read_detail_token_user_nested_shared_live_media_urls_signed(
         self,
@@ -618,7 +618,7 @@ class VideoAPITest(TestCase):
 
     @override_settings(
         CLOUDFRONT_SIGNED_URLS_ACTIVE=True,
-        CLOUDFRONT_ACCESS_KEY_ID="cloudfront-access-key-id",
+        CLOUDFRONT_SIGNED_PUBLIC_KEY_ID="cloudfront-access-key-id",
     )
     def test_api_video_read_detail_token_student_user_nested_shared_live_media_urls_signed(
         self,
@@ -1073,7 +1073,7 @@ class VideoAPITest(TestCase):
 
     @override_settings(
         CLOUDFRONT_SIGNED_URLS_ACTIVE=True,
-        CLOUDFRONT_ACCESS_KEY_ID="cloudfront-access-key-id",
+        CLOUDFRONT_SIGNED_PUBLIC_KEY_ID="cloudfront-access-key-id",
     )
     @mock.patch("builtins.open", new_callable=mock.mock_open, read_data=RSA_KEY_MOCK)
     def test_api_video_read_detail_token_user_signed_urls(self, mock_open):

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -298,12 +298,12 @@ class Base(Configuration):
     LIVE_RAW_ENABLED = values.BooleanValue(False)
 
     # Cloud Front key pair for signed urls
-    CLOUDFRONT_ACCESS_KEY_ID = values.Value(None)
     CLOUDFRONT_PRIVATE_KEY_PATH = values.Value(
         os.path.join(BASE_DIR, "..", ".ssh", "cloudfront_private_key")
     )
     CLOUDFRONT_SIGNED_URLS_ACTIVE = values.BooleanValue(True)
     CLOUDFRONT_SIGNED_URLS_VALIDITY = 2 * 60 * 60  # 2 hours
+    CLOUDFRONT_SIGNED_PUBLIC_KEY_ID = values.Value(None)
 
     CLOUDFRONT_DOMAIN = values.Value(None)
 


### PR DESCRIPTION
## Purpose

Previously we used the trusted signer from the AWS root account. This
strategy is no more recommanded. The recommanded way is to manage the
public keys in the cloudfront account. This keys can be created by an
IAM user and easily rotate.

## Migration path

First you have to install `hashicorp/tls` provider by running `./bin/terraform init` in the `src/aws` directory.

Then the new terraform plan must be applied:

```bash
$ cd src/aws
$ make apply
```

Once done, a new ssh key pair has been generated. The public key is in the cloudfront management public keys and you have to use the corresponding ssh private key in your marsha installation. You have to retrieve it and replace your actual ssh private key by this one.

```bash
$ ./bin/terraform output cloudfront_ssh_private_key
```

You also have to remove the `DJANGO_CLOUDFRONT_ACCESS_KEY_ID` environment variable and add the new one `DJANGO_CLOUDFRONT_SIGNED_PUBLIC_KEY_ID`. It's value can be retrieve in the terraform output:

```bash
$ /bin/terraform output cloudfront_publick_key_id
```

## Proposal

- [x] install hashicorp/tls provider
- [x] use cloudfront public keys management to sign urls
- [x]  add settings CLOUDFRONT_SIGNED_PUBLIC_KEY_ID
