### PR TITLE
🐛(front) fix player crash when subtitles are updated

### DIFF
--- a/src/frontend/Player/createPlayer.ts
+++ b/src/frontend/Player/createPlayer.ts
@@ -1,6 +1,6 @@
+import { TimedText, timedTextMode } from 'types/tracks';
 import { VideoPlayerCreator } from 'types/VideoPlayer';
 import { report } from 'utils/errors/report';
-
 import { createVideojsPlayer } from './createVideojsPlayer';
 
 export const createPlayer: VideoPlayerCreator = (
@@ -20,7 +20,42 @@ export const createPlayer: VideoPlayerCreator = (
         locale,
         onReady,
       );
+
+      const trackTextKind: {
+        [key in timedTextMode]?: videojs.default.TextTrack.Kind;
+      } = {
+        [timedTextMode.CLOSED_CAPTIONING]: 'captions',
+        [timedTextMode.SUBTITLE]: 'subtitles',
+      };
+
+      const addTrackToPlayer = (
+        track: TimedText,
+        languages: { [key: string]: string },
+      ) => {
+        player.addRemoteTextTrack(
+          {
+            id: track.id,
+            src: track.url,
+            language: track.language,
+            kind: trackTextKind[track.mode],
+            label: languages[track.language] || track.language,
+          },
+          true,
+        );
+      };
+
+      const removeTrackFromPlayer = (track: TimedText) => {
+        if (track.id) {
+          player.removeRemoteTextTrack(
+            player.remoteTextTracks().getTrackById(track.id) as any,
+          );
+        }
+      };
+
       return {
+        addTrack: (track: TimedText, languages: { [key: string]: string }) =>
+          addTrackToPlayer(track, languages),
+        removeTrack: (track: TimedText) => removeTrackFromPlayer(track),
         destroy: () => player.dispose(),
         getSource: () => player.currentSource().src,
         setSource: (url: string) => player.src(url),

--- a/src/frontend/components/PublicVideoDashboard/index.spec.tsx
+++ b/src/frontend/components/PublicVideoDashboard/index.spec.tsx
@@ -113,6 +113,8 @@ describe('PublicVideoDashboard', () => {
       { method: 'OPTIONS' },
     );
     mockCreatePlayer.mockReturnValue({
+      addTrack: jest.fn(),
+      removeTrack: jest.fn(),
       destroy: jest.fn(),
       getSource: jest.fn(),
       setSource: jest.fn(),

--- a/src/frontend/components/StudentLiveWrapper/index.spec.tsx
+++ b/src/frontend/components/StudentLiveWrapper/index.spec.tsx
@@ -105,6 +105,8 @@ describe('<StudentLiveWrapper /> as a viewer', () => {
       { method: 'OPTIONS' },
     );
     mockCreatePlayer.mockReturnValue({
+      addTrack: jest.fn(),
+      removeTrack: jest.fn(),
       destroy: jest.fn(),
       getSource: jest.fn(),
       setSource: jest.fn(),
@@ -921,6 +923,8 @@ describe('<StudentLiveWrapper /> as a streamer', () => {
       { method: 'OPTIONS' },
     );
     mockCreatePlayer.mockReturnValue({
+      addTrack: jest.fn(),
+      removeTrack: jest.fn(),
       destroy: jest.fn(),
       getSource: jest.fn(),
       setSource: jest.fn(),

--- a/src/frontend/components/VideoPlayer/index.spec.tsx
+++ b/src/frontend/components/VideoPlayer/index.spec.tsx
@@ -84,6 +84,8 @@ describe('VideoPlayer', () => {
 
   beforeEach(() => {
     mockCreatePlayer.mockReturnValue({
+      addTrack: jest.fn(),
+      removeTrack: jest.fn(),
       destroy: jest.fn(),
       getSource: jest.fn(),
       setSource: jest.fn(),
@@ -148,7 +150,6 @@ describe('VideoPlayer', () => {
       ),
     );
 
-    expect(container.querySelectorAll('track')).toHaveLength(2);
     expect(
       container.querySelector('source[src="https://example.com/144p.mp4"]'),
     ).not.toBeNull();

--- a/src/frontend/components/VideoPlayer/index.tsx
+++ b/src/frontend/components/VideoPlayer/index.tsx
@@ -1,21 +1,16 @@
 import { Stack } from 'grommet';
 import React, { useRef, useEffect } from 'react';
+import { useIntl } from 'react-intl';
 import { Redirect } from 'react-router';
 
 import { FULL_SCREEN_ERROR_ROUTE } from 'components/ErrorComponents/route';
-
 import { useThumbnail } from 'data/stores/useThumbnail';
 import { useTimedTextTrackLanguageChoices } from 'data/stores/useTimedTextTrackLanguageChoices';
 import { useVideoProgress } from 'data/stores/useVideoProgress';
 import { createPlayer } from 'Player/createPlayer';
 import { TimedText, timedTextMode, Video, videoSize } from 'types/tracks';
-import { Nullable } from 'utils/types';
-import { useIntl } from 'react-intl';
-
-const trackTextKind: { [key in timedTextMode]?: string } = {
-  [timedTextMode.CLOSED_CAPTIONING]: 'captions',
-  [timedTextMode.SUBTITLE]: 'subtitles',
-};
+import { VideoPlayerInterface } from 'types/VideoPlayer';
+import { Maybe, Nullable } from 'utils/types';
 
 interface BaseVideoPlayerProps {
   video: Nullable<Video>;
@@ -54,16 +49,16 @@ const VideoPlayer = ({
       )) ||
     {};
 
+  const playerRef = useRef<Maybe<VideoPlayerInterface>>(undefined);
   /**
    * Initialize the video player.
    * Noop out if the video is missing, render will redirect to an error page.
    */
   useEffect(() => {
     getChoices();
-
     if (video) {
       // Instantiate the player and keep the instance in state
-      const createdPlayer = createPlayer(
+      playerRef.current = createPlayer(
         playerType,
         videoNodeRef.current!,
         setPlayerCurrentTime,
@@ -73,21 +68,65 @@ const VideoPlayer = ({
           if (defaultVolume !== undefined) {
             videoPlayer.volume(Math.min(1, Math.max(0, defaultVolume)));
           }
+          timedTextTracks
+            .filter((track) => track.is_ready_to_show)
+            .filter((track) =>
+              [
+                timedTextMode.CLOSED_CAPTIONING,
+                timedTextMode.SUBTITLE,
+              ].includes(track.mode),
+            )
+            .forEach((track) => {
+              if (playerRef.current) {
+                playerRef.current.addTrack(track, languages);
+              }
+            });
         },
       );
 
-      document.dispatchEvent(
-        new CustomEvent('marsha_player_created', {
-          detail: {
-            videoNode: videoNodeRef.current!,
-          },
-        }),
-      );
-
       /** Make sure to destroy the player on unmount. */
-      return () => createdPlayer && createdPlayer.destroy();
+      return () => playerRef.current && playerRef.current.destroy();
     }
   }, []);
+
+  useEffect(() => {
+    if (video?.urls?.manifests && playerRef.current) {
+      playerRef.current.setSource(video.urls.manifests.hls);
+    }
+  }, [video?.urls?.manifests.hls]);
+
+  const oldTimedTextTracks = useRef(timedTextTracks);
+  useEffect(() => {
+    if (!playerRef.current) {
+      return;
+    }
+    const playerApi = playerRef.current;
+
+    // tracks to add
+    timedTextTracks
+      .filter(
+        (track) =>
+          !oldTimedTextTracks.current.includes(track) &&
+          track.is_ready_to_show &&
+          [timedTextMode.CLOSED_CAPTIONING, timedTextMode.SUBTITLE].includes(
+            track.mode,
+          ),
+      )
+      .forEach((track) => playerApi.addTrack(track, languages));
+    // tracks to remove
+    oldTimedTextTracks.current
+      .filter(
+        (track) =>
+          !timedTextTracks.includes(track) &&
+          track.is_ready_to_show &&
+          [timedTextMode.CLOSED_CAPTIONING, timedTextMode.SUBTITLE].includes(
+            track.mode,
+          ),
+      )
+      .forEach((track) => playerApi.removeTrack(track));
+
+    oldTimedTextTracks.current = timedTextTracks;
+  }, [timedTextTracks]);
 
   // The video is somehow missing and jwt must be set
   if (!video) {
@@ -114,31 +153,14 @@ const VideoPlayer = ({
         poster={thumbnailUrls[resolutions[0]]}
         tabIndex={-1}
       >
-        {resolutions.map((size) => (
+        {resolutions.map((size, index) => (
           <source
-            key={video.urls!.mp4[size]}
+            key={`url_${index}`}
             size={`${size}`}
             src={video.urls!.mp4[size]}
             type="video/mp4"
           />
         ))}
-
-        {timedTextTracks
-          .filter((track) => track.is_ready_to_show)
-          .filter((track) =>
-            [timedTextMode.CLOSED_CAPTIONING, timedTextMode.SUBTITLE].includes(
-              track.mode,
-            ),
-          )
-          .map((track) => (
-            <track
-              key={track.id}
-              src={track.url}
-              srcLang={track.language}
-              kind={trackTextKind[track.mode]}
-              label={languages[track.language] || track.language}
-            />
-          ))}
       </video>
     </Stack>
   );

--- a/src/frontend/data/stores/useTimedTextTrack/index.tsx
+++ b/src/frontend/data/stores/useTimedTextTrack/index.tsx
@@ -1,10 +1,14 @@
 import create from 'zustand';
 
-import { modelName } from '../../../types/models';
-import { StoreState } from '../../../types/stores';
-import { TimedText } from '../../../types/tracks';
-import { appData } from '../../appData';
-import { addMultipleResources, addResource, removeResource } from '../actions';
+import { appData } from 'data/appData';
+import {
+  addMultipleResources,
+  addResource,
+  removeResource,
+} from 'data/stores/actions';
+import { modelName } from 'types/models';
+import { StoreState } from 'types/stores';
+import { TimedText } from 'types/tracks';
 
 type TimedTextTrackStore = {
   [modelName.TIMEDTEXTTRACKS]: {

--- a/src/frontend/data/stores/useTimedTextTrackLanguageChoices/index.tsx
+++ b/src/frontend/data/stores/useTimedTextTrackLanguageChoices/index.tsx
@@ -1,14 +1,14 @@
 import create from 'zustand';
 
-import { API_ENDPOINT } from '../../../settings';
-import { requestStatus } from '../../../types/api';
-import { LanguageChoice } from '../../../types/LanguageChoice';
-import { modelName } from '../../../types/models';
-import { RouteOptions } from '../../../types/RouteOptions';
-import { TimedText } from '../../../types/tracks';
-import { report } from '../../../utils/errors/report';
-import { Maybe } from '../../../utils/types';
-import { appData } from '../../appData';
+import { appData } from 'data/appData';
+import { API_ENDPOINT } from 'settings';
+import { requestStatus } from 'types/api';
+import { LanguageChoice } from 'types/LanguageChoice';
+import { modelName } from 'types/models';
+import { RouteOptions } from 'types/RouteOptions';
+import { TimedText } from 'types/tracks';
+import { report } from 'utils/errors/report';
+import { Maybe } from 'utils/types';
 
 type State = {
   choices: Maybe<LanguageChoice[]>;

--- a/src/frontend/types/VideoPlayer.ts
+++ b/src/frontend/types/VideoPlayer.ts
@@ -1,8 +1,11 @@
-import { Maybe } from 'utils/types';
 import { VideoJsPlayer } from 'video.js';
-import { Video } from './tracks';
+
+import { Video, TimedText } from 'types/tracks';
+import { Maybe } from 'utils/types';
 
 export interface VideoPlayerInterface {
+  addTrack(track: TimedText, languages: { [key: string]: string }): void;
+  removeTrack(track: TimedText): void;
   /** Destroy the instance and garbage collect any elements. */
   destroy(): void;
   getSource(): string;


### PR DESCRIPTION
## Purpose

When subtitles were added / removed in the useTimedTextTrack store, VideoPlayer
was rerendering and adding new track tags in the DOM. But VideoPlayer was not
able to correctly manage this use case and was crashing because it wasn't able
to remove old track tags. This commit aims to fix this flaw.

## Proposal

With this commit, this process is now managed
programmatically, which is resulting in a better functionning of the videojs API.

