### PR TITLE
♻️(backend) Make different JWT authentication more explicit in API views

### DIFF
--- a/src/backend/marsha/.cookiecutter/{{cookiecutter.app_name}}/api.py
+++ b/src/backend/marsha/.cookiecutter/{{cookiecutter.app_name}}/api.py
@@ -6,7 +6,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
 from marsha.core import permissions as core_permissions
-from marsha.core.api import ObjectPkMixin
+from marsha.core.api import APIViewMixin, ObjectPkMixin
 from marsha.core.utils.url_utils import build_absolute_uri_behind_proxy
 
 from . import serializers
@@ -15,6 +15,7 @@ from .models import {{cookiecutter.model}}
 
 
 class {{cookiecutter.model}}ViewSet(
+    APIViewMixin,
     ObjectPkMixin,
     mixins.CreateModelMixin,
     mixins.RetrieveModelMixin,
@@ -88,7 +89,7 @@ class {{cookiecutter.model}}ViewSet(
 
         {{cookiecutter.model_plural_lower}} = serializers.{{cookiecutter.model}}SelectLTISerializer(
             {{cookiecutter.model}}.objects.filter(
-                playlist__id=request.user.token.payload.get("playlist_id")
+                playlist__id=request.resource.playlist_id,
             ),
             many=True,
             context={"request": self.request},

--- a/src/backend/marsha/.cookiecutter/{{cookiecutter.app_name}}/api.py
+++ b/src/backend/marsha/.cookiecutter/{{cookiecutter.app_name}}/api.py
@@ -2,7 +2,6 @@
 
 from rest_framework import mixins, viewsets
 from rest_framework.decorators import action
-from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
 from marsha.core import permissions as core_permissions
@@ -45,7 +44,7 @@ class {{cookiecutter.model}}ViewSet(
                 & (core_permissions.IsTokenInstructor | core_permissions.IsTokenAdmin)
             ]
         elif self.action in ["retrieve"]:
-            permission_classes = [IsAuthenticated]
+            permission_classes = [core_permissions.ResourceIsAuthenticated]
         else:
             permission_classes = self.permission_classes
         return [permission() for permission in permission_classes]

--- a/src/backend/marsha/bbb/api.py
+++ b/src/backend/marsha/bbb/api.py
@@ -2,7 +2,6 @@
 
 from rest_framework import mixins, viewsets
 from rest_framework.decorators import action
-from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
 from marsha.bbb.utils.bbb_utils import ApiMeetingException, create, end, join
@@ -11,6 +10,7 @@ from marsha.core.api import APIViewMixin, ObjectPkMixin
 from marsha.core.utils.url_utils import build_absolute_uri_behind_proxy
 
 from . import serializers
+from ..core.permissions import ResourceIsAuthenticated
 from .forms import ClassroomForm
 from .models import Classroom
 
@@ -47,7 +47,7 @@ class ClassroomViewSet(
                 & (core_permissions.IsTokenInstructor | core_permissions.IsTokenAdmin)
             ]
         elif self.action in ["retrieve"]:
-            permission_classes = [IsAuthenticated]
+            permission_classes = [ResourceIsAuthenticated]
         else:
             permission_classes = self.permission_classes
         return [permission() for permission in permission_classes]
@@ -137,7 +137,7 @@ class ClassroomViewSet(
         methods=["patch"],
         detail=True,
         url_path="join",
-        permission_classes=[IsAuthenticated],
+        permission_classes=[ResourceIsAuthenticated],
     )
     def service_join(self, request, *args, **kwargs):
         """Join a Big Blue Button classroom.

--- a/src/backend/marsha/bbb/api.py
+++ b/src/backend/marsha/bbb/api.py
@@ -161,7 +161,7 @@ class ClassroomViewSet(
             moderator = "administrator" in roles or "instructor" in roles
             consumer_site_user_id = (
                 f"{request.resource.consumer_site}_"
-                f"{(request.resource.user or {}).get('id')}"
+                f"{request.resource.user.get('id')}"
             )
             response = join(
                 classroom=self.get_object(),

--- a/src/backend/marsha/core/api/account.py
+++ b/src/backend/marsha/core/api/account.py
@@ -7,10 +7,10 @@ from rest_framework.response import Response
 
 from .. import permissions, serializers
 from ..models import Organization
-from .base import ObjectPkMixin
+from .base import APIViewMixin, ObjectPkMixin
 
 
-class UserViewSet(viewsets.GenericViewSet):
+class UserViewSet(APIViewMixin, viewsets.GenericViewSet):
     """ViewSet for all user-related interactions."""
 
     serializer_class = serializers.UserSerializer
@@ -44,7 +44,7 @@ class UserViewSet(viewsets.GenericViewSet):
         return Response(data=self.get_serializer(user).data)
 
 
-class OrganizationViewSet(ObjectPkMixin, viewsets.ModelViewSet):
+class OrganizationViewSet(APIViewMixin, ObjectPkMixin, viewsets.ModelViewSet):
     """ViewSet for all organization-related interactions."""
 
     permission_classes = [permissions.NotAllowed]

--- a/src/backend/marsha/core/api/file.py
+++ b/src/backend/marsha/core/api/file.py
@@ -9,10 +9,11 @@ from rest_framework.response import Response
 from .. import defaults, permissions, serializers, storage
 from ..forms import DocumentForm
 from ..models import Document
-from .base import ObjectPkMixin
+from .base import APIViewMixin, ObjectPkMixin
 
 
 class DocumentViewSet(
+    APIViewMixin,
     ObjectPkMixin,
     mixins.CreateModelMixin,
     mixins.RetrieveModelMixin,

--- a/src/backend/marsha/core/api/live_session.py
+++ b/src/backend/marsha/core/api/live_session.py
@@ -80,10 +80,9 @@ class LiveSessionViewSet(
                 )
 
             # admin and instructors can access all registrations of this course
-            if any(
-                role in ["administrator", "instructor"]
-                for role in self.request.resource.roles
-            ):
+            if permissions.IsTokenInstructor().check_role(
+                self.request.resource.token
+            ) or permissions.IsTokenAdmin().check_role(self.request.resource.token):
                 return LiveSession.objects.filter(**filters)
 
             filters["lti_id"] = self.request.resource.context_id

--- a/src/backend/marsha/core/api/live_session.py
+++ b/src/backend/marsha/core/api/live_session.py
@@ -59,7 +59,7 @@ class LiveSessionViewSet(
 ):
     """Viewset for the API of the LiveSession object."""
 
-    permission_classes = [permissions.IsVideoToken]
+    permission_classes = [permissions.ResourceIsAuthenticated]
     queryset = LiveSession.objects.all()
     serializer_class = serializers.LiveSessionSerializer
 

--- a/src/backend/marsha/core/api/live_session.py
+++ b/src/backend/marsha/core/api/live_session.py
@@ -82,7 +82,7 @@ class LiveSessionViewSet(
             # admin and instructors can access all registrations of this course
             if any(
                 role in ["administrator", "instructor"]
-                for role in self.request.resource.roles or []
+                for role in self.request.resource.roles
             ):
                 return LiveSession.objects.filter(**filters)
 
@@ -221,7 +221,7 @@ class LiveSessionViewSet(
                 status=status.HTTP_401_UNAUTHORIZED,
             )
 
-        token_user = self.request.resource.user or {}
+        token_user = self.request.resource.user
         # livesession already exists, we update email and username if necessary
         if not created:
             # Update livesession email only if it's defined in the token user

--- a/src/backend/marsha/core/api/playlist.py
+++ b/src/backend/marsha/core/api/playlist.py
@@ -5,10 +5,10 @@ from rest_framework.response import Response
 
 from .. import permissions, serializers
 from ..models import Playlist
-from .base import ObjectPkMixin
+from .base import APIViewMixin, ObjectPkMixin
 
 
-class PlaylistViewSet(ObjectPkMixin, viewsets.ModelViewSet):
+class PlaylistViewSet(APIViewMixin, ObjectPkMixin, viewsets.ModelViewSet):
     """ViewSet for all playlist-related interactions."""
 
     permission_classes = [permissions.NotAllowed]

--- a/src/backend/marsha/core/api/playlist.py
+++ b/src/backend/marsha/core/api/playlist.py
@@ -1,6 +1,5 @@
 """Declare API endpoints for playlist with Django RestFramework viewsets."""
 from rest_framework import viewsets
-from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
 from .. import permissions, serializers
@@ -23,7 +22,7 @@ class PlaylistViewSet(APIViewMixin, ObjectPkMixin, viewsets.ModelViewSet):
         to the ViewSet's default permissions.
         """
         if self.action in ["list"]:
-            permission_classes = [IsAuthenticated]
+            permission_classes = [permissions.UserIsAuthenticated]
         elif self.action in ["retrieve"]:
             permission_classes = [
                 # users who are playlist administrators

--- a/src/backend/marsha/core/api/shared_live_media.py
+++ b/src/backend/marsha/core/api/shared_live_media.py
@@ -83,7 +83,7 @@ class SharedLiveMediaViewSet(APIViewMixin, ObjectPkMixin, viewsets.ModelViewSet)
         # If the "user" is just representing a resource and not an actual user profile,
         # restrict the queryset to tracks linked to said resource
         if request.resource and (
-            (request.resource.user or {}).get("id") != request.resource.id
+            request.resource.user.get("id") != request.resource.id
         ):
             queryset = (
                 self.get_queryset()

--- a/src/backend/marsha/core/api/shared_live_media.py
+++ b/src/backend/marsha/core/api/shared_live_media.py
@@ -6,12 +6,12 @@ from django.utils import timezone
 from rest_framework import viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
-from rest_framework_simplejwt.models import TokenUser
 
 from marsha.websocket.utils import channel_layers_utils
 
 from .. import defaults, permissions, serializers
 from ..models import SharedLiveMedia
+from ..simple_jwt.authentication import TokenResource
 from ..utils.s3_utils import create_presigned_post
 from ..utils.time_utils import to_timestamp
 from .base import ObjectPkMixin
@@ -84,7 +84,7 @@ class SharedLiveMediaViewSet(ObjectPkMixin, viewsets.ModelViewSet):
         # If the "user" is just representing a resource and not an actual user profile,
         # restrict the queryset to tracks linked to said resource
         user = self.request.user
-        if isinstance(user, TokenUser) and (
+        if isinstance(user, TokenResource) and (
             not user.token.get("user")
             or user.token.get("user", {}).get("id") != user.token.get("resource_id")
         ):

--- a/src/backend/marsha/core/api/thumbnail.py
+++ b/src/backend/marsha/core/api/thumbnail.py
@@ -5,10 +5,10 @@ from django.utils import timezone
 from rest_framework import mixins, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
-from rest_framework_simplejwt.models import TokenUser
 
 from .. import defaults, permissions, serializers
 from ..models import Thumbnail
+from ..simple_jwt.authentication import TokenResource
 from ..utils.s3_utils import create_presigned_post
 from ..utils.time_utils import to_timestamp
 from .base import ObjectPkMixin
@@ -44,7 +44,7 @@ class ThumbnailViewSet(
     def get_queryset(self):
         """Restrict list access to thumbnail related to the video in the JWT token."""
         user = self.request.user
-        if isinstance(user, TokenUser):
+        if isinstance(user, TokenResource):
             return Thumbnail.objects.filter(video__id=user.id)
         return Thumbnail.objects.none()
 

--- a/src/backend/marsha/core/api/thumbnail.py
+++ b/src/backend/marsha/core/api/thumbnail.py
@@ -8,13 +8,13 @@ from rest_framework.response import Response
 
 from .. import defaults, permissions, serializers
 from ..models import Thumbnail
-from ..simple_jwt.authentication import TokenResource
 from ..utils.s3_utils import create_presigned_post
 from ..utils.time_utils import to_timestamp
-from .base import ObjectPkMixin
+from .base import APIViewMixin, ObjectPkMixin
 
 
 class ThumbnailViewSet(
+    APIViewMixin,
     ObjectPkMixin,
     mixins.CreateModelMixin,
     mixins.DestroyModelMixin,
@@ -43,9 +43,8 @@ class ThumbnailViewSet(
 
     def get_queryset(self):
         """Restrict list access to thumbnail related to the video in the JWT token."""
-        user = self.request.user
-        if isinstance(user, TokenResource):
-            return Thumbnail.objects.filter(video__id=user.id)
+        if self.request.resource:
+            return Thumbnail.objects.filter(video__id=self.request.resource.id)
         return Thumbnail.objects.none()
 
     @action(methods=["post"], detail=True, url_path="initiate-upload")

--- a/src/backend/marsha/core/api/timed_text_track.py
+++ b/src/backend/marsha/core/api/timed_text_track.py
@@ -5,10 +5,10 @@ from django.utils import timezone
 from rest_framework import viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
-from rest_framework_simplejwt.models import TokenUser
 
 from .. import defaults, permissions, serializers
 from ..models import TimedTextTrack
+from ..simple_jwt.authentication import TokenResource
 from ..utils.s3_utils import create_presigned_post
 from ..utils.time_utils import to_timestamp
 from .base import ObjectPkMixin
@@ -49,7 +49,7 @@ class TimedTextTrackViewSet(ObjectPkMixin, viewsets.ModelViewSet):
         # If the "user" is just representing a resource and not an actual user profile, restrict
         # the queryset to tracks linked to said resource
         user = self.request.user
-        if isinstance(user, TokenUser) and (
+        if isinstance(user, TokenResource) and (
             not user.token.get("user")
             or user.token.get("user", {}).get("id") != user.token.get("resource_id")
         ):

--- a/src/backend/marsha/core/api/timed_text_track.py
+++ b/src/backend/marsha/core/api/timed_text_track.py
@@ -23,7 +23,7 @@ class TimedTextTrackViewSet(APIViewMixin, ObjectPkMixin, viewsets.ModelViewSet):
     def get_permissions(self):
         """Instantiate and return the list of permissions that this view requires."""
         if self.action == "metadata":
-            permission_classes = [permissions.IsVideoToken]
+            permission_classes = [permissions.ResourceIsAuthenticated]
         elif self.action in ["create", "list"]:
             permission_classes = [
                 permissions.IsTokenInstructor

--- a/src/backend/marsha/core/api/video.py
+++ b/src/backend/marsha/core/api/video.py
@@ -35,7 +35,6 @@ from ..services.video_recording import (
     start_recording,
     stop_recording,
 )
-from ..simple_jwt.authentication import TokenResource
 from ..utils import time_utils
 from ..utils.api_utils import validate_signature
 from ..utils.medialive_utils import (
@@ -50,13 +49,13 @@ from ..utils.medialive_utils import (
 )
 from ..utils.time_utils import to_timestamp
 from ..utils.xmpp_utils import close_room, create_room
-from .base import ObjectPkMixin
+from .base import APIViewMixin, ObjectPkMixin
 
 
 # pylint: disable=too-many-public-methods
 
 
-class VideoViewSet(ObjectPkMixin, viewsets.ModelViewSet):
+class VideoViewSet(APIViewMixin, ObjectPkMixin, viewsets.ModelViewSet):
     """Viewset for the API of the video object."""
 
     queryset = Video.objects.all()
@@ -113,9 +112,8 @@ class VideoViewSet(ObjectPkMixin, viewsets.ModelViewSet):
         """Extra context provided to the serializer class."""
         context = super().get_serializer_context()
 
-        user = self.request.user
-        if isinstance(user, TokenResource):
-            context.update(user.token.payload)
+        if self.request.resource:
+            context.update(self.request.resource.token.payload)
             admin_role_permission = permissions.IsTokenAdmin()
             instructor_role_permission = permissions.IsTokenInstructor()
 

--- a/src/backend/marsha/core/api/video.py
+++ b/src/backend/marsha/core/api/video.py
@@ -17,7 +17,6 @@ from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
-from rest_framework_simplejwt.models import TokenUser
 
 from marsha.core.defaults import JITSI
 from marsha.websocket.utils import channel_layers_utils
@@ -36,6 +35,7 @@ from ..services.video_recording import (
     start_recording,
     stop_recording,
 )
+from ..simple_jwt.authentication import TokenResource
 from ..utils import time_utils
 from ..utils.api_utils import validate_signature
 from ..utils.medialive_utils import (
@@ -114,7 +114,7 @@ class VideoViewSet(ObjectPkMixin, viewsets.ModelViewSet):
         context = super().get_serializer_context()
 
         user = self.request.user
-        if isinstance(user, TokenUser):
+        if isinstance(user, TokenResource):
             context.update(user.token.payload)
             admin_role_permission = permissions.IsTokenAdmin()
             instructor_role_permission = permissions.IsTokenInstructor()

--- a/src/backend/marsha/core/api/video.py
+++ b/src/backend/marsha/core/api/video.py
@@ -15,7 +15,6 @@ from django.utils.module_loading import import_string
 
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
-from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
 from marsha.core.defaults import JITSI
@@ -83,7 +82,7 @@ class VideoViewSet(APIViewMixin, ObjectPkMixin, viewsets.ModelViewSet):
                 | permissions.IsVideoOrganizationAdmin
             ]
         elif self.action in ["list", "metadata"]:
-            permission_classes = [IsAuthenticated]
+            permission_classes = [permissions.UserOrResourceIsAuthenticated]
         elif self.action in ["create"]:
             permission_classes = [
                 permissions.IsParamsPlaylistAdmin

--- a/src/backend/marsha/core/api/xapi.py
+++ b/src/backend/marsha/core/api/xapi.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 class XAPIStatementView(APIViewMixin, APIView):
     """Viewset managing xAPI requests."""
 
-    permission_classes = [permissions.IsVideoToken]
+    permission_classes = [permissions.ResourceIsAuthenticated]
     http_method_names = ["post"]
 
     def post(self, request, resource_kind):
@@ -45,7 +45,7 @@ class XAPIStatementView(APIViewMixin, APIView):
 
         model = apps.get_model(app_label="core", model_name=resource_kind)
         try:
-            # Note: permissions.IsVideoToken asserts request.resource is not None
+            # Note: permissions.ResourceIsAuthenticated asserts request.resource is not None
             object_instance = model.objects.get(pk=request.resource.id)
         except model.DoesNotExist:
             return Response(

--- a/src/backend/marsha/core/serializers/live_session.py
+++ b/src/backend/marsha/core/serializers/live_session.py
@@ -7,9 +7,9 @@ from django.shortcuts import get_object_or_404
 from django.utils import timezone
 
 from rest_framework import serializers
-from rest_framework_simplejwt.models import TokenUser
 
 from ..models import ConsumerSite, LiveSession, Video
+from ..simple_jwt.authentication import TokenResource
 
 
 class LiveSessionDisplayUsernameSerializer(serializers.ModelSerializer):
@@ -86,7 +86,7 @@ class LiveSessionSerializer(serializers.ModelSerializer):
                 {"video": f"video with id {user.id} doesn't accept registration."}
             )
 
-        if not validated_data.get("video_id") and isinstance(user, TokenUser):
+        if not validated_data.get("video_id") and isinstance(user, TokenResource):
             validated_data["video_id"] = user.id
             is_lti = (
                 user.token.payload.get("context_id")

--- a/src/backend/marsha/core/serializers/live_session.py
+++ b/src/backend/marsha/core/serializers/live_session.py
@@ -88,7 +88,7 @@ class LiveSessionSerializer(serializers.ModelSerializer):
             is_lti = (
                 resource.context_id
                 and resource.consumer_site
-                and (resource.user or {}).get("id")
+                and resource.user.get("id")
             )
 
             if is_lti:
@@ -128,10 +128,11 @@ class LiveSessionSerializer(serializers.ModelSerializer):
                 # If username is present in the token we catch it
                 validated_data["username"] = resource.user.get("username")
             else:  # public token should have no LTI info
+                print(type(resource), dir(resource))
                 if (
                     resource.context_id
                     or resource.consumer_site
-                    or (resource.user or {}).get("id")
+                    or resource.user.get("id")
                 ):
                     # we prevent any side effects if token's creation changes.
                     raise serializers.ValidationError(
@@ -180,10 +181,9 @@ class LiveSessionSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError({"not_allowed_fields": extra_fields})
         if validated_data.get("email"):
             # If the email is present in the token, we don't allow a different email
-            token_email = (resource.user or {}).get("email")
+            token_email = resource.user.get("email")
             is_admin = any(
-                role in ["administrator", "instructor"]
-                for role in (resource.roles or [])
+                role in ["administrator", "instructor"] for role in resource.roles
             )
             if not is_admin and token_email and token_email != validated_data["email"]:
                 raise serializers.ValidationError(

--- a/src/backend/marsha/core/serializers/live_session.py
+++ b/src/backend/marsha/core/serializers/live_session.py
@@ -8,6 +8,8 @@ from django.utils import timezone
 
 from rest_framework import serializers
 
+from marsha.core.permissions import IsTokenAdmin, IsTokenInstructor
+
 from ..models import ConsumerSite, LiveSession, Video
 
 
@@ -182,9 +184,9 @@ class LiveSessionSerializer(serializers.ModelSerializer):
         if validated_data.get("email"):
             # If the email is present in the token, we don't allow a different email
             token_email = resource.user.get("email")
-            is_admin = any(
-                role in ["administrator", "instructor"] for role in resource.roles
-            )
+            is_admin = IsTokenInstructor().check_role(
+                resource.token
+            ) or IsTokenAdmin().check_role(resource.token)
             if not is_admin and token_email and token_email != validated_data["email"]:
                 raise serializers.ValidationError(
                     {

--- a/src/backend/marsha/core/serializers/shared_live_media.py
+++ b/src/backend/marsha/core/serializers/shared_live_media.py
@@ -7,6 +7,7 @@ from rest_framework import serializers
 from rest_framework_simplejwt.models import TokenUser
 
 from ..models import SharedLiveMedia
+from ..simple_jwt.authentication import TokenResource
 from ..utils import cloudfront_utils, time_utils
 from .base import (
     TimestampField,
@@ -75,14 +76,10 @@ class SharedLiveMediaSerializer(
         user = self.context["request"].user
         # Set the video field from the payload if there is one and the user is identified
         # as a proper user object through access rights
-        if (
-            self.initial_data.get("video")
-            and user.token.get("user")
-            and user.token["resource_id"] == user.token.get("user", {}).get("id")
-        ):
+        if self.initial_data.get("video") and isinstance(user, TokenUser):
             validated_data["video_id"] = self.initial_data.get("video")
         # If the user just has a token for a video, force the video ID on the shared live media
-        if not validated_data.get("video_id") and isinstance(user, TokenUser):
+        if not validated_data.get("video_id") and isinstance(user, TokenResource):
             validated_data["video_id"] = user.id
         return super().create(validated_data)
 

--- a/src/backend/marsha/core/serializers/thumbnail.py
+++ b/src/backend/marsha/core/serializers/thumbnail.py
@@ -3,9 +3,9 @@ from django.conf import settings
 from django.db.utils import IntegrityError
 
 from rest_framework import serializers
-from rest_framework_simplejwt.models import TokenUser
 
 from ..models import Thumbnail
+from ..simple_jwt.authentication import TokenResource
 from ..utils import time_utils
 from .base import TimestampField
 
@@ -58,7 +58,7 @@ class ThumbnailSerializer(serializers.ModelSerializer):
         # user here is a video as it comes from the JWT
         # It is named "user" by convention in the `rest_framework_simplejwt` dependency we use.
         user = self.context["request"].user
-        if not validated_data.get("video_id") and isinstance(user, TokenUser):
+        if not validated_data.get("video_id") and isinstance(user, TokenResource):
             validated_data["video_id"] = user.id
         try:
             return super().create(validated_data)

--- a/src/backend/marsha/core/serializers/thumbnail.py
+++ b/src/backend/marsha/core/serializers/thumbnail.py
@@ -5,7 +5,6 @@ from django.db.utils import IntegrityError
 from rest_framework import serializers
 
 from ..models import Thumbnail
-from ..simple_jwt.authentication import TokenResource
 from ..utils import time_utils
 from .base import TimestampField
 
@@ -57,9 +56,9 @@ class ThumbnailSerializer(serializers.ModelSerializer):
         """
         # user here is a video as it comes from the JWT
         # It is named "user" by convention in the `rest_framework_simplejwt` dependency we use.
-        user = self.context["request"].user
-        if not validated_data.get("video_id") and isinstance(user, TokenResource):
-            validated_data["video_id"] = user.id
+        resource = self.context["request"].resource
+        if not validated_data.get("video_id") and resource:
+            validated_data["video_id"] = resource.id
         try:
             return super().create(validated_data)
         except IntegrityError as exc:

--- a/src/backend/marsha/core/serializers/timed_text_track.py
+++ b/src/backend/marsha/core/serializers/timed_text_track.py
@@ -8,6 +8,7 @@ from rest_framework import serializers
 from rest_framework_simplejwt.models import TokenUser
 
 from ..models import TimedTextTrack
+from ..simple_jwt.authentication import TokenResource
 from ..utils import cloudfront_utils, time_utils
 from .base import TimestampField, get_video_cloudfront_url_params
 
@@ -67,14 +68,10 @@ class TimedTextTrackSerializer(serializers.ModelSerializer):
         user = self.context["request"].user
         # Set the video field from the payload if there is one and the user is identified
         # as a proper user object through access rights
-        if (
-            self.initial_data.get("video")
-            and user.token.get("user")
-            and user.token["resource_id"] == user.token.get("user", {}).get("id")
-        ):
+        if self.initial_data.get("video") and isinstance(user, TokenUser):
             validated_data["video_id"] = self.initial_data.get("video")
         # If the user just has a token for a video, force the video ID on the timed text track
-        if not validated_data.get("video_id") and isinstance(user, TokenUser):
+        if not validated_data.get("video_id") and isinstance(user, TokenResource):
             validated_data["video_id"] = user.id
         return super().create(validated_data)
 

--- a/src/backend/marsha/core/simple_jwt/authentication.py
+++ b/src/backend/marsha/core/simple_jwt/authentication.py
@@ -8,12 +8,22 @@ from rest_framework_simplejwt.models import TokenUser
 
 
 class TokenResource(TokenUser):
-    """Same as TokenUser but for resource access JWT"""
+    """Same as TokenUser but for resource access JWT, with helpers for payload."""
 
     @cached_property
     def id(self):
         """Returns the resource ID."""
         return self.token["resource_id"]
+
+    @cached_property
+    def roles(self):
+        """Payload roles is a list"""
+        return self.token.get("roles", [])
+
+    @cached_property
+    def user(self):
+        """Payload user is a dict"""
+        return self.token.get("user", {})
 
 
 class JWTStatelessUserOrResourceAuthentication(JWTStatelessUserAuthentication):

--- a/src/backend/marsha/core/simple_jwt/authentication.py
+++ b/src/backend/marsha/core/simple_jwt/authentication.py
@@ -1,0 +1,45 @@
+"""Marsha specific authentication class for API."""
+from django.utils.functional import cached_property
+from django.utils.translation import gettext_lazy as _
+
+from rest_framework_simplejwt.authentication import JWTStatelessUserAuthentication
+from rest_framework_simplejwt.exceptions import InvalidToken
+from rest_framework_simplejwt.models import TokenUser
+
+
+class TokenResource(TokenUser):
+    """Same as TokenUser but for resource access JWT"""
+
+    @cached_property
+    def id(self):
+        """Returns the resource ID."""
+        return self.token["resource_id"]
+
+
+class JWTStatelessUserOrResourceAuthentication(JWTStatelessUserAuthentication):
+    """
+    An authentication plugin that authenticates requests through a JSON web
+    token provided in a request header without performing a database lookup
+    to obtain a user instance.
+    """
+
+    def get_user(self, validated_token):
+        """
+        Returns a stateless user object which is backed by the given validated
+        token.
+
+        We keep an actual user-like object to go through Django logic but this
+        method can return:
+         - TokenUser for user authentication
+         - TokenResource for resource authentication
+        """
+        try:
+            user = super().get_user(validated_token)
+        except InvalidToken as exc:
+            if "resource_id" not in validated_token:
+                raise InvalidToken(
+                    _("Token contained no recognizable resource identification")
+                ) from exc
+            return TokenResource(validated_token)
+
+        return user

--- a/src/backend/marsha/core/simple_jwt/tokens.py
+++ b/src/backend/marsha/core/simple_jwt/tokens.py
@@ -286,32 +286,9 @@ class UserAccessToken(AccessToken):
 
     token_type = "user_access"  # nosec
 
-    PAYLOAD_USER = "user"
-
-    @classmethod
-    def for_user(cls, user):
-        """
-        Build a user JWT, used to authenticate user through the application.
-
-        Parameters
-        ----------
-        user: Type[core.User]
-            the user whom information are to store in JWT.
-
-        Returns
-        -------
-        AccessToken
-            JWT containing:
-            - resource_id (`api_settings.USER_ID_CLAIM`)
-            - user
-        """
-        token = super().for_user(user)
-        token.payload[cls.PAYLOAD_USER] = {"id": str(user.id)}
-        return token
-
     def verify(self):
         """Performs additional validation steps to test payload content."""
         super().verify()
 
-        if self.PAYLOAD_USER not in self.payload:
+        if "user_id" not in self.payload:
             raise TokenError(_("Malformed user token"))

--- a/src/backend/marsha/core/tests/test_simple_jwt_tokens.py
+++ b/src/backend/marsha/core/tests/test_simple_jwt_tokens.py
@@ -305,8 +305,7 @@ class UserAccessTokenTestCase(TestCase):
     def test_for_user(self):
         """Test JWT initialization from `for_user` method"""
         token = UserAccessToken.for_user(self.user)
-        self.assertEqual(token.payload["resource_id"], str(self.user.pk))
-        self.assertDictEqual(token.payload["user"], {"id": str(self.user.pk)})
+        self.assertEqual(token.payload["user_id"], str(self.user.pk))
 
     def test_verify(self):
         """Test JWT `verify` method"""
@@ -316,19 +315,8 @@ class UserAccessTokenTestCase(TestCase):
 
         handmade_token = UserAccessToken()  # new empty token
         with self.assertRaises(TokenError):
-            # missing in payload: resource_id, user
-            handmade_token.verify()
-
-        handmade_token.payload["resource_id"] = self.user.pk
-
-        with self.assertRaises(TokenError):
             # missing in payload: user
             handmade_token.verify()
 
-        handmade_token.payload["user"] = self.user.pk
+        handmade_token.payload["user_id"] = self.user.pk
         handmade_token.verify()  # Should not raise
-
-        del handmade_token.payload["resource_id"]
-        # missing in payload: resource_id, but not tested in verify
-        # (this is done in the authentication backend for now)
-        handmade_token.verify()

--- a/src/backend/marsha/core/tests/test_views_site.py
+++ b/src/backend/marsha/core/tests/test_views_site.py
@@ -40,11 +40,7 @@ class SiteViewTestCase(TestCase):
 
         context = json.loads(unescape(match.group(1)))
         jwt_token = UserAccessToken(context.get("jwt"))
-        self.assertEqual(jwt_token.payload["resource_id"], str(user.id))
-        self.assertDictEqual(
-            jwt_token.payload["user"],
-            {"id": str(user.id)},
-        )
+        self.assertEqual(jwt_token.payload["user_id"], str(user.id))
 
         self.assertEqual(context.get("sentry_dsn"), "https://sentry.dsn")
         self.assertEqual(context.get("environment"), "test")

--- a/src/backend/marsha/markdown/api.py
+++ b/src/backend/marsha/markdown/api.py
@@ -6,7 +6,7 @@ from rest_framework.response import Response
 from rest_framework.status import HTTP_200_OK, HTTP_400_BAD_REQUEST
 
 from marsha.core import permissions as core_permissions
-from marsha.core.api import ObjectPkMixin
+from marsha.core.api import APIViewMixin, ObjectPkMixin
 from marsha.core.utils.url_utils import build_absolute_uri_behind_proxy
 
 from . import serializers
@@ -16,6 +16,7 @@ from .utils.converter import LatexConversionException, render_latex_to_image
 
 
 class MarkdownDocumentViewSet(
+    APIViewMixin,
     ObjectPkMixin,
     mixins.CreateModelMixin,
     mixins.RetrieveModelMixin,
@@ -88,7 +89,7 @@ class MarkdownDocumentViewSet(
 
         markdown_documents = serializers.MarkdownDocumentSelectLTISerializer(
             MarkdownDocument.objects.filter(
-                playlist__id=request.user.token.payload.get("playlist_id")
+                playlist__id=request.resource.playlist_id,
             ),
             many=True,
             context={"request": self.request},

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -198,7 +198,7 @@ class Base(Configuration):
 
     REST_FRAMEWORK = {
         "DEFAULT_AUTHENTICATION_CLASSES": (
-            "rest_framework_simplejwt.authentication.JWTStatelessUserAuthentication",
+            "marsha.core.simple_jwt.authentication.JWTStatelessUserOrResourceAuthentication",
         ),
         "EXCEPTION_HANDLER": "marsha.core.views.exception_handler",
         "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.LimitOffsetPagination",
@@ -620,7 +620,6 @@ class Base(Configuration):
             "ACCESS_TOKEN_LIFETIME": timedelta(days=1),
             "ALGORITHM": "HS256",
             "SIGNING_KEY": str(self.JWT_SIGNING_KEY),
-            "USER_ID_CLAIM": "resource_id",
             "AUTH_TOKEN_CLASSES": (
                 "rest_framework_simplejwt.tokens.AccessToken",
                 # For now ResourceAccessToken & UserAccessToken are also AccessToken

--- a/src/backend/marsha/urls.py
+++ b/src/backend/marsha/urls.py
@@ -103,7 +103,7 @@ urlpatterns = [
         name="reminders_cancel",
     ),
     re_path(
-        r"^xapi/(?P<resource>video|document)/$",
+        r"^xapi/(?P<resource_kind>video|document)/$",
         XAPIStatementView.as_view(),
         name="xapi",
     ),

--- a/src/backend/marsha/websocket/consumers/video.py
+++ b/src/backend/marsha/websocket/consumers/video.py
@@ -96,7 +96,7 @@ class VideoConsumer(AsyncJsonWebsocketConsumer):
         live_session.save()
 
     def _is_admin(self):
-        """Check if the connected user has admin persmissions."""
+        """Check if the connected user has admin permissions."""
         token = self.scope["token"]
         return IsTokenInstructor().check_role(token) or IsTokenAdmin().check_role(token)
 


### PR DESCRIPTION
## Purpose

This aims at make API views more explicit for authorization between user and resource.

## Proposal

We want to stop using the `request.user` when talking about a resource.

- [x] Use a dedicated object to represent a resource when authenticating (to not call it a `UserToken`)
- [x] Replace the use of `request.user` with `request.resource`

