### PR TITLE
🗃️(marsha) migration live_attendance's key are timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ react-query, react-hot-toast, breadcrumb, styled-components)
 
 - Rename meetings to classrooms (no database change yet)
 
+### Fixed
+
+- Missing migration to migrate key format of live_attendance 
+field of liveSession
+
 ## [4.0.0-beta.7] - 2022-06-27
 
 ### Added

--- a/src/backend/marsha/core/migrations/0052_migrate_livesession_liveattendance.py
+++ b/src/backend/marsha/core/migrations/0052_migrate_livesession_liveattendance.py
@@ -1,0 +1,37 @@
+from datetime import datetime
+
+from django.db import migrations
+
+
+def migrate_live_attendance(apps, schema_editor):
+    """Update existing records to set live_attendance with timestamps
+    keys."""
+    try:
+        livesessions = apps.get_model("core", "LiveSession")
+    except LookupError:
+        return
+    livesessions_to_migrate = livesessions.objects.filter(live_attendance__isnull=False)
+    for livesession in livesessions_to_migrate.iterator():
+        for key in list(livesession.live_attendance):
+            try:
+                datetime.fromtimestamp(int(key))
+            except ValueError as error:
+                try:
+                    new_key = int(key) // 1000
+                    datetime.fromtimestamp(new_key)
+                    livesession.live_attendance[
+                        str(new_key)
+                    ] = livesession.live_attendance.pop(key)
+                except ValueError as error:  # shouldn't happen
+                    livesession.live_attendance.pop(key)
+
+        livesession.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0051_migrate_live_state"),
+    ]
+
+    operations = [migrations.RunPython(migrate_live_attendance)]

--- a/src/backend/marsha/core/tests/test_migration_livesession.py
+++ b/src/backend/marsha/core/tests/test_migration_livesession.py
@@ -1,0 +1,101 @@
+"""Tests for the models in the ``core`` app of the Marsha project."""
+from importlib import import_module
+import uuid
+
+from django.apps import apps
+from django.db import connection
+from django.test import TestCase
+
+from ..factories import LiveSessionFactory
+
+
+data_migration = import_module(
+    "marsha.core.migrations.0052_migrate_livesession_liveattendance"
+)
+
+
+class LiveSessionModelsMigrationgLiveAttendanceTestCase(TestCase):
+    """Test livesession model's migration for the field live_attendance."""
+
+    def test_migration_livesession_liveattendance(self):
+        """Test the migration applied on field live_attendance from the
+        model LiveSession"""
+
+        # livesession with one good key, one key in milliseconds and one wrong key
+        livesession_mixed = LiveSessionFactory(
+            anonymous_id=uuid.uuid4(),
+            live_attendance={
+                "1657032736123": {"milliseconds": True, "well_formated": False},
+                "1657032745": {"well_formated": True},
+                "wrong_key": {"well_formated": False},
+            },
+        )
+
+        livesession_milliseconds = LiveSessionFactory(
+            anonymous_id=uuid.uuid4(),
+            live_attendance={
+                "1657032736123": {"milliseconds": True, "well_formated": False},
+                "1657032745123": {"milliseconds": True, "well_formated": False},
+                "1657032768123": {"milliseconds": True, "well_formated": False},
+                "1657032778123": {"milliseconds": True, "well_formated": False},
+                "1657032788123": {"milliseconds": True, "well_formated": False},
+                "1657032798123": {"milliseconds": True, "well_formated": False},
+            },
+        )
+
+        livesession_empty = LiveSessionFactory(
+            anonymous_id=uuid.uuid4(), live_attendance={}
+        )
+
+        livesession_none = LiveSessionFactory(
+            anonymous_id=uuid.uuid4(), live_attendance=None
+        )
+
+        livesession_timestamps = LiveSessionFactory(
+            anonymous_id=uuid.uuid4(),
+            live_attendance={
+                "1657032736": {"well_formated": True},
+                "1657032745": {"well_formated": True},
+                "1657032768": {"well_formated": True},
+            },
+        )
+        data_migration.migrate_live_attendance(apps, connection.schema_editor())
+
+        livesession_mixed.refresh_from_db()
+        livesession_empty.refresh_from_db()
+        livesession_none.refresh_from_db()
+        livesession_timestamps.refresh_from_db()
+        livesession_milliseconds.refresh_from_db()
+
+        # wrong key has been dropped and millisecond's one has been reformated
+        self.assertEqual(
+            livesession_mixed.live_attendance,
+            {
+                "1657032736": {"milliseconds": True, "well_formated": False},
+                "1657032745": {"well_formated": True},
+            },
+        )
+        # all keys have been set in seconds
+        self.assertEqual(
+            livesession_milliseconds.live_attendance,
+            {
+                "1657032736": {"milliseconds": True, "well_formated": False},
+                "1657032745": {"milliseconds": True, "well_formated": False},
+                "1657032768": {"milliseconds": True, "well_formated": False},
+                "1657032778": {"milliseconds": True, "well_formated": False},
+                "1657032788": {"milliseconds": True, "well_formated": False},
+                "1657032798": {"milliseconds": True, "well_formated": False},
+            },
+        )
+        # nothing has changed
+        self.assertEqual(livesession_empty.live_attendance, {})
+        self.assertEqual(livesession_none.live_attendance, None)
+
+        self.assertEqual(
+            livesession_timestamps.live_attendance,
+            {
+                "1657032736": {"well_formated": True},
+                "1657032745": {"well_formated": True},
+                "1657032768": {"well_formated": True},
+            },
+        )


### PR DESCRIPTION

## Purpose

Previous commit 67f8233b transformed milliseconds keys to
keys in seconds. For data existing in the database, a migration
is needed to do this conversion.

## Proposal

Description...

For existing record containing wrong keys, data are transformed

