### PR TITLE
♻️(backend) don't mix JWT usages

### DIFF
--- a/src/backend/marsha/core/simple_jwt/__init__.py
+++ b/src/backend/marsha/core/simple_jwt/__init__.py
@@ -1,0 +1,1 @@
+"""Marsha module to manage the JWTs"""

--- a/src/backend/marsha/core/simple_jwt/tokens.py
+++ b/src/backend/marsha/core/simple_jwt/tokens.py
@@ -1,6 +1,8 @@
 """Specific Marsha JWT models"""
 from django.conf import settings
+from django.utils.translation import gettext_lazy as _
 
+from rest_framework_simplejwt.exceptions import TokenError
 from rest_framework_simplejwt.tokens import AccessToken
 
 from marsha.core.models import NONE, STUDENT
@@ -44,6 +46,13 @@ class LTISelectFormAccessToken(AccessToken):
         token = cls()
         token.payload[cls.PAYLOAD_FORM_DATA] = lti_select_form_data
         return token
+
+    def verify(self):
+        """Performs additional validation steps to test payload content."""
+        super().verify()
+
+        if self.PAYLOAD_FORM_DATA not in self.payload:
+            raise TokenError(_("Malformed LTI form token"))
 
 
 class ResourceAccessToken(AccessToken):
@@ -247,3 +256,10 @@ class UserAccessToken(AccessToken):
         token = super().for_user(user)
         token.payload[cls.PAYLOAD_USER] = {"id": str(user.id)}
         return token
+
+    def verify(self):
+        """Performs additional validation steps to test payload content."""
+        super().verify()
+
+        if self.PAYLOAD_USER not in self.payload:
+            raise TokenError(_("Malformed user token"))

--- a/src/backend/marsha/core/simple_jwt/tokens.py
+++ b/src/backend/marsha/core/simple_jwt/tokens.py
@@ -1,0 +1,249 @@
+"""Specific Marsha JWT models"""
+from django.conf import settings
+
+from rest_framework_simplejwt.tokens import AccessToken
+
+from marsha.core.models import NONE, STUDENT
+from marsha.core.simple_jwt.utils import define_locales
+from marsha.core.utils.react_locales_utils import react_locale
+
+
+class LTISelectFormAccessToken(AccessToken):
+    """
+    LTI select form access JWT.
+
+    For now, we stay with the same attributes as the original AccessToken for
+    backward compatibility:
+    ```
+        token_type = "access"
+        lifetime = api_settings.ACCESS_TOKEN_LIFETIME
+    ```
+
+    Note: not usable through our authentication backend since it doesn't provide the
+    `api_settings.USER_ID_CLAIM` information in payload.
+    """
+
+    PAYLOAD_FORM_DATA = "lti_select_form_data"
+
+    @classmethod
+    def for_lti_select_form_data(cls, lti_select_form_data):
+        """
+        Build an LTI Select Form JWT.
+
+        Parameters
+        ----------
+        lti_select_form_data: dict
+            the data to enclose in the JWT's payload.
+
+        Returns
+        -------
+        LTISelectFormAccessToken
+            JWT containing:
+            - lti_select_form_data
+        """
+        token = cls()
+        token.payload[cls.PAYLOAD_FORM_DATA] = lti_select_form_data
+        return token
+
+
+class ResourceAccessToken(AccessToken):
+    """
+    Resource dedicated access JWT.
+
+    For now, we stay with the same attributes as the original AccessToken for
+    backward compatibility:
+    ```
+        token_type = "access"
+        lifetime = api_settings.ACCESS_TOKEN_LIFETIME
+    ```
+
+    Note: `api_settings.USER_ID_CLAIM` is currently `resource_id`.
+    """
+
+    @classmethod
+    def for_resource_id(  # pylint: disable=too-many-arguments
+        cls,
+        permissions,
+        session_id,
+        lti=None,
+        playlist_id=None,
+        resource_id=None,
+    ):
+        """
+        Returns an authorization token for the given resource that will be provided
+        after authenticating the resource's credentials.
+
+        Might be split later between LTI and simple behavior.
+
+        Parameters
+        ----------
+        permissions: Type[Dict]
+            permissions to add to the token.
+
+        session_id: Type[str]
+            session id to add to the token.
+
+        lti: Type[LTI]
+            LTI request.
+
+        playlist_id: Type[str]
+            playlist id to add to the token.
+
+        resource_id: Type[str]
+            resource id to add to the token.
+
+        Returns
+        -------
+        ResourceAccessToken
+            JWT containing:
+            - session_id
+            - resource_id
+            - roles
+            - locale
+            - permissions
+            - maintenance
+            - user:
+                - email
+                - id
+                - username
+                - user_fullname
+        """
+        user_id = getattr(lti, "user_id", None) if lti else None
+
+        locale = define_locales(lti)
+
+        # Create a short-lived JWT token for the resource selection
+        token = cls()
+
+        if lti:
+            token.payload["context_id"] = lti.context_id
+            token.payload["consumer_site"] = str(lti.get_consumer_site().id)
+
+        if playlist_id:
+            token.payload["playlist_id"] = playlist_id
+
+        token.payload.update(
+            {
+                "session_id": session_id,
+                "resource_id": str(lti.resource_id) if lti else resource_id,
+                "roles": lti.roles if lti else [NONE],
+                "locale": locale,
+                "permissions": permissions,
+                "maintenance": settings.MAINTENANCE_MODE,
+            }
+        )
+        if user_id:
+            token.payload["user"] = {
+                "email": lti.email,
+                "id": user_id,
+                "username": lti.username,
+                "user_fullname": lti.user_fullname,
+            }
+        return token
+
+    @classmethod
+    def for_live_session(cls, live_session, session_id):
+        """
+        Returns an authorization token for the resource liked to the live session
+        that will be provided after authenticating the resource's credentials.
+
+        Parameters
+        ----------
+        live_session: Type[LiveSession]
+            the live session associated to the token.
+
+        session_id: Type[str]
+            session id to add to the token.
+
+        Returns
+        -------
+        ResourceAccessToken
+            JWT containing:
+            - resource_id
+            - consumer_site (if from LTI connection)
+            - context_id (if from LTI connection)
+            - roles
+            - session_id
+            - locale
+            - permissions
+            - maintenance
+            - user:
+                - email
+                - id (if from LTI connection)
+                - username (if from LTI connection)
+                - anonymous_id (if not from LTI connection)
+        """
+        token = cls()
+
+        token.payload["resource_id"] = str(live_session.video.id)
+        token.payload["user"] = {
+            "email": live_session.email,
+        }
+
+        if live_session.is_from_lti_connection:
+
+            token.payload["consumer_site"] = str(live_session.consumer_site.id)
+            token.payload["context_id"] = str(live_session.video.playlist.lti_id)
+            token.payload["roles"] = [STUDENT]
+            token.payload["user"].update(
+                {
+                    "id": live_session.lti_user_id,
+                    "username": live_session.username,
+                }
+            )
+
+        else:
+
+            token.payload["user"].update(
+                {"anonymous_id": str(live_session.anonymous_id)}
+            )
+            token.payload["roles"] = [NONE]
+
+        token.payload.update(
+            {
+                "session_id": session_id,
+                "locale": react_locale(live_session.language),
+                "permissions": {"can_access_dashboard": False, "can_update": False},
+                "maintenance": settings.MAINTENANCE_MODE,
+            }
+        )
+
+        return token
+
+
+class UserAccessToken(AccessToken):
+    """
+    User access JWT.
+
+    For now, we stay with the same attributes as the original AccessToken for
+    backward compatibility:
+    ```
+        token_type = "access"
+        lifetime = api_settings.ACCESS_TOKEN_LIFETIME
+    ```
+
+    Note: `api_settings.USER_ID_CLAIM` is currently `resource_id`.
+    """
+
+    PAYLOAD_USER = "user"
+
+    @classmethod
+    def for_user(cls, user):
+        """
+        Build a user JWT, used to authenticate user through the application.
+
+        Parameters
+        ----------
+        user: Type[core.User]
+            the user whom information are to store in JWT.
+
+        Returns
+        -------
+        AccessToken
+            JWT containing:
+            - resource_id (`api_settings.USER_ID_CLAIM`)
+            - user
+        """
+        token = super().for_user(user)
+        token.payload[cls.PAYLOAD_USER] = {"id": str(user.id)}
+        return token

--- a/src/backend/marsha/core/simple_jwt/utils.py
+++ b/src/backend/marsha/core/simple_jwt/utils.py
@@ -1,0 +1,27 @@
+"""Helpers/API for Marsha JWT use"""
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+
+from marsha.core.utils.react_locales_utils import react_locale
+
+
+def define_locales(lti) -> str:
+    """
+    Get locale from LTI to pass to the frontend (React).
+
+    lti: Type[LTI]
+        LTI request.
+
+    Returns
+    -------
+    str
+        The locale formatted like xx_XX (eg. `fr_FR`).
+    """
+    try:
+        return (
+            react_locale(lti.launch_presentation_locale)
+            if lti
+            else settings.REACT_LOCALES[0]
+        )
+    except ImproperlyConfigured:
+        return settings.REACT_LOCALES[0]

--- a/src/backend/marsha/core/tests/test_simple_jwt_tokens.py
+++ b/src/backend/marsha/core/tests/test_simple_jwt_tokens.py
@@ -1,0 +1,289 @@
+"""Test Marsha JWTs"""
+import uuid
+
+from django.test import RequestFactory, TestCase
+
+from rest_framework_simplejwt.exceptions import TokenError
+
+from marsha.core.factories import LiveSessionFactory, UserFactory, VideoFactory
+from marsha.core.lti import LTI
+from marsha.core.models import INSTRUCTOR, NONE, STUDENT
+from marsha.core.simple_jwt.tokens import (
+    LTISelectFormAccessToken,
+    ResourceAccessToken,
+    UserAccessToken,
+)
+from marsha.core.tests.utils import generate_passport_and_signed_lti_parameters
+
+
+class LTISelectFormAccessTokenTestCase(TestCase):
+    """Test suite for the LTISelectFormAccessToken"""
+
+    @classmethod
+    def setUpClass(cls):
+        """Provides test case with some common `lti_select_form_data`"""
+        super().setUpClass()
+
+        # `lti_select_form_data` should be a `self.request.POST` which behaves like a dict
+        cls.lti_select_form_data = {"lti_message_type": "ContentItemSelection"}
+
+    def test_for_lti_select_form_data(self):
+        """Test JWT initialization from `for_lti_select_form_data` method"""
+        # The `lti_select_form_data` content is not tested here
+        token = LTISelectFormAccessToken.for_lti_select_form_data(
+            self.lti_select_form_data
+        )
+
+        # Assert the payload contains the expected value
+        self.assertDictEqual(
+            token.payload["lti_select_form_data"], self.lti_select_form_data
+        )
+
+    def test_verify(self):
+        """Test JWT `verify` method"""
+
+        # The `lti_select_form_data` content is not tested here
+        token = LTISelectFormAccessToken.for_lti_select_form_data(
+            self.lti_select_form_data
+        )
+
+        token.verify()  # Should not raise
+
+        handmade_token = LTISelectFormAccessToken()  # new empty token
+        with self.assertRaises(TokenError):
+            handmade_token.verify()
+
+        handmade_token.payload["lti_select_form_data"] = self.lti_select_form_data
+        handmade_token.verify()  # Should not raise
+
+
+class ResourceAccessTokenTestCase(TestCase):
+    """Test suite for the ResourceAccessToken"""
+
+    def make_lti_instance(self, resource_id=None):
+        """Helper to init some LTI context."""
+        url = f"http://testserver/lti/videos/{resource_id or uuid.uuid4()}"
+        lti_parameters, passport = generate_passport_and_signed_lti_parameters(
+            url=url,
+            lti_parameters={
+                "resource_link_id": "df7",
+                "context_id": "course-v1:ufr+mathematics+0001",
+                "roles": INSTRUCTOR,
+                "user_id": "56255f3807599c377bf0e5bf072359fd",
+                "lis_person_sourcedid": "jane_doe",
+                "lis_person_contact_email_primary": "jane@test-mooc.fr",
+            },
+        )
+
+        request = RequestFactory().post(
+            url, lti_parameters, HTTP_REFERER="https://testserver"
+        )
+        lti = LTI(request, resource_id)
+        self.assertTrue(lti.verify())
+
+        return lti, passport
+
+    def test_for_resource_id(self):
+        """Test JWT initialization from `for_resource_id` method without LTI"""
+        permissions = {"can_access_dashboard": False, "can_update": False}
+        session_id = str(uuid.uuid4())
+        resource_id = str(uuid.uuid4())
+
+        token = ResourceAccessToken.for_resource_id(
+            permissions, session_id, resource_id=resource_id
+        )
+
+        self.assertEqual(token.payload["session_id"], session_id)
+        self.assertEqual(token.payload["resource_id"], resource_id)
+        self.assertListEqual(token.payload["roles"], [NONE])
+        self.assertEqual(token.payload["locale"], "en_US")  # settings.REACT_LOCALES[0]
+        self.assertDictEqual(token.payload["permissions"], permissions)
+        self.assertFalse(token.payload["maintenance"])  # settings.MAINTENANCE_MODE
+
+        # Same, with a playlist given
+        playlist_id = str(uuid.uuid4())
+        token_with_playlist = ResourceAccessToken.for_resource_id(
+            permissions,
+            session_id,
+            resource_id=resource_id,
+            playlist_id=playlist_id,
+        )
+        self.assertEqual(token_with_playlist.payload["session_id"], session_id)
+        self.assertEqual(token_with_playlist.payload["resource_id"], resource_id)
+        self.assertListEqual(token_with_playlist.payload["roles"], [NONE])
+        self.assertEqual(token_with_playlist.payload["locale"], "en_US")
+        self.assertDictEqual(token_with_playlist.payload["permissions"], permissions)
+        self.assertFalse(token_with_playlist.payload["maintenance"])
+        self.assertEqual(token_with_playlist.payload["playlist_id"], playlist_id)
+
+    def test_for_resource_id_with_lti(self):
+        """Test JWT initialization from `for_resource_id` method with LTI"""
+        permissions = {"can_access_dashboard": False, "can_update": False}
+        session_id = str(uuid.uuid4())
+        resource_id = str(uuid.uuid4())
+        lti, passport = self.make_lti_instance(resource_id=resource_id)
+
+        token = ResourceAccessToken.for_resource_id(permissions, session_id, lti=lti)
+
+        self.assertEqual(token.payload["session_id"], session_id)
+        self.assertEqual(token.payload["resource_id"], resource_id)
+        self.assertEqual(token.payload["roles"], [INSTRUCTOR])
+        self.assertEqual(token.payload["locale"], "en_US")
+        self.assertDictEqual(token.payload["permissions"], permissions)
+        self.assertFalse(token.payload["maintenance"])  # settings.MAINTENANCE_MODE
+
+        self.assertEqual(token.payload["context_id"], "course-v1:ufr+mathematics+0001")
+        self.assertEqual(token.payload["consumer_site"], str(passport.consumer_site.pk))
+        self.assertDictEqual(
+            token.payload["user"],
+            {
+                "email": "jane@test-mooc.fr",
+                "id": "56255f3807599c377bf0e5bf072359fd",
+                "user_fullname": None,
+                "username": "jane_doe",
+            },
+        )
+
+        # Same, with a playlist given
+        playlist_id = str(uuid.uuid4())
+        token_with_playlist = ResourceAccessToken.for_resource_id(
+            permissions,
+            session_id,
+            lti=lti,
+            playlist_id=playlist_id,
+        )
+
+        self.assertEqual(token_with_playlist.payload["session_id"], session_id)
+        self.assertEqual(token_with_playlist.payload["resource_id"], resource_id)
+        self.assertEqual(token_with_playlist.payload["roles"], [INSTRUCTOR])
+        self.assertEqual(token_with_playlist.payload["locale"], "en_US")
+        self.assertDictEqual(token_with_playlist.payload["permissions"], permissions)
+        self.assertFalse(
+            token_with_playlist.payload["maintenance"]
+        )  # settings.MAINTENANCE_MODE
+
+        self.assertEqual(
+            token_with_playlist.payload["context_id"],
+            "course-v1:ufr+mathematics+0001",
+        )
+        self.assertEqual(
+            token_with_playlist.payload["consumer_site"],
+            str(passport.consumer_site.pk),
+        )
+        self.assertDictEqual(
+            token_with_playlist.payload["user"],
+            {
+                "email": "jane@test-mooc.fr",
+                "id": "56255f3807599c377bf0e5bf072359fd",
+                "user_fullname": None,
+                "username": "jane_doe",
+            },
+        )
+        self.assertEqual(token_with_playlist.payload["playlist_id"], playlist_id)
+
+    def test_for_live_session_anonymous(self):
+        """Test JWT initialization from `for_live_session` method with public session."""
+        permissions = {"can_access_dashboard": False, "can_update": False}
+        session_id = str(uuid.uuid4())
+        anonymous_id = str(uuid.uuid4())
+        live_session = LiveSessionFactory(
+            anonymous_id=anonymous_id,
+            email="chantal@test-fun-mooc.fr",
+        )
+
+        token = ResourceAccessToken.for_live_session(live_session, session_id)
+
+        self.assertEqual(token.payload["session_id"], session_id)
+        self.assertEqual(token.payload["locale"], "en_US")  # settings.REACT_LOCALES[0]
+        self.assertDictEqual(token.payload["permissions"], permissions)
+        self.assertFalse(token.payload["maintenance"])  # settings.MAINTENANCE_MODE
+
+        self.assertEqual(token.payload["resource_id"], str(live_session.video.pk))
+        self.assertDictEqual(
+            token.payload["user"],
+            {
+                "email": "chantal@test-fun-mooc.fr",
+                "anonymous_id": anonymous_id,
+            },
+        )
+        self.assertListEqual(token.payload["roles"], [NONE])
+
+    def test_for_live_session_lti(self):
+        """Test JWT initialization from `for_live_session` method with LTI session."""
+        permissions = {"can_access_dashboard": False, "can_update": False}
+        session_id = str(uuid.uuid4())
+        video = VideoFactory()
+        live_session = LiveSessionFactory(
+            consumer_site=video.playlist.consumer_site,
+            email="chantal@test-fun-mooc.fr",
+            lti_id="Maths",
+            lti_user_id="56255f3807599c377bf0e5bf072359fd",
+            username="chantal",
+            video=video,
+        )
+
+        self.assertTrue(live_session.is_from_lti_connection)
+
+        token = ResourceAccessToken.for_live_session(live_session, session_id)
+
+        self.assertEqual(token.payload["session_id"], session_id)
+        self.assertEqual(token.payload["locale"], "en_US")  # settings.REACT_LOCALES[0]
+        self.assertDictEqual(token.payload["permissions"], permissions)
+        self.assertFalse(token.payload["maintenance"])  # settings.MAINTENANCE_MODE
+
+        self.assertEqual(
+            token.payload["consumer_site"], str(video.playlist.consumer_site.pk)
+        )
+        self.assertEqual(token.payload["context_id"], str(video.playlist.lti_id))
+        self.assertEqual(token.payload["resource_id"], str(video.pk))
+        self.assertDictEqual(
+            token.payload["user"],
+            {
+                "email": "chantal@test-fun-mooc.fr",
+                "id": "56255f3807599c377bf0e5bf072359fd",
+                "username": "chantal",
+            },
+        )
+        self.assertListEqual(token.payload["roles"], [STUDENT])
+
+
+class UserAccessTokenTestCase(TestCase):
+    """Test suite for the ResourceAccessToken"""
+
+    @classmethod
+    def setUpClass(cls):
+        """Provides test case with some common `user` data"""
+        super().setUpClass()
+
+        cls.user = UserFactory()
+
+    def test_for_user(self):
+        """Test JWT initialization from `for_user` method"""
+        token = UserAccessToken.for_user(self.user)
+        self.assertEqual(token.payload["resource_id"], str(self.user.pk))
+        self.assertDictEqual(token.payload["user"], {"id": str(self.user.pk)})
+
+    def test_verify(self):
+        """Test JWT `verify` method"""
+
+        token = UserAccessToken.for_user(self.user)
+        token.verify()  # Should not raise
+
+        handmade_token = UserAccessToken()  # new empty token
+        with self.assertRaises(TokenError):
+            # missing in payload: resource_id, user
+            handmade_token.verify()
+
+        handmade_token.payload["resource_id"] = self.user.pk
+
+        with self.assertRaises(TokenError):
+            # missing in payload: user
+            handmade_token.verify()
+
+        handmade_token.payload["user"] = self.user.pk
+        handmade_token.verify()  # Should not raise
+
+        del handmade_token.payload["resource_id"]
+        # missing in payload: resource_id, but not tested in verify
+        # (this is done in the authentication backend for now)
+        handmade_token.verify()

--- a/src/backend/marsha/core/tests/test_views_lti_respond.py
+++ b/src/backend/marsha/core/tests/test_views_lti_respond.py
@@ -140,7 +140,7 @@ class RespondLTIViewTestCase(TestCase):
         self.assertEqual(response.status_code, 403)
 
     def test_views_lti_respond_no_lti_select_form_data(self):
-        """Missing lti_select_form_data in JWT should raise a 400 error."""
+        """Missing lti_select_form_data in JWT should raise a 403 error."""
         jwt_token = AccessToken()
         response = self.client.post(
             "/lti/respond/",
@@ -149,7 +149,8 @@ class RespondLTIViewTestCase(TestCase):
                 "content_items": "some content items",
             },
         )
-        self.assertEqual(response.status_code, 400)
+        # The token is invalid because of its payload, making it unauthorized access
+        self.assertEqual(response.status_code, 403)
 
     def test_views_lti_respond_no_content_items(self):
         """Missing content_items post data should raise a 400 error."""

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -621,7 +621,15 @@ class Base(Configuration):
             "ALGORITHM": "HS256",
             "SIGNING_KEY": str(self.JWT_SIGNING_KEY),
             "USER_ID_CLAIM": "resource_id",
-            "AUTH_TOKEN_CLASSES": ("rest_framework_simplejwt.tokens.AccessToken",),
+            "AUTH_TOKEN_CLASSES": (
+                "rest_framework_simplejwt.tokens.AccessToken",
+                # For now ResourceAccessToken & UserAccessToken are also AccessToken
+                # but this will allow migration when types will differ.
+                # Note: AccessToken must remain enabled during the migration and removed
+                # only after (version N changes token types, N+1 removes AccessToken).
+                "marsha.core.simple_jwt.tokens.ResourceAccessToken",
+                "marsha.core.simple_jwt.tokens.UserAccessToken",
+            ),
         }
 
     # pylint: disable=invalid-name


### PR DESCRIPTION
## Purpose

Marsha uses different kind of JWT along the way, this PR aims to make different uses more explicit.

## Proposal

Refactor JWT use in Marsha to separate their concerns between JWT for resource and JWT for user (and other JWTs).
This first step, moves the JWT creation to a dedicated module.

Three classes are introduced here:

- `LTISelectFormAccessToken` not used for authentication
- `ResourceAccessToken` built from resource or live session
- `UserAccessToken` for user authentication

The tokens in the testing suite are still forged using the `AccessToken` class and will require a global refactor to use proper class in each case. This will be done in another pull request.

- [x] Regroup JWT mechanics in a dedicated module
- [x] Split AccessToken into ResourceAccessToken and UserAccessToken

