### PR TITLE
👽️(backend) use newly added JWTStatelessUserAuthentication

### DIFF
--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -186,7 +186,7 @@ class Base(Configuration):
 
     REST_FRAMEWORK = {
         "DEFAULT_AUTHENTICATION_CLASSES": (
-            "rest_framework_simplejwt.authentication.JWTTokenUserAuthentication",
+            "rest_framework_simplejwt.authentication.JWTStatelessUserAuthentication",
         ),
         "EXCEPTION_HANDLER": "marsha.core.views.exception_handler",
         "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.LimitOffsetPagination",


### PR DESCRIPTION
Last simplejwt update introduced JWTStatelessUserAuthentication as a
replacement for JWTTokenUserAuthentication.
Even if they provided backward compatibility, we align our code with
their current implementation.

