### PR TITLE
🐛(front) redirect to the VOD dashboard when the live_state is ended

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ managing on-stage request
 
 - Missing migration to migrate key format of live_attendance 
 field of liveSession
+- Redirect to VOD dashboard when the live_state is ENDED and the 
+  upload_state is pending
 
 ## [4.0.0-beta.7] - 2022-06-27
 

--- a/src/frontend/components/Dashboard/DashboardVideoWrapper/index.spec.tsx
+++ b/src/frontend/components/Dashboard/DashboardVideoWrapper/index.spec.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from '@testing-library/react';
+import { cleanup, screen, waitFor } from '@testing-library/react';
 import fetchMock from 'fetch-mock';
 import React, { Suspense } from 'react';
 
@@ -44,6 +44,10 @@ jest.mock('components/DashboardVideoPaneStats', () => ({
   DashboardVideoPaneStats: (props: { video: Video }) => (
     <p>{`Stats for ${props.video.id}`}</p>
   ),
+}));
+
+jest.mock('components/DashboardVideoLive', () => ({
+  DashboardVideoLive: () => <p>{`Dashboard video live`}</p>,
 }));
 
 const spiedInitVideoWebsocket = jest.spyOn(websocket, 'initVideoWebsocket');
@@ -106,60 +110,77 @@ describe('<DashboardVideoWrapper />', () => {
   });
 
   it('renders the live layout when upload state is pending', async () => {
-    const video = videoMockFactory({
-      live_type: LiveModeType.JITSI,
-      live_state: liveState.IDLE,
-      live_info: {
-        jitsi: {
-          external_api_url: 'some_url',
-          config_overwrite: {},
-          interface_config_overwrite: {},
-          room_name: 'jitsi_conference',
+    for (const state of Object.values(liveState)) {
+      if (state === liveState.ENDED) {
+        continue;
+      }
+      const video = videoMockFactory({
+        live_type: LiveModeType.JITSI,
+        live_state: state,
+        live_info: {
+          jitsi: {
+            external_api_url: 'some_url',
+            config_overwrite: {},
+            interface_config_overwrite: {},
+            room_name: 'jitsi_conference',
+          },
         },
-      },
-      upload_state: uploadState.PENDING,
-    });
+        upload_state: uploadState.PENDING,
+      });
 
-    render(
-      <LiveModaleConfigurationProvider value={null}>
-        <Suspense fallback="loading...">
-          <DashboardVideoWrapper video={video} />
-        </Suspense>
-      </LiveModaleConfigurationProvider>,
-    );
+      render(
+        <LiveModaleConfigurationProvider value={null}>
+          <Suspense fallback="loading...">
+            <DashboardVideoWrapper video={video} />
+          </Suspense>
+        </LiveModaleConfigurationProvider>,
+      );
 
-    expect(spiedInitVideoWebsocket).toHaveBeenCalled();
+      expect(spiedInitVideoWebsocket).toHaveBeenCalled();
+      screen.getByText('Dashboard video live');
+
+      cleanup();
+      jest.clearAllMocks();
+      fetchMock.restore();
+    }
   });
 
-  it('renders the video layout when live_state is null', async () => {
-    const video = videoMockFactory({
-      live_state: null,
+  it('renders the video layout when live_state is null or ended', async () => {
+    [null, liveState.ENDED].forEach(async (videoLiveState) => {
+      const video = videoMockFactory({
+        live_state: videoLiveState,
+        upload_state: uploadState.PENDING,
+      });
+
+      render(<DashboardVideoWrapper video={video} />);
+
+      await waitFor(() => expect(fetchMock.calls().length).toEqual(4));
+
+      expect(spiedInitVideoWebsocket).toHaveBeenCalled();
+
+      screen.getByRole('link', { name: 'Dashboard' });
+      screen.getByRole('link', { name: 'Preview' });
+      screen.getByRole('link', { name: 'Playlist' });
+
+      screen.getByRole('heading', { name: 'Video status' });
+
+      screen.getByRole('checkbox', { name: 'Allow video download' });
+
+      screen.getByRole('button', { name: 'Replace this thumbnail' });
+      screen.getByRole('button', { name: 'Replace the video' });
+      screen.getByRole('button', { name: 'Watch' });
+
+      screen.getByRole('heading', { name: 'Subtitles' });
+      screen.getByRole('heading', { name: 'Transcripts' });
+      screen.getByRole('heading', { name: 'Closed captions' });
+      expect(
+        screen.getAllByRole('button', { name: 'Upload the file' }).length,
+      ).toBe(3);
+
+      cleanup();
+      jest.clearAllMocks();
+      fetchMock.restore();
     });
-
-    render(<DashboardVideoWrapper video={video} />);
-
-    await waitFor(() => expect(fetchMock.calls().length).toEqual(4));
-
-    expect(spiedInitVideoWebsocket).toHaveBeenCalled();
-
-    screen.getByRole('link', { name: 'Dashboard' });
-    screen.getByRole('link', { name: 'Preview' });
-    screen.getByRole('link', { name: 'Playlist' });
-
-    screen.getByRole('heading', { name: 'Video status' });
-
-    screen.getByRole('checkbox', { name: 'Allow video download' });
-
-    screen.getByRole('button', { name: 'Replace this thumbnail' });
-    screen.getByRole('button', { name: 'Replace the video' });
-    screen.getByRole('button', { name: 'Watch' });
-
-    screen.getByRole('heading', { name: 'Subtitles' });
-    screen.getByRole('heading', { name: 'Transcripts' });
-    screen.getByRole('heading', { name: 'Closed captions' });
-    expect(
-      screen.getAllByRole('button', { name: 'Upload the file' }).length,
-    ).toBe(3);
   });
 
   it('renders the video layout when upload state is not pending', async () => {

--- a/src/frontend/components/Dashboard/DashboardVideoWrapper/index.tsx
+++ b/src/frontend/components/Dashboard/DashboardVideoWrapper/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { uploadState, Video } from 'types/tracks';
+import { liveState, uploadState, Video } from 'types/tracks';
 
 import { DashboardVideo } from 'components/DashboardVideo';
 import { DashboardVideoLive } from 'components/DashboardVideoLive';
@@ -22,7 +22,7 @@ export const DashboardVideoWrapper = ({
   initVideoWebsocket(currentVideo);
 
   if (
-    currentVideo.live_state &&
+    ![null, liveState.ENDED].includes(currentVideo.live_state) &&
     currentVideo.upload_state === uploadState.PENDING
   ) {
     return (


### PR DESCRIPTION
## Purpose

Once a webinar ended, there is no reason, no matter the video
upload_state, to redirect the user to the webinar dashboard. It must be
redirected to the VOD dashboard.

## Proposal

- [x] redirect to the VOD dashboard when the live_state is ended

