### PR TITLE
create fallback cache strategy when redis is down 

### DIFF
--- a/docs/cache.md
+++ b/docs/cache.md
@@ -1,0 +1,26 @@
+# Cache
+
+## RedisCacheWithFallback
+
+Marsha has a cache allowing to use redis backend and to fallback on the memory cache if redis is not available.
+The package `django-redis` is used in combination with the backend `marsha.core.cache.RedisCacheWithFallback`.
+
+The configuration followed the [django-redis](https://github.com/jazzband/django-redis) configuration but you have to use the `marsha.core.cache.RedisCacheWithFallback` backend instead of `django_redis.cache.RedisCache` for your `default` backend.
+Then you have to declare a second backend named `memory_cache` where you can use the `django.core.cache.backends.locmem.LocMemCache` backend.
+
+A complete simple example:
+
+```
+CACHES = {
+    "default": {
+        "BACKEND": "marsha.core.cache.RedisCacheWithFallback",
+        "LOCATION": "redis://127.0.0.1:6379/1",
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+        }
+    },
+    "memory_cache": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+    },
+}
+```

--- a/src/backend/marsha/core/cache.py
+++ b/src/backend/marsha/core/cache.py
@@ -1,0 +1,185 @@
+"""
+    RedisCache with a fallback cache to prevent denial of service if Redis is down
+    Freely inspired by django-cache-fallback
+
+    Credits:
+    - https://github.com/Kub-AT/django-cache-fallback/
+"""
+
+import logging
+
+from django.conf import settings
+from django.core.cache import caches
+from django.core.cache.backends.base import BaseCache
+
+from django_redis.cache import RedisCache
+
+from .utils.throttle import throttle
+
+
+FALLBACK_CACHE_INVALIDATION_INTERVAL = 60  # seconds
+DJANGO_REDIS_LOGGER = getattr(settings, "DJANGO_REDIS_LOGGER", __name__)
+logger = logging.getLogger(DJANGO_REDIS_LOGGER)
+
+
+class RedisCacheWithFallback(BaseCache):
+    """
+    BaseCache object with a redis_cache used as main cache
+    and the "fallback" aliased cache which takes over
+    in case redis_cache is down.
+    """
+
+    def __init__(self, server, params):
+        """
+        Instantiate the Redis Cache with server and params
+        and retrieve the cache with alias "fallback"
+        """
+        super().__init__(params)
+        self._redis_cache = RedisCache(server, params)
+        self._fallback_cache = caches["memory_cache"]
+
+    def _call_with_fallback(self, method, *args, **kwargs):
+        """
+        Try first to exec provided method through Redis cache instance,
+        in case of success, invalidate the fallback cache so it is clean and
+        ready for next failure,
+        in case of failure, logger reports the exception and
+        the fallback cache takes over.
+        """
+        try:
+            next_cache_state = self._call_redis_cache(method, args, kwargs)
+        # pylint: disable=broad-except
+        except Exception as exception:
+            logger.warning("[DEGRADED CACHE MODE] - Switch to fallback cache")
+            logger.exception(exception)
+            return self._call_fallback_cache(method, args, kwargs)
+        else:
+            self._invalidate_fallback_cache()
+            return next_cache_state
+
+    @throttle(FALLBACK_CACHE_INVALIDATION_INTERVAL)  # 60 seconds
+    def _invalidate_fallback_cache(self):
+        """
+        Clear asynchronously cache in the fallback cache.
+        """
+        self._fallback_cache.aclear()
+
+    def _call_redis_cache(self, method, args, kwargs):
+        """
+        Exec the provided method through the redis cache instance
+        """
+        return getattr(self._redis_cache, method)(*args, **kwargs)
+
+    def _call_fallback_cache(self, method, args, kwargs):
+        """
+        Exec the provided method through the fallback cache instance
+        """
+        return getattr(self._fallback_cache, method)(*args, **kwargs)
+
+    def get_backend_timeout(self, *args, **kwargs):
+        """
+        Pass get_backend_timeout cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("get_backend_timeout", *args, **kwargs)
+
+    def make_key(self, *args, **kwargs):
+        """
+        Pass make_key cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("make_key", *args, **kwargs)
+
+    def add(self, *args, **kwargs):
+        """
+        Pass add cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("add", *args, **kwargs)
+
+    def get(self, *args, **kwargs):
+        """
+        Pass get cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("get", *args, **kwargs)
+
+    def set(self, *args, **kwargs):
+        """
+        Pass set cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("set", *args, **kwargs)
+
+    def touch(self, *args, **kwargs):
+        """
+        Pass touch cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("touch", *args, **kwargs)
+
+    def delete(self, *args, **kwargs):
+        """
+        Pass delete cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("delete", *args, **kwargs)
+
+    def get_many(self, *args, **kwargs):
+        """
+        Pass get_many cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("get_many", *args, **kwargs)
+
+    def get_or_set(self, *args, **kwargs):
+        """
+        Pass get_or_set cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("get_or_set", *args, **kwargs)
+
+    def has_key(self, *args, **kwargs):
+        """
+        Pass has_key cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("has_key", *args, **kwargs)
+
+    def incr(self, *args, **kwargs):
+        """
+        Pass incr cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("incr", *args, **kwargs)
+
+    def decr(self, *args, **kwargs):
+        """
+        Pass decr cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("decr", *args, **kwargs)
+
+    def set_many(self, *args, **kwargs):
+        """
+        Pass set_many cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("set_many", *args, **kwargs)
+
+    def delete_many(self, *args, **kwargs):
+        """
+        Pass delete_many cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("delete_many", *args, **kwargs)
+
+    def clear(self):
+        """
+        Pass clear cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("clear")
+
+    def validate_key(self, *args, **kwargs):
+        """
+        Pass validate_key cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("validate_key", *args, **kwargs)
+
+    def incr_version(self, *args, **kwargs):
+        """
+        Pass incr_version cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("incr_version", *args, **kwargs)
+
+    def decr_version(self, *args, **kwargs):
+        """
+        Pass decr_version cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("decr_version", *args, **kwargs)

--- a/src/backend/marsha/core/tests/test_cache.py
+++ b/src/backend/marsha/core/tests/test_cache.py
@@ -1,0 +1,179 @@
+"""Test funmooc cache plugin"""
+# pylint: disable=protected-access
+import datetime
+from unittest import mock
+
+from django.core.cache.backends.dummy import DummyCache
+from django.test import TestCase, override_settings
+
+from django_redis.cache import RedisCache
+
+from ..cache import RedisCacheWithFallback
+
+
+class RedisCacheWithFallbackTestCase(TestCase):
+    """
+    Test suite for the RedisCacheWithFallback
+
+    Credits:
+    - https://github.com/Kub-AT/django-cache-fallback
+    """
+
+    @override_settings(
+        CACHES={
+            "default": {
+                "BACKEND": "marsha.core.cache.RedisCacheWithFallback",
+                "LOCATION": "redis://mymaster/0",
+                "OPTIONS": {
+                    "CLIENT_CLASS": "django_redis.client.SentinelClient",
+                    "SENTINELS": [
+                        ("sentinel1", 26379),
+                    ],
+                },
+            },
+            "memory_cache": {
+                "BACKEND": "django.core.cache.backends.dummy.DummyCache",
+            },
+        }
+    )
+    def test_client(self):
+        """Test class instance of caches"""
+        client = RedisCacheWithFallback(None, {})
+        self.assertIs(type(client), RedisCacheWithFallback)
+        self.assertIs(type(client._redis_cache), RedisCache)
+        self.assertIs(type(client._fallback_cache), DummyCache)
+
+    @override_settings(
+        CACHES={
+            "memory_cache": {
+                "BACKEND": "django.core.cache.backends.dummy.DummyCache",
+            },
+        }
+    )
+    @mock.patch.object(RedisCacheWithFallback, "_call_fallback_cache")
+    @mock.patch.object(RedisCacheWithFallback, "_call_redis_cache")
+    def test_get_redis_cache(self, redis_cache_mock, fallback_cache_mock):
+        """Test that redis_cache is used by default."""
+        client = RedisCacheWithFallback(None, {})
+        client.get("irrelevent")
+
+        redis_cache_mock.assert_called_once()
+        fallback_cache_mock.assert_not_called()
+
+    @override_settings(
+        CACHES={
+            "memory_cache": {
+                "BACKEND": "django.core.cache.backends.dummy.DummyCache",
+            },
+        }
+    )
+    @mock.patch("marsha.core.cache.logger")
+    @mock.patch.object(RedisCacheWithFallback, "_call_fallback_cache")
+    @mock.patch.object(RedisCacheWithFallback, "_call_redis_cache")
+    def test_get_fallback_cache(
+        self, redis_cache_mock, fallback_cache_mock, logger_mock
+    ):
+        """
+        Test case when redis_cache raises an exception,
+        logger logs the exception then fallback_cache takes over
+        """
+        client = RedisCacheWithFallback(None, {})
+        client.get("irrelevent")
+
+        redis_cache_mock.assert_called_once()
+        fallback_cache_mock.assert_not_called()
+
+        redis_cache_mock.side_effect = Exception()
+        client.get("irrelevent")
+
+        logger_mock.warning.assert_called_with(
+            "[DEGRADED CACHE MODE] - Switch to fallback cache"
+        )
+        logger_mock.exception.assert_called_once()
+        fallback_cache_mock.assert_called_once()
+
+    @override_settings(
+        CACHES={
+            "default": {
+                "BACKEND": "marsha.core.cache.RedisCacheWithFallback",
+                "LOCATION": "redis://mymaster/0",
+                "OPTIONS": {
+                    "CLIENT_CLASS": "django_redis.client.SentinelClient",
+                    "SENTINELS": [
+                        ("sentinel1", 26379),
+                    ],
+                },
+            },
+            "memory_cache": {
+                "BACKEND": "django.core.cache.backends.dummy.DummyCache",
+            },
+        }
+    )
+    @mock.patch.object(DummyCache, "aclear")
+    @mock.patch.object(RedisCacheWithFallback, "_call_redis_cache")
+    def test_invalidate_fallback_cache(self, redis_cache_mock, clear_mock):
+        """
+        Test that fallback_cache is invalidated every 60 seconds
+        when Redis is up
+        """
+        now = datetime.datetime.now()
+
+        client = RedisCacheWithFallback(None, {})
+        client.get("round_0")
+        redis_cache_mock.reset_mock()
+        clear_mock.reset_mock()
+
+        # A second cache access should not delete the fallback cache again
+        client.get("round_1")
+        redis_cache_mock.assert_called_once()
+        clear_mock.assert_not_called()
+        redis_cache_mock.reset_mock()
+        clear_mock.reset_mock()
+
+        # Another call to Redis cache 120 seconds later
+        # should delete the fallback cache again
+        read_time = now + datetime.timedelta(seconds=120)
+        with mock.patch("marsha.core.utils.throttle.datetime") as mock_datetime:
+            mock_datetime.now.return_value = read_time
+            client.get("round_2")
+
+        redis_cache_mock.assert_called_once()
+        clear_mock.assert_called_once()
+        redis_cache_mock.reset_mock()
+        clear_mock.reset_mock()
+
+        # Another call to Redis cache 30 seconds later (<1 minute)
+        # should not delete the fallback cache again
+        read_time += datetime.timedelta(seconds=30)
+        with mock.patch("marsha.core.utils.throttle.datetime") as mock_datetime:
+            mock_datetime.now.return_value = read_time
+            client.get("round_3")
+
+        redis_cache_mock.assert_called_once()
+        clear_mock.assert_not_called()
+        redis_cache_mock.reset_mock()
+        clear_mock.reset_mock()
+
+        # Another call to Redis cache exactly 1 minute after
+        # the latest call should not delete the fallback cache again
+        read_time += datetime.timedelta(seconds=30)
+        with mock.patch("marsha.core.utils.throttle.datetime") as mock_datetime:
+            mock_datetime.now.return_value = read_time
+            client.get("round_4")
+
+        redis_cache_mock.assert_called_once()
+        clear_mock.assert_not_called()
+        redis_cache_mock.reset_mock()
+        clear_mock.reset_mock()
+
+        # Another call to Redis cache exactly 1 minute and 1 second after
+        # the latest call should delete the fallback cache again
+        read_time += datetime.timedelta(seconds=1)
+        with mock.patch("marsha.core.utils.throttle.datetime") as mock_datetime:
+            mock_datetime.now.return_value = read_time
+            client.get("round_5")
+
+        redis_cache_mock.assert_called_once()
+        clear_mock.assert_called_once()
+        redis_cache_mock.reset_mock()
+        clear_mock.reset_mock()

--- a/src/backend/marsha/core/utils/throttle.py
+++ b/src/backend/marsha/core/utils/throttle.py
@@ -1,0 +1,35 @@
+from datetime import datetime, timedelta
+from functools import wraps
+
+
+class throttle(object):
+    """
+    Throttle Decorator
+    Limit execution of a function to a defined interval
+    """
+
+    def __init__(self, interval):
+        """
+        Initialize throttle decorator
+        Define the throttle_interval with the provided interval (in seconds)
+        and set time_of_last_call to the earliest representable datetime
+        """
+        self.throttle_interval = timedelta(seconds=interval)
+        self.time_of_last_call = datetime.min
+
+    def __call__(self, callback):
+        """
+        Process `elapsed_since_last_call`,
+        if it is greater than `throttle_interval`, callback is executed.
+        """
+
+        @wraps(callback)
+        def wrapper(*args, **kwargs):
+            now = datetime.now()
+            elapsed_since_last_call = now - self.time_of_last_call
+
+            if elapsed_since_last_call > self.throttle_interval:
+                self.time_of_last_call = now
+                return callback(*args, **kwargs)
+
+        return wrapper

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -40,6 +40,7 @@ install_requires =
     django-extensions==3.1.5
     djangorestframework==3.13.1
     djangorestframework_simplejwt==5.1.0
+    django-redis==5.2.0
     django-safedelete==1.2.2
     django-storages==1.12.3
     django-waffle==2.4.1


### PR DESCRIPTION
## Purpose

When redis is down and used as cache backend we want to fallback on an
other backend cache to avoid denial of service. For this we have copied
the fallback cache used in the openfun/richie project and we adapt it to
our use case. For example we don't need to clear any cache if redis is
up again, the cache we are using has a lifetime.

## Proposal

- [x] install django-redis 5.2.0
- [x] create fallback cache strategy when redis is down 

