### PR TITLE
close websocket with specific code when JWT invalid

### DIFF
--- a/src/backend/marsha/websocket/tests/test_consumers_video.py
+++ b/src/backend/marsha/websocket/tests/test_consumers_video.py
@@ -203,7 +203,12 @@ class VideoConsumerTest(TransactionTestCase):
 
         connected, _ = await communicator.connect()
 
-        self.assertFalse(connected)
+        self.assertTrue(connected)
+
+        response = await communicator.receive_output()
+
+        self.assertEqual(response["type"], "websocket.close")
+        self.assertEqual(response["code"], 4003)
 
         await communicator.disconnect()
 
@@ -222,7 +227,12 @@ class VideoConsumerTest(TransactionTestCase):
 
         connected, _ = await communicator.connect()
 
-        self.assertFalse(connected)
+        self.assertTrue(connected)
+
+        response = await communicator.receive_output()
+
+        self.assertEqual(response["type"], "websocket.close")
+        self.assertEqual(response["code"], 4003)
 
         await communicator.disconnect()
 

--- a/src/backend/marsha/websocket/tests/test_middleware_jwt.py
+++ b/src/backend/marsha/websocket/tests/test_middleware_jwt.py
@@ -35,11 +35,16 @@ class JWTMiddlewareTest(TestCase):
         )
 
         application = JWTMiddleware(AsyncWebsocketConsumer())
-        comminucator = WebsocketCommunicator(application, f"/?jwt={token}")
+        communicator = WebsocketCommunicator(application, f"/?jwt={token}")
 
-        connected, _ = await comminucator.connect()
-        self.assertFalse(connected)
-        await comminucator.disconnect()
+        connected, _ = await communicator.connect()
+        self.assertTrue(connected)
+
+        response = await communicator.receive_output()
+
+        self.assertEqual(response["type"], "websocket.close")
+        self.assertEqual(response["code"], 4003)
+        await communicator.disconnect()
 
     async def test_valid_token(self):
         """With a valid token the connection is accepted."""

--- a/src/frontend/data/websocket.ts
+++ b/src/frontend/data/websocket.ts
@@ -32,7 +32,12 @@ export const initVideoWebsocket = (video: Video) => {
   }
 
   videoWebsocket = new RobustWebSocket(url, null, {
-    shouldReconnect: (_, ws) => {
+    shouldReconnect: (event, ws) => {
+      // code 4003 is used by marsha backend to close the connection
+      // when the JWT token is not valid or does not match the current video.
+      if (event.code === 4003) {
+        return;
+      }
       // On the first 10 attempts we try to reconnect immediatly.
       // Then the delay between each attempts is 500ms
       if (ws.attempts < 10) {


### PR DESCRIPTION
## Purpose

When a JWT is invalid and the current video does not match the JWT, we
want to close the websocket with a 4003 code. Unfortunately, the code
can't be specified during handshake process. We must first accept the
connection and close it immediatly with the wanted code.

## Proposal

- [x] close websocket with specific code when JWT invalid
- [x] stop retrying websocket connection when code is 4003
