### PR TITLE
✨(back) started_at and ended_at are reseted on running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- stopped_at is deleted and started_at is reinitialized when the
+live is restarted
+
 ## [4.0.0-beta.6] - 2022-06-20
 
 ### Added

--- a/src/backend/marsha/core/api/video.py
+++ b/src/backend/marsha/core/api/video.py
@@ -597,8 +597,8 @@ class VideoViewSet(ObjectPkMixin, viewsets.ModelViewSet):
 
         if serializer.validated_data["state"] == defaults.RUNNING:
             video.live_state = defaults.RUNNING
-            if live_info.get("started_at") is None:
-                live_info.update({"started_at": stamp})
+            live_info.update({"started_at": stamp})
+            live_info.pop("stopped_at", None)
 
         if serializer.validated_data["state"] == defaults.STOPPED:
             video.live_state = defaults.STOPPED


### PR DESCRIPTION


## Purpose

When the live restart we need to delete the stopped_at key.
We reset the started_at to the current timestamp of the
last restart.

## Proposal

delete the stopped_at and set started_at to the new timestamp

