### PR TITLE
🔖(beta) bump release to 4.0.0-beta.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.0.0-beta.7] - 2022-06-27
+
 ### Added
 
 - Allow instructor to share a video and use breakout rooms
@@ -1177,7 +1179,8 @@ the video to the ViewersList in the right panel
 
 - Minor fixes and improvements on features and tests
 
-[unreleased]: https://github.com/openfun/marsha/compare/v4.0.0-beta.6...master
+[unreleased]: https://github.com/openfun/marsha/compare/v4.0.0-beta.7...master
+[4.0.0-beta.7]: https://github.com/openfun/marsha/compare/v4.0.0-beta.6...v4.0.0-beta.7
 [4.0.0-beta.6]: https://github.com/openfun/marsha/compare/v4.0.0-beta.5...v4.0.0-beta.6
 [4.0.0-beta.5]: https://github.com/openfun/marsha/compare/v4.0.0-beta.4...v4.0.0-beta.5
 [4.0.0-beta.4]: https://github.com/openfun/marsha/compare/v4.0.0-beta.3...v4.0.0-beta.4

--- a/src/aws/lambda-complete/package.json
+++ b/src/aws/lambda-complete/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-complete",
-  "version": "4.0.0-beta.6",
+  "version": "4.0.0-beta.7",
   "engines": {
     "node": "14"
   },

--- a/src/aws/lambda-configure/package.json
+++ b/src/aws/lambda-configure/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-configure",
-  "version": "4.0.0-beta.6",
+  "version": "4.0.0-beta.7",
   "engines": {
     "node": "14"
   },

--- a/src/aws/lambda-convert/package.json
+++ b/src/aws/lambda-convert/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-convert",
-  "version": "4.0.0-beta.6",
+  "version": "4.0.0-beta.7",
   "engines": {
     "node": "14"
   },

--- a/src/aws/lambda-elemental-routing/package.json
+++ b/src/aws/lambda-elemental-routing/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-elemental-routing",
-  "version": "4.0.0-beta.6",
+  "version": "4.0.0-beta.7",
   "engines": {
     "node": "14"
   },

--- a/src/aws/lambda-medialive/package.json
+++ b/src/aws/lambda-medialive/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-medialive",
-  "version": "4.0.0-beta.6",
+  "version": "4.0.0-beta.7",
   "engines": {
     "node": "14"
   },

--- a/src/aws/lambda-mediapackage/package.json
+++ b/src/aws/lambda-mediapackage/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-mediapackage",
-  "version": "4.0.0-beta.6",
+  "version": "4.0.0-beta.7",
   "engines": {
     "node": "14"
   },

--- a/src/aws/lambda-migrate/package.json
+++ b/src/aws/lambda-migrate/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-migrate",
-  "version": "4.0.0-beta.6",
+  "version": "4.0.0-beta.7",
   "engines": {
     "node": "14"
   },

--- a/src/aws/utils/update-state/package.json
+++ b/src/aws/utils/update-state/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-update-state",
-  "version": "4.0.0-beta.6",
+  "version": "4.0.0-beta.7",
   "engines": {
     "node": "14"
   },

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = marsha
 description = A FUN video provider for Open edX
-version = 4.0.0-beta.6
+version = 4.0.0-beta.7
 author = Open FUN (France Universite Numerique)
 author_email = fun.dev@fun-mooc.fr
 license = MIT

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marsha",
-  "version": "4.0.0-beta.6",
+  "version": "4.0.0-beta.7",
   "description": "🐠 a FUN LTI video provider",
   "main": "front/index.tsx",
   "scripts": {


### PR DESCRIPTION
### Added

- Allow instructor to share a video and use breakout rooms
- Add resizing feature to the picture in picture mode

###Changed

- stopped_at is deleted and started_at is reinitialized when the
live is restarted
- Display number of anonymous instead of their pseudos
- Rename markdown route in markdown-documents

### Fixed

- Missing migration to migrate video upload_state and live_state data
