### PR TITLE
🧑‍💻(frontend) add jest test helper commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,6 +125,7 @@ venv.bak/
 # Front
 __diff_output__/
 node_modules
+src/frontend/coverage
 src/frontend/i18n/frontend.json
 src/backend/marsha/static/css
 src/backend/marsha/static/js

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -18,6 +18,8 @@
     "build-sass": "sass scss/_main.scss ../backend/marsha/static/css/main.css --load-path=node_modules",
     "build-sass-production": "sass scss/_main.scss ../backend/marsha/static/css/main.css --style=compressed --load-path=node_modules",
     "test": "TZ=UTC jest",
+    "test-summary": "TZ=UTC jest 2>&1 | grep 'FAIL' | sort -t: -u -k1,1",
+    "test-coverage": "sh -c 'TZ=UTC jest $0 --coverage --collectCoverageFrom=\"$0/**\"'",
     "storybook": "start-storybook -p 6006"
   },
   "repository": "git@github.com:openfun/marsha.git",


### PR DESCRIPTION

## Purpose

When we want to have a list of the failing tests, regular jest output
isn't very convenient. A script shortcut has been added to display them
nicely.

Also, a quick and dirty test coverage command has been added to target a
specific component, run his test and display the coverage report on it
only.

![image](https://user-images.githubusercontent.com/720491/167873256-26826de1-3904-4951-aa11-1ff9aaea4118.png)

![image](https://user-images.githubusercontent.com/720491/167873347-9aafa6b4-f826-4005-b7d3-f2606433dbed.png)

![image](https://user-images.githubusercontent.com/720491/168077628-0ad99f90-049d-46fc-8a4e-c53de72aedc3.png)
