### PR TITLE
[backend] Redirect user to frontend with challenge token after login

### DIFF
--- a/src/backend/marsha/account/tests/test_views_social_edu_federation_saml_auth.py
+++ b/src/backend/marsha/account/tests/test_views_social_edu_federation_saml_auth.py
@@ -174,7 +174,7 @@ class RenaterSAMLFullProcessTestCase(TestCase):
                 },
             )
             self.assertEqual(response.status_code, 302)
-            self.assertEqual(response["Location"], "/")
+            self.assertEqual(response["Location"], "/account/login/complete/")
 
         # Assert the user is authenticated
         user = auth_get_user(self.client)

--- a/src/backend/marsha/account/urls.py
+++ b/src/backend/marsha/account/urls.py
@@ -11,6 +11,7 @@ from .views import (
     PasswordResetConfirmView,
     PasswordResetDoneView,
     PasswordResetView,
+    RedirectToFrontendView,
 )
 from .views.social_edu_federation_saml_auth import MarshaEduFederationIdpChoiceView
 
@@ -38,6 +39,11 @@ urlpatterns = [
         name="password_reset_complete",
     ),
     # Django social auth
+    path(
+        "login/complete/",
+        RedirectToFrontendView.as_view(),
+        name="login_complete_redirect",
+    ),
     path("", include("social_django.urls", namespace="social")),
     # SAML
     path(

--- a/src/backend/marsha/account/views/model_auth.py
+++ b/src/backend/marsha/account/views/model_auth.py
@@ -1,6 +1,7 @@
 """Marsha django model authentication views."""
 from django.conf import settings
 from django.contrib.auth import logout as auth_logout
+from django.contrib.auth.decorators import login_required
 from django.contrib.auth.views import (
     LoginView as AuthLoginView,
     PasswordResetCompleteView as AuthPasswordResetCompleteView,
@@ -9,9 +10,12 @@ from django.contrib.auth.views import (
     PasswordResetView as AuthPasswordResetView,
 )
 from django.urls import reverse_lazy
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import never_cache
 from django.views.generic import RedirectView
 
 from marsha.core.defaults import RENATER_FER_SAML
+from marsha.core.simple_jwt.tokens import ChallengeToken
 
 
 class LoginView(AuthLoginView):
@@ -34,7 +38,7 @@ class LogoutView(RedirectView):
     Log out the user and redirect to the main page.
     """
 
-    pattern_name = settings.LOGIN_REDIRECT_URL
+    url = settings.FRONTEND_HOME_URL
 
     def get(self, request, *args, **kwargs):
         """Logout the user then redirect to the home page."""
@@ -79,3 +83,26 @@ class PasswordResetCompleteView(AuthPasswordResetCompleteView):
     """
 
     template_name = "account/password_reset_complete.html"
+
+
+class RedirectToFrontendView(RedirectView):
+    """Redirect the user to frontend, right after login with a challenge to authenticate."""
+
+    url = "%(frontend_login_url)s?token=%(challenge_token)s"
+
+    @method_decorator(login_required)
+    @method_decorator(never_cache)
+    def dispatch(self, request, *args, **kwargs):
+        """Prevent unauthenticated users to access this view."""
+        return super().dispatch(request, *args, **kwargs)
+
+    def get(self, request, *args, **kwargs):
+        """Redirect the user to the frontend providing a challenge token for authentication."""
+
+        return super().get(
+            request,
+            *args,
+            frontend_login_url=settings.FRONTEND_HOME_URL,
+            challenge_token=ChallengeToken.for_user(request.user),
+            **kwargs,
+        )

--- a/src/backend/marsha/core/simple_jwt/factories.py
+++ b/src/backend/marsha/core/simple_jwt/factories.py
@@ -10,7 +10,11 @@ from faker.utils.text import slugify
 from marsha.core.factories import LiveSessionFactory, PlaylistFactory, UserFactory
 from marsha.core.models import ADMINISTRATOR, INSTRUCTOR, LTI_ROLES, NONE, STUDENT
 from marsha.core.simple_jwt.permissions import ResourceAccessPermissions
-from marsha.core.simple_jwt.tokens import ResourceAccessToken, UserAccessToken
+from marsha.core.simple_jwt.tokens import (
+    ChallengeToken,
+    ResourceAccessToken,
+    UserAccessToken,
+)
 
 
 class BaseTokenFactory(factory.Factory):
@@ -88,6 +92,15 @@ class UserAccessTokenFactory(BaseTokenFactory):
 
     class Meta:  # pylint:disable=missing-class-docstring
         model = UserAccessToken.for_user
+
+
+class ChallengeTokenFactory(BaseTokenFactory):
+    """ChallengeToken factory, this creates a User if not provided."""
+
+    user = factory.SubFactory(UserFactory)
+
+    class Meta:  # pylint:disable=missing-class-docstring
+        model = ChallengeToken.for_user
 
 
 class ResourcePermissionsFactory(factory.DictFactory):

--- a/src/backend/marsha/core/tests/test_api_challenge_token.py
+++ b/src/backend/marsha/core/tests/test_api_challenge_token.py
@@ -1,0 +1,37 @@
+"""Tests for the challenge token API."""
+
+from django.test import TestCase
+
+from marsha.core.simple_jwt.factories import ChallengeTokenFactory
+from marsha.core.simple_jwt.tokens import ChallengeToken, UserAccessToken
+
+
+class ChallengeAuthenticationViewTestCase(TestCase):
+    """Test the API for challenge token conversion."""
+
+    def test_access_by_anonymous_user(self):
+        """Test case of badly authenticated users."""
+        response = self.client.get("/api/auth/challenge/")
+        self.assertEqual(response.status_code, 405)  # Method not provided
+
+        response = self.client.post("/api/auth/challenge/")
+        self.assertEqual(response.status_code, 400)  # Bad request, token mandatory
+
+        response = self.client.post(
+            "/api/auth/challenge/", data={"token": str(ChallengeToken())}
+        )
+        self.assertEqual(response.status_code, 401)
+
+    def test_challenge_accepted_by_logged_in_user(self):
+        """Test proper user access token retrieval."""
+        challenge = ChallengeTokenFactory()
+
+        response = self.client.post(
+            "/api/auth/challenge/", data={"token": str(challenge)}
+        )
+        self.assertEqual(response.status_code, 200)
+
+        access_token = response.json()["access"]
+        user_token = UserAccessToken(access_token)
+
+        self.assertEqual(user_token.payload["user_id"], challenge.payload["user_id"])

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -521,6 +521,7 @@ class Base(Configuration):
     SOCIAL_AUTH_JSONFIELD_ENABLED = True
     SOCIAL_AUTH_URL_NAMESPACE = "account:social"
     SOCIAL_AUTH_SAML_FER_IDP_FAKER = False
+    SOCIAL_AUTH_SAML_FER_IDP_FAKER_DOCKER_PORT = 8060
 
     SOCIAL_AUTH_SAML_FER_SECURITY_CONFIG = {
         "authnRequestsSigned": values.BooleanValue(

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -222,8 +222,16 @@ class Base(Configuration):
     WAFFLE_CREATE_MISSING_SWITCHES = True
 
     # User login base Django settings
-    LOGIN_REDIRECT_URL = "site"  # redirect to home (React site)
+    LOGIN_REDIRECT_URL = "account:login_complete_redirect"
     LOGIN_URL = "account:login"
+
+    FRONTEND_HOME_URL = values.URLValue("http://localhost:8060/")
+    CHALLENGE_TOKEN_LIFETIME = timedelta(
+        seconds=values.IntegerValue(
+            default=60,
+            environ_name="CHALLENGE_TOKEN_LIFETIME",
+        ),
+    )
 
     # Password validation
     # https://docs.djangoproject.com/en/2.0/ref/settings/#auth-password-validators
@@ -643,6 +651,7 @@ class Base(Configuration):
             "SIGNING_KEY": str(self.JWT_SIGNING_KEY),
             "AUTH_TOKEN_CLASSES": (
                 "rest_framework_simplejwt.tokens.AccessToken",
+                "marsha.core.simple_jwt.tokens.ChallengeToken",
                 # For now ResourceAccessToken & UserAccessToken are also AccessToken
                 # but this will allow migration when types will differ.
                 # Note: AccessToken must remain enabled during the migration and removed

--- a/src/backend/marsha/urls.py
+++ b/src/backend/marsha/urls.py
@@ -10,6 +10,7 @@ from rest_framework.schemas import get_schema_view
 
 from marsha.core import models
 from marsha.core.api import (
+    ChallengeAuthenticationView,
     DocumentViewSet,
     LiveSessionViewSet,
     OrganizationViewSet,
@@ -79,6 +80,11 @@ urlpatterns = [
     path("videos/<uuid:uuid>", VideoView.as_view(), name="video_direct_access"),
     path("documents/<uuid:uuid>", DocumentView.as_view(), name="document_public"),
     # API
+    path(
+        "api/auth/challenge/",
+        ChallengeAuthenticationView.as_view(),
+        name="api_authentication",
+    ),
     path("api/pairing-challenge", pairing_challenge, name="pairing_challenge"),
     path("api/update-state", update_state, name="update_state"),
     path(


### PR DESCRIPTION
## Purpose

To allow the frontend authentication when it will become a single page application, we need to provide a new authentication loop.

## Proposal

The authentication is still made using the Django pages, except at the end, the user is redirected to a "frontend" view with a challenge token. The frontend can then make a request to the backend's API to get a real access token (and maybe later, a pair of access token and refresh token).

- [x] add new kind of challenge JWT
- [x] add redirect view to the frontend with a challenge token argument (and use it a the "Django" login redirect view).
- [x] add API endpoint for challenge to access token conversion
- [x] add tests

