### PR TITLE
🐛(front) start jitsi streaming once component load and already running

### DIFF
--- a/src/frontend/components/DashboardVideoLiveJitsi/index.tsx
+++ b/src/frontend/components/DashboardVideoLiveJitsi/index.tsx
@@ -186,9 +186,11 @@ const DashboardVideoLiveJitsi = ({
         jitsiIsRecording.current = false;
       }
 
-      // recording has started. Reset the retry delay
+      // recording has started. Reset the retry delay and set jitsiIsRecording to true
+      // to avoid intempestive start for other moderators.
       if (event.on) {
         retryStartRecordingDelay.current = retryDelayStep;
+        jitsiIsRecording.current = true;
       }
     });
 
@@ -240,7 +242,7 @@ const DashboardVideoLiveJitsi = ({
     if (video.live_state === liveState.STOPPING && jitsiIsRecording.current) {
       jitsi.current!.executeCommand('stopRecording', 'stream');
     }
-  }, [video.live_state, video.live_info.medialive]);
+  }, [video.live_state, video.live_info.medialive, isModerator.current]);
 
   return <Box height={'large'} ref={jitsiNode} />;
 };


### PR DESCRIPTION
## Purpose

When the DashboardVideoLiveJitsi is mounted and the video.live_state is
already running but jitsi was not streaming, nothing happened. Now when
the first moderator joins, jitsi will start streaming.


## Proposal

- [x] start jitsi streaming once component load and already running
