### PR TITLE
Notify students when a recording is started

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ VOD dashboard
 quality in the VOD dashboard
 - Add 3 widgets to upload timed text tracks to the video
 in the VOD dashboard
+- Notify students when a recording is started
 
 ### Changed
 

--- a/src/frontend/components/StudentLiveRecordingInfo/index.spec.tsx
+++ b/src/frontend/components/StudentLiveRecordingInfo/index.spec.tsx
@@ -1,0 +1,13 @@
+import { screen } from '@testing-library/react';
+import React from 'react';
+
+import render from 'utils/tests/render';
+import { StudentLiveRecordingInfo } from '.';
+
+describe('<StudentLiveRecordingInfo />', () => {
+  it('displays the default Recording message', () => {
+    render(<StudentLiveRecordingInfo />);
+
+    screen.getByText('Recording');
+  });
+});

--- a/src/frontend/components/StudentLiveRecordingInfo/index.tsx
+++ b/src/frontend/components/StudentLiveRecordingInfo/index.tsx
@@ -1,0 +1,40 @@
+import { Box, Text } from 'grommet';
+import React from 'react';
+import { defineMessages, useIntl } from 'react-intl';
+import styled from 'styled-components';
+
+const RecordingText = styled(Text)`
+  font-size: 12px;
+  line-height: 12px;
+`;
+
+const messages = defineMessages({
+  recording: {
+    defaultMessage: 'Recording',
+    description:
+      'Display message to let the user know that the live is recorded',
+    id: 'components.StudentLiveRecordingInfo.recording',
+  },
+});
+
+export const StudentLiveRecordingInfo = () => {
+  const intl = useIntl();
+
+  return (
+    <Box
+      direction="row"
+      round="small"
+      background={{ color: '#002438' }}
+      pad="xsmall"
+      margin="xsmall"
+    >
+      <Box
+        round={true}
+        background="red"
+        pad="xsmall"
+        margin={{ right: 'xsmall' }}
+      />
+      <RecordingText>{intl.formatMessage(messages.recording)}</RecordingText>
+    </Box>
+  );
+};

--- a/src/frontend/components/StudentLiveWrapper/index.spec.tsx
+++ b/src/frontend/components/StudentLiveWrapper/index.spec.tsx
@@ -196,6 +196,60 @@ describe('<StudentLiveWrapper /> as a viewer', () => {
     expect(useLivePanelState.getState().isPanelVisible).toEqual(false);
   });
 
+  it('configures live state with recording on', async () => {
+    useLivePanelState.setState({
+      isPanelVisible: false,
+      currentItem: undefined,
+      availableItems: [],
+    });
+    useLiveStateStarted.getState().setIsStarted(true);
+    const video = videoMockFactory({
+      title: 'live title',
+      live_state: liveState.RUNNING,
+      is_recording: true,
+      urls: {
+        manifests: {
+          hls: 'https://example.com/hls.m3u8',
+        },
+        mp4: {},
+        thumbnails: {},
+      },
+      xmpp: {
+        bosh_url: 'https://xmpp-server.com/http-bind',
+        converse_persistent_store: PersistentStore.LOCALSTORAGE,
+        websocket_url: null,
+        conference_url:
+          '870c467b-d66e-4949-8ee5-fcf460c72e88@conference.xmpp-server.com',
+        prebind_url: 'https://xmpp-server.com/http-pre-bind',
+        jid: 'xmpp-server.com',
+      },
+    });
+
+    render(
+      wrapInVideo(
+        <PictureInPictureProvider value={{ reversed: true }}>
+          <StudentLiveWrapper playerType={'player_type'} />
+        </PictureInPictureProvider>,
+        video,
+      ),
+    );
+
+    await waitFor(() =>
+      // The player is created
+      expect(mockCreatePlayer).toHaveBeenCalledWith(
+        'player_type',
+        expect.any(Element),
+        expect.anything(),
+        video,
+        'en',
+        expect.any(Function),
+      ),
+    );
+
+    screen.getByText('live title');
+    screen.getByText('Recording');
+  });
+
   it('configures live state with panel opened on chat', async () => {
     useLivePanelState.setState({
       isPanelVisible: true,


### PR DESCRIPTION
## Purpose

We want to inform a student when a live is recording. A label is added on top of the player while recording is on and removed once the recording is stopped.

## Proposal

- [x] Display a  permanent layer in PictureInPictureLayer
- [x] Create a component to display that the live is recording
- [x] Mount the recording info component in the StudentLiveWrapper 

Fixes #1390 
