### PR TITLE
🔧(renovate) remove jest from ignored packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,7 +23,6 @@
         "@types/react-dom",
         "@types/react-test-renderer",
         "faker",
-        "jest",
         "node",
         "node-fetch",
         "react",


### PR DESCRIPTION
## Purpose

We upgraded jest to version 28 but we missed to remove it from the
package to ignore to update with renovate. We must remove it to accept
future releases.

## Proposal

- [x] remove jest from renovate configuration

