### PR TITLE
♻️(aws) allow to configure allocated memory to lambda convert

### DIFF
--- a/docs/env.md
+++ b/docs/env.md
@@ -568,3 +568,11 @@ the event should be routed.
 - Type: string
 - Required: Yes
 - Default: marsha-medialive
+
+#### TF_VAR_lambda_convert_memory
+
+This variable allow you to configure the amount of memory allocated for the lambda convert. Depending the environment you are using you would like to increase this value.
+
+- Type: number
+- Required: No
+- Default: 1536

--- a/src/aws/lambda.tf
+++ b/src/aws/lambda.tf
@@ -55,7 +55,7 @@ resource "aws_lambda_function" "marsha_convert_lambda" {
   image_uri        = "${var.lambda_image_name}:${var.lambda_image_tag}"
   package_type     = "Image"
   role             = aws_iam_role.lambda_invocation_role.arn
-  memory_size      = "1536"
+  memory_size      = "${var.lambda_convert_memory}"
   timeout          = "90"
 
   image_config {

--- a/src/aws/variables.tf
+++ b/src/aws/variables.tf
@@ -108,3 +108,8 @@ variable "ffmpeg_transmux_container_port" {
   type    = number
   default = 8081
 }
+
+variable "lambda_convert_memory" {
+  type    = number
+  default = 1536
+}


### PR DESCRIPTION
## Purpose

Depending the environment you are using this lambda, you can change the
allocated memory by using the TF_VAR_lambda_convert_memory environment
variable. For example in production you can increase it to convert large
shared live media.

## Proposal

- [x] allow to configure allocated memory to lambda convert

