### PR TITLE
✅(backend) fix a broken test

### DIFF
--- a/src/backend/marsha/core/tests/test_api_xapi_statement.py
+++ b/src/backend/marsha/core/tests/test_api_xapi_statement.py
@@ -111,8 +111,8 @@ class XAPIStatementApiTest(TestCase):
 
         self.assertEqual(response.status_code, 404)
 
-    @mock.patch("marsha.core.api.XAPI")
-    def test_xapi_statement_with_request_error_to_lrs(self, xapi_mock):
+    @mock.patch("marsha.core.api.XAPI.send")
+    def test_xapi_statement_with_request_error_to_lrs(self, xapi_send_mock):
         """Sending a request to the LRS fails. The response should reflect this failure."""
         video = VideoFactory(
             playlist__consumer_site__lrs_url="http://lrs.com/data/xAPI",
@@ -141,8 +141,7 @@ class XAPIStatementApiTest(TestCase):
         mock_response.status_code.return_value = 400
 
         exception = requests.exceptions.HTTPError(response=mock_response)
-        xapi_instance = xapi_mock.return_value
-        xapi_instance.send.side_effect = exception
+        xapi_send_mock.side_effect = exception
 
         response = self.client.post(
             "/xapi/video/",


### PR DESCRIPTION

## Purpose

One of our test was wrongly mocking an XAPI call.
Maybe some change on the targeted server suddenly broke it.

See https://app.circleci.com/pipelines/github/openfun/marsha/7595/workflows/09889488-699d-4b54-befc-cacfc7f1cf90/jobs/231970

## Proposal

Fix the mock in the test.

