### PR TITLE
Avoid record length lower than a video segment length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ quality in the VOD dashboard
 - Add 3 widgets to upload timed text tracks to the video
 in the VOD dashboard
 - Notify students when a recording is started
+- Avoid record length lower than a video segment length
 
 ### Changed
 

--- a/src/backend/marsha/core/api/video.py
+++ b/src/backend/marsha/core/api/video.py
@@ -21,6 +21,7 @@ from marsha.core.defaults import JITSI
 from marsha.websocket.utils import channel_layers_utils
 
 from .. import defaults, forms, permissions, serializers, storage
+from ..metadata import VideoMetadata
 from ..models import LivePairing, LiveSession, SharedLiveMedia, Video
 from ..services.video_participants import (
     VideoParticipantsException,
@@ -60,6 +61,7 @@ class VideoViewSet(APIViewMixin, ObjectPkMixin, viewsets.ModelViewSet):
     queryset = Video.objects.all()
     serializer_class = serializers.VideoSerializer
     permission_classes = [permissions.NotAllowed]
+    metadata_class = VideoMetadata
 
     def get_permissions(self):
         """

--- a/src/backend/marsha/core/metadata.py
+++ b/src/backend/marsha/core/metadata.py
@@ -1,0 +1,17 @@
+"""This module holds custome metadata class dedicated to Marsha."""
+from django.conf import settings
+
+from rest_framework.metadata import SimpleMetadata
+
+
+class VideoMetadata(SimpleMetadata):
+    """Metadata class dedicated to video model."""
+
+    def determine_metadata(self, request, view):
+        """Adds live info in video metadata."""
+        metadata = super().determine_metadata(request, view)
+        metadata["live"] = {
+            "segment_duration_seconds": settings.LIVE_SEGMENT_DURATION_SECONDS
+        }
+
+        return metadata

--- a/src/backend/marsha/core/tests/test_api_video.py
+++ b/src/backend/marsha/core/tests/test_api_video.py
@@ -6628,6 +6628,7 @@ class VideoAPITest(TestCase):
 
         self.assertEqual(response.status_code, 200)
 
+    @override_settings(LIVE_SEGMENT_DURATION_SECONDS=4)
     def test_api_video_options_as_student(self):
         """A student can fetch the video options endpoint"""
 
@@ -6665,7 +6666,9 @@ class VideoAPITest(TestCase):
                 {"value": "NO_CC", "display_name": "All rights reserved"},
             ],
         )
+        self.assertEqual(content["live"]["segment_duration_seconds"], 4)
 
+    @override_settings(LIVE_SEGMENT_DURATION_SECONDS=4)
     def test_api_video_options_as_instructor(self):
         """An instructor can fetch the video options endpoint"""
 
@@ -6707,6 +6710,7 @@ class VideoAPITest(TestCase):
                 {"value": "NO_CC", "display_name": "All rights reserved"},
             ],
         )
+        self.assertEqual(content["live"]["segment_duration_seconds"], 4)
 
     def test_api_video_options_anonymous(self):
         """Anonymous user can't fetch the video options endpoint"""

--- a/src/frontend/data/queries/index.tsx
+++ b/src/frontend/data/queries/index.tsx
@@ -29,6 +29,8 @@ import { deleteOne } from './deleteOne';
 import { fetchList, FetchListQueryKey } from './fetchList';
 import { fetchOne } from './fetchOne';
 import { updateOne } from './updateOne';
+import { metadata } from './metadata';
+import { VideoMetadata } from 'types/metadata';
 
 export const useOrganization = (
   organizationId: string,
@@ -244,6 +246,20 @@ export const useVideo = (
 ) => {
   const key = ['videos', videoId];
   return useQuery<Video, 'videos'>(key, fetchOne, queryConfig);
+};
+
+export const useVideoMetadata = (
+  queryConfig?: UseQueryOptions<VideoMetadata, 'videos', VideoMetadata>,
+) => {
+  const key = ['videos'];
+  return useQuery<VideoMetadata, 'videos'>(key, metadata, {
+    refetchInterval: false,
+    refetchIntervalInBackground: false,
+    refetchOnWindowFocus: false,
+    cacheTime: Infinity,
+    staleTime: Infinity,
+    ...queryConfig,
+  });
 };
 
 type UseCreateVideoData = {

--- a/src/frontend/data/queries/metadata.spec.tsx
+++ b/src/frontend/data/queries/metadata.spec.tsx
@@ -1,0 +1,105 @@
+import fetchMock from 'fetch-mock';
+
+import { useJwt } from 'data/stores/useJwt';
+
+import { metadata } from './metadata';
+
+describe('metadata', () => {
+  afterEach(() => fetchMock.restore());
+
+  it('requests the metadata, handles the response and resolves with a success', async () => {
+    useJwt.setState({
+      jwt: 'some token',
+    });
+    fetchMock.mock('/api/model-name/', { key: 'value' });
+
+    const response = await metadata({
+      meta: undefined,
+      pageParam: undefined,
+      queryKey: ['model-name'],
+    });
+
+    expect(fetchMock.lastCall()![0]).toEqual('/api/model-name/');
+    expect(fetchMock.lastCall()![1]).toEqual({
+      headers: {
+        Authorization: 'Bearer some token',
+        'Content-Type': 'application/json',
+      },
+      method: 'OPTIONS',
+    });
+    expect(response).toEqual({ key: 'value' });
+  });
+
+  it('requests the metadata without JWT token', async () => {
+    useJwt.setState({
+      jwt: undefined,
+    });
+    fetchMock.mock('/api/model-name/', { key: 'value' });
+
+    const response = await metadata({
+      meta: undefined,
+      pageParam: undefined,
+      queryKey: ['model-name'],
+    });
+
+    expect(fetchMock.lastCall()![0]).toEqual('/api/model-name/');
+    expect(fetchMock.lastCall()![1]).toEqual({
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      method: 'OPTIONS',
+    });
+    expect(response).toEqual({ key: 'value' });
+  });
+
+  it('resolves with a failure and handles it when it fails to get the resource (local)', async () => {
+    useJwt.setState({
+      jwt: 'some token',
+    });
+    fetchMock.mock(
+      '/api/model-name/',
+      Promise.reject(new Error('Failed to perform the request')),
+    );
+
+    await expect(
+      metadata({
+        meta: undefined,
+        pageParam: undefined,
+        queryKey: ['model-name'],
+      }),
+    ).rejects.toThrowError('Failed to perform the request');
+
+    expect(fetchMock.lastCall()![0]).toEqual('/api/model-name/');
+    expect(fetchMock.lastCall()![1]).toEqual({
+      headers: {
+        Authorization: 'Bearer some token',
+        'Content-Type': 'application/json',
+      },
+      method: 'OPTIONS',
+    });
+  });
+
+  it('resolves with a failure and handles it when it fails to get the resource (api)', async () => {
+    useJwt.setState({
+      jwt: 'some token',
+    });
+    fetchMock.mock('/api/model-name/', 404);
+
+    await expect(
+      metadata({
+        meta: undefined,
+        pageParam: undefined,
+        queryKey: ['model-name'],
+      }),
+    ).rejects.toThrowError('Failed to get metadata for /model-name/.');
+
+    expect(fetchMock.lastCall()![0]).toEqual('/api/model-name/');
+    expect(fetchMock.lastCall()![1]).toEqual({
+      headers: {
+        Authorization: 'Bearer some token',
+        'Content-Type': 'application/json',
+      },
+      method: 'OPTIONS',
+    });
+  });
+});

--- a/src/frontend/data/queries/metadata.tsx
+++ b/src/frontend/data/queries/metadata.tsx
@@ -1,0 +1,24 @@
+import { QueryFunction } from 'react-query';
+
+import { useJwt } from 'data/stores/useJwt';
+
+/**
+ * `react-query` fetcher for individual metadata model.
+ */
+export const metadata: QueryFunction<any> = async ({ queryKey }) => {
+  const jwt = useJwt.getState().jwt;
+  const [name] = queryKey;
+  const response = await fetch(`/api/${name}/`, {
+    headers: {
+      'Content-Type': 'application/json',
+      ...(jwt ? { Authorization: `Bearer ${jwt}` } : {}),
+    },
+    method: 'OPTIONS',
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to get metadata for /${name}/.`);
+  }
+
+  return await response.json();
+};

--- a/src/frontend/types/metadata.ts
+++ b/src/frontend/types/metadata.ts
@@ -1,0 +1,13 @@
+export interface ResourceMetadata {
+  name: string;
+  description: string;
+  renders: string[];
+  parses: string[];
+  actions: object;
+}
+
+export interface VideoMetadata extends ResourceMetadata {
+  live: {
+    segment_duration_seconds: number;
+  };
+}


### PR DESCRIPTION
## Purpose

If a video record is too short, lower than the video segment length, the mediapackage harvest job will fail. We have to control, for each record slice this record length and not allow to stop recording while the length is lower than the segment length.

## Proposal

- [x] block too short recorded slice
- [x] create metadata class dedicated to video model
- [x] manage metadata request with react-query
- [x] disable stop record button while segment length is too short

Fixes #1626 