### PR TITLE
♻️(front) reorganize widget order in the live dashboard

### DIFF
--- a/src/frontend/components/DashboardVideoLiveControlPane/index.tsx
+++ b/src/frontend/components/DashboardVideoLiveControlPane/index.tsx
@@ -18,8 +18,8 @@ export const DashboardVideoLiveControlPane = ({
   return (
     <DashboardVideoLiveWidgetsContainer>
       <DashboardVideoLiveWidgetToolsAndApplications video={video} />
-      <DashboardVideoLiveWidgetVisibilityAndInteraction video={video} />
       <DashboardVideoLiveWidgetGeneralTitle video={video} />
+      <DashboardVideoLiveWidgetVisibilityAndInteraction video={video} />
       <DashboardVideoLiveWidgetSchedulingAndDescription video={video} />
       <DashboardVideoLiveWidgetLivePairing video={video} />
     </DashboardVideoLiveWidgetsContainer>


### PR DESCRIPTION
## Purpose

When we are using the Dashboard video live control panel with 2 columns,
we want to have the general and the description on the right side with
the general widget before the description one.

## Proposal

- [x] reorganize widget order in the live dashboard
