### PR TITLE
♻️(backend) make updateable models state dynamic

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -569,12 +569,18 @@ jobs:
     steps:
       - checkout:
           path: ~/marsha
+      - run: # Can be removed when switching to mcr.microsoft.com/playwright:jammy
+          name: Install Python 3.10
+          command: apt update && apt upgrade -y && apt install -y software-properties-common && add-apt-repository -y ppa:deadsnakes/ppa && apt install -y python3.10 python3.10-dev build-essential
+      - run:  # Can be removed when switching to mcr.microsoft.com/playwright:jammy
+          name: Install pip for Python 3.10
+          command: curl -sS https://bootstrap.pypa.io/get-pip.py | python3.10
       - run:
-          name: Install pip & xmlsec1 requirements
-          command: apt-get update && apt-get install -y python3-pip pkg-config libxml2-dev libxmlsec1-openssl libxmlsec1-dev
+          name: Install xmlsec1 requirements
+          command: apt-get update && apt-get install -y pkg-config libxml2-dev libxmlsec1-openssl libxmlsec1-dev
       - run:
           name: Install e2e dependencies
-          command: pip install --user .[dev,e2e]
+          command: python3.10 -m pip install --user .[dev,e2e]
       - run:
           name: Install front-end dependencies
           working_directory: ~/marsha/src/frontend
@@ -589,7 +595,7 @@ jobs:
           command: yarn copy-iframe-resizer
       - run:
           name: Ensure << parameters.browser >> browser is installed
-          command: python3 -m playwright install "<< parameters.browser >>"
+          command: python3.10 -m playwright install "<< parameters.browser >>"
       - run:
           name: Install dockerize
           command: |
@@ -610,7 +616,7 @@ jobs:
                 command: apt update
             - run:
                 name: Install chrome
-                command: python3 -m playwright install chrome
+                command: python3.10 -m playwright install chrome
       - run:
           name: Run e2e tests
           command: |

--- a/docker/images/e2e/Dockerfile
+++ b/docker/images/e2e/Dockerfile
@@ -1,6 +1,6 @@
 FROM marsha:dev as marsha
 
-FROM mcr.microsoft.com/playwright:focal
+FROM mcr.microsoft.com/playwright:jammy
 
 COPY --from=marsha /app /app
 COPY src/backend/setup.cfg /app/src/backend/

--- a/src/backend/marsha/core/api/base.py
+++ b/src/backend/marsha/core/api/base.py
@@ -1,6 +1,5 @@
 """Declare API endpoints with Django RestFramework viewsets."""
 
-from django.apps import apps
 from django.shortcuts import get_object_or_404
 
 from rest_framework.decorators import api_view
@@ -9,7 +8,7 @@ from rest_framework.response import Response
 from .. import defaults, serializers
 from ..models import Video
 from ..simple_jwt.tokens import ResourceAccessToken
-from ..utils.api_utils import validate_signature
+from ..utils.api_utils import get_uploadable_models_s3_mapping, validate_signature
 
 
 class ObjectPkMixin:
@@ -58,7 +57,8 @@ def update_state(request):
     key_elements = serializer.get_key_elements()
 
     # Update the object targeted by the "object_id" and "resource_id"
-    model = apps.get_model(app_label="core", model_name=key_elements["model_name"])
+    model_from_s3_identifier = get_uploadable_models_s3_mapping()
+    model = model_from_s3_identifier[key_elements["model_name"]]
 
     extra_parameters = serializer.validated_data["extraParameters"]
     if (

--- a/src/backend/marsha/core/models/file.py
+++ b/src/backend/marsha/core/models/file.py
@@ -12,6 +12,8 @@ from .playlist import Playlist
 class UploadableFileMixin(models.Model):
     """Mixin adding fields related to upload management."""
 
+    S3_IDENTIFIER = None
+
     uploaded_on = models.DateTimeField(
         verbose_name=_("uploaded on"),
         help_text=_("datetime at which the active version of the file was uploaded."),
@@ -142,6 +144,7 @@ class Document(BaseFile):
     """Model representing a document."""
 
     RESOURCE_NAME = "documents"
+    S3_IDENTIFIER = "document"
 
     extension = models.CharField(
         blank=True,

--- a/src/backend/marsha/core/models/video.py
+++ b/src/backend/marsha/core/models/video.py
@@ -41,6 +41,7 @@ class Video(BaseFile):
     """Model representing a video, created by an author."""
 
     RESOURCE_NAME = "videos"
+    S3_IDENTIFIER = "video"
 
     active_shared_live_media = models.ForeignKey(
         "SharedLiveMedia",
@@ -445,6 +446,7 @@ class TimedTextTrack(BaseTrack):
     """
 
     RESOURCE_NAME = "timedtexttracks"
+    S3_IDENTIFIER = "timedtexttrack"
 
     SUBTITLE, TRANSCRIPT, CLOSED_CAPTIONING = "st", "ts", "cc"
     MODE_CHOICES = (
@@ -563,6 +565,7 @@ class Thumbnail(AbstractImage):
     """Thumbnail model illustrating a video."""
 
     RESOURCE_NAME = "thumbnails"
+    S3_IDENTIFIER = "thumbnail"
 
     video = models.ForeignKey(
         Video,
@@ -947,6 +950,7 @@ class SharedLiveMedia(UploadableFileMixin, BaseModel):
     """Model representing a shared media in a video live."""
 
     RESOURCE_NAME = "sharedlivemedias"
+    S3_IDENTIFIER = "sharedlivemedia"
 
     video = models.ForeignKey(
         Video,

--- a/src/backend/marsha/core/serializers/base.py
+++ b/src/backend/marsha/core/serializers/base.py
@@ -13,21 +13,27 @@ from rest_framework import serializers
 from ..defaults import ERROR, HARVESTED, PROCESSING, READY, STATE_CHOICES
 from ..models import TimedTextTrack
 from ..utils import cloudfront_utils, time_utils
+from ..utils.api_utils import get_uploadable_models_s3_mapping
 
 
 UUID_REGEX = (
     "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
 )
 EXTENSION_REGEX = '[^.\\/:*?&"<>|\r\n]+'
-# This regex matches keys in AWS for videos, timed text tracks, thumbail and document
 TIMED_TEXT_EXTENSIONS = "|".join(m[0] for m in TimedTextTrack.MODE_CHOICES)
+MODEL_REGEX = "|".join(get_uploadable_models_s3_mapping().keys())
 KEY_PATTERN = (
-    r"^{uuid:s}/(?P<model_name>video|thumbnail|timedtexttrack|document|sharedlivemedia)/"
+    r"^{uuid:s}/(?P<model_name>{models:s})/"
     r"(?P<object_id>{uuid:s})/(?P<stamp>[0-9]{{10}})(_[a-z-]{{2,10}}_({tt_ex}))?"
     # The extension is captured and is optional. If present and the resource has an extension
     # attribute we will save it in database.
     r"(\.(?P<extension>{extension:s}))?$"
-).format(uuid=UUID_REGEX, tt_ex=TIMED_TEXT_EXTENSIONS, extension=EXTENSION_REGEX)
+).format(
+    uuid=UUID_REGEX,
+    tt_ex=TIMED_TEXT_EXTENSIONS,
+    extension=EXTENSION_REGEX,
+    models=MODEL_REGEX,
+)
 KEY_REGEX = re.compile(KEY_PATTERN)
 
 

--- a/src/backend/marsha/core/tests/test_utils_api_utils.py
+++ b/src/backend/marsha/core/tests/test_utils_api_utils.py
@@ -1,0 +1,53 @@
+"""Tests for the `core.api_utils` module."""
+import django.apps
+from django.test import TestCase
+
+from marsha.core.models import (
+    AudioTrack,
+    Document,
+    SharedLiveMedia,
+    SignTrack,
+    Thumbnail,
+    TimedTextTrack,
+    Video,
+)
+from marsha.core.utils.api_utils import get_uploadable_models_s3_mapping
+
+
+class UploadableModelsS3MappingTestCase(TestCase):
+    """Test the `get_uploadable_models_s3_mapping` function."""
+
+    def test_get_uploadable_models_s3_mapping(self):
+        """
+        Simply test the function returns what we expect.
+
+        We only check specific keys to not break when new model with S3 identifier are added.
+        """
+        mapping = get_uploadable_models_s3_mapping()
+
+        self.assertEqual(mapping["document"], Document)
+        self.assertEqual(mapping["sharedlivemedia"], SharedLiveMedia)
+        self.assertEqual(mapping["thumbnail"], Thumbnail)
+        self.assertEqual(mapping["timedtexttrack"], TimedTextTrack)
+        self.assertEqual(mapping["video"], Video)
+
+    def test_models_consistency(self):
+        """
+        Assert all models with an `upload_state` defines also an `S3_IDENTIFIER`
+
+        For now there are two models which don't:
+         - marsha.core.models.video.AudioTrack
+         - marsha.core.models.video.SignTrack
+        and it's okay like that.
+        """
+        all_models = django.apps.apps.get_models()
+        undefined_s3_identifier = [
+            model
+            for model in all_models
+            if getattr(model, "S3_IDENTIFIER", "has no S3_IDENTIFIER attribute") is None
+        ]
+        self.assertListEqual(
+            undefined_s3_identifier,
+            [AudioTrack, SignTrack],
+            "All `UploadableFileMixin` models must define an `S3_IDENTIFIER` attribute",
+        )

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -105,6 +105,8 @@ dev =
 e2e =
     playwright==1.25.1
     pytest-playwright==0.3.0
+    # mcr.microsoft.com/playwright:jammy requires tzdata
+    tzdata==2022.2
 
 [bdist_wheel]
 universal = 1


### PR DESCRIPTION
## Purpose

This uncouples the model application and name from the key received by the `lambda convert`.

## Proposal

~Add a mapping between the key received by `update_state` API and the associated resource model.~
Generates a mapping between the key received by `update_state` API and the associated resource model by adding the S3 identifier to the model description.

