### PR TITLE
✨(front) fetch video data after websocket reconnection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - On LTI select request, only send title and description for existing resources
 - Adding a new resource through LTI select (deeplinking) now creates it
 with data from Moodle activity titles and description.
+- Fetch video data after websocket reconnection
 
 ### Fixed
 

--- a/src/frontend/data/websocket.ts
+++ b/src/frontend/data/websocket.ts
@@ -8,11 +8,16 @@ import { checkLtiToken } from 'utils/checkLtiToken';
 import { getOrInitAnonymousId } from 'utils/getOrInitAnonymousId';
 
 import { appData, getDecodedJwt } from './appData';
+import { getResource } from './sideEffects/getResource';
 
 type WSMessageType = {
   resource: UploadableObject;
   type: modelName;
 };
+
+interface OpenEvent extends Event {
+  reconnects?: number;
+}
 
 let videoWebsocket: RobustWebSocket;
 
@@ -25,10 +30,27 @@ export const initVideoWebsocket = (video: Video) => {
     const anonymousId = getOrInitAnonymousId();
     url = `${url}&anonymous_id=${anonymousId}`;
   }
-  videoWebsocket = new RobustWebSocket(url);
+
+  videoWebsocket = new RobustWebSocket(url, null, {
+    shouldReconnect: (_, ws) => {
+      // On the first 10 attempts we try to reconnect immediatly.
+      // Then the delay between each attempts is 500ms
+      if (ws.attempts < 10) {
+        return 0;
+      }
+
+      return 500;
+    },
+  });
 
   videoWebsocket.addEventListener('message', async (message) => {
     const data: WSMessageType = JSON.parse(message.data);
     await addResource(data.type, data.resource);
+  });
+
+  videoWebsocket.addEventListener('open', async (event: OpenEvent) => {
+    if (event.reconnects && event.reconnects > 0) {
+      await getResource(modelName.VIDEOS, video.id);
+    }
   });
 };

--- a/src/frontend/tsconfig.json
+++ b/src/frontend/tsconfig.json
@@ -20,6 +20,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "paths": {
+      "altamoon-robust-websocket": ["types/libs/altamoon-robust-websocket"],
       "converse": ["types/libs/converse"],
       "intl-pluralrules": ["types/libs/intl-pluralrules"],
       "JitsiMeetExternalAPI": ["types/libs/JitsiMeetExternalAPI"],

--- a/src/frontend/types/libs/altamoon-robust-websocket/index.d.ts
+++ b/src/frontend/types/libs/altamoon-robust-websocket/index.d.ts
@@ -1,0 +1,20 @@
+import 'altamoon-robust-websocket';
+
+declare module 'altamoon-robust-websocket' {
+  class RobustWebSocket extends WebSocket {
+    constructor(
+      streamUri: string | (() => string | Promise<string>),
+      protocols?: Nullable<string>,
+      options?: {
+        timeout?: number;
+        shouldReconnect?: (event: CloseEvent, ws: RobustWebSocket) => any;
+        automaticOpen?: boolean;
+        ignoreConnectivityEvents?: boolean;
+      },
+    );
+    attempts: number;
+    reconnects: number;
+  }
+
+  export = RobustWebSocket;
+}


### PR DESCRIPTION
## Purpose

When the websocket reconnect to the server after a disconnection, we
fetch the video data in order to refresh them in the zustand store.
Doing this, we will not miss data between disconnection.
Also, the robustwebsocket library type are wrong. We choose to create
our own and overrde the reconnection strategy. By default, the lib does
not reconnect to the server after three attempts. We do not limit the
number of attempt anymore but we increse the delay to 500 ms after 10
attempts.

## Proposal

- [x] fetch video data after websocket reconnection

