### PR TITLE
🩹(front) fix calendar display

### DIFF
--- a/src/frontend/components/SchedulingFields/index.tsx
+++ b/src/frontend/components/SchedulingFields/index.tsx
@@ -211,8 +211,11 @@ export const SchedulingFields = ({
           htmlFor="starting_at_date"
           margin="none"
           background={startingAtError ? 'status-error-off' : 'white'}
+          // Fix of the calendar icon still clickable when component disabled (see below)
+          style={{ pointerEvents: disabled ? 'none' : undefined }}
         >
           <DateInput
+            dropProps={{ align: { bottom: 'top' } }}
             id="starting_at_date"
             format={intl.locale === 'fr' ? 'dd/mm/yyyy' : 'yyyy/mm/dd'}
             value={currentStartingAtDate || undefined}


### PR DESCRIPTION
## Purpose

The calendar was displayed under the date input and part of it was sometimes
appearing outside the iframe, making it unusable. The current behavior is now
to be always displayed above the dateinput and given our application layout, it
guarantees it will always have enought space to display.There was also a
problem with the calendar button on the date input, which wasn't disabled when
the prop 'disabled' was on. It is now fixed by disabling pointerEvents on its
parent component.