### PR TITLE
🔨(front) allow to disable chrome sandboxing with puppeteer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Allow to disable chrome sandboxing in puppeteer.
+  To disable it set DISABLE_PUPPETEER_SANDBOX=1
+
 ### Changed
 
 - Rename meetings to classrooms (no database change yet)

--- a/src/frontend/utils/tests/imageSnapshot.tsx
+++ b/src/frontend/utils/tests/imageSnapshot.tsx
@@ -1,5 +1,5 @@
 import { cleanup, render } from '@testing-library/react';
-import { generateImage } from 'jsdom-screenshot';
+import { generateImage, GenerateImageOptions } from 'jsdom-screenshot';
 import { Grommet } from 'grommet';
 import React from 'react';
 import path from 'path';
@@ -16,11 +16,24 @@ const checkSnapshot = () => {
   }
 };
 
+// To disable puppeteer sandbox if needed, launch the test suite
+// using DISABLE_PUPPETEER_SANDBOX=1 as environment variable.
+// see https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#setting-up-chrome-linux-sandbox
+const disableSandbox = !!process.env.DISABLE_PUPPETEER_SANDBOX;
+
 export const imageSnapshot = async (width?: number, height?: number) => {
   checkSnapshot();
   width = width || 800;
   height = height || 600;
-  const screenshot = await generateImage({ viewport: { width, height } });
+  const generateImageOptions: GenerateImageOptions = {
+    viewport: { width, height },
+  };
+  if (disableSandbox) {
+    generateImageOptions.launch = {
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+    };
+  }
+  const screenshot = await generateImage(generateImageOptions);
   expect(screenshot).toMatchImageSnapshot({
     customDiffDir: path.resolve(__dirname, '../../__diff_output__'),
     failureThreshold: 0.01,


### PR DESCRIPTION
## Purpose

Chrome uses multiples layers of sandboxing and the host should be
configure to work with these sandbox. Since ubuntu 22.04 I found no way
to configure chrome sandboxing and I am not able anymore to run the all
test suite without disabling the sandbox. Disabling the sandbox is
optional and you must use an environment variable for this. To disable
it, the environment variable to use is DISABLE_PUPPETEER_SANDBOX and you
must set it to 1 to disable sandboxing.

## Proposal

- [x] allow to disable chrome sandboxing with puppeteer

