### PR TITLE
🐛(back) missing migration migrating video upload_state and live_state data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ live is restarted
 - Display number of anonymous instead of their pseudos
 - Rename markdown route in markdown-documents
 
+### Fixed
+
+- Missing migration to migrate video upload_state and live_state data
 
 ## [4.0.0-beta.6] - 2022-06-20
 

--- a/src/backend/marsha/core/migrations/0051_migrate_live_state.py
+++ b/src/backend/marsha/core/migrations/0051_migrate_live_state.py
@@ -1,0 +1,23 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0050_alter_video_join_mode"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql=(
+                "UPDATE video "
+                "SET live_state=upload_state, upload_state='pending' "
+                "WHERE upload_state='harvesting' OR upload_state='harvested';"
+            ),
+            reverse_sql=(
+                "UPDATE video "
+                "SET upload_state=live_state, live_state='stopped' "
+                "WHERE live_state='harvesting' OR live_state='harvested';"
+            ),
+        ),
+    ]


### PR DESCRIPTION
## Purpose

In the migration 0049 we apply some modification that were pending since
a while to finish the beta process without any pending migration. Doing
this, we missed to migrate some data in the database. The video
upload_state and live_state choices have changed. We must migrate the
corresponding data to have a coherent database.


## Proposal

- [x] missing migration migrating video upload_state and live_state data

