### PR TITLE
Configure rest framework throttling

### DIFF
--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -192,8 +192,12 @@ class Base(Configuration):
         "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.LimitOffsetPagination",
         "PAGE_SIZE": 50,
         "DEFAULT_THROTTLE_RATES": {
-            "anon": "3/minute",
-            "live_session": "3/minute",
+            "anon": values.Value(
+                "3/minute", environ_name="REST_FRAMEWORK_ANON_THROTTLE_RATE"
+            ),
+            "live_session": values.Value(
+                "3/minute", environ_name="REST_FRAMEWORK_LIVE_SESSION_THROTTLE_RATE"
+            ),
         },
     }
 


### PR DESCRIPTION
## Purpose

The cache_key used in the LiveSessionThrottle only take care of the
current request. We should restrict more this cache_key by adding the
current anonymous_id.

Also, the throtlle used in the application is not configurable. We want to
ajust it to a given situation. For this, the settings are overriding
using REST_FRAMEWORK_ANON_THROTTLE_RATE and
REST_FRAMEWORK_LIVE_SESSION_THROTTLE_RATE environment variable.

## Proposal

- [x] restrict live session throttle to the current anonymous_id
- [x] allow to configure rest_framework throttle
