### PR TITLE
🐛(front) do not execute start streaming in jitsi for non moderator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Use custom policy to generate cloudfront signed url
 
+### Fixed
+
+- Do not execute start streaming in jitsi for non moderator
+
 ## [4.0.0-beta.4] - 2022-05-17
 
 ### Added


### PR DESCRIPTION
## Purpose

Non moderator will also execute the start-streaming command in jitsi
when a moderator start streaming resulting in log of notification error
telling that the user is not allowed to start streaming.
Fixes #1554

## Proposal


- [x] do not execute start streaming in jitsi for non moderator