### PR TITLE
🔖(beta) bump release to 4.0.0-beta.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.0.0-beta.4] - 2022-05-17
+
 ### Added
 
 - Add a control pane destined to contain widgets for the instructor to 
@@ -1114,7 +1116,8 @@ the video to the ViewersList in the right panel
 
 - Minor fixes and improvements on features and tests
 
-[unreleased]: https://github.com/openfun/marsha/compare/v4.0.0-beta.3...master
+[unreleased]: https://github.com/openfun/marsha/compare/v4.0.0-beta.4...master
+[4.0.0-beta.4]: https://github.com/openfun/marsha/compare/v4.0.0-beta.3...v4.0.0-beta.4
 [4.0.0-beta.3]: https://github.com/openfun/marsha/compare/v4.0.0-beta.2...v4.0.0-beta.3
 [4.0.0-beta.2]: https://github.com/openfun/marsha/compare/v4.0.0-beta.1...v4.0.0-beta.2
 [4.0.0-beta.1]: https://github.com/openfun/marsha/compare/v3.27.0...v4.0.0-beta.1

--- a/src/aws/lambda-complete/package.json
+++ b/src/aws/lambda-complete/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-complete",
-  "version": "4.0.0-beta.3",
+  "version": "4.0.0-beta.4",
   "engines": {
     "node": "14"
   },

--- a/src/aws/lambda-configure/package.json
+++ b/src/aws/lambda-configure/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-configure",
-  "version": "4.0.0-beta.3",
+  "version": "4.0.0-beta.4",
   "engines": {
     "node": "14"
   },

--- a/src/aws/lambda-convert/package.json
+++ b/src/aws/lambda-convert/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-convert",
-  "version": "4.0.0-beta.3",
+  "version": "4.0.0-beta.4",
   "engines": {
     "node": "14"
   },

--- a/src/aws/lambda-elemental-routing/package.json
+++ b/src/aws/lambda-elemental-routing/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-elemental-routing",
-  "version": "4.0.0-beta.3",
+  "version": "4.0.0-beta.4",
   "engines": {
     "node": "14"
   },

--- a/src/aws/lambda-medialive/package.json
+++ b/src/aws/lambda-medialive/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-medialive",
-  "version": "4.0.0-beta.3",
+  "version": "4.0.0-beta.4",
   "engines": {
     "node": "14"
   },

--- a/src/aws/lambda-mediapackage/package.json
+++ b/src/aws/lambda-mediapackage/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-mediapackage",
-  "version": "4.0.0-beta.3",
+  "version": "4.0.0-beta.4",
   "engines": {
     "node": "14"
   },

--- a/src/aws/lambda-migrate/package.json
+++ b/src/aws/lambda-migrate/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-migrate",
-  "version": "4.0.0-beta.3",
+  "version": "4.0.0-beta.4",
   "engines": {
     "node": "14"
   },

--- a/src/aws/utils/update-state/package.json
+++ b/src/aws/utils/update-state/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-update-state",
-  "version": "4.0.0-beta.3",
+  "version": "4.0.0-beta.4",
   "engines": {
     "node": "14"
   },

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = marsha
 description = A FUN video provider for Open edX
-version = 4.0.0-beta.3
+version = 4.0.0-beta.4
 author = Open FUN (France Universite Numerique)
 author_email = fun.dev@fun-mooc.fr
 license = MIT

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marsha",
-  "version": "4.0.0-beta.3",
+  "version": "4.0.0-beta.4",
   "description": "🐠 a FUN LTI video provider",
   "main": "front/index.tsx",
   "scripts": {


### PR DESCRIPTION
### Added

- Add a control pane destined to contain widgets for the instructor to
control the live
- Add a widget to modify live title and allow / disallow live recording
- Add a widget to schedule live and modify description
- Add a widget to hide / unhide the chat, for the instructor and for its
students
- Add Markdown document edition (new feature)
- Add a widget to make live publicly available and get the shareable url
- New field deleted_by_cascade on all model inheriting from SafeDeleteModel
  Field added in django-safedelete version 1.2.0
- CLOUDFRONT_SIGNED_PUBLIC_KEY_ID settings is added. It contains the
  public key id created on AWS cloudfront public keys
- Push attendances for students watching a live
- Add a login page to authenticate Marsha users
- Allow live restarting after harvesting

### Changed

- Move appairing device component in the widget dashboard
- Use cloudfront key groups to sign urls instead of using root AWS ssh key

### Removed

- CLOUDFRONT_ACCESS_KEY_ID settings is removed
