### PR TITLE
🐛(back) force to return None in Thumbnail serializer if deleted

### DIFF
--- a/src/backend/marsha/core/serializers/thumbnail.py
+++ b/src/backend/marsha/core/serializers/thumbnail.py
@@ -40,6 +40,13 @@ class ThumbnailSerializer(serializers.ModelSerializer):
     is_ready_to_show = serializers.BooleanField(read_only=True)
     urls = serializers.SerializerMethodField()
 
+    def to_representation(self, instance):
+        """
+        Object instance -> Dict of primitive datatypes.
+        Force to return None if the thumbnail is deleted
+        """
+        return None if instance.deleted else super().to_representation(instance)
+
     def create(self, validated_data):
         """Force the video field to the video of the JWT Token if any.
 

--- a/src/backend/marsha/core/tests/test_api_thumbnail.py
+++ b/src/backend/marsha/core/tests/test_api_thumbnail.py
@@ -314,12 +314,25 @@ class ThumbnailApiTest(TestCase):
         jwt_token.payload["roles"] = [random.choice(["instructor", "administrator"])]
         jwt_token.payload["permissions"] = {"can_update": True}
 
+        self.assertEqual(Thumbnail.objects.count(), 1)
+
         response = self.client.delete(
             f"/api/thumbnails/{thumbnail.id}/",
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
         self.assertEqual(response.status_code, 204)
         self.assertFalse(Thumbnail.objects.filter(id=thumbnail.id).exists())
+        self.assertEqual(Thumbnail.objects.count(), 0)
+
+        video.refresh_from_db()
+
+        response = self.client.get(
+            f"/api/videos/{video.id}/",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+
+        content = response.json()
+        self.assertIsNone(content["thumbnail"])
 
     def test_api_thumbnail_delete_instructor_in_read_only(self):
         """Instructor should not be able to delete thumbnails in a read_only mode."""


### PR DESCRIPTION
## Purpose

The django-safedelete apps does not manage OneToOneField relation so a
deleted thumbnail is return in the VideoSerializer even though the
thumbnail is deleted. To simply resolve this issue we check in
ThumbnailSerializer.to_representation if the thumbnail is deleted and
force to return False if deleted.
An issue is open on the makinacorpus/django-safedelete to track this bug
https://github.com/makinacorpus/django-safedelete/issues/211


## Proposal

- [x] orce to return None in Thumbnail serializer if deleted
