### PR TITLE
✨(lti-select) split webinars from videos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Add video stats from configurable grafana backend
 - Add shared media support for the teacher
 - Manage live media sharing with picture-in-picture on student side
+- Add a webinar tab to the LTI select view
 
 ### Fixed
 

--- a/src/backend/marsha/core/api/video.py
+++ b/src/backend/marsha/core/api/video.py
@@ -242,6 +242,7 @@ class VideoViewSet(ObjectPkMixin, viewsets.ModelViewSet):
         permission_classes=[
             permissions.IsTokenResourceRouteObject & permissions.IsTokenInstructor
             | permissions.IsTokenResourceRouteObject & permissions.IsTokenAdmin
+            | permissions.HasPlaylistToken
         ],
     )
     # pylint: disable=unused-argument

--- a/src/backend/marsha/e2e/test_lti.py
+++ b/src/backend/marsha/e2e/test_lti.py
@@ -836,4 +836,5 @@ def test_lti_playlist_portability_video(page: Page, live_server: LiveServer):
 
     # ensure video is available in new_playlist
     lti_select_iframe = page.frame("lti_select")
+    lti_select_iframe.click('button[role="tab"]:has-text("Videos")')
     lti_select_iframe.text_content(f'[title="Select {video.title}"]')

--- a/src/frontend/components/LTIRoutes/index.tsx
+++ b/src/frontend/components/LTIRoutes/index.tsx
@@ -83,6 +83,7 @@ export const Routes = () => (
               playlist={appData.playlist}
               documents={appData.documents}
               videos={appData.videos}
+              webinars={appData.webinars}
               new_document_url={appData.new_document_url}
               new_video_url={appData.new_video_url}
               lti_select_form_action_url={appData.lti_select_form_action_url!}

--- a/src/frontend/data/queries/index.tsx
+++ b/src/frontend/data/queries/index.tsx
@@ -11,6 +11,7 @@ import { APIList } from 'types/api';
 import { Document } from 'types/file';
 import { Organization } from 'types/Organization';
 import {
+  LiveModeType,
   Playlist,
   SharedLiveMedia,
   Thumbnail,
@@ -18,6 +19,8 @@ import {
   Video,
   VideoStats,
 } from 'types/tracks';
+import { Nullable } from 'utils/types';
+
 import { actionOne } from './actionOne';
 import { createOne } from './createOne';
 import { deleteOne } from './deleteOne';
@@ -176,6 +179,7 @@ type UseCreateVideoData = {
   title: string;
   description?: string;
   lti_id?: string;
+  live_type?: Nullable<LiveModeType>;
 };
 type UseCreateVideoError =
   | { code: 'exception' }

--- a/src/frontend/types/AppData.ts
+++ b/src/frontend/types/AppData.ts
@@ -1,7 +1,7 @@
 import { Nullable } from 'utils/types';
 import { Document } from './file';
 import { modelName } from './models';
-import { Playlist, Video } from './tracks';
+import { Live, Playlist, Video } from './tracks';
 
 export enum appState {
   ERROR = 'error',
@@ -29,6 +29,7 @@ export interface AppData {
   state: appState;
   video?: Nullable<Video>;
   videos?: Video[];
+  webinars?: Live[];
   document?: Nullable<Document>;
   documents?: Document[];
   resource?: any;

--- a/src/frontend/utils/tests/factories.ts
+++ b/src/frontend/utils/tests/factories.ts
@@ -6,7 +6,10 @@ import { Organization } from 'types/Organization';
 import { Participant } from 'types/Participant';
 import {
   JoinMode,
+  Live,
+  LiveModeType,
   LiveSession,
+  liveState,
   Playlist,
   PlaylistLite,
   SharedLiveMedia,
@@ -152,6 +155,15 @@ export const videoMockFactory = (video: Partial<Video> = {}): Video => {
     xmpp: null,
     shared_live_medias: [],
     ...video,
+  };
+};
+
+export const liveMockFactory = (live: Partial<Live> = {}): Live => {
+  return {
+    ...videoMockFactory(live),
+    live_state: liveState.IDLE,
+    live_type: LiveModeType.JITSI,
+    ...live,
   };
 };
 


### PR DESCRIPTION
## Purpose

In the LTI select view (deeplinking) we want to separate webinars from VOD.

## Proposal

When a user adds a new webinar here, the AWS stack is created.

- [x] Separate webinar and videos in the LTI select view tabs
- [x] Initiate the webinar AWS stack when a new one is requested

