### PR TITLE
♻️(back) use custom policy to generate cloudfront signed url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Push attendance when a student is on stage
 
+### Changed
+
+- Use custom policy to generate cloudfront signed url
+
 ## [4.0.0-beta.4] - 2022-05-17
 
 ### Added

--- a/src/backend/marsha/core/tests/test_api_shared_live_media.py
+++ b/src/backend/marsha/core/tests/test_api_shared_live_media.py
@@ -415,6 +415,19 @@ class SharedLiveMediaAPITest(TestCase):
 
         self.assertEqual(response.status_code, 200)
 
+        expected_cloudfront_signture = (
+            "Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiaHR0cHM6L"
+            "y9hYmMuY2xvdWRmcm9udC5uZXQvZDlkNzA0OWMtNWEzZi00MDcwLWE0OTQtZTZiZj"
+            "BiZDhiOWZiLyoiLCJDb25kaXRpb24iOnsiRGF0ZUxlc3NUaGFuIjp7IkFXUzpFcG9"
+            "jaFRpbWUiOjE2MzgyMzc2MDB9fX1dfQ__&Signature=IVWMFfS7WQVTKLZl~gKgG"
+            "ES~BS~wVLBIOncSE6yVgg9zIrEI1Epq3AVkOsI7z10dyjgInNbPviArnxmlV~DQeN"
+            "-ykgEWmGy7aT4lRCx61oXuHFtNkq8Qx-we~UY87mZ4~UTqmM~JVuuLduMiRQB-I3X"
+            "KaRQGRlsok5yGu0RhvLcZntVFp6QgYui3WtGvxSs2LjW0IakR1qepSDl9LXI-F2bg"
+            "l9Vd1U9eapPBhhoD0okebXm7NGg9gUMLXlmUo-RvsrAzzEteKctPp0Xzkydk~tcnM"
+            "kJs4jfbQxKrpyF~N9OuCRYCs68ONhHvypOYU3K-wQEoAFlERBLiaOzDZUzlyA__&K"
+            "ey-Pair-Id=cloudfront-access-key-id"
+        )
+
         content = json.loads(response.content)
         self.assertEqual(
             content,
@@ -429,50 +442,26 @@ class SharedLiveMediaAPITest(TestCase):
                 "upload_state": "ready",
                 "urls": {
                     "media": (
-                        "https://abc.cloudfront.net/d9d7049c-5a3f-4070-a494-e6bf0bd8b9fb/"
-                        "sharedlivemedia/7520c16b-5846-41ca-822b-52b446a96809/1638230400."
-                        "pdf?response-content-disposition=attachment%3B+filename%3Dpython"
-                        "-structures.pdf&Expires=1638237600&Signature=Sm8I4Mnuc6e8sn9mxYY"
-                        "Vt53G6wpBeGEBQCKdkpXpd2Keyq9U-Vcm7pkYVjoHpqyeUcfpFBfkYXb1iwQAZvJ"
-                        "SxIP0-4wtO~118oDd11SzjkoQWXA8~ksCK13YR0WqrBH78SaUmwx3mCkE4IAHqZA"
-                        "R46o2ATZ7YTo9rA4qme9wYoKEj1dOgc~FNVv~ROuc-~xFzh~te39ngxoTw4E2ZRe"
-                        "8zLOvwfAri1yzaBk4EjZlCI90lp-Kyv~sLjpO47uIZ2k1g-llTFwscyH8rRpQSDv"
-                        "Rn1yzlrlrGa3yhdieH-hElr1iaHZUAQx-FdH11HXBSwe1eUeRrk1iOoxowEKS9rP"
-                        "DWA__&Key-Pair-Id=cloudfront-access-key-id"
+                        "https://abc.cloudfront.net/d9d7049c-5a3f-4070-a494-e6bf0bd8b9fb/s"
+                        "haredlivemedia/7520c16b-5846-41ca-822b-52b446a96809/1638230400.pd"
+                        "f?response-content-disposition=attachment%3B+filename%3Dpython-st"
+                        f"ructures.pdf&{expected_cloudfront_signture}"
                     ),
                     "pages": {
                         "1": (
                             "https://abc.cloudfront.net/d9d7049c-5a3f-4070-a494-e6bf0bd8b9"
                             "fb/sharedlivemedia/7520c16b-5846-41ca-822b-52b446a96809/16382"
-                            "30400_1.svg?Expires=1638237600&Signature=HhuTM-~v5kxNnQ4tPeI0"
-                            "yh8xvmJTwJa3AhedgDYWnpalIQcC~uEeU1yLO1gecVwzq4R0UaGf8rmbWvGwj"
-                            "cfG6T-5An7eRfK3JLz9-K7hRXSTFe-dyu9Xzy6vjP6WRj9qJWm7N7EIl8gj~I"
-                            "3E17IIALCfcXZ1oLYrrmKpikOZZfRUnzFKpiMVJ2yr0pM31T4rzjR-yiyupBp"
-                            "DfHomKsi8tS-b7D3Eymm9nKxjXK6zJ6sVE25kL1PejFUQnTQ55gNqsA5IhNuW"
-                            "rYOItpXHeFXoa9b2uGagyp1D3EPpv8p5fk5lizMq8fUykViloSWWR1DsQ6MND"
-                            "YU0L3TezfR4EUCMvQ__&Key-Pair-Id=cloudfront-access-key-id"
+                            f"30400_1.svg?{expected_cloudfront_signture}"
                         ),
                         "2": (
                             "https://abc.cloudfront.net/d9d7049c-5a3f-4070-a494-e6bf0bd8b9"
                             "fb/sharedlivemedia/7520c16b-5846-41ca-822b-52b446a96809/16382"
-                            "30400_2.svg?Expires=1638237600&Signature=PPHBoj50fbVYCokpkFZT"
-                            "cOUNGGabqokah2A9FbiOv3j82hWerD8-X95pClUAfNp3-DuMg1VMA4XOEB~Am"
-                            "7DSDxXshO72BPE0Qh~C-5IFOYfztmQfQg2bdfVTOSMfz8dP1jdkSZ~PVd8hQa"
-                            "4jlAm4yVbUwVtAlIDIJNNGcAB-ORBda1qClW2i1KDJONf8CI9lGo9LKK3AhtA"
-                            "3WKe27YPFJcsR7NIlYx3kfV-XccwjlmQ0fkEw5DG2SRkMm~qyw5HIxzadjMXr"
-                            "9~mbdLZ7GPnnoUmHBfuiYeHCBhv2-7jXAOkx7h8OChGdwqr-hlhkTolTuDrkM"
-                            "7zTfF8Slq85ZSYYBA__&Key-Pair-Id=cloudfront-access-key-id"
+                            f"30400_2.svg?{expected_cloudfront_signture}"
                         ),
                         "3": (
                             "https://abc.cloudfront.net/d9d7049c-5a3f-4070-a494-e6bf0bd8b9"
                             "fb/sharedlivemedia/7520c16b-5846-41ca-822b-52b446a96809/16382"
-                            "30400_3.svg?Expires=1638237600&Signature=P2XH0MDnottQ~kXpXLBb"
-                            "wp9h2SGU5R~b~-~zZKsajdjhdacMfO66p5pLaA3YW2m7nsMcLEigRJR0aZpp~"
-                            "SwPTAl43anzhgsDPttg4-PH6dloE43FHkfW0su8RvfkTjuSFL~Y8old1OY3W6"
-                            "NU92axsVqFvZPQSOFVJS7elt8--t0bY1zwJoOfqR3pw3Ru2TzBE~qvegLdzTA"
-                            "4-emEkr2rI1VpQnAH2jBPqNLFb3AwghjIwY927m0g0YF9HXJyM~t4nSQ5oap5"
-                            "D6hei1Xg7do6BcFH4RBNMB1II70961MnAz-mG39hWHK7v2o2xmui~zJISSZZT"
-                            "I7k68LYfRzEbuA64A__&Key-Pair-Id=cloudfront-access-key-id"
+                            f"30400_3.svg?{expected_cloudfront_signture}"
                         ),
                     },
                 },
@@ -518,6 +507,19 @@ class SharedLiveMediaAPITest(TestCase):
 
         self.assertEqual(response.status_code, 200)
 
+        expect_cloudfront_signature = (
+            "Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiaHR0cHM6Ly9hY"
+            "mMuY2xvdWRmcm9udC5uZXQvZDlkNzA0OWMtNWEzZi00MDcwLWE0OTQtZTZiZjBi"
+            "ZDhiOWZiLyoiLCJDb25kaXRpb24iOnsiRGF0ZUxlc3NUaGFuIjp7IkFXUzpFcG9"
+            "jaFRpbWUiOjE2MzgyMzc2MDB9fX1dfQ__&Signature=IVWMFfS7WQVTKLZl~gK"
+            "gGES~BS~wVLBIOncSE6yVgg9zIrEI1Epq3AVkOsI7z10dyjgInNbPviArnxmlV~"
+            "DQeN-ykgEWmGy7aT4lRCx61oXuHFtNkq8Qx-we~UY87mZ4~UTqmM~JVuuLduMiR"
+            "QB-I3XKaRQGRlsok5yGu0RhvLcZntVFp6QgYui3WtGvxSs2LjW0IakR1qepSDl9"
+            "LXI-F2bgl9Vd1U9eapPBhhoD0okebXm7NGg9gUMLXlmUo-RvsrAzzEteKctPp0X"
+            "zkydk~tcnMkJs4jfbQxKrpyF~N9OuCRYCs68ONhHvypOYU3K-wQEoAFlERBLiaO"
+            "zDZUzlyA__&Key-Pair-Id=cloudfront-access-key-id"
+        )
+
         content = json.loads(response.content)
         self.assertEqual(
             content,
@@ -533,37 +535,19 @@ class SharedLiveMediaAPITest(TestCase):
                 "urls": {
                     "pages": {
                         "1": (
-                            "https://abc.cloudfront.net/d9d7049c-5a3f-4070-a494-e6bf0bd8b9"
-                            "fb/sharedlivemedia/7520c16b-5846-41ca-822b-52b446a96809/16382"
-                            "30400_1.svg?Expires=1638237600&Signature=HhuTM-~v5kxNnQ4tPeI0"
-                            "yh8xvmJTwJa3AhedgDYWnpalIQcC~uEeU1yLO1gecVwzq4R0UaGf8rmbWvGwj"
-                            "cfG6T-5An7eRfK3JLz9-K7hRXSTFe-dyu9Xzy6vjP6WRj9qJWm7N7EIl8gj~I"
-                            "3E17IIALCfcXZ1oLYrrmKpikOZZfRUnzFKpiMVJ2yr0pM31T4rzjR-yiyupBp"
-                            "DfHomKsi8tS-b7D3Eymm9nKxjXK6zJ6sVE25kL1PejFUQnTQ55gNqsA5IhNuW"
-                            "rYOItpXHeFXoa9b2uGagyp1D3EPpv8p5fk5lizMq8fUykViloSWWR1DsQ6MND"
-                            "YU0L3TezfR4EUCMvQ__&Key-Pair-Id=cloudfront-access-key-id"
+                            "https://abc.cloudfront.net/d9d7049c-5a3f-4070-a494-e6bf0bd8b9fb/"
+                            "sharedlivemedia/7520c16b-5846-41ca-822b-52b446a96809/1638230400"
+                            f"_1.svg?{expect_cloudfront_signature}"
                         ),
                         "2": (
-                            "https://abc.cloudfront.net/d9d7049c-5a3f-4070-a494-e6bf0bd8b9"
-                            "fb/sharedlivemedia/7520c16b-5846-41ca-822b-52b446a96809/16382"
-                            "30400_2.svg?Expires=1638237600&Signature=PPHBoj50fbVYCokpkFZT"
-                            "cOUNGGabqokah2A9FbiOv3j82hWerD8-X95pClUAfNp3-DuMg1VMA4XOEB~Am"
-                            "7DSDxXshO72BPE0Qh~C-5IFOYfztmQfQg2bdfVTOSMfz8dP1jdkSZ~PVd8hQa"
-                            "4jlAm4yVbUwVtAlIDIJNNGcAB-ORBda1qClW2i1KDJONf8CI9lGo9LKK3AhtA"
-                            "3WKe27YPFJcsR7NIlYx3kfV-XccwjlmQ0fkEw5DG2SRkMm~qyw5HIxzadjMXr"
-                            "9~mbdLZ7GPnnoUmHBfuiYeHCBhv2-7jXAOkx7h8OChGdwqr-hlhkTolTuDrkM"
-                            "7zTfF8Slq85ZSYYBA__&Key-Pair-Id=cloudfront-access-key-id"
+                            "https://abc.cloudfront.net/d9d7049c-5a3f-4070-a494-e6bf0bd8b9fb/"
+                            "sharedlivemedia/7520c16b-5846-41ca-822b-52b446a96809/1638230400_"
+                            f"2.svg?{expect_cloudfront_signature}"
                         ),
                         "3": (
-                            "https://abc.cloudfront.net/d9d7049c-5a3f-4070-a494-e6bf0bd8b9"
-                            "fb/sharedlivemedia/7520c16b-5846-41ca-822b-52b446a96809/16382"
-                            "30400_3.svg?Expires=1638237600&Signature=P2XH0MDnottQ~kXpXLBb"
-                            "wp9h2SGU5R~b~-~zZKsajdjhdacMfO66p5pLaA3YW2m7nsMcLEigRJR0aZpp~"
-                            "SwPTAl43anzhgsDPttg4-PH6dloE43FHkfW0su8RvfkTjuSFL~Y8old1OY3W6"
-                            "NU92axsVqFvZPQSOFVJS7elt8--t0bY1zwJoOfqR3pw3Ru2TzBE~qvegLdzTA"
-                            "4-emEkr2rI1VpQnAH2jBPqNLFb3AwghjIwY927m0g0YF9HXJyM~t4nSQ5oap5"
-                            "D6hei1Xg7do6BcFH4RBNMB1II70961MnAz-mG39hWHK7v2o2xmui~zJISSZZT"
-                            "I7k68LYfRzEbuA64A__&Key-Pair-Id=cloudfront-access-key-id"
+                            "https://abc.cloudfront.net/d9d7049c-5a3f-4070-a494-e6bf0bd8b9fb/"
+                            "sharedlivemedia/7520c16b-5846-41ca-822b-52b446a96809/1638230400"
+                            f"_3.svg?{expect_cloudfront_signature}"
                         ),
                     },
                 },
@@ -699,6 +683,19 @@ class SharedLiveMediaAPITest(TestCase):
 
         self.assertEqual(response.status_code, 200)
 
+        expected_cloudfront_signature = (
+            "Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNl"
+            "IjoiaHR0cHM6Ly9hYmMuY2xvdWRmcm9udC5uZXQvZDlkNzA0OWMtNWEzZi00MDcw"
+            "LWE0OTQtZTZiZjBiZDhiOWZiLyoiLCJDb25kaXRpb24iOnsiRGF0ZUxlc3NUaGFu"
+            "Ijp7IkFXUzpFcG9jaFRpbWUiOjE2MzgyMzc2MDB9fX1dfQ__&Signature=IVWMF"
+            "fS7WQVTKLZl~gKgGES~BS~wVLBIOncSE6yVgg9zIrEI1Epq3AVkOsI7z10dyjgIn"
+            "NbPviArnxmlV~DQeN-ykgEWmGy7aT4lRCx61oXuHFtNkq8Qx-we~UY87mZ4~UTqm"
+            "M~JVuuLduMiRQB-I3XKaRQGRlsok5yGu0RhvLcZntVFp6QgYui3WtGvxSs2LjW0I"
+            "akR1qepSDl9LXI-F2bgl9Vd1U9eapPBhhoD0okebXm7NGg9gUMLXlmUo-RvsrAzz"
+            "EteKctPp0Xzkydk~tcnMkJs4jfbQxKrpyF~N9OuCRYCs68ONhHvypOYU3K-wQEoA"
+            "FlERBLiaOzDZUzlyA__&Key-Pair-Id=cloudfront-access-key-id"
+        )
+
         content = json.loads(response.content)
         self.assertEqual(
             content,
@@ -716,47 +713,23 @@ class SharedLiveMediaAPITest(TestCase):
                         "https://abc.cloudfront.net/d9d7049c-5a3f-4070-a494-e6bf0bd8b9fb/"
                         "sharedlivemedia/7520c16b-5846-41ca-822b-52b446a96809/1638230400."
                         "pdf?response-content-disposition=attachment%3B+filename%3Dpython"
-                        "-compound-statements.pdf&Expires=1638237600&Signature=FfdLhpZUfM"
-                        "Iu5NtKTZFCcu7GmrlmwL356YwnFAO4nW8hSQ6KxiZfsOoo47vWhtztMFOhPKQHTn"
-                        "ayQvM574G-usHhfyih9Anw22mziKALfAh5l6sDgoRTSZNA1vt7C1wC-k~pJoIYBD"
-                        "2FOohrJnFXHhipHDIzlCYu3d6u5Dgs~QHmLufbNBYth6SsE9AI7kMt1bXhSZTGf6"
-                        "UqWRkQvmfUVNgSE1VQAQgRIBgcB8xLbxMdPcXkld~qkyyxqw7k7ZJbbTabqhzsno"
-                        "wBRH6L44pird2l0r5rWtCT088ecXSOQEUvDpUpgLVoGt0Dzj-~pjc9gQOJcps2l5"
-                        "MUl0ufvjGspA__&Key-Pair-Id=cloudfront-access-key-id"
+                        f"-compound-statements.pdf&{expected_cloudfront_signature}"
                     ),
                     "pages": {
                         "1": (
                             "https://abc.cloudfront.net/d9d7049c-5a3f-4070-a494-e6bf0bd8b9"
                             "fb/sharedlivemedia/7520c16b-5846-41ca-822b-52b446a96809/16382"
-                            "30400_1.svg?Expires=1638237600&Signature=HhuTM-~v5kxNnQ4tPeI0"
-                            "yh8xvmJTwJa3AhedgDYWnpalIQcC~uEeU1yLO1gecVwzq4R0UaGf8rmbWvGwj"
-                            "cfG6T-5An7eRfK3JLz9-K7hRXSTFe-dyu9Xzy6vjP6WRj9qJWm7N7EIl8gj~I"
-                            "3E17IIALCfcXZ1oLYrrmKpikOZZfRUnzFKpiMVJ2yr0pM31T4rzjR-yiyupBp"
-                            "DfHomKsi8tS-b7D3Eymm9nKxjXK6zJ6sVE25kL1PejFUQnTQ55gNqsA5IhNuW"
-                            "rYOItpXHeFXoa9b2uGagyp1D3EPpv8p5fk5lizMq8fUykViloSWWR1DsQ6MND"
-                            "YU0L3TezfR4EUCMvQ__&Key-Pair-Id=cloudfront-access-key-id"
+                            f"30400_1.svg?{expected_cloudfront_signature}"
                         ),
                         "2": (
                             "https://abc.cloudfront.net/d9d7049c-5a3f-4070-a494-e6bf0bd8b9"
                             "fb/sharedlivemedia/7520c16b-5846-41ca-822b-52b446a96809/16382"
-                            "30400_2.svg?Expires=1638237600&Signature=PPHBoj50fbVYCokpkFZT"
-                            "cOUNGGabqokah2A9FbiOv3j82hWerD8-X95pClUAfNp3-DuMg1VMA4XOEB~Am"
-                            "7DSDxXshO72BPE0Qh~C-5IFOYfztmQfQg2bdfVTOSMfz8dP1jdkSZ~PVd8hQa"
-                            "4jlAm4yVbUwVtAlIDIJNNGcAB-ORBda1qClW2i1KDJONf8CI9lGo9LKK3AhtA"
-                            "3WKe27YPFJcsR7NIlYx3kfV-XccwjlmQ0fkEw5DG2SRkMm~qyw5HIxzadjMXr"
-                            "9~mbdLZ7GPnnoUmHBfuiYeHCBhv2-7jXAOkx7h8OChGdwqr-hlhkTolTuDrkM"
-                            "7zTfF8Slq85ZSYYBA__&Key-Pair-Id=cloudfront-access-key-id"
+                            f"30400_2.svg?{expected_cloudfront_signature}"
                         ),
                         "3": (
                             "https://abc.cloudfront.net/d9d7049c-5a3f-4070-a494-e6bf0bd8b9"
                             "fb/sharedlivemedia/7520c16b-5846-41ca-822b-52b446a96809/16382"
-                            "30400_3.svg?Expires=1638237600&Signature=P2XH0MDnottQ~kXpXLBb"
-                            "wp9h2SGU5R~b~-~zZKsajdjhdacMfO66p5pLaA3YW2m7nsMcLEigRJR0aZpp~"
-                            "SwPTAl43anzhgsDPttg4-PH6dloE43FHkfW0su8RvfkTjuSFL~Y8old1OY3W6"
-                            "NU92axsVqFvZPQSOFVJS7elt8--t0bY1zwJoOfqR3pw3Ru2TzBE~qvegLdzTA"
-                            "4-emEkr2rI1VpQnAH2jBPqNLFb3AwghjIwY927m0g0YF9HXJyM~t4nSQ5oap5"
-                            "D6hei1Xg7do6BcFH4RBNMB1II70961MnAz-mG39hWHK7v2o2xmui~zJISSZZT"
-                            "I7k68LYfRzEbuA64A__&Key-Pair-Id=cloudfront-access-key-id"
+                            f"30400_3.svg?{expected_cloudfront_signature}"
                         ),
                     },
                 },
@@ -1167,6 +1140,19 @@ class SharedLiveMediaAPITest(TestCase):
 
         self.assertEqual(response.status_code, 200)
 
+        expected_cloudfront_signature = (
+            "Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiaHR0"
+            "cHM6Ly9hYmMuY2xvdWRmcm9udC5uZXQvZDlkNzA0OWMtNWEzZi00MDcwLWE0OTQt"
+            "ZTZiZjBiZDhiOWZiLyoiLCJDb25kaXRpb24iOnsiRGF0ZUxlc3NUaGFuIjp7IkFX"
+            "UzpFcG9jaFRpbWUiOjE2MzgyMzc2MDB9fX1dfQ__&Signature=IVWMFfS7WQVTK"
+            "LZl~gKgGES~BS~wVLBIOncSE6yVgg9zIrEI1Epq3AVkOsI7z10dyjgInNbPviArn"
+            "xmlV~DQeN-ykgEWmGy7aT4lRCx61oXuHFtNkq8Qx-we~UY87mZ4~UTqmM~JVuuLd"
+            "uMiRQB-I3XKaRQGRlsok5yGu0RhvLcZntVFp6QgYui3WtGvxSs2LjW0IakR1qepS"
+            "Dl9LXI-F2bgl9Vd1U9eapPBhhoD0okebXm7NGg9gUMLXlmUo-RvsrAzzEteKctPp"
+            "0Xzkydk~tcnMkJs4jfbQxKrpyF~N9OuCRYCs68ONhHvypOYU3K-wQEoAFlERBLia"
+            "OzDZUzlyA__&Key-Pair-Id=cloudfront-access-key-id"
+        )
+
         content = json.loads(response.content)
         self.assertEqual(
             content,
@@ -1189,47 +1175,23 @@ class SharedLiveMediaAPITest(TestCase):
                                 "https://abc.cloudfront.net/d9d7049c-5a3f-4070-a494-e6bf0bd8b9fb/"
                                 "sharedlivemedia/7520c16b-5846-41ca-822b-52b446a96809/1638230400."
                                 "pdf?response-content-disposition=attachment%3B+filename%3Dpython"
-                                "-expressions.pdf&Expires=1638237600&Signature=FrElaE~yVca9D~Phjo"
-                                "cqk2FOGPXqWe7Aq3Jga74i9A~RxjA3qjXy436X6Mu0RMV~iYRqrOUYNlPYq7rYX9"
-                                "zsXwGeiJ9K12PIs~KsbjnOG5cv9aJrO0vn3JOrgNtjnK-L6ggrNbb8eAmQrdcdKb"
-                                "jjrAa1r2b0g8-vuR0XCztIGOQCfVDjA-7qdL9WPKiCCILrCV2qOkSmA41ENW1wrd"
-                                "F6~19Yn3YLvlJ3edBqI1Uvoo-5nY5ry8vLmh0TXUz2Mn7RjEmNb-j0UHkNlf93Fs"
-                                "a3oXZiL97KiilZkWD7MlPMMTH0Mv9~QuQsR~8fqJNFMyD7FE2yJaKckNGNp2YVOa"
-                                "vU7A__&Key-Pair-Id=cloudfront-access-key-id"
+                                f"-expressions.pdf&{expected_cloudfront_signature}"
                             ),
                             "pages": {
                                 "1": (
                                     "https://abc.cloudfront.net/d9d7049c-5a3f-4070-a494-e6bf0bd8b9"
                                     "fb/sharedlivemedia/7520c16b-5846-41ca-822b-52b446a96809/16382"
-                                    "30400_1.svg?Expires=1638237600&Signature=HhuTM-~v5kxNnQ4tPeI0"
-                                    "yh8xvmJTwJa3AhedgDYWnpalIQcC~uEeU1yLO1gecVwzq4R0UaGf8rmbWvGwj"
-                                    "cfG6T-5An7eRfK3JLz9-K7hRXSTFe-dyu9Xzy6vjP6WRj9qJWm7N7EIl8gj~I"
-                                    "3E17IIALCfcXZ1oLYrrmKpikOZZfRUnzFKpiMVJ2yr0pM31T4rzjR-yiyupBp"
-                                    "DfHomKsi8tS-b7D3Eymm9nKxjXK6zJ6sVE25kL1PejFUQnTQ55gNqsA5IhNuW"
-                                    "rYOItpXHeFXoa9b2uGagyp1D3EPpv8p5fk5lizMq8fUykViloSWWR1DsQ6MND"
-                                    "YU0L3TezfR4EUCMvQ__&Key-Pair-Id=cloudfront-access-key-id"
+                                    f"30400_1.svg?{expected_cloudfront_signature}"
                                 ),
                                 "2": (
                                     "https://abc.cloudfront.net/d9d7049c-5a3f-4070-a494-e6bf0bd8b9"
                                     "fb/sharedlivemedia/7520c16b-5846-41ca-822b-52b446a96809/16382"
-                                    "30400_2.svg?Expires=1638237600&Signature=PPHBoj50fbVYCokpkFZT"
-                                    "cOUNGGabqokah2A9FbiOv3j82hWerD8-X95pClUAfNp3-DuMg1VMA4XOEB~Am"
-                                    "7DSDxXshO72BPE0Qh~C-5IFOYfztmQfQg2bdfVTOSMfz8dP1jdkSZ~PVd8hQa"
-                                    "4jlAm4yVbUwVtAlIDIJNNGcAB-ORBda1qClW2i1KDJONf8CI9lGo9LKK3AhtA"
-                                    "3WKe27YPFJcsR7NIlYx3kfV-XccwjlmQ0fkEw5DG2SRkMm~qyw5HIxzadjMXr"
-                                    "9~mbdLZ7GPnnoUmHBfuiYeHCBhv2-7jXAOkx7h8OChGdwqr-hlhkTolTuDrkM"
-                                    "7zTfF8Slq85ZSYYBA__&Key-Pair-Id=cloudfront-access-key-id"
+                                    f"30400_2.svg?{expected_cloudfront_signature}"
                                 ),
                                 "3": (
                                     "https://abc.cloudfront.net/d9d7049c-5a3f-4070-a494-e6bf0bd8b9"
                                     "fb/sharedlivemedia/7520c16b-5846-41ca-822b-52b446a96809/16382"
-                                    "30400_3.svg?Expires=1638237600&Signature=P2XH0MDnottQ~kXpXLBb"
-                                    "wp9h2SGU5R~b~-~zZKsajdjhdacMfO66p5pLaA3YW2m7nsMcLEigRJR0aZpp~"
-                                    "SwPTAl43anzhgsDPttg4-PH6dloE43FHkfW0su8RvfkTjuSFL~Y8old1OY3W6"
-                                    "NU92axsVqFvZPQSOFVJS7elt8--t0bY1zwJoOfqR3pw3Ru2TzBE~qvegLdzTA"
-                                    "4-emEkr2rI1VpQnAH2jBPqNLFb3AwghjIwY927m0g0YF9HXJyM~t4nSQ5oap5"
-                                    "D6hei1Xg7do6BcFH4RBNMB1II70961MnAz-mG39hWHK7v2o2xmui~zJISSZZT"
-                                    "I7k68LYfRzEbuA64A__&Key-Pair-Id=cloudfront-access-key-id"
+                                    f"30400_3.svg?{expected_cloudfront_signature}"
                                 ),
                             },
                         },

--- a/src/backend/marsha/core/tests/test_api_timed_text_track.py
+++ b/src/backend/marsha/core/tests/test_api_timed_text_track.py
@@ -405,16 +405,23 @@ class TimedTextTrackAPITest(TestCase):
         self.assertEqual(response.status_code, 200)
         content = json.loads(response.content)
 
+        expected_cloudfront_signature = (
+            "Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiaHR0cHM6"
+            "Ly9hYmMuY2xvdWRmcm9udC5uZXQvYjhkNDBlZDctOTViOC00ODQ4LTk4YzktNTA3MjhkZmVlM"
+            "jVkLyoiLCJDb25kaXRpb24iOnsiRGF0ZUxlc3NUaGFuIjp7IkFXUzpFcG9jaFRpbWUiOjE1Mz"
+            "M2OTM2MDB9fX1dfQ__&Signature=PkRZOcfOxbalcuNG9XN6wO72enDenSetWgTthNjR4Nsy"
+            "UvCao1rZ9s4MZbqU61NDxB8Q3yDoWZUm-PP0uFa6v2Rz9g6XSTCA~-x8Yhh72-jc1J5NZOavh"
+            "~HT6lbC2HnPAesaxbVG4EejSDuXjncE8kBiUdT6YNotAv1JzbqidXuOBdkSjR32PEav98PT0r"
+            "UKmXohNAL-RFdwHL1cKGhy17CoxABn4ToDJ-t0Z4cT4husb5HebH~6nOmhlDDdFMSdmD7FjZ~"
+            "qaJwagJ3sAqG1ph9NcTX45bDn2rcrDXUy0jHWxBPYUId6NGbKCITp1SFj0QAsoxsXnh90Ibkr"
+            "GQ4XUA__&Key-Pair-Id=cloudfront-access-key-id"
+        )
+
         self.assertEqual(
             content["url"],
             (
                 "https://abc.cloudfront.net/b8d40ed7-95b8-4848-98c9-50728dfee25d/timedtext"
-                "/1533686400_fr_cc.vtt?Expires=1533693600&Signature=CWr09YDiSe-j2sKML3f29n"
-                "KfjCdF8nUMUeL1~yHPkMkQpxDXGc5mnKDKkelvzLyAhIUmEi1CtZgG18siFD4RzDVCNufOINx"
-                "KCWzKYmVjN67PJAitNi2nUazFhOA-QODJ03gEpCPgea7ntwgJemOtqkd1uj7kgay~HeslK1L2"
-                "HEIRHjbjaYEoCldCISC8l2FIh~fFryFv9Ptu9ajm4OfIrpc2~oDqe5QkGotQ7IrcZlq8MqMte"
-                "1tbDaGkaQD-NpURCj7rmkt8vkqpWij-IkWxzNWyX38SL1bg2Co762Ab~YKpdiS8jf-WppVS31"
-                "cCehf1bPdsqypBzSFMCqORZvEBtw__&Key-Pair-Id=cloudfront-access-key-id"
+                f"/1533686400_fr_cc.vtt?{expected_cloudfront_signature}"
             ),
         )
         self.assertEqual(
@@ -422,12 +429,7 @@ class TimedTextTrackAPITest(TestCase):
             (
                 "https://abc.cloudfront.net/b8d40ed7-95b8-4848-98c9-50728dfee25d/timedtext"
                 "/source/1533686400_fr_cc?response-content-disposition=attachment%3B+filen"
-                "ame%3Dfoo_1533686400.srt&Expires=1533693600&Signature=Fcb5y9wuTPBPQ2PETBZ"
-                "qAnlMYKTHWkv9fCm5uItq4t28GMMtITGKjpjzlnnUmRvlP0DI6IUjDKXWkZEFN8mM70z4oSn9"
-                "NSh9OLIOG0mAyXRq3XNPh4P0UG8RBkbq2JLSJHgzsDy~AS06LS6i14IQonXoTLsvXGoELNVuN"
-                "sIImqHh2jeH0qaOo34pTWc~GXROYKwwYGEhkmuI1LhX5tJ14aFAEq9ggcm1YRu-aFabQj6yin"
-                "ZkZAgfEqIOScVyG78h5NNDWdU4JbPoQgUr-r97uN91FuoZYn2nJDTxYS0wQQVAc5LGNFB4pjq"
-                "57uxu-aKIRDzKaxOiTrOn75GztmV4OA__&Key-Pair-Id=cloudfront-access-key-id"
+                f"ame%3Dfoo_1533686400.srt&{expected_cloudfront_signature}"
             ),
         )
 

--- a/src/backend/marsha/core/tests/test_api_video.py
+++ b/src/backend/marsha/core/tests/test_api_video.py
@@ -422,6 +422,19 @@ class VideoAPITest(TestCase):
             for resolution in resolutions
         }
 
+        expected_cloudfront_signature = (
+            "Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNl"
+            "IjoiaHR0cHM6Ly9hYmMuY2xvdWRmcm9udC5uZXQvZDlkNzA0OWMtNWEzZi00MDcwLWE0"
+            "OTQtZTZiZjBiZDhiOWZiLyoiLCJDb25kaXRpb24iOnsiRGF0ZUxlc3NUaGFuIjp7IkFX"
+            "UzpFcG9jaFRpbWUiOjE2MzgyMzc2MDB9fX1dfQ__&Signature=IVWMFfS7WQVTKLZl~"
+            "gKgGES~BS~wVLBIOncSE6yVgg9zIrEI1Epq3AVkOsI7z10dyjgInNbPviArnxmlV~DQe"
+            "N-ykgEWmGy7aT4lRCx61oXuHFtNkq8Qx-we~UY87mZ4~UTqmM~JVuuLduMiRQB-I3XKa"
+            "RQGRlsok5yGu0RhvLcZntVFp6QgYui3WtGvxSs2LjW0IakR1qepSDl9LXI-F2bgl9Vd1"
+            "U9eapPBhhoD0okebXm7NGg9gUMLXlmUo-RvsrAzzEteKctPp0Xzkydk~tcnMkJs4jfbQ"
+            "xKrpyF~N9OuCRYCs68ONhHvypOYU3K-wQEoAFlERBLiaOzDZUzlyA__&Key-Pair-Id="
+            "cloudfront-access-key-id"
+        )
+
         self.assertEqual(
             content,
             {
@@ -449,58 +462,28 @@ class VideoAPITest(TestCase):
                     "mp4": {
                         "144": (
                             "https://abc.cloudfront.net/d9d7049c-5a3f-4070-a494-e6bf0bd8b9fb/mp4/"
-                            "1533686400_144.mp4?response-content-disposition=attachment%3B"
-                            "+filename%3Dfoo-bar_1533686400.mp4&Expires=1638237600&Signature=Hn-h"
-                            "chOvM-DOA2ThXN2CXlG1lJioPxC8tz2RbMuN9hthqYDsGVKlEvVz9gpa1PDz26Cnxaai"
-                            "b-lHXuEDtypQEGypA5E~58iAhCGC-CY8T6W3mRSD2oODAnPCcuaBIpihoXNK81DDGBST"
-                            "rXvscORFP87xZRix4C7tRGESSQwuFzi~HERnkcT6cufWL8ydMrv0OsKvSBt79co6XF2c"
-                            "409A~9TfVEuXT6DY5UCwLUtscGoDTH5dRSRd~XRW7nS2K1KigA-C8zkiiimh2TwBqE2m"
-                            "URR-rOc~e4Kb16IuzRRpnZf0eqrnKHWpG0BGWFEEJzbyD8BwkaaA18Kmr53IWyjTlw__"
-                            "&Key-Pair-Id=cloudfront-access-key-id"
+                            "1533686400_144.mp4?response-content-disposition=attachment%3B+filen"
+                            f"ame%3Dfoo-bar_1533686400.mp4&{expected_cloudfront_signature}"
                         ),
                         "240": (
                             "https://abc.cloudfront.net/d9d7049c-5a3f-4070-a494-e6bf0bd8b9fb/mp4/"
-                            "1533686400_240.mp4?response-content-disposition=attachment%3B"
-                            "+filename%3Dfoo-bar_1533686400.mp4&Expires=1638237600&Signature=KNxe"
-                            "uY~6OlOUYpAhSJ5mPqf8hxI6rmnvT34A8B6hROoPTsQZJcKH2b~1hDVmNwX5DOw6TQpm"
-                            "9dAufzyWiQZBZcfLcafOWufmzS36RYlZi8-uzq74Nxl1HkeSCrOphLgwNg7CvN89318S"
-                            "eeayFeCgfIm3zneUKIaZyX2wEl~WUJCtKRvx3Phnsheu-5qcasN-q7WnCPNm7wWTGaVT"
-                            "N624EUNp-8MkmeaSczZLEemXrRWVI7Ekl60SNEMl94fZncouow3nKHp8afy37qdU3jnP"
-                            "CuxtDdyVksGsbDPIMUKCoig22YwJko2yaB~~n~QF~Xq5iBtAr~HX1vtxOqT4d9Mv~g__"
-                            "&Key-Pair-Id=cloudfront-access-key-id"
+                            "1533686400_240.mp4?response-content-disposition=attachment%3B+filen"
+                            f"ame%3Dfoo-bar_1533686400.mp4&{expected_cloudfront_signature}"
                         ),
                         "480": (
                             "https://abc.cloudfront.net/d9d7049c-5a3f-4070-a494-e6bf0bd8b9fb/mp4/"
-                            "1533686400_480.mp4?response-content-disposition=attachment%3B"
-                            "+filename%3Dfoo-bar_1533686400.mp4&Expires=1638237600&Signature=HiV0"
-                            "2qb-cWi6dQPBruMm8RThvB8yX~rfY5HV4cIznZsitm1gCW5eEREGICOx3PM3zmZ2aLGL"
-                            "GKBwlDKbXl3ehVRFXkFKU1-p4PBOkbY9YquPwv1syBLvVlDeNzQyqZZzmt1j4xQGtONv"
-                            "oyUqGrRrMkaFa5YPnaOSPYZDLf2SJIQ8OkQr-OEQk6UQVQO7~mMyknG0iTZdQT5HTRus"
-                            "qmw5xFTZitoS6RzTS4G2SR~uKoaxV3ZtZznAHcDBb7tbAvHN6ckSNSs7~9i2e~AJblXt"
-                            "dsX9O3quO9-IPpQsMpihNASp43M8n-7wa1Uln2dY4jDi~JrYBE6jWG1QkjIBFQkcJg__"
-                            "&Key-Pair-Id=cloudfront-access-key-id"
+                            "1533686400_480.mp4?response-content-disposition=attachment%3B+filen"
+                            f"ame%3Dfoo-bar_1533686400.mp4&{expected_cloudfront_signature}"
                         ),
                         "720": (
                             "https://abc.cloudfront.net/d9d7049c-5a3f-4070-a494-e6bf0bd8b9fb/mp4/"
-                            "1533686400_720.mp4?response-content-disposition=attachment%3B"
-                            "+filename%3Dfoo-bar_1533686400.mp4&Expires=1638237600&Signature=TKVO"
-                            "yKTl2gS8m2gx7lDdjKslJK7R9IJ0Sal3HpoTHcY6LsRDsEpPqAJsUpoR3m1VLfXSoFPC"
-                            "kQdyFPACwocSceMCDMlEylOZetP102D6SiTFT4OP7Al9MwRtPTVKlh-PDrZ-oQfnBQzX"
-                            "JkwQgK~sqIW87QMT4l36homlwkvQWt3oXa4QoxpE58lgY1GkaHrUcVbwEDojE3qF8X9a"
-                            "4ENuPifUYZttKyBNaeVrnRYcd2E4yQXXzpDpeU360ykFHvZDqRCZvu~U~pgboO8aRbY6"
-                            "4lhdevLVdwgH3ESrOoD6MITKm7jbRwcy85gcU5IpOW~9Wc9Vd3nVvKzdWgnWWr7h~w__"
-                            "&Key-Pair-Id=cloudfront-access-key-id"
+                            "1533686400_720.mp4?response-content-disposition=attachment%3B+filen"
+                            f"ame%3Dfoo-bar_1533686400.mp4&{expected_cloudfront_signature}"
                         ),
                         "1080": (
                             "https://abc.cloudfront.net/d9d7049c-5a3f-4070-a494-e6bf0bd8b9fb/mp4/"
-                            "1533686400_1080.mp4?response-content-disposition=attachment%3B"
-                            "+filename%3Dfoo-bar_1533686400.mp4&Expires=1638237600&Signature=HBHL"
-                            "NrEL8xHY~N0kxqdrDtwHLtNq6jsuKMFjU4ro9tyVSUGPlU960c8V23ZMi5KDM1UTvMwF"
-                            "p2TY3ZSOefHaNJvHlwCGpfbscg5mcR5RQBTHvUpFTg2XtvvonzblqcWs6UEY7kSr-wAF"
-                            "9Kviq94x0EeUj43PH7CAJN6q6nXG32fNi1zwyvsXEYCZT6gXyFF6rY9wK1zsE0zgqaR8"
-                            "NLK6dULsuDOg~t2KY33njW51zfQgwH1nW6f9BJwYxyQAAt4UyXUifjOb4ZYEQoEJrSTb"
-                            "8PzvtWsqyTdnOwM8juPknv3Yao8QoVyaE0K84I2BhOE4imVH5T0KskykkoZUHvNGkg__"
-                            "&Key-Pair-Id=cloudfront-access-key-id"
+                            "1533686400_1080.mp4?response-content-disposition=attachment%3B+filen"
+                            f"ame%3Dfoo-bar_1533686400.mp4&{expected_cloudfront_signature}"
                         ),
                     },
                     "thumbnails": thumbnails_dict,
@@ -551,47 +534,23 @@ class VideoAPITest(TestCase):
                                 "https://abc.cloudfront.net/d9d7049c-5a3f-4070-a494-e6bf0bd8b9fb/"
                                 "sharedlivemedia/f16dc536-8cba-473c-a85d-0eb88f64d8f9/1638230400."
                                 "pdf?response-content-disposition=attachment%3B+filename%3Dpython"
-                                "-expressions.pdf&Expires=1638237600&Signature=KJeU8~a7gmBi9tOgPk"
-                                "3WuLzSpO0vn6F1Mxk7XTp7MkmjOW5zZN96aRP3TixixWLY58vsHNH6atGD22MBl7"
-                                "gQiVdaW5Aehjb0t23fZZRavIo~A3d5P4zJsw1xjJxULSxZMj~4Pirs61Tnx5DShz"
-                                "bHH3iXlACFvjYxjbknzSwuWnrk9XvgEXCcrtNArMNrAYWySdy69YkEp5MkBu83r2"
-                                "XAUP0Uli6KlqcOacMJNXq-HOSiWboTecPNkxaNIEvxrwu6fhCrimfXeA2YPg0wQv"
-                                "4YZ0vY8aGuUmKUcrABa2DLGjaCo3s1lyeDfXftb2DAe5ifgOOdsVJ8nq2ar8wRrr"
-                                "vo-A__&Key-Pair-Id=cloudfront-access-key-id"
+                                f"-expressions.pdf&{expected_cloudfront_signature}"
                             ),
                             "pages": {
                                 "1": (
-                                    "https://abc.cloudfront.net/d9d7049c-5a3f-4070-a494-e6bf0bd8b9"
-                                    "fb/sharedlivemedia/f16dc536-8cba-473c-a85d-0eb88f64d8f9/16382"
-                                    "30400_1.svg?Expires=1638237600&Signature=RH9wkrn-3H3xIyrnr8Jm"
-                                    "fL99kADbi-mQuW5~EjainxJh4BjJ6taNWGV3RjCKbErTiqawCCM1WaNJ1iIy~"
-                                    "zcnNEZMd1bTUamDACNovRodTK146zmk9hMYyiB4Ly~nBYoNpRYtY9PlG93LeS"
-                                    "ydT6alykt6s22oEKD0SURGYkdH2Lqi3KRm~9zie6cf7c~FeRtn3pZ0lcjzjzz"
-                                    "zYNiHgH8zQMxEtYscHxsLy-6IR6ZSDgaFSOT2pKi9k2Hp7t2j7Dkr~dUoNwv3"
-                                    "r8aG7Gx~KxokFo1zG16kjn~Ypi~h3Dgo4TeUOE~UvjbxJEUvIEFbFlTm6HUrQ"
-                                    "LzyYhgn-ksruWUhfg__&Key-Pair-Id=cloudfront-access-key-id"
+                                    "https://abc.cloudfront.net/d9d7049c-5a3f-4070-a494-e6bf0bd8b"
+                                    "9fb/sharedlivemedia/f16dc536-8cba-473c-a85d-0eb88f64d8f9/163"
+                                    f"8230400_1.svg?{expected_cloudfront_signature}"
                                 ),
                                 "2": (
-                                    "https://abc.cloudfront.net/d9d7049c-5a3f-4070-a494-e6bf0bd8b9"
-                                    "fb/sharedlivemedia/f16dc536-8cba-473c-a85d-0eb88f64d8f9/16382"
-                                    "30400_2.svg?Expires=1638237600&Signature=DQo6REOTI5Y~F~gDTL~g"
-                                    "8mw~ibCKB0l1EYKmJLIvd3UrbsCqQ6ogxmOg7uUhakW5u3uZqT3xW~NpBE2Qm"
-                                    "AW03X568KJffa6PsyzquvfTd-CQ7aNpARSqX9j8OPw9Z4bmKpk-lbZfib~DV1"
-                                    "3IC4oaXmHO9l1L0T4yQewn2Ua2QuKGmHBcbFeJ~GPFKPkc5P1KcRVPAR1oAMY"
-                                    "Phmijo-PdARV~hhQtayVBX0k4CBnqesF7ib~A-UzVCaMkrgKUGWbnpAF9Bqn~"
-                                    "nk6ibf5uno9wtJVOhdQVlaON2SPQF3PGWvLPB~nmDhYBLKQM215gy79AiF5lF"
-                                    "rF8gsl8cjUvcsqnuw__&Key-Pair-Id=cloudfront-access-key-id"
+                                    "https://abc.cloudfront.net/d9d7049c-5a3f-4070-a494-e6bf0bd8b"
+                                    "9fb/sharedlivemedia/f16dc536-8cba-473c-a85d-0eb88f64d8f9/163"
+                                    f"8230400_2.svg?{expected_cloudfront_signature}"
                                 ),
                                 "3": (
-                                    "https://abc.cloudfront.net/d9d7049c-5a3f-4070-a494-e6bf0bd8b9"
-                                    "fb/sharedlivemedia/f16dc536-8cba-473c-a85d-0eb88f64d8f9/16382"
-                                    "30400_3.svg?Expires=1638237600&Signature=RQrXLWwtI0tOnbo0tkam"
-                                    "KBU9OpZRMVoHQFA3UdwE6rBwIQq~8el4oFUc6hUOTEg6JSK~E9U0FWJ8r-RBB"
-                                    "59Bh-bHZwPkC7sDeD7bH17hd~B01mCtp2DSPvsLQgRi8lMfnDuWtfamuaFJ5Y"
-                                    "GRHVxO~Ad2zG~my1yy1EV4dRDKm80yXg7xufH7ahTzjNiR0RZTEBafsS3IX65"
-                                    "nWM78X96lA-aOJFXdpx4srR7CXdFyIMqroY5SMlKvaQBe-tpb2gjqklNOTkF3"
-                                    "-MoV7C2xGrkcUrMU-1s89bIeNCPjqzEcpb7e4LWOc5j7ZIg8NggFI3CFkXpf~"
-                                    "uykQ25xRFyjWfc2sg__&Key-Pair-Id=cloudfront-access-key-id"
+                                    "https://abc.cloudfront.net/d9d7049c-5a3f-4070-a494-e6bf0bd8b"
+                                    "9fb/sharedlivemedia/f16dc536-8cba-473c-a85d-0eb88f64d8f9/163"
+                                    f"8230400_3.svg?{expected_cloudfront_signature}"
                                 ),
                             },
                         },
@@ -679,6 +638,19 @@ class VideoAPITest(TestCase):
             for resolution in resolutions
         }
 
+        expected_cloudfront_signature = (
+            "Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNl"
+            "IjoiaHR0cHM6Ly9hYmMuY2xvdWRmcm9udC5uZXQvZDlkNzA0OWMtNWEzZi00MDcwLWE0"
+            "OTQtZTZiZjBiZDhiOWZiLyoiLCJDb25kaXRpb24iOnsiRGF0ZUxlc3NUaGFuIjp7IkFX"
+            "UzpFcG9jaFRpbWUiOjE2MzgyMzc2MDB9fX1dfQ__&Signature=IVWMFfS7WQVTKLZl~"
+            "gKgGES~BS~wVLBIOncSE6yVgg9zIrEI1Epq3AVkOsI7z10dyjgInNbPviArnxmlV~DQe"
+            "N-ykgEWmGy7aT4lRCx61oXuHFtNkq8Qx-we~UY87mZ4~UTqmM~JVuuLduMiRQB-I3XKa"
+            "RQGRlsok5yGu0RhvLcZntVFp6QgYui3WtGvxSs2LjW0IakR1qepSDl9LXI-F2bgl9Vd1"
+            "U9eapPBhhoD0okebXm7NGg9gUMLXlmUo-RvsrAzzEteKctPp0Xzkydk~tcnMkJs4jfbQ"
+            "xKrpyF~N9OuCRYCs68ONhHvypOYU3K-wQEoAFlERBLiaOzDZUzlyA__&Key-Pair-Id="
+            "cloudfront-access-key-id"
+        )
+
         self.assertEqual(
             content,
             {
@@ -706,58 +678,28 @@ class VideoAPITest(TestCase):
                     "mp4": {
                         "144": (
                             "https://abc.cloudfront.net/d9d7049c-5a3f-4070-a494-e6bf0bd8b9fb/mp4/"
-                            "1533686400_144.mp4?response-content-disposition=attachment%3B"
-                            "+filename%3Dfoo-bar_1533686400.mp4&Expires=1638237600&Signature=Hn-h"
-                            "chOvM-DOA2ThXN2CXlG1lJioPxC8tz2RbMuN9hthqYDsGVKlEvVz9gpa1PDz26Cnxaai"
-                            "b-lHXuEDtypQEGypA5E~58iAhCGC-CY8T6W3mRSD2oODAnPCcuaBIpihoXNK81DDGBST"
-                            "rXvscORFP87xZRix4C7tRGESSQwuFzi~HERnkcT6cufWL8ydMrv0OsKvSBt79co6XF2c"
-                            "409A~9TfVEuXT6DY5UCwLUtscGoDTH5dRSRd~XRW7nS2K1KigA-C8zkiiimh2TwBqE2m"
-                            "URR-rOc~e4Kb16IuzRRpnZf0eqrnKHWpG0BGWFEEJzbyD8BwkaaA18Kmr53IWyjTlw__"
-                            "&Key-Pair-Id=cloudfront-access-key-id"
+                            "1533686400_144.mp4?response-content-disposition=attachment%3B+filen"
+                            f"ame%3Dfoo-bar_1533686400.mp4&{expected_cloudfront_signature}"
                         ),
                         "240": (
                             "https://abc.cloudfront.net/d9d7049c-5a3f-4070-a494-e6bf0bd8b9fb/mp4/"
-                            "1533686400_240.mp4?response-content-disposition=attachment%3B"
-                            "+filename%3Dfoo-bar_1533686400.mp4&Expires=1638237600&Signature=KNxe"
-                            "uY~6OlOUYpAhSJ5mPqf8hxI6rmnvT34A8B6hROoPTsQZJcKH2b~1hDVmNwX5DOw6TQpm"
-                            "9dAufzyWiQZBZcfLcafOWufmzS36RYlZi8-uzq74Nxl1HkeSCrOphLgwNg7CvN89318S"
-                            "eeayFeCgfIm3zneUKIaZyX2wEl~WUJCtKRvx3Phnsheu-5qcasN-q7WnCPNm7wWTGaVT"
-                            "N624EUNp-8MkmeaSczZLEemXrRWVI7Ekl60SNEMl94fZncouow3nKHp8afy37qdU3jnP"
-                            "CuxtDdyVksGsbDPIMUKCoig22YwJko2yaB~~n~QF~Xq5iBtAr~HX1vtxOqT4d9Mv~g__"
-                            "&Key-Pair-Id=cloudfront-access-key-id"
+                            "1533686400_240.mp4?response-content-disposition=attachment%3B+filen"
+                            f"ame%3Dfoo-bar_1533686400.mp4&{expected_cloudfront_signature}"
                         ),
                         "480": (
                             "https://abc.cloudfront.net/d9d7049c-5a3f-4070-a494-e6bf0bd8b9fb/mp4/"
-                            "1533686400_480.mp4?response-content-disposition=attachment%3B"
-                            "+filename%3Dfoo-bar_1533686400.mp4&Expires=1638237600&Signature=HiV0"
-                            "2qb-cWi6dQPBruMm8RThvB8yX~rfY5HV4cIznZsitm1gCW5eEREGICOx3PM3zmZ2aLGL"
-                            "GKBwlDKbXl3ehVRFXkFKU1-p4PBOkbY9YquPwv1syBLvVlDeNzQyqZZzmt1j4xQGtONv"
-                            "oyUqGrRrMkaFa5YPnaOSPYZDLf2SJIQ8OkQr-OEQk6UQVQO7~mMyknG0iTZdQT5HTRus"
-                            "qmw5xFTZitoS6RzTS4G2SR~uKoaxV3ZtZznAHcDBb7tbAvHN6ckSNSs7~9i2e~AJblXt"
-                            "dsX9O3quO9-IPpQsMpihNASp43M8n-7wa1Uln2dY4jDi~JrYBE6jWG1QkjIBFQkcJg__"
-                            "&Key-Pair-Id=cloudfront-access-key-id"
+                            "1533686400_480.mp4?response-content-disposition=attachment%3B+filen"
+                            f"ame%3Dfoo-bar_1533686400.mp4&{expected_cloudfront_signature}"
                         ),
                         "720": (
                             "https://abc.cloudfront.net/d9d7049c-5a3f-4070-a494-e6bf0bd8b9fb/mp4/"
-                            "1533686400_720.mp4?response-content-disposition=attachment%3B"
-                            "+filename%3Dfoo-bar_1533686400.mp4&Expires=1638237600&Signature=TKVO"
-                            "yKTl2gS8m2gx7lDdjKslJK7R9IJ0Sal3HpoTHcY6LsRDsEpPqAJsUpoR3m1VLfXSoFPC"
-                            "kQdyFPACwocSceMCDMlEylOZetP102D6SiTFT4OP7Al9MwRtPTVKlh-PDrZ-oQfnBQzX"
-                            "JkwQgK~sqIW87QMT4l36homlwkvQWt3oXa4QoxpE58lgY1GkaHrUcVbwEDojE3qF8X9a"
-                            "4ENuPifUYZttKyBNaeVrnRYcd2E4yQXXzpDpeU360ykFHvZDqRCZvu~U~pgboO8aRbY6"
-                            "4lhdevLVdwgH3ESrOoD6MITKm7jbRwcy85gcU5IpOW~9Wc9Vd3nVvKzdWgnWWr7h~w__"
-                            "&Key-Pair-Id=cloudfront-access-key-id"
+                            "1533686400_720.mp4?response-content-disposition=attachment%3B+filen"
+                            f"ame%3Dfoo-bar_1533686400.mp4&{expected_cloudfront_signature}"
                         ),
                         "1080": (
                             "https://abc.cloudfront.net/d9d7049c-5a3f-4070-a494-e6bf0bd8b9fb/mp4/"
-                            "1533686400_1080.mp4?response-content-disposition=attachment%3B"
-                            "+filename%3Dfoo-bar_1533686400.mp4&Expires=1638237600&Signature=HBHL"
-                            "NrEL8xHY~N0kxqdrDtwHLtNq6jsuKMFjU4ro9tyVSUGPlU960c8V23ZMi5KDM1UTvMwF"
-                            "p2TY3ZSOefHaNJvHlwCGpfbscg5mcR5RQBTHvUpFTg2XtvvonzblqcWs6UEY7kSr-wAF"
-                            "9Kviq94x0EeUj43PH7CAJN6q6nXG32fNi1zwyvsXEYCZT6gXyFF6rY9wK1zsE0zgqaR8"
-                            "NLK6dULsuDOg~t2KY33njW51zfQgwH1nW6f9BJwYxyQAAt4UyXUifjOb4ZYEQoEJrSTb"
-                            "8PzvtWsqyTdnOwM8juPknv3Yao8QoVyaE0K84I2BhOE4imVH5T0KskykkoZUHvNGkg__"
-                            "&Key-Pair-Id=cloudfront-access-key-id"
+                            "1533686400_1080.mp4?response-content-disposition=attachment%3B+filen"
+                            f"ame%3Dfoo-bar_1533686400.mp4&{expected_cloudfront_signature}"
                         ),
                     },
                     "thumbnails": thumbnails_dict,
@@ -806,37 +748,19 @@ class VideoAPITest(TestCase):
                         "urls": {
                             "pages": {
                                 "1": (
-                                    "https://abc.cloudfront.net/d9d7049c-5a3f-4070-a494-e6bf0bd8b9"
-                                    "fb/sharedlivemedia/7d9a2087-79be-4731-bcda-f59c7b8b9699/16382"
-                                    "30400_1.svg?Expires=1638237600&Signature=Dw~pu14UQfhsaqoQL2F3"
-                                    "3K6lQRcoI4KYuK~uq9CLjDnCawZKJ8pqv3OKY~O5q~GpUfDfmVH86zXmh1AUI"
-                                    "yR9Yme0GUQNviyo2JPXsXlc6aTGYhPEjNaxuM7WWb1dmjFA3p-twKhPEZBGwi"
-                                    "LCCVIgydhevFI9MQUOlSu4CdAtceaNcrnlH9Zajpq-U1Hxr7POjAXgXwEZHaz"
-                                    "GIw9aQho6WfpqStoS-6BaWUXF3cbtqZjBYKs~zE8kW3W2Z8vUu0PqHa4D72MF"
-                                    "7335kH0epyWzpWNdpTNlzDu~LAM-Hn9PZAe-Z5Hp-uG3Envf0bbM8VpCCA1GQ"
-                                    "MbaLAb1RU7IfHM7Mg__&Key-Pair-Id=cloudfront-access-key-id"
+                                    "https://abc.cloudfront.net/d9d7049c-5a3f-4070-a494-e6bf0bd8b"
+                                    "9fb/sharedlivemedia/7d9a2087-79be-4731-bcda-f59c7b8b9699/163"
+                                    f"8230400_1.svg?{expected_cloudfront_signature}"
                                 ),
                                 "2": (
-                                    "https://abc.cloudfront.net/d9d7049c-5a3f-4070-a494-e6bf0bd8b9"
-                                    "fb/sharedlivemedia/7d9a2087-79be-4731-bcda-f59c7b8b9699/16382"
-                                    "30400_2.svg?Expires=1638237600&Signature=JRTM0xNx-LKy~xsLtE6t"
-                                    "cHhVrH4ZTCDcqjCHoXrscUwstr8mQLmUQBtG3GMc5bQnkGWDfBEvM~LK8j-z1"
-                                    "i1lPJKrzilLs8wxJMzQS36M6PUrJd5enPnZjO-sNUyGXxEK89kmZWJH-X6oTN"
-                                    "6PPKCPEREqPVACFuYcB9JQvMdbxViJWxAKUdIWcYqntBvMKdWiweBVftVTFiV"
-                                    "QDIIUjFFg3rLr2gzBXI~DSLcLGkorAwvC2PVdpKAvpinVmktkYlS-ijZXEsvu"
-                                    "qgm1-8xw4CQF1BgVc3JWgAoSiNgUfjoQSDnrYfZEf4EGGr-USv82qgO89Fu2B"
-                                    "qlt1d3El7PIpE0xQg__&Key-Pair-Id=cloudfront-access-key-id"
+                                    "https://abc.cloudfront.net/d9d7049c-5a3f-4070-a494-e6bf0bd8b"
+                                    "9fb/sharedlivemedia/7d9a2087-79be-4731-bcda-f59c7b8b9699/163"
+                                    f"8230400_2.svg?{expected_cloudfront_signature}"
                                 ),
                                 "3": (
-                                    "https://abc.cloudfront.net/d9d7049c-5a3f-4070-a494-e6bf0bd8b9"
-                                    "fb/sharedlivemedia/7d9a2087-79be-4731-bcda-f59c7b8b9699/16382"
-                                    "30400_3.svg?Expires=1638237600&Signature=O0vBJo~JoANdViQISaf9"
-                                    "y35U8RE61JXr7LMcDAxZA~5HBwc31-Z7eHXvOP920jKXPJX5PBRmDjcsHC3fp"
-                                    "CzHJoHAU9vIn3L62ZxctqXv-~R-5BBjU~yCMhxXxoCK97BbuLagqaH8aqH7ul"
-                                    "jLalCsTmcw3PTnNdkmbd6vqpxDR5Wk~KD5qYgKd961xlBPRPY8JdEozKlMU5p"
-                                    "MNVC0Rf1F7SPmv5Np-qxLApRwKr~K-faIcvEZpVTUdQ95nvf7JGEjxSimC2-7"
-                                    "FMljDvDdppLdDmJSxqXuriSsax98L6eEaXnPHyynHFeULk5~z2S0HbS0BTJO2"
-                                    "7yKKBk~gIWHijnijA__&Key-Pair-Id=cloudfront-access-key-id"
+                                    "https://abc.cloudfront.net/d9d7049c-5a3f-4070-a494-e6bf0bd8b"
+                                    "9fb/sharedlivemedia/7d9a2087-79be-4731-bcda-f59c7b8b9699/163"
+                                    f"8230400_3.svg?{expected_cloudfront_signature}"
                                 ),
                             },
                         },
@@ -1112,14 +1036,16 @@ class VideoAPITest(TestCase):
         self.assertEqual(
             content["urls"]["mp4"]["144"],
             (
-                "https://abc.cloudfront.net/a2f27fde-973a-4e89-8dca-cc59e01d255c/mp4/1533686400_1"
-                "44.mp4?response-content-disposition=attachment%3B+filename%3Dfoo_1533686400.mp4&"
-                "Expires=1533693600&Signature=RmAPJfO~TI6aTyL9NJbEwi2Hyn80i3GdbLHdjm78wR~J3HLgVqa"
-                "Zdw6U88iMQ9aMsF3vYLsxJ8FH1l8BySSc~UGOPgyT-1qpSnyYmLXsINNHgw8WUKUvxy5syZO8E7sD70-"
-                "D~QuxvCAT1UBacZuoRCB~ITZqZlpEKcm7D4UmM7mwQXACdOF5a~6XCISWUYGPRMInUMPXLCPFsEuflx-"
-                "QDB~Rxkwybl~vEi31M2FQuU8ab1fwjC~Jy2RLzmQBDJwzvPuJDTRItJEj137Ohcacf6lGJbAZi8Fu63A"
-                "6lfKXgqgT~lFdwN-LAoehi4IYomUial7Wh8TkMmLPOMXvf5PgEw__"
-                "&Key-Pair-Id=cloudfront-access-key-id"
+                "https://abc.cloudfront.net/a2f27fde-973a-4e89-8dca-cc59e01d255c/mp4/1533686400_14"
+                "4.mp4?response-content-disposition=attachment%3B+filename%3Dfoo_1533686400.mp4&Po"
+                "licy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiaHR0cHM6Ly9hYmMuY2xvdWRmcm9udC5uZXQvYTJm"
+                "MjdmZGUtOTczYS00ZTg5LThkY2EtY2M1OWUwMWQyNTVjLyoiLCJDb25kaXRpb24iOnsiRGF0ZUxlc3NUa"
+                "GFuIjp7IkFXUzpFcG9jaFRpbWUiOjE1MzM2OTM2MDB9fX1dfQ__&Signature=DMuAMeYCa4sslOKW7X4"
+                "R5kXJlYt0k8X49j-4h0x-DTkKN7cYKyDVmsUyEKn1kVBMZLQC1GwnnNjOpbsvyg6hKo7cskwn-zkEr~FM"
+                "fpzO3fAh6PHDqCJa7pBf8iiykCtj~Xm3yF0ATesAnuVda1jAmExM3j43YYFsp2ovU9tXRfeZTD8yJ9QXd"
+                "cSd6phfPNSOE091Bc1OxhBycMjQu7UgYsYYKRQg6tmizzYzv30jp5dNVKh8DPREd1hL3V1O1XnqrCxI1W"
+                "FJ-L680yBs3DzjJyiEeUWsBL2PcjSExKqa0YZkEVhN3N5jYwxmFxWiox1DjBeQg5~mWVF6Of~-xr0XrQ_"
+                "_&Key-Pair-Id=cloudfront-access-key-id"
             ),
         )
 

--- a/src/backend/marsha/core/tests/test_views_lti_cache.py
+++ b/src/backend/marsha/core/tests/test_views_lti_cache.py
@@ -64,7 +64,7 @@ class CacheLTIViewTestCase(TestCase):
         with self.assertNumQueries(6):
             elapsed, resource_origin = self._fetch_lti_request(url, data)
         self.assertEqual(resource_origin["id"], str(video1.id))
-        self.assertLess(elapsed, 0.2)
+        self.assertLess(elapsed, 0.1)
 
         # Calling the same resource a second time with the same LTI parameters
         # should hit the cache and be ultra fast
@@ -78,7 +78,7 @@ class CacheLTIViewTestCase(TestCase):
         with self.assertNumQueries(5):
             elapsed, resource = self._fetch_lti_request(url, data)
         self.assertEqual(resource, resource_origin)
-        self.assertLess(elapsed, 0.2)
+        self.assertLess(elapsed, 0.1)
 
         with self.assertNumQueries(0):
             elapsed, resource = self._fetch_lti_request(url, data)
@@ -90,7 +90,7 @@ class CacheLTIViewTestCase(TestCase):
         with self.assertNumQueries(5):
             elapsed, resource = self._fetch_lti_request(url, data)
         self.assertEqual(resource, resource_origin)
-        self.assertLess(elapsed, 0.2)
+        self.assertLess(elapsed, 0.1)
 
         with self.assertNumQueries(0):
             elapsed, resource = self._fetch_lti_request(
@@ -143,7 +143,7 @@ class CacheLTIViewTestCase(TestCase):
         with self.assertNumQueries(6):
             elapsed, resource_origin = self._fetch_lti_request(url, data)
         self.assertEqual(resource_origin["id"], str(video.id))
-        self.assertLess(elapsed, 0.2)
+        self.assertLess(elapsed, 0.1)
 
         # Calling the same resource a second time with the same LTI parameters
         # should not hit the cache
@@ -166,7 +166,7 @@ class CacheLTIViewTestCase(TestCase):
         with self.assertNumQueries(6):
             elapsed, resource_origin = self._fetch_lti_request(url)
         self.assertEqual(resource_origin["id"], str(video.id))
-        self.assertLess(elapsed, 0.2)
+        self.assertLess(elapsed, 0.1)
 
         with self.assertNumQueries(0):
             elapsed, resource_origin = self._fetch_lti_request(url)
@@ -222,7 +222,7 @@ class CacheLTIViewTestCase(TestCase):
             elapsed, resource_origin = self._fetch_lti_request(url)
 
         self.assertEqual(resource_origin["id"], str(video.id))
-        self.assertLess(elapsed, 0.2)
+        self.assertLess(elapsed, 0.1)
 
         with self.assertNumQueries(2):
             elapsed, resource_origin = self._fetch_lti_request(url)

--- a/src/backend/marsha/core/utils/cloudfront_utils.py
+++ b/src/backend/marsha/core/utils/cloudfront_utils.py
@@ -4,8 +4,11 @@ Utils to sign CloudFront urls and cookies.
 Following boto3's documentation to sign CloudFront urls
 https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloudfront.html
 """
+import base64
+
 from django.conf import settings
 
+from botocore.signers import CloudFrontSigner
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding
@@ -42,3 +45,44 @@ def rsa_signer(message):
     # The following line is excluded from bandit security check because cloudfront supports
     # only sha1 hash for signed URLs.
     return private_key.sign(message, padding.PKCS1v15(), hashes.SHA1())  # nosec
+
+
+def generate_cloudfront_urls_signed_parameters(resource, date_less_than):
+    """
+    Generate all parameters use by a cloudfront signed url.
+    Mainly extracted from CloudFrontSigner class.
+    """
+    cloudfront_signer = CloudFrontSigner(
+        settings.CLOUDFRONT_SIGNED_PUBLIC_KEY_ID,
+        rsa_signer,
+    )
+    policy = cloudfront_signer.build_policy(
+        resource=resource, date_less_than=date_less_than
+    ).encode("utf8")
+    signature = cloudfront_signer.rsa_signer(policy)
+    return [
+        f"Policy={_url_b64encode(policy).decode('utf8')}",
+        f"Signature={_url_b64encode(signature).decode('utf8')}",
+        f"Key-Pair-Id={cloudfront_signer.key_id}",
+    ]
+
+
+def build_signed_url(base_url, extra_params):
+    """
+    Build an url by concatening the base url and the parameters needed to sign it.
+    Extracted from CloudFrontSigner class
+    """
+    separator = "&" if "?" in base_url else "?"
+    return base_url + separator + "&".join(extra_params)
+
+
+def _url_b64encode(data):
+    """Extracted from CloudFrontSigner class"""
+    # Required by CloudFront. See also:
+    # http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-linux-openssl.html
+    return (
+        base64.b64encode(data)
+        .replace(b"+", b"-")
+        .replace(b"=", b"_")
+        .replace(b"/", b"~")
+    )

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -308,6 +308,7 @@ class Base(Configuration):
     )
     CLOUDFRONT_SIGNED_URLS_ACTIVE = values.BooleanValue(True)
     CLOUDFRONT_SIGNED_URLS_VALIDITY = 2 * 60 * 60  # 2 hours
+    CLOUDFRONT_SIGNED_URL_CACHE_DURATION = values.Value(900)  # 15 minutes
     CLOUDFRONT_SIGNED_PUBLIC_KEY_ID = values.Value(None)
 
     CLOUDFRONT_DOMAIN = values.Value(None)


### PR DESCRIPTION
## Purpose

Since the beginning of marsha we used predefined signed url to request
cloudfront. So we needed to generate a signed url for each resources we
want to fetch. Signing a url is a low operation and when we introduced
shared_live_media resources we had a bottleneck on the video and
shared_live_media serializer. To fix this issue, we decided to use a
custom policy[1]. This custom policy target at once all the resource
belonging to a given video. We sign this this policy once and then we
catch all the needed parameters to use them with all the resources
related to this video.

[1]: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-signed-urls.html#private-content-choosing-canned-custom-policy

## Proposal

- [x] use custom policy to generate cloudfront signed url

