### PR TITLE
(backend) update user related JWT kind

### DIFF
--- a/src/backend/marsha/core/simple_jwt/factories.py
+++ b/src/backend/marsha/core/simple_jwt/factories.py
@@ -1,0 +1,84 @@
+"""Factories for the Marsha JWTs module"""
+import types
+
+import factory
+
+from marsha.core.factories import UserFactory
+from marsha.core.simple_jwt.tokens import UserAccessToken
+
+
+class BaseTokenFactory(factory.Factory):
+    """
+    Base factory for JWT classes.
+
+    Can be used to build payload directly (not recommended
+    since the JWT payload may change without the factory
+    being updated...), this can be useful to reduce the database
+    objects creation (a user in the example bellow).
+    ```
+    class ExampleTokenFactory(BaseTokenFactory):
+        user = factory.Dict({
+            "id": factory.Faker("uuid4"),
+        })
+
+        class Meta:
+            model = UserAccessToken
+
+    token = ExampleTokenFactory()
+    # token.payload["user"] = {"id": "204d0484-0ceb-11ed-afce-576d78a3588b"}
+    ```
+
+    Or can be used to call the JWT class method which usually create the token:
+    ```
+    class ExampleTokenFactory(BaseTokenFactory):
+        user = factory.SubFactory(UserFactory)
+
+        class Meta:
+            model = UserAccessToken.for_user  # expects a `user` argument
+
+    token = ExampleTokenFactory()
+    # token.payload["user"] = {"id": user.pk}
+    ```
+    """
+
+    class Meta:  # pylint:disable=missing-class-docstring
+        abstract = True
+
+    @classmethod
+    def _build(cls, model_class, *args, **kwargs):
+        """Build the JWT from the factory attributes. See class docstring above."""
+        if args:
+            # Accepts only kwargs to prevent wrong argument order
+            raise ValueError(
+                f"BaseTokenFactory {cls} does not support Meta.inline_args."
+            )
+
+        # When the model_class points directly to the class method we call it straightaway
+        if isinstance(model_class, types.MethodType):
+            token = model_class(**kwargs)
+        else:  # Otherwise, we manually populate the payload
+            token = cls._build_payload(model_class, **kwargs)
+
+        token.verify()
+        return token
+
+    @classmethod
+    def _build_payload(cls, model_class, **kwargs):
+        """Populate the JWT's payload from the factory attributes."""
+        token = model_class()
+        token.payload.update(**kwargs)
+        return token
+
+    @classmethod
+    def _create(cls, model_class, *args, **kwargs):
+        """Inherited from parent class, boilerplate to the "build" method."""
+        return cls._build(model_class, *args, **kwargs)
+
+
+class UserAccessTokenFactory(BaseTokenFactory):
+    """UserAccessToken factory, this creates a User if not provided."""
+
+    user = factory.SubFactory(UserFactory)
+
+    class Meta:  # pylint:disable=missing-class-docstring
+        model = UserAccessToken.for_user

--- a/src/backend/marsha/core/simple_jwt/tokens.py
+++ b/src/backend/marsha/core/simple_jwt/tokens.py
@@ -234,6 +234,8 @@ class UserAccessToken(AccessToken):
     Note: `api_settings.USER_ID_CLAIM` is currently `resource_id`.
     """
 
+    token_type = "user_access"  # nosec
+
     PAYLOAD_USER = "user"
 
     @classmethod

--- a/src/backend/marsha/core/tests/test_api_organization.py
+++ b/src/backend/marsha/core/tests/test_api_organization.py
@@ -1,7 +1,7 @@
 """Tests for the Organization API of the Marsha project."""
 from django.test import TestCase
 
-from rest_framework_simplejwt.tokens import AccessToken
+from marsha.core.simple_jwt.factories import UserAccessTokenFactory
 
 from .. import factories, models
 
@@ -20,15 +20,7 @@ class OrganizationAPITest(TestCase):
 
     def test_create_organization_by_random_logged_in_user(self):
         """Random logged-in users cannot create organizations."""
-        user = factories.UserFactory()
-
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "email": user.email,
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory()
 
         response = self.client.post(
             "/api/organizations/",
@@ -47,16 +39,9 @@ class OrganizationAPITest(TestCase):
 
     def test_retrieve_organization_by_random_logged_in_user(self):
         """Random logged-in users cannot retrieve organizations unrelated to them."""
-        user = factories.UserFactory()
         organization = factories.OrganizationFactory()
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "email": user.email,
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory()
 
         response = self.client.get(
             f"/api/organizations/{organization.id}/",
@@ -73,12 +58,7 @@ class OrganizationAPITest(TestCase):
             user=user, organization=organization, role=models.INSTRUCTOR
         )
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
             f"/api/organizations/{organization.id}/",
@@ -95,13 +75,7 @@ class OrganizationAPITest(TestCase):
             user=user, organization=organization, role=models.ADMINISTRATOR
         )
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": str(user.username),
-        }
-
+        jwt_token = UserAccessTokenFactory(user=user)
         response = self.client.get(
             f"/api/organizations/{organization.id}/",
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
@@ -128,15 +102,9 @@ class OrganizationAPITest(TestCase):
 
     def test_list_organizations_by_random_logged_in_user(self):
         """Random logged-in users cannot list organizations."""
-        user = factories.UserFactory()
         factories.OrganizationFactory()
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory()
 
         response = self.client.get(
             "/api/organizations/",
@@ -152,12 +120,7 @@ class OrganizationAPITest(TestCase):
             user=user, organization=organization, role=models.ADMINISTRATOR
         )
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
             "/api/organizations/",
@@ -176,16 +139,10 @@ class OrganizationAPITest(TestCase):
 
     def test_delete_organization_by_random_logged_in_user(self):
         """Random logged-in users cannot delete organizations."""
-        user = factories.UserFactory()
         organization = factories.OrganizationFactory()
         self.assertEqual(models.Organization.objects.count(), 1)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory()
 
         response = self.client.delete(
             f"/api/organizations/{organization.id}/",
@@ -203,12 +160,7 @@ class OrganizationAPITest(TestCase):
         )
         self.assertEqual(models.Organization.objects.count(), 1)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.delete(
             f"/api/organizations/{organization.id}/",
@@ -230,15 +182,9 @@ class OrganizationAPITest(TestCase):
 
     def test_update_organization_by_random_logged_in_user(self):
         """Random logged-in users cannot update organizations."""
-        user = factories.UserFactory()
         organization = factories.OrganizationFactory(name="existing name")
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory()
 
         response = self.client.put(
             f"/api/organizations/{organization.id}/",
@@ -258,12 +204,7 @@ class OrganizationAPITest(TestCase):
             user=user, organization=organization, role=models.ADMINISTRATOR
         )
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.put(
             f"/api/organizations/{organization.id}/",

--- a/src/backend/marsha/core/tests/test_api_playlist.py
+++ b/src/backend/marsha/core/tests/test_api_playlist.py
@@ -7,6 +7,8 @@ from django.test import TestCase
 
 from rest_framework_simplejwt.tokens import AccessToken
 
+from marsha.core.simple_jwt.factories import UserAccessTokenFactory
+
 from .. import factories, models
 
 
@@ -38,12 +40,7 @@ class PlaylistAPITest(TestCase):
         org = factories.OrganizationFactory()
         consumer_site = factories.ConsumerSiteFactory()
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.post(
             "/api/playlists/",
@@ -70,13 +67,7 @@ class PlaylistAPITest(TestCase):
         random_uuid = uuid.uuid4()
         consumer_site = factories.ConsumerSiteFactory()
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "email": user.email,
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.post(
             "/api/playlists/",
@@ -99,12 +90,7 @@ class PlaylistAPITest(TestCase):
         )
         consumer_site = factories.ConsumerSiteFactory()
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.post(
             "/api/playlists/",
@@ -127,12 +113,7 @@ class PlaylistAPITest(TestCase):
         )
         consumer_site = factories.ConsumerSiteFactory()
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory(user=user)
 
         self.assertEqual(models.Playlist.objects.count(), 0)
 
@@ -179,12 +160,7 @@ class PlaylistAPITest(TestCase):
         user = factories.UserFactory()
         playlist = factories.PlaylistFactory()
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
             f"/api/playlists/{playlist.id}/",
@@ -201,12 +177,7 @@ class PlaylistAPITest(TestCase):
             user=user, playlist=playlist, role=models.INSTRUCTOR
         )
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
             f"/api/playlists/{playlist.id}/",
@@ -255,12 +226,7 @@ class PlaylistAPITest(TestCase):
             user=user, playlist=playlist, role=models.ADMINISTRATOR
         )
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
             f"/api/playlists/{playlist.id}/",
@@ -295,12 +261,7 @@ class PlaylistAPITest(TestCase):
             user=user, organization=organization, role=models.ADMINISTRATOR
         )
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
             f"/api/playlists/{playlist.id}/",
@@ -341,12 +302,7 @@ class PlaylistAPITest(TestCase):
         user = factories.UserFactory()
         factories.PlaylistFactory()
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
             "/api/playlists/",
@@ -377,12 +333,7 @@ class PlaylistAPITest(TestCase):
         org_3 = factories.OrganizationFactory()
         factories.PlaylistFactory(organization=org_3)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
             "/api/playlists/",
@@ -451,12 +402,7 @@ class PlaylistAPITest(TestCase):
         org_3 = factories.OrganizationFactory()
         factories.PlaylistFactory(organization=org_3)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
             f"/api/playlists/?organization={str(org_1.id)}",
@@ -501,12 +447,7 @@ class PlaylistAPITest(TestCase):
         playlist = factories.PlaylistFactory()
         self.assertEqual(models.Playlist.objects.count(), 1)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.delete(
             f"/api/playlists/{playlist.id}/",
@@ -524,12 +465,7 @@ class PlaylistAPITest(TestCase):
         )
         self.assertEqual(models.Playlist.objects.count(), 1)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.delete(
             f"/api/playlists/{playlist.id}/",
@@ -555,12 +491,7 @@ class PlaylistAPITest(TestCase):
         user = factories.UserFactory()
         playlist = factories.PlaylistFactory(title="existing title")
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.put(
             f"/api/playlists/{playlist.id}/",
@@ -579,12 +510,7 @@ class PlaylistAPITest(TestCase):
             user=user, playlist=playlist, role=models.ADMINISTRATOR
         )
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.put(
             f"/api/playlists/{playlist.id}/",

--- a/src/backend/marsha/core/tests/test_api_shared_live_media.py
+++ b/src/backend/marsha/core/tests/test_api_shared_live_media.py
@@ -8,6 +8,8 @@ from django.test import TestCase, override_settings
 
 from rest_framework_simplejwt.tokens import AccessToken
 
+from marsha.core.simple_jwt.factories import UserAccessTokenFactory
+
 from .. import defaults
 from ..api import timezone
 from ..factories import (
@@ -119,12 +121,9 @@ class SharedLiveMediaAPITest(TestCase):
         A user with a user token, without any specific access, cannot create a shared live
         media for any given video.
         """
-        user = UserFactory()
         video = VideoFactory()
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory()
 
         response = self.client.post(
             "/api/sharedlivemedias/",
@@ -149,9 +148,7 @@ class SharedLiveMediaAPITest(TestCase):
         video = VideoFactory(playlist=playlist)
         PlaylistAccessFactory(user=user, playlist=playlist, role=INSTRUCTOR)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.post(
             "/api/sharedlivemedias/",
@@ -175,9 +172,7 @@ class SharedLiveMediaAPITest(TestCase):
         video = VideoFactory(playlist=playlist)
         PlaylistAccessFactory(user=user, playlist=playlist, role=ADMINISTRATOR)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.post(
             "/api/sharedlivemedias/",
@@ -219,9 +214,7 @@ class SharedLiveMediaAPITest(TestCase):
         video = VideoFactory(playlist=playlist)
         OrganizationAccessFactory(user=user, organization=organization, role=INSTRUCTOR)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.post(
             "/api/sharedlivemedias/",
@@ -248,9 +241,7 @@ class SharedLiveMediaAPITest(TestCase):
             user=user, organization=organization, role=ADMINISTRATOR
         )
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.post(
             "/api/sharedlivemedias/",
@@ -770,11 +761,8 @@ class SharedLiveMediaAPITest(TestCase):
         A user with a user token, without any specific access, cannot read a shared live
         media for any given video.
         """
-        user = UserFactory()
         shared_live_media = SharedLiveMediaFactory()
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory()
 
         response = self.client.get(
             f"/api/sharedlivemedias/{shared_live_media.id}/",
@@ -797,9 +785,7 @@ class SharedLiveMediaAPITest(TestCase):
         shared_live_media = SharedLiveMediaFactory(video=video)
         PlaylistAccessFactory(user=user, playlist=playlist, role=INSTRUCTOR)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
             f"/api/sharedlivemedias/{shared_live_media.id}/",
@@ -822,9 +808,7 @@ class SharedLiveMediaAPITest(TestCase):
         shared_live_media = SharedLiveMediaFactory(video=video)
         PlaylistAccessFactory(user=user, playlist=playlist, role=ADMINISTRATOR)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
             f"/api/sharedlivemedias/{shared_live_media.id}/",
@@ -864,9 +848,7 @@ class SharedLiveMediaAPITest(TestCase):
         shared_live_media = SharedLiveMediaFactory(video=video)
         OrganizationAccessFactory(user=user, organization=organization, role=INSTRUCTOR)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
             f"/api/sharedlivemedias/{shared_live_media.id}/",
@@ -892,9 +874,7 @@ class SharedLiveMediaAPITest(TestCase):
             user=user, organization=organization, role=ADMINISTRATOR
         )
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
             f"/api/sharedlivemedias/{shared_live_media.id}/",
@@ -1227,11 +1207,8 @@ class SharedLiveMediaAPITest(TestCase):
         A user with a user token, without any specific access, cannot list shared live
         medias for any given video.
         """
-        user = UserFactory()
         SharedLiveMediaFactory.create_batch(2)
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory()
 
         response = self.client.get(
             "/api/sharedlivemedias/",
@@ -1254,9 +1231,7 @@ class SharedLiveMediaAPITest(TestCase):
         SharedLiveMediaFactory(video=video)
         PlaylistAccessFactory(user=user, playlist=playlist, role=INSTRUCTOR)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
             "/api/sharedlivemedias/",
@@ -1297,9 +1272,7 @@ class SharedLiveMediaAPITest(TestCase):
         )
         PlaylistAccessFactory(user=user, playlist=playlist, role=ADMINISTRATOR)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
             f"/api/sharedlivemedias/?video={video.id}",
@@ -1389,9 +1362,7 @@ class SharedLiveMediaAPITest(TestCase):
         )
         PlaylistAccessFactory(user=user, playlist=playlist, role=ADMINISTRATOR)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
             f"/api/sharedlivemedias/?video={other_video.id}",
@@ -1415,9 +1386,7 @@ class SharedLiveMediaAPITest(TestCase):
         SharedLiveMediaFactory(video=video)
         OrganizationAccessFactory(user=user, organization=organization, role=INSTRUCTOR)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
             f"/api/sharedlivemedias/?video={video.id}",
@@ -1461,9 +1430,7 @@ class SharedLiveMediaAPITest(TestCase):
             nb_pages=5,
         )
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
             f"/api/sharedlivemedias/?video={video.id}",
@@ -1557,9 +1524,7 @@ class SharedLiveMediaAPITest(TestCase):
             video=other_video,
         )
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
             f"/api/sharedlivemedias/?video={other_video.id}",
@@ -1654,12 +1619,9 @@ class SharedLiveMediaAPITest(TestCase):
         A user with a user token, without any specific access, cannot update a shared live
         medias for any given video.
         """
-        user = UserFactory()
         shared_live_media = SharedLiveMediaFactory()
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory()
 
         response = self.client.put(
             f"/api/sharedlivemedias/{shared_live_media.id}/",
@@ -1684,9 +1646,7 @@ class SharedLiveMediaAPITest(TestCase):
         shared_live_media = SharedLiveMediaFactory(video=video)
         PlaylistAccessFactory(user=user, playlist=playlist, role=INSTRUCTOR)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.put(
             f"/api/sharedlivemedias/{shared_live_media.id}/",
@@ -1717,9 +1677,7 @@ class SharedLiveMediaAPITest(TestCase):
         )
         PlaylistAccessFactory(user=user, playlist=playlist, role=ADMINISTRATOR)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         with mock.patch(
             "marsha.websocket.utils.channel_layers_utils.dispatch_shared_live_media"
@@ -1765,9 +1723,7 @@ class SharedLiveMediaAPITest(TestCase):
         shared_live_media = SharedLiveMediaFactory(video=video)
         OrganizationAccessFactory(user=user, organization=organization, role=INSTRUCTOR)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.put(
             f"/api/sharedlivemedias/{shared_live_media.id}/",
@@ -1801,9 +1757,7 @@ class SharedLiveMediaAPITest(TestCase):
             user=user, organization=organization, role=ADMINISTRATOR
         )
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         with mock.patch(
             "marsha.websocket.utils.channel_layers_utils.dispatch_shared_live_media"
@@ -1902,12 +1856,9 @@ class SharedLiveMediaAPITest(TestCase):
         A user with a user token, without any specific access, cannot delete a shared live
         medias for any given video.
         """
-        user = UserFactory()
         shared_live_media = SharedLiveMediaFactory()
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory()
 
         response = self.client.delete(
             f"/api/sharedlivemedias/{shared_live_media.id}/",
@@ -1930,9 +1881,7 @@ class SharedLiveMediaAPITest(TestCase):
         shared_live_media = SharedLiveMediaFactory(video=video)
         PlaylistAccessFactory(user=user, playlist=playlist, role=INSTRUCTOR)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.delete(
             f"/api/sharedlivemedias/{shared_live_media.id}/",
@@ -1961,9 +1910,7 @@ class SharedLiveMediaAPITest(TestCase):
         )
         PlaylistAccessFactory(user=user, playlist=playlist, role=ADMINISTRATOR)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         self.assertTrue(SharedLiveMedia.objects.exists())
 
@@ -1994,9 +1941,7 @@ class SharedLiveMediaAPITest(TestCase):
         shared_live_media = SharedLiveMediaFactory(video=video)
         OrganizationAccessFactory(user=user, organization=organization, role=INSTRUCTOR)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.delete(
             f"/api/sharedlivemedias/{shared_live_media.id}/",
@@ -2028,9 +1973,7 @@ class SharedLiveMediaAPITest(TestCase):
             user=user, organization=organization, role=ADMINISTRATOR
         )
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         self.assertTrue(SharedLiveMedia.objects.exists())
 
@@ -2320,12 +2263,9 @@ class SharedLiveMediaAPITest(TestCase):
         A user with a user token, without any specific access, cannot initiate an upload
         on shared live medias for any given video.
         """
-        user = UserFactory()
         shared_live_media = SharedLiveMediaFactory()
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory()
 
         response = self.client.post(
             f"/api/sharedlivemedias/{shared_live_media.id}/initiate-upload/",
@@ -2350,9 +2290,7 @@ class SharedLiveMediaAPITest(TestCase):
         shared_live_media = SharedLiveMediaFactory(video=video)
         PlaylistAccessFactory(user=user, playlist=playlist, role=INSTRUCTOR)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.post(
             f"/api/sharedlivemedias/{shared_live_media.id}/initiate-upload/",
@@ -2386,9 +2324,7 @@ class SharedLiveMediaAPITest(TestCase):
         )
         PlaylistAccessFactory(user=user, playlist=playlist, role=ADMINISTRATOR)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         now = datetime(2021, 12, 2, tzinfo=timezone.utc)
         with mock.patch.object(timezone, "now", return_value=now), mock.patch(
@@ -2456,9 +2392,7 @@ class SharedLiveMediaAPITest(TestCase):
         shared_live_media = SharedLiveMediaFactory(video=video)
         OrganizationAccessFactory(user=user, organization=organization, role=INSTRUCTOR)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.post(
             f"/api/sharedlivemedias/{shared_live_media.id}/initiate-upload/",
@@ -2496,9 +2430,7 @@ class SharedLiveMediaAPITest(TestCase):
             user=user, organization=organization, role=ADMINISTRATOR
         )
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         now = datetime(2021, 12, 2, tzinfo=timezone.utc)
         with mock.patch.object(timezone, "now", return_value=now), mock.patch(

--- a/src/backend/marsha/core/tests/test_api_timed_text_track.py
+++ b/src/backend/marsha/core/tests/test_api_timed_text_track.py
@@ -8,6 +8,8 @@ from django.test import TestCase, override_settings
 
 from rest_framework_simplejwt.tokens import AccessToken
 
+from marsha.core.simple_jwt.factories import UserAccessTokenFactory
+
 from .. import factories, models
 from ..api import timezone
 from ..factories import TimedTextTrackFactory, UserFactory, VideoFactory
@@ -456,9 +458,7 @@ class TimedTextTrackAPITest(TestCase):
         video = factories.VideoFactory()
         track = TimedTextTrackFactory(video=video)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
             f"/api/timedtexttracks/{track.id}/",
@@ -483,9 +483,7 @@ class TimedTextTrackAPITest(TestCase):
         )
         track = TimedTextTrackFactory(video=video)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
             f"/api/timedtexttracks/{track.id}/",
@@ -510,9 +508,7 @@ class TimedTextTrackAPITest(TestCase):
         )
         track = TimedTextTrackFactory(mode="cc", video=video)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
             f"/api/timedtexttracks/{track.id}/",
@@ -552,9 +548,7 @@ class TimedTextTrackAPITest(TestCase):
         )
         track = TimedTextTrackFactory(mode="cc", video=video)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
             f"/api/timedtexttracks/{track.id}/",
@@ -580,9 +574,7 @@ class TimedTextTrackAPITest(TestCase):
         )
         track = TimedTextTrackFactory(mode="cc", video=video)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
             f"/api/timedtexttracks/{track.id}/",
@@ -658,7 +650,6 @@ class TimedTextTrackAPITest(TestCase):
         A user with a user token, without any specific access, cannot list
         timed text tracks for a video.
         """
-        user = factories.UserFactory()
         video = factories.VideoFactory()
 
         TimedTextTrackFactory(mode="st", video=video)
@@ -666,9 +657,7 @@ class TimedTextTrackAPITest(TestCase):
         # Add a timed text track for another video
         TimedTextTrackFactory()
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory()
 
         response = self.client.get(
             f"/api/timedtexttracks/?video={video.id}",
@@ -697,9 +686,7 @@ class TimedTextTrackAPITest(TestCase):
         # Add a timed text track for another video
         TimedTextTrackFactory()
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
             f"/api/timedtexttracks/?video={video.id}",
@@ -728,9 +715,7 @@ class TimedTextTrackAPITest(TestCase):
         # Add a timed text track for another video
         TimedTextTrackFactory()
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
             f"/api/timedtexttracks/?video={video.id}",
@@ -771,9 +756,7 @@ class TimedTextTrackAPITest(TestCase):
         # Add a timed text track for another video
         TimedTextTrackFactory()
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
             f"/api/timedtexttracks/?video={video.id}",
@@ -803,9 +786,7 @@ class TimedTextTrackAPITest(TestCase):
         # Add a timed text track for another video
         TimedTextTrackFactory()
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
             f"/api/timedtexttracks/?video={video.id}",
@@ -846,9 +827,7 @@ class TimedTextTrackAPITest(TestCase):
         # Add a timed text track for another video
         TimedTextTrackFactory()
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
             "/api/timedtexttracks/",
@@ -925,12 +904,9 @@ class TimedTextTrackAPITest(TestCase):
         A user with a user token, without any specific access, cannot create a timed text
         track for any given video.
         """
-        user = factories.UserFactory()
         video = factories.VideoFactory()
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory()
 
         response = self.client.post(
             "/api/timedtexttracks/",
@@ -956,9 +932,7 @@ class TimedTextTrackAPITest(TestCase):
             user=user, playlist=playlist, role=models.INSTRUCTOR
         )
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.post(
             "/api/timedtexttracks/",
@@ -984,9 +958,7 @@ class TimedTextTrackAPITest(TestCase):
             user=user, playlist=playlist, role=models.ADMINISTRATOR
         )
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.post(
             "/api/timedtexttracks/",
@@ -1028,9 +1000,7 @@ class TimedTextTrackAPITest(TestCase):
             user=user, organization=organization, role=models.INSTRUCTOR
         )
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.post(
             "/api/timedtexttracks/",
@@ -1057,9 +1027,7 @@ class TimedTextTrackAPITest(TestCase):
             user=user, organization=organization, role=models.ADMINISTRATOR
         )
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.post(
             "/api/timedtexttracks/",
@@ -1221,12 +1189,9 @@ class TimedTextTrackAPITest(TestCase):
         A user with a user token, without any specific access, cannot update
         a single timed text track.
         """
-        user = factories.UserFactory()
         track = factories.TimedTextTrackFactory(language="fr")
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory()
 
         response = self.client.get(
             f"/api/timedtexttracks/{track.id}/",
@@ -1261,9 +1226,7 @@ class TimedTextTrackAPITest(TestCase):
         )
         track = factories.TimedTextTrackFactory(language="fr", video=video)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
             f"/api/timedtexttracks/{track.id}/",
@@ -1298,9 +1261,7 @@ class TimedTextTrackAPITest(TestCase):
         )
         track = factories.TimedTextTrackFactory(language="fr", video=video)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
             f"/api/timedtexttracks/{track.id}/",
@@ -1336,9 +1297,7 @@ class TimedTextTrackAPITest(TestCase):
         )
         track = factories.TimedTextTrackFactory(language="fr", video=video)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
             f"/api/timedtexttracks/{track.id}/",
@@ -1374,9 +1333,7 @@ class TimedTextTrackAPITest(TestCase):
         )
         track = factories.TimedTextTrackFactory(language="fr", video=video)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
             f"/api/timedtexttracks/{track.id}/",
@@ -1516,12 +1473,9 @@ class TimedTextTrackAPITest(TestCase):
         A user with a user token, without any specific access, cannot patch
         a single timed text track.
         """
-        user = factories.UserFactory()
         track = factories.TimedTextTrackFactory(language="fr")
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory()
 
         data = {"language": "en"}
 
@@ -1551,9 +1505,7 @@ class TimedTextTrackAPITest(TestCase):
         )
         track = factories.TimedTextTrackFactory(language="fr", video=video)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         data = {"language": "en"}
 
@@ -1583,9 +1535,7 @@ class TimedTextTrackAPITest(TestCase):
         )
         track = factories.TimedTextTrackFactory(language="fr", video=video)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         data = {"language": "en"}
 
@@ -1616,9 +1566,7 @@ class TimedTextTrackAPITest(TestCase):
         )
         track = factories.TimedTextTrackFactory(language="fr", video=video)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         data = {"language": "en"}
 
@@ -1649,9 +1597,7 @@ class TimedTextTrackAPITest(TestCase):
         )
         track = factories.TimedTextTrackFactory(language="fr", video=video)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         data = {"language": "en"}
 
@@ -1742,15 +1688,12 @@ class TimedTextTrackAPITest(TestCase):
         A user with a user token, without any specific access, cannot delete
         a single timed text track.
         """
-        user = factories.UserFactory()
         video = factories.VideoFactory()
 
         track = TimedTextTrackFactory(video=video)
         self.assertEqual(TimedTextTrack.objects.count(), 1)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory()
 
         response = self.client.delete(
             f"/api/timedtexttracks/{track.id}/",
@@ -1778,9 +1721,7 @@ class TimedTextTrackAPITest(TestCase):
         track = factories.TimedTextTrackFactory(video=video)
         self.assertEqual(TimedTextTrack.objects.count(), 1)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.delete(
             f"/api/timedtexttracks/{track.id}/",
@@ -1808,9 +1749,7 @@ class TimedTextTrackAPITest(TestCase):
         track = factories.TimedTextTrackFactory(video=video)
         self.assertEqual(TimedTextTrack.objects.count(), 1)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.delete(
             f"/api/timedtexttracks/{track.id}/",
@@ -1839,9 +1778,7 @@ class TimedTextTrackAPITest(TestCase):
         track = factories.TimedTextTrackFactory(video=video)
         self.assertEqual(TimedTextTrack.objects.count(), 1)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.delete(
             f"/api/timedtexttracks/{track.id}/",
@@ -1870,9 +1807,7 @@ class TimedTextTrackAPITest(TestCase):
         track = factories.TimedTextTrackFactory(video=video)
         self.assertEqual(TimedTextTrack.objects.count(), 1)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.delete(
             f"/api/timedtexttracks/{track.id}/",
@@ -2023,7 +1958,6 @@ class TimedTextTrackAPITest(TestCase):
         A user with a user token, without any specific access, cannot initiate an upload
         for any timed text track.
         """
-        user = factories.UserFactory()
         video = factories.VideoFactory(
             id="b8d40ed7-95b8-4848-98c9-50728dfee25d",
         )
@@ -2035,9 +1969,7 @@ class TimedTextTrackAPITest(TestCase):
             video=video,
         )
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory()
 
         now = datetime(2018, 8, 8, tzinfo=timezone.utc)
         with mock.patch.object(timezone, "now", return_value=now), mock.patch(
@@ -2074,9 +2006,7 @@ class TimedTextTrackAPITest(TestCase):
             video=video,
         )
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         now = datetime(2018, 8, 8, tzinfo=timezone.utc)
         with mock.patch.object(timezone, "now", return_value=now), mock.patch(
@@ -2113,9 +2043,7 @@ class TimedTextTrackAPITest(TestCase):
             video=video,
         )
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         # Get the upload policy for this timed text track
         # It should generate a key file with the Unix timestamp of the present time
@@ -2186,9 +2114,7 @@ class TimedTextTrackAPITest(TestCase):
             video=video,
         )
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         now = datetime(2018, 8, 8, tzinfo=timezone.utc)
         with mock.patch.object(timezone, "now", return_value=now), mock.patch(
@@ -2226,9 +2152,7 @@ class TimedTextTrackAPITest(TestCase):
             video=video,
         )
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {"id": str(user.id)}
+        jwt_token = UserAccessTokenFactory(user=user)
 
         # Get the upload policy for this timed text track
         # It should generate a key file with the Unix timestamp of the present time

--- a/src/backend/marsha/core/tests/test_api_user.py
+++ b/src/backend/marsha/core/tests/test_api_user.py
@@ -1,7 +1,7 @@
 """Tests for the User API of the Marsha project."""
 from django.test import TestCase
 
-from rest_framework_simplejwt.tokens import AccessToken
+from marsha.core.simple_jwt.factories import UserAccessTokenFactory
 
 from .. import factories
 
@@ -37,13 +37,7 @@ class UserAPITest(TestCase):
             user=user, organization=org_2
         )
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": str(user.username),
-        }
-        print(jwt_token.payload["user"])
+        jwt_token = UserAccessTokenFactory(user=user)
 
         with self.assertNumQueries(3):
             response = self.client.get(

--- a/src/backend/marsha/core/tests/test_api_video.py
+++ b/src/backend/marsha/core/tests/test_api_video.py
@@ -10,6 +10,8 @@ from django.test import TestCase, override_settings
 
 from rest_framework_simplejwt.tokens import AccessToken
 
+from marsha.core.simple_jwt.factories import UserAccessTokenFactory
+
 from .. import api, factories, models
 from ..api import timezone
 from ..defaults import (
@@ -1115,12 +1117,7 @@ class VideoAPITest(TestCase):
         playlist = factories.PlaylistFactory(organization=organization)
         video = factories.VideoFactory(playlist=playlist)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
             f"/api/videos/{video.id}/",
@@ -1139,12 +1136,7 @@ class VideoAPITest(TestCase):
         playlist = factories.PlaylistFactory(organization=organization)
         video = factories.VideoFactory(playlist=playlist)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
             f"/api/videos/{video.id}/",
@@ -1205,12 +1197,7 @@ class VideoAPITest(TestCase):
         )
         video = factories.VideoFactory(playlist=playlist)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
             f"/api/videos/{video.id}/",
@@ -1228,12 +1215,7 @@ class VideoAPITest(TestCase):
         )
         video = factories.VideoFactory(playlist=playlist)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
             f"/api/videos/{video.id}/",
@@ -1318,7 +1300,6 @@ class VideoAPITest(TestCase):
         A user with a user token, with no playlist or organization access should not
         get any videos in response to video list requests.
         """
-        user = factories.UserFactory()
         # An organization with a playlist and one video
         organization = factories.OrganizationFactory()
         organization_playlist = factories.PlaylistFactory(organization=organization)
@@ -1327,12 +1308,7 @@ class VideoAPITest(TestCase):
         other_playlist = factories.PlaylistFactory()
         factories.VideoFactory(playlist=other_playlist)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory()
 
         response = self.client.get(
             "/api/videos/", HTTP_AUTHORIZATION=f"Bearer {jwt_token}"
@@ -1363,12 +1339,7 @@ class VideoAPITest(TestCase):
         other_playlist = factories.PlaylistFactory()
         factories.VideoFactory(playlist=other_playlist)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
             "/api/videos/", HTTP_AUTHORIZATION=f"Bearer {jwt_token}"
@@ -1456,12 +1427,7 @@ class VideoAPITest(TestCase):
         other_playlist = factories.PlaylistFactory(organization=organization_2)
         factories.VideoFactory(playlist=other_playlist)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
             "/api/videos/", HTTP_AUTHORIZATION=f"Bearer {jwt_token}"
@@ -1565,17 +1531,11 @@ class VideoAPITest(TestCase):
         A user with a user token, with no playlist or organization access should not
         get any videos in response to requests to list videos by playlist.
         """
-        user = factories.UserFactory()
         # A playlist, where the user has no access, with a video
         playlist = factories.PlaylistFactory()
         factories.VideoFactory(playlist=playlist)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory()
 
         response = self.client.get(
             f"/api/videos/?playlist={playlist.id}",
@@ -1601,12 +1561,7 @@ class VideoAPITest(TestCase):
         other_playlist = factories.PlaylistFactory()
         factories.VideoFactory(playlist=other_playlist)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
             f"/api/videos/?playlist={first_playlist.id}",
@@ -1682,12 +1637,7 @@ class VideoAPITest(TestCase):
         other_playlist = factories.PlaylistFactory(organization=other_organization)
         factories.VideoFactory(playlist=other_playlist)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
             f"/api/videos/?playlist={first_playlist.id}",
@@ -1758,12 +1708,7 @@ class VideoAPITest(TestCase):
         playlist = factories.PlaylistFactory(organization=organization)
         factories.VideoFactory(playlist=playlist)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory(user=user)
         response = self.client.get(
             f"/api/videos/?organization={organization.id}",
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
@@ -1792,12 +1737,7 @@ class VideoAPITest(TestCase):
         other_playlist = factories.PlaylistFactory(organization=organization)
         factories.VideoFactory(playlist=other_playlist)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
             f"/api/videos/?organization={organization.id}",
@@ -1872,12 +1812,7 @@ class VideoAPITest(TestCase):
         playlist_2 = factories.PlaylistFactory(organization=organization)
         video_2 = factories.VideoFactory(playlist=playlist_2, title="Second video")
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
             f"/api/videos/?organization={organization.id}",
@@ -2058,11 +1993,12 @@ class VideoAPITest(TestCase):
 
     def test_api_video_create_token_user_playlist_preexists(self):
         """A token user should not be able to create a video."""
-        jwt_token = AccessToken()
+        jwt_token = UserAccessTokenFactory()
         response = self.client.post(
             "/api/videos/", HTTP_AUTHORIZATION=f"Bearer {jwt_token}"
         )
-        self.assertEqual(response.status_code, 401)
+        # Te user is authenticated, but action is forbidden => 403
+        self.assertEqual(response.status_code, 403)
         self.assertFalse(models.Video.objects.exists())
 
     def test_api_video_create_student(self):
@@ -2118,12 +2054,7 @@ class VideoAPITest(TestCase):
             role=models.ADMINISTRATOR, playlist=playlist, user=user
         )
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory(user=user)
 
         self.assertEqual(models.Video.objects.count(), 0)
 
@@ -2189,15 +2120,9 @@ class VideoAPITest(TestCase):
 
         Requests with a UUID that does not match an existing playlist should fail.
         """
-        user = factories.UserFactory()
         some_uuid = uuid.uuid4()
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory()
         self.assertEqual(models.Video.objects.count(), 0)
 
         response = self.client.post(
@@ -2222,12 +2147,7 @@ class VideoAPITest(TestCase):
             role=models.INSTRUCTOR, playlist=playlist, user=user
         )
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory(user=user)
 
         self.assertEqual(models.Video.objects.count(), 0)
 
@@ -2258,12 +2178,7 @@ class VideoAPITest(TestCase):
         )
         playlist = factories.PlaylistFactory(organization=organization)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory(user=user)
 
         self.assertEqual(models.Video.objects.count(), 0)
 
@@ -2336,12 +2251,7 @@ class VideoAPITest(TestCase):
         )
         playlist = factories.PlaylistFactory(organization=organization)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory(user=user)
 
         self.assertEqual(models.Video.objects.count(), 0)
         # try to set starting_at and is_scheduled
@@ -2418,12 +2328,7 @@ class VideoAPITest(TestCase):
         )
         playlist = factories.PlaylistFactory(organization=organization)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory(user=user)
 
         self.assertEqual(models.Video.objects.count(), 0)
 
@@ -3453,12 +3358,7 @@ class VideoAPITest(TestCase):
         playlist = factories.PlaylistFactory(organization=organization)
         video = factories.VideoFactory(playlist=playlist, title="existing title")
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.patch(
             f"/api/videos/{video.id}/",
@@ -3632,12 +3532,7 @@ class VideoAPITest(TestCase):
         playlist = factories.PlaylistFactory(organization=organization)
         video = factories.VideoFactory(playlist=playlist, title="existing title")
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.patch(
             f"/api/videos/{video.id}/",
@@ -3659,12 +3554,7 @@ class VideoAPITest(TestCase):
         )
         video = factories.VideoFactory(playlist=playlist, title="existing title")
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.patch(
             f"/api/videos/{video.id}/",
@@ -3686,12 +3576,7 @@ class VideoAPITest(TestCase):
         )
         video = factories.VideoFactory(playlist=playlist, title="existing title")
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.patch(
             f"/api/videos/{video.id}/",
@@ -3714,12 +3599,7 @@ class VideoAPITest(TestCase):
         playlist = factories.PlaylistFactory(organization=organization)
         video = factories.VideoFactory(playlist=playlist, title="existing title")
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.put(
             f"/api/videos/{video.id}/",
@@ -3742,12 +3622,7 @@ class VideoAPITest(TestCase):
         playlist = factories.PlaylistFactory(organization=organization)
         video = factories.VideoFactory(playlist=playlist, title="existing title")
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.put(
             f"/api/videos/{video.id}/",
@@ -3769,12 +3644,7 @@ class VideoAPITest(TestCase):
         )
         video = factories.VideoFactory(playlist=playlist, title="existing title")
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.put(
             f"/api/videos/{video.id}/",
@@ -3796,12 +3666,7 @@ class VideoAPITest(TestCase):
         )
         video = factories.VideoFactory(playlist=playlist, title="existing title")
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.put(
             f"/api/videos/{video.id}/",
@@ -3965,12 +3830,7 @@ class VideoAPITest(TestCase):
         )
         video = factories.VideoFactory(playlist=playlist)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory(user=user)
 
         self.assertEqual(models.Video.objects.count(), 1)
 
@@ -3995,12 +3855,7 @@ class VideoAPITest(TestCase):
         )
         video = factories.VideoFactory(playlist=playlist)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory(user=user)
 
         self.assertEqual(models.Video.objects.count(), 1)
 
@@ -4027,12 +3882,7 @@ class VideoAPITest(TestCase):
         playlist = factories.PlaylistFactory(organization=organization)
         video = factories.VideoFactory(playlist=playlist)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory(user=user)
 
         self.assertEqual(models.Video.objects.count(), 1)
 
@@ -4059,12 +3909,7 @@ class VideoAPITest(TestCase):
         playlist = factories.PlaylistFactory(organization=organization)
         video = factories.VideoFactory(playlist=playlist)
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory(user=user)
 
         self.assertEqual(models.Video.objects.count(), 1)
 
@@ -4254,12 +4099,7 @@ class VideoAPITest(TestCase):
             upload_state="ready",
         )
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory(user=user)
 
         # Get the upload policy for this video
         # It should generate a key file with the Unix timestamp of the present time
@@ -4296,12 +4136,7 @@ class VideoAPITest(TestCase):
             upload_state="ready",
         )
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory(user=user)
 
         # Get the upload policy for this video
         # It should generate a key file with the Unix timestamp of the present time
@@ -4363,12 +4198,7 @@ class VideoAPITest(TestCase):
             upload_state="ready",
         )
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory(user=user)
 
         # Get the upload policy for this video
         # It should generate a key file with the Unix timestamp of the present time
@@ -4404,12 +4234,7 @@ class VideoAPITest(TestCase):
             upload_state="ready",
         )
 
-        jwt_token = AccessToken()
-        jwt_token.payload["resource_id"] = str(user.id)
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-            "username": user.username,
-        }
+        jwt_token = UserAccessTokenFactory(user=user)
         # Get the upload policy for this video
         # It should generate a key file with the Unix timestamp of the present time
         now = datetime(2018, 8, 8, tzinfo=timezone.utc)

--- a/src/backend/marsha/core/tests/test_views_site.py
+++ b/src/backend/marsha/core/tests/test_views_site.py
@@ -5,8 +5,9 @@ import re
 
 from django.test import Client, TestCase, override_settings
 
-from rest_framework_simplejwt.tokens import AccessToken
 from waffle.testutils import override_switch
+
+from marsha.core.simple_jwt.tokens import UserAccessToken
 
 from .. import factories
 
@@ -38,11 +39,12 @@ class SiteViewTestCase(TestCase):
         )
 
         context = json.loads(unescape(match.group(1)))
-        jwt_token = AccessToken(context.get("jwt"))
+        jwt_token = UserAccessToken(context.get("jwt"))
         self.assertEqual(jwt_token.payload["resource_id"], str(user.id))
-        jwt_token.payload["user"] = {
-            "id": str(user.id),
-        }
+        self.assertDictEqual(
+            jwt_token.payload["user"],
+            {"id": str(user.id)},
+        )
 
         self.assertEqual(context.get("sentry_dsn"), "https://sentry.dsn")
         self.assertEqual(context.get("environment"), "test")


### PR DESCRIPTION
## Purpose

Turn the current "user authentication JWT" into a JWT with a specific kind (`user_access`).

## Proposal

First step to be able to use a different kind is to update all the test suite to use the proper JWT. Two solutions exist for this :
 - Call the `UserAccessToken.for_user` in tests
 - Create a factory to ease (slightly) the process of user token creation

Choice has been made in this pull request to create a factory even if does not provide real help, it might be consistent with further developments (for `ResourceAccessToken` probably).


- [x] Create a `UserAccessTokenFactory` factory
- [x] Update tests
- [x] Update `UserAccessToken` kind to `user_access`

