### PR TITLE
🐛(back) correctly check if video is live to set the activity_type 

### DIFF
--- a/src/backend/marsha/core/models/video.py
+++ b/src/backend/marsha/core/models/video.py
@@ -17,6 +17,7 @@ from safedelete import HARD_DELETE_NOCASCADE
 from ..defaults import (
     APPROVAL,
     DELETED,
+    ENDED,
     HARVESTED,
     IDLE,
     JOIN_MODE_CHOICES,
@@ -232,6 +233,11 @@ class Video(BaseFile):
         return (
             self.uploaded_on is not None and self.upload_state != DELETED
         ) or self.live_state is not None
+
+    @property
+    def is_live(self):
+        """Whether the video is a live one."""
+        return self.live_state is not None and self.live_state != ENDED
 
     @staticmethod
     def get_ready_clause():

--- a/src/backend/marsha/core/tests/test_models_video.py
+++ b/src/backend/marsha/core/tests/test_models_video.py
@@ -9,6 +9,7 @@ from django.utils import timezone
 
 from ..defaults import (
     DELETED,
+    ENDED,
     HARVESTED,
     IDLE,
     LIVE_CHOICES,
@@ -88,6 +89,20 @@ class VideoModelsTestCase(TestCase):
             video = VideoFactory(live_state=live_choice[0], live_type=RAW)
 
             self.assertEqual(video.is_ready_to_show, True)
+
+    def test_models_video_is_live(self):
+        """All combination where a video is a live one."""
+        for live_choice in LIVE_CHOICES:
+            video = VideoFactory(live_state=live_choice[0], live_type=RAW)
+
+            self.assertEqual(video.is_live, live_choice[0] not in [ENDED])
+
+        # a video without live_state can't be a live_state
+        video = VideoFactory(
+            live_state=None,
+        )
+
+        self.assertFalse(video.is_live)
 
     def test_models_video_is_scheduled_none(self):
         """Checks that with a starting_at set to None video is not in the scheduled mode."""

--- a/src/backend/marsha/core/tests/test_xapi.py
+++ b/src/backend/marsha/core/tests/test_xapi.py
@@ -5,7 +5,7 @@ from django.test import TestCase, override_settings
 
 from rest_framework_simplejwt.tokens import AccessToken
 
-from ..defaults import RAW, RUNNING
+from ..defaults import ENDED, RAW, READY, RUNNING
 from ..factories import DocumentFactory, VideoFactory
 from ..xapi import (
     XAPI,
@@ -248,6 +248,95 @@ class XAPIVideoStatmentTest(TestCase):
             {
                 "definition": {
                     "type": "http://id.tincanapi.com/activitytype/webinar",
+                    "name": {"en-US": "test video xapi"},
+                },
+                "id": "uuid://68333c45-4b8c-4018-a195-5d5e1706b838",
+                "objectType": "Activity",
+            },
+        )
+        self.assertEqual(
+            statement["context"],
+            {
+                "extensions": {
+                    "https://w3id.org/xapi/video/extensions/session-id": "a6151456-18b7-"
+                    "43b4-8452-2037fed588df"
+                },
+                "contextActivities": {
+                    "category": [{"id": "https://w3id.org/xapi/video"}],
+                    "parent": [
+                        {
+                            "id": "course-v1:ufr+mathematics+0001",
+                            "objectType": "Activity",
+                            "definition": {
+                                "type": "http://adlnet.gov/expapi/activities/course"
+                            },
+                        }
+                    ],
+                },
+            },
+        )
+        self.assertEqual(statement["verb"], base_statement["verb"])
+        self.assertEqual(statement["id"], base_statement["id"])
+        self.assertEqual(statement["result"], base_statement["result"])
+
+    def test_xapi_statement_live_video_ended(self):
+        """An ended live video should send a video activity type."""
+        video = VideoFactory(
+            id="68333c45-4b8c-4018-a195-5d5e1706b838",
+            playlist__consumer_site__domain="example.com",
+            title="test video xapi",
+            live_state=ENDED,
+            live_type=RAW,
+            upload_state=READY,
+        )
+
+        jwt_token = AccessToken()
+        jwt_token.payload["user"] = {"id": "b2584aa405540758db2a6278521b6478"}
+        jwt_token.payload["session_id"] = "326c0689-48c1-493e-8d2d-9fb0c289de7f"
+        jwt_token.payload["context_id"] = "course-v1:ufr+mathematics+0001"
+
+        base_statement = {
+            "context": {
+                "extensions": {
+                    "https://w3id.org/xapi/video/extensions/session-id": "a6151456-18b7-"
+                    "43b4-8452-2037fed588df"
+                }
+            },
+            "result": {
+                "extensions": {
+                    "https://w3id.org/xapi/video/extensions/time-from": 0,
+                    "https://w3id.org/xapi/video/extensions/time-to": 0,
+                    "https://w3id.org/xapi/video/extensions/length": 104.304,
+                    "https://w3id.org/xapi/video/extensions/progress": 0,
+                    "https://w3id.org/xapi/video/extensions/played-segments": "0",
+                }
+            },
+            "verb": {
+                "display": {"en-US": "seeked"},
+                "id": "https://w3id.org/xapi/video/verbs/seeked",
+            },
+            "id": "17dfcd44-b3e0-403d-ab96-e3ef7da616d4",
+        }
+
+        xapi_statement = XAPIVideoStatement(video, base_statement, jwt_token)
+        statement = xapi_statement.get_statement()
+
+        self.assertIsNotNone(statement["timestamp"])
+        self.assertEqual(
+            statement["actor"],
+            {
+                "objectType": "Agent",
+                "account": {
+                    "name": "b2584aa405540758db2a6278521b6478",
+                    "homePage": "http://example.com",
+                },
+            },
+        )
+        self.assertEqual(
+            statement["object"],
+            {
+                "definition": {
+                    "type": "https://w3id.org/xapi/video/activity-type/video",
                     "name": {"en-US": "test video xapi"},
                 },
                 "id": "uuid://68333c45-4b8c-4018-a195-5d5e1706b838",

--- a/src/backend/marsha/core/xapi.py
+++ b/src/backend/marsha/core/xapi.py
@@ -137,7 +137,7 @@ class XAPIVideoStatement(XAPIStatementMixin):
         activity_type = "https://w3id.org/xapi/video/activity-type/video"
 
         # When the video is a live we change the activity to webinar
-        if video.live_state is not None:
+        if video.is_live:
             activity_type = "http://id.tincanapi.com/activitytype/webinar"
 
         if re.match(r"^http(s?):\/\/.*", homepage) is None:


### PR DESCRIPTION
## Purpose

The activity_type in a video XAPI statement depends if it's a live or
not. We use the new model property is_live to check this.

## Proposal

- [x] add `is_live` property to the video model
- [x] correctly check if video is live to set the XAPI activity_type
