### PR TITLE
♻️(markdown) rename route in markdown-documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - stopped_at is deleted and started_at is reinitialized when the
 live is restarted
 - Display number of anonymous instead of their pseudos
+- Rename markdown route in markdown-documents
 
 
 ## [4.0.0-beta.6] - 2022-06-20

--- a/src/backend/marsha/core/templates/core/lti_development.html
+++ b/src/backend/marsha/core/templates/core/lti_development.html
@@ -229,7 +229,7 @@
             <option value="videos" selected>video</option>
             <option value="documents">document</option>
             <option value="meetings">meeting</option>
-            <option value="markdown_documents">Markdown document</option>
+            <option value="markdown-documents">Markdown document</option>
           </select>
         </div>
         <div class="input-group">
@@ -331,7 +331,7 @@
             <option value="videos" selected>video</option>
             <option value="documents">document</option>
             <option value="meetings">meeting</option>
-            <option value="markdown_documents">Markdown document</option>
+            <option value="markdown-documents">Markdown document</option>
           </select>
         </div>
         <div class="input-group">
@@ -390,7 +390,6 @@
         document.querySelectorAll('.resource-detail pre').forEach((detail) => {
           detail.className = '';
         });
-        console.log(resource.dataset.id);
         document.getElementById(resource.dataset.id).className = 'show';
       };
     });

--- a/src/backend/marsha/markdown/api.py
+++ b/src/backend/marsha/markdown/api.py
@@ -83,7 +83,7 @@ class MarkdownDocumentViewSet(
 
         """
         new_url = build_absolute_uri_behind_proxy(
-            self.request, "/lti/markdown_documents/"
+            self.request, "/lti/markdown-documents/"
         )
 
         markdown_documents = serializers.MarkdownDocumentSelectLTISerializer(

--- a/src/backend/marsha/markdown/models.py
+++ b/src/backend/marsha/markdown/models.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 class MarkdownDocument(TranslatableModelMixin, BaseModel):
     """Model representing a markdown document."""
 
-    RESOURCE_NAME = "markdown_documents"
+    RESOURCE_NAME = "markdown-documents"
 
     # Common LTI resource fields
     lti_id = models.CharField(

--- a/src/backend/marsha/markdown/tests/test_api.py
+++ b/src/backend/marsha/markdown/tests/test_api.py
@@ -471,7 +471,7 @@ class MarkdownAPITest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertDictEqual(
             {
-                "new_url": "http://testserver/lti/markdown_documents/",
+                "new_url": "http://testserver/lti/markdown-documents/",
                 "markdown_documents": [],
             },
             response.json(),
@@ -498,14 +498,14 @@ class MarkdownAPITest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertDictEqual(
             {
-                "new_url": "http://testserver/lti/markdown_documents/",
+                "new_url": "http://testserver/lti/markdown-documents/",
                 "markdown_documents": [
                     {
                         "id": str(markdown_document.id),
                         "is_draft": markdown_document.is_draft,
                         "lti_id": str(markdown_document.lti_id),
                         "lti_url": (
-                            f"http://testserver/lti/markdown_documents/{str(markdown_document.id)}"
+                            f"http://testserver/lti/markdown-documents/{str(markdown_document.id)}"
                         ),
                         "rendering_options": {},
                         "translations": [

--- a/src/backend/marsha/markdown/tests/test_views_lti.py
+++ b/src/backend/marsha/markdown/tests/test_views_lti.py
@@ -47,7 +47,7 @@ class MarkdownLTIViewTestCase(TestCase):
         mock_get_consumer_site.return_value = passport.consumer_site
 
         response = self.client.post(
-            f"/lti/markdown_documents/{markdown_document.id}", data
+            f"/lti/markdown-documents/{markdown_document.id}", data
         )
 
         self.assertEqual(response.status_code, 200)
@@ -62,7 +62,7 @@ class MarkdownLTIViewTestCase(TestCase):
         jwt_token = AccessToken(context.get("jwt"))
         self.assertEqual(context.get("state"), "success")
         self.assertIsNotNone(context.get("resource"))
-        self.assertEqual(context.get("modelName"), "markdown_documents")
+        self.assertEqual(context.get("modelName"), "markdown-documents")
         self.assertEqual(
             jwt_token.payload["user"],
             {
@@ -98,7 +98,7 @@ class MarkdownLTIViewTestCase(TestCase):
         }
         mock_get_consumer_site.return_value = passport.consumer_site
 
-        response = self.client.post(f"/lti/markdown_documents/{uuid.uuid4()}", data)
+        response = self.client.post(f"/lti/markdown-documents/{uuid.uuid4()}", data)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "<html>")
         content = response.content.decode("utf-8")
@@ -111,7 +111,7 @@ class MarkdownLTIViewTestCase(TestCase):
         self.assertIsNotNone(context.get("jwt"))
         self.assertEqual(context.get("state"), "success")
         self.assertIsNotNone(context.get("resource"))
-        self.assertEqual(context.get("modelName"), "markdown_documents")
+        self.assertEqual(context.get("modelName"), "markdown-documents")
 
         # Make sure we only go through LTI verification once as it is costly (getting passport +
         # signature)
@@ -141,7 +141,7 @@ class MarkdownLTIViewTestCase(TestCase):
         mock_get_consumer_site.return_value = passport.consumer_site
 
         response = self.client.post(
-            f"/lti/markdown_documents/{markdown_document.pk}", data
+            f"/lti/markdown-documents/{markdown_document.pk}", data
         )
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "<html>")
@@ -194,7 +194,7 @@ class MarkdownLTIViewTestCase(TestCase):
             },
             context.get("resource"),
         )
-        self.assertEqual(context.get("modelName"), "markdown_documents")
+        self.assertEqual(context.get("modelName"), "markdown-documents")
         self.assertEqual(context.get("appName"), "markdown")
         # Make sure we only go through LTI verification once as it is costly (getting passport +
         # signature)

--- a/src/backend/marsha/markdown/urls.py
+++ b/src/backend/marsha/markdown/urls.py
@@ -17,7 +17,7 @@ router.register(
 
 urlpatterns = [
     path(
-        "lti/markdown_documents/<uuid:uuid>",
+        "lti/markdown-documents/<uuid:uuid>",
         MarkdownDocumentView.as_view(),
         name="markdown_document_lti_view",
     ),

--- a/src/frontend/apps/markdown/types/models.ts
+++ b/src/frontend/apps/markdown/types/models.ts
@@ -1,7 +1,7 @@
 import { Playlist, Resource } from 'types/tracks';
 
 export enum modelName {
-  MARKDOWN_DOCUMENTS = 'markdown_documents',
+  MARKDOWN_DOCUMENTS = 'markdown-documents',
 }
 
 export interface MarkdownDocumentRenderingOptions {


### PR DESCRIPTION
## Purpose

The path to request a markdown document in LTI was
/lti/markdown_documents while we are using /api/markdown-documents for
the API. We choose to normalize every routes and choose
markdown-documents.

## Proposal

- [x] rename route in markdown-documents

