### PR TITLE
♻️(backend) Simplify marsha base views (for JWT use)

### DIFF
--- a/src/backend/marsha/core/tests/test_views_lti_video.py
+++ b/src/backend/marsha/core/tests/test_views_lti_video.py
@@ -1587,6 +1587,9 @@ class VideoLTIViewTestCase(TestCase):
                     },
                     "svg": {"icons": "/static/svg/icons.svg"},
                 },
+                "player": "videojs",
+                "uploadPollInterval": "60",
+                "attendanceDelay": 60000,
             },
         )
 

--- a/src/backend/marsha/core/views.py
+++ b/src/backend/marsha/core/views.py
@@ -267,12 +267,6 @@ class BaseLTIView(ABC, TemplateResponseMixin, View):
             app_data = self._get_base_app_data()
             app_data.update(
                 {
-                    "flags": {
-                        SENTRY: switch_is_active(SENTRY),
-                        BBB: settings.BBB_ENABLED,
-                        LIVE_RAW: settings.LIVE_RAW_ENABLED,
-                        MARKDOWN: settings.MARKDOWN_ENABLED,
-                    },
                     "resource": self.serializer_class(
                         resource,
                         context={
@@ -356,11 +350,6 @@ class BaseView(BaseLTIView, ABC):
             app_data = self._get_base_app_data()
             app_data.update(
                 {
-                    "flags": {
-                        SENTRY: switch_is_active(SENTRY),
-                        BBB: settings.BBB_ENABLED,
-                        LIVE_RAW: settings.LIVE_RAW_ENABLED,
-                    },
                     "resource": self.serializer_class(
                         resource,
                         context={


### PR DESCRIPTION
## Purpose

Reduce code complexity by explicitly splitting LTI and "public" behavior for JWT management.

## Proposal

`BaseLTIView` defines `_get_app_data` method and accept both with and without LTI process. On the other hand `BaseView` inherits from `BaseLTIView` and redefines `_get_app_data` method for public access. 

In both views, the "with or without" LTI complexity is propagated all along the way until the JWT creation. This pull request aims at making both path more distinct to improve readability and understanding of "what happens, when".

