### PR TITLE
♻️(backend) update "LTI select form" related JWT kind

### DIFF
--- a/src/backend/marsha/core/simple_jwt/tokens.py
+++ b/src/backend/marsha/core/simple_jwt/tokens.py
@@ -18,16 +18,14 @@ class LTISelectFormAccessToken(AccessToken):
     """
     LTI select form access JWT.
 
-    For now, we stay with the same attributes as the original AccessToken for
-    backward compatibility:
-    ```
-        token_type = "access"
-        lifetime = api_settings.ACCESS_TOKEN_LIFETIME
-    ```
+    This token has the same lifetime as the default AccessToken (see `ACCESS_TOKEN_LIFETIME`
+    setting).
 
     Note: not usable through our authentication backend since it doesn't provide the
     `api_settings.USER_ID_CLAIM` information in payload.
     """
+
+    token_type = "lti_select_form_access"  # nosec
 
     PAYLOAD_FORM_DATA = "lti_select_form_data"
 

--- a/src/backend/marsha/core/tests/test_views_lti_respond.py
+++ b/src/backend/marsha/core/tests/test_views_lti_respond.py
@@ -4,7 +4,7 @@ from unittest import mock
 
 from django.test import TestCase
 
-from rest_framework_simplejwt.tokens import AccessToken
+from marsha.core.simple_jwt.tokens import LTISelectFormAccessToken
 
 from .utils import generate_passport_and_signed_lti_parameters
 
@@ -28,8 +28,9 @@ class RespondLTIViewTestCase(TestCase):
                 "context_id": "unknown",
             },
         )
-        jwt_token = AccessToken()
-        jwt_token.payload["lti_select_form_data"] = lti_select_form_data
+        jwt_token = LTISelectFormAccessToken.for_lti_select_form_data(
+            lti_select_form_data,
+        )
         response = self.client.post(
             "/lti/respond/",
             {
@@ -93,8 +94,9 @@ class RespondLTIViewTestCase(TestCase):
                 "shared_secret": "passport_secret",
             },
         )
-        jwt_token = AccessToken()
-        jwt_token.payload["lti_select_form_data"] = lti_select_form_data
+        jwt_token = LTISelectFormAccessToken.for_lti_select_form_data(
+            lti_select_form_data,
+        )
         response = self.client.post(
             "/lti/respond/",
             {
@@ -121,8 +123,9 @@ class RespondLTIViewTestCase(TestCase):
                 "context_id": "unknown",
             },
         )
-        jwt_token = AccessToken()
-        jwt_token.payload["lti_select_form_data"] = lti_select_form_data
+        jwt_token = LTISelectFormAccessToken.for_lti_select_form_data(
+            lti_select_form_data,
+        )
         response = self.client.post(
             "/lti/respond/",
             {
@@ -141,7 +144,7 @@ class RespondLTIViewTestCase(TestCase):
 
     def test_views_lti_respond_no_lti_select_form_data(self):
         """Missing lti_select_form_data in JWT should raise a 403 error."""
-        jwt_token = AccessToken()
+        jwt_token = LTISelectFormAccessToken()
         response = self.client.post(
             "/lti/respond/",
             {
@@ -162,8 +165,9 @@ class RespondLTIViewTestCase(TestCase):
                 "context_id": "unknown",
             },
         )
-        jwt_token = AccessToken()
-        jwt_token.payload["lti_select_form_data"] = lti_select_form_data
+        jwt_token = LTISelectFormAccessToken.for_lti_select_form_data(
+            lti_select_form_data,
+        )
         response = self.client.post(
             "/lti/respond/",
             {
@@ -181,8 +185,9 @@ class RespondLTIViewTestCase(TestCase):
                 "context_id": "unknown",
             },
         )
-        jwt_token = AccessToken()
-        jwt_token.payload["lti_select_form_data"] = lti_select_form_data
+        jwt_token = LTISelectFormAccessToken.for_lti_select_form_data(
+            lti_select_form_data,
+        )
         response = self.client.post(
             "/lti/respond/",
             {
@@ -202,8 +207,9 @@ class RespondLTIViewTestCase(TestCase):
                 "context_id": "unknown",
             },
         )
-        jwt_token = AccessToken()
-        jwt_token.payload["lti_select_form_data"] = lti_select_form_data
+        jwt_token = LTISelectFormAccessToken.for_lti_select_form_data(
+            lti_select_form_data,
+        )
         response = self.client.post(
             "/lti/respond/",
             {
@@ -224,8 +230,9 @@ class RespondLTIViewTestCase(TestCase):
             },
         )
         lti_select_form_data.pop("oauth_consumer_key")
-        jwt_token = AccessToken()
-        jwt_token.payload["lti_select_form_data"] = lti_select_form_data
+        jwt_token = LTISelectFormAccessToken.for_lti_select_form_data(
+            lti_select_form_data,
+        )
         response = self.client.post(
             "/lti/respond/",
             {
@@ -246,8 +253,9 @@ class RespondLTIViewTestCase(TestCase):
             },
         )
         lti_select_form_data["oauth_consumer_key"] = "wrong oauth_consumer_key"
-        jwt_token = AccessToken()
-        jwt_token.payload["lti_select_form_data"] = lti_select_form_data
+        jwt_token = LTISelectFormAccessToken.for_lti_select_form_data(
+            lti_select_form_data,
+        )
         response = self.client.post(
             "/lti/respond/",
             {

--- a/src/backend/marsha/core/tests/test_views_lti_select.py
+++ b/src/backend/marsha/core/tests/test_views_lti_select.py
@@ -12,6 +12,8 @@ from django.utils import timezone
 
 from rest_framework_simplejwt.tokens import AccessToken
 
+from marsha.core.simple_jwt.tokens import LTISelectFormAccessToken
+
 from ..defaults import ENDED, IDLE, JITSI
 from ..factories import DocumentFactory, PlaylistFactory, VideoFactory
 from ..models import Playlist
@@ -135,7 +137,7 @@ class SelectLTIViewTestCase(TestCase):
         )
 
         form_data = context.get("lti_select_form_data")
-        initial_jwt_token = AccessToken(form_data.get("jwt"))
+        initial_jwt_token = LTISelectFormAccessToken(form_data.get("jwt"))
         lti_parameters.update({"lti_message_type": "ContentItemSelection"})
         self.assertEqual(initial_jwt_token.get("lti_select_form_data"), lti_parameters)
 
@@ -212,7 +214,7 @@ class SelectLTIViewTestCase(TestCase):
         )
 
         form_data = context.get("lti_select_form_data")
-        jwt_token = AccessToken(form_data.get("jwt"))
+        jwt_token = LTISelectFormAccessToken(form_data.get("jwt"))
         lti_parameters.update({"lti_message_type": "ContentItemSelection"})
         self.assertEqual(jwt_token.get("lti_select_form_data"), lti_parameters)
 
@@ -274,7 +276,7 @@ class SelectLTIViewTestCase(TestCase):
         self.assertEqual(context.get("new_video_url"), "https://testserver/lti/videos/")
 
         form_data = context.get("lti_select_form_data")
-        jwt_token = AccessToken(form_data.get("jwt"))
+        jwt_token = LTISelectFormAccessToken(form_data.get("jwt"))
         lti_parameters.update({"lti_message_type": "ContentItemSelection"})
         self.assertEqual(jwt_token.get("lti_select_form_data"), lti_parameters)
 


### PR DESCRIPTION
## Purpose

Turn the current "LTI select form JWT" into a JWT with a specific kind (`lti_select_form_access`).

## Proposal

This JWT does not require a dedicated factory as its use is very limited in code and the major part of the tests asserts broken JWTs don't work.

- [x]  Update tests
- [x]  Update `LTISelectFormAccessToken` kind to `lti_select_form_access`

