### PR TITLE
♻️(back) cloudfront URL parameter for resource

### DIFF
--- a/src/backend/marsha/core/tests/test_api_shared_live_media.py
+++ b/src/backend/marsha/core/tests/test_api_shared_live_media.py
@@ -25,7 +25,7 @@ from ..factories import (
 )
 from ..models import SharedLiveMedia
 from ..models.account import ADMINISTRATOR, INSTRUCTOR
-from .test_api_video import RSA_KEY_MOCK
+from .utils import RSA_KEY_MOCK
 
 
 # We don't enforce arguments documentation in tests

--- a/src/backend/marsha/core/tests/test_api_timed_text_track.py
+++ b/src/backend/marsha/core/tests/test_api_timed_text_track.py
@@ -16,7 +16,7 @@ from .. import factories, models
 from ..api import timezone
 from ..factories import TimedTextTrackFactory, UserFactory, VideoFactory
 from ..models import TimedTextTrack
-from .test_api_video import RSA_KEY_MOCK
+from .utils import RSA_KEY_MOCK
 
 
 # We don't enforce arguments documentation in tests

--- a/src/backend/marsha/core/tests/test_api_video.py
+++ b/src/backend/marsha/core/tests/test_api_video.py
@@ -40,37 +40,8 @@ from ..factories import LiveSessionFactory, VideoFactory
 from ..utils.api_utils import generate_hash
 from ..utils.medialive_utils import ManifestMissingException
 from ..utils.time_utils import to_timestamp
+from .utils import RSA_KEY_MOCK
 
-
-RSA_KEY_MOCK = b"""
------BEGIN RSA PRIVATE KEY-----
-MIIEoQIBAAKCAQBNUKgvL8k3rd882JuuAwg/3102KEuOgJV47X+cEmaWDKZWbnIL
-1r+ondm8xtpLTDtYtZ2IYBZsrfa5DJjhllkIhtSOWpT/YnDJWnV9mHeuh1elfsB+
-szs/aCDezf3piNi4WdpDzNwmqcUBopn4rydKpADjup6zXoBXyh7pLtLyLk2Xdnt5
-LHlnRTgatBQmCcraLMRrvQfmscD0zA0TRlZyimWmktt/+eEli0bWgNwm2kPkcfG8
-SSdIp2GUMpV3rjILlWlybRDpNR0H7qO9Ea6JzjcNAAi+33pKDTJZ472TmetT51G/
-ZypymDNyh1wn3CIavQLMGBOp4HtoX0cX7x3/AgMBAAECggEAOsDffjRXOhvEeI23
-CK6/NyK7x+spN9qZPDNndSg6ky57vVTjEAIa1b1W+PE4dF4y/z/MvhUfFWnCA3AC
-QfQqJqOnpaJKdiTNxwYaIN6bnKK3RUmkaOQ1UwMDb62kljLrVnTZvApTBoKe9pYl
-Yelg94TYNDbeYTqgV5Z+lP+DSIx3dg+2Ow90scQt8ZQt20XsL9CANZye9bUwUcLn
-JQEjLIE3k+YpGSSDvJz+vbgozBvNfv0M4/BTLGvUvMRBinfqRJVXc09WTqqsDJb9
-GJHcP8TSdwm/6CHrkUkVjsDZvzUiVIp8R+DBmZfPO6KfS0ig5H/uA5NwaHhSMRi+
-6KSL+QKBgQCRMxdFjcCJFc5T/H3A/uJreAyuH8gn7jiK6pF3bplvnE6zpz9LzhNW
-5a+7F5rSZrRYRIQ6Rn67PpRd/T7N9wvMEItIp7cAGqfAwPwhaX/INkkVtmxFGrjg
-Muwpxi9zb8cmRYKL/j7WgwtzRsoR+BRqkAd+WqltRxq0dYqrAIExtQKBgQCIUD83
-WDoa8fguIj3VHeRnLBEg+5L7IUf7ldOhgzifhde/cEOlqFy7AQuLMnj4NJzmEwa8
-IKV+brcbAW1v7e3hElpFBFmVjcj9JSezuK3NS41iX5ZDPlLCGy0b1+3BS7ucMrHv
-CLWsDaTVacnD+vLzYk1ssppotAlFOMt4Z+hxYwKBgAw7Yp2AaJTj2mLm5W0py8dD
-8MWGdeUvQ2IoiqKmFZT6dQLbdxCaxrROWzSGs4tADbdV5lHGeIyro/IbEHxncH37
-ctBnGJqQpEsvts3VxmcGc7e5i3ty2dpBT/Xg9URjSUKnHm1OuNp3ZbKLZyCGZqnn
-gkoZtyY2lEBZmpn3S+r1AoGAY+CAYTnY4TNYB9149rU/TEUii8spB658Ap/l/5qZ
-G3FDAnbsae2xfCeo4KXrstlB+OYJ8j/tYnUW3set+uwXdukukRE93nGTyb+2ll2D
-oz9vaZvmCoEYvDaTV6pf/1hRL4KJkz4LdvRMST6I4nr2FlR5rGI09vCrNjgGBcQE
-sUcCgYBgICkGE5v7DltVOA1cT65bjyRh8xso+/LGTM2A6jORVZpC4DnqyxkVpJaA
-FjzCJG6LdHZH5df8TbqEz4dl2ddNT5wgYheLizH5YcJ+MyeMeGM+JHHAWyl2p016
-ASOu/Da3/eg8PI5Rsh6ubNVlEAMQdDFhL/TpfaHqSwim6mxbrQ==
------END RSA PRIVATE KEY-----
-"""
 
 # We don't enforce arguments documentation in tests
 # pylint: disable=unused-argument,too-many-lines

--- a/src/backend/marsha/core/tests/test_serializers_base.py
+++ b/src/backend/marsha/core/tests/test_serializers_base.py
@@ -1,0 +1,133 @@
+"""Tests for the serializer base module of the Marsha project."""
+from datetime import datetime, timedelta
+import time
+from unittest import mock
+
+from django.test import TestCase, override_settings
+from django.utils import timezone
+
+from ..serializers import (
+    get_resource_cloudfront_url_params,
+    get_video_cloudfront_url_params,
+)
+from ..utils.time_utils import to_timestamp
+
+
+FIXED_TIME = datetime(2018, 8, 8, tzinfo=timezone.utc)
+
+
+@override_settings(
+    AWS_S3_URL_PROTOCOL="https",
+    CACHES={
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        },
+    },
+    CLOUDFRONT_DOMAIN="abc.cloudfront.net",
+    CLOUDFRONT_SIGNED_URLS_VALIDITY=2 * 60 * 60,  # 2 hours
+    CLOUDFRONT_SIGNED_PUBLIC_KEY_ID="YourCloudfrontPublicKeyId",
+    CLOUDFRONT_SIGNED_URL_CACHE_DURATION=15 * 60,  # 15 minutes
+)
+@mock.patch("builtins.open", new_callable=mock.mock_open, read_data=RSA_KEY_MOCK)
+class ResourceCloudfrontUrlParamsTest(TestCase):
+    """Test the function which generates the Cloudfront URL parameters."""
+
+    maxDiff = None
+
+    @mock.patch.object(timezone, "now", return_value=FIXED_TIME)
+    def test_get_resource_cloudfront_url_params(self, _time_mock, _open_mock):
+        """The `get_resource_cloudfront_url_params` function must return consistent values."""
+        self.assertListEqual(
+            get_resource_cloudfront_url_params(
+                "some_resource",
+                "dc3104d6-2cfb-11ed-aeff-7f0c85456c82",
+            ),
+            [
+                "Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiaHR0cHM6Ly9hYmMuY2xvdWRmcm9udC5u"
+                "ZXQvZGMzMTA0ZDYtMmNmYi0xMWVkLWFlZmYtN2YwYzg1NDU2YzgyLyoiLCJDb25kaXRpb24iOns"
+                "iRGF0ZUxlc3NUaGFuIjp7IkFXUzpFcG9jaFRpbWUiOjE1MzM2OTM2MDB9fX1dfQ__",
+                "Signature=Ol2-nKxREmIWlqfkqyQSDWHhhYjyocA73X1N5LQHCLVdJiN2gxzM3mqe-heSbhWxC"
+                "RwztcqETrzKQuAV~Oo1gNaizXApP6iykEVxBlYS8NmEfDne2rHbZUs9U90DnhVUx~E~2yfFhGzK"
+                "ewaWKpjo1KVG9dR8yQlavJ1MICtheU94DK1s6qP6aJ1B6lPlwV1QyGirzKqcbGU-l-sqGv3fTXo"
+                "pbDMKvFz8yYAoUCBh2IHcAkfRP6hjMJsjERnPA7FKBt5z2199WRGiF~9kcGLgEA2vEWF-FyI6r-"
+                "JU6xJWgc3dHMUBf6oXOWbqsijYEhJMWr3EDwXnIfwYx52GejGS2w__",
+                "Key-Pair-Id=YourCloudfrontPublicKeyId",
+            ],
+        )
+
+    @mock.patch(
+        "marsha.core.utils.cloudfront_utils.generate_cloudfront_urls_signed_parameters",
+        return_value=["Policy", "Signature", "Key-Pair-Id"],
+    )
+    def test_get_resource_cloudfront_url_params_uses_cache(
+        self, cloudfront_urls_mock, _open_mock
+    ):
+        """The `get_resource_cloudfront_url_params` function uses cache."""
+        resource_kind = "some_resource"
+        resource_id = "d0e8bcb8-2d00-11ed-b434-b3045e7f77ad"
+
+        with (
+            mock.patch.object(timezone, "now", return_value=FIXED_TIME),
+            # mock time for LocMemCache
+            mock.patch.object(time, "time", return_value=int(to_timestamp(FIXED_TIME))),
+        ):
+            self.assertListEqual(
+                get_resource_cloudfront_url_params(
+                    resource_kind,
+                    resource_id,
+                ),
+                ["Policy", "Signature", "Key-Pair-Id"],
+            )
+            cloudfront_urls_mock.assert_called_once()
+
+        cloudfront_urls_mock.reset_mock()
+
+        now = FIXED_TIME + timedelta(seconds=15 * 60 - 1)
+        with (
+            mock.patch.object(timezone, "now", return_value=now),
+            # mock time for LocMemCache
+            mock.patch.object(time, "time", return_value=int(to_timestamp(now))),
+        ):
+            self.assertListEqual(
+                get_resource_cloudfront_url_params(
+                    resource_kind,
+                    resource_id,
+                ),
+                ["Policy", "Signature", "Key-Pair-Id"],
+            )
+            cloudfront_urls_mock.assert_not_called()
+
+        now = FIXED_TIME + timedelta(seconds=15 * 60 + 1)
+        with (
+            mock.patch.object(timezone, "now", return_value=now),
+            # mock time for LocMemCache
+            mock.patch.object(time, "time", return_value=int(to_timestamp(now))),
+        ):
+            self.assertListEqual(
+                get_resource_cloudfront_url_params(
+                    resource_kind,
+                    resource_id,
+                ),
+                ["Policy", "Signature", "Key-Pair-Id"],
+            )
+            cloudfront_urls_mock.assert_called_once()
+
+    @mock.patch.object(timezone, "now", return_value=FIXED_TIME)
+    def test_get_video_cloudfront_url_params(self, _time_mock, _open_mock):
+        """The `get_video_cloudfront_url_params` function must return consistent values."""
+        self.assertListEqual(
+            get_video_cloudfront_url_params(
+                "5ad68da6-2cfc-11ed-85d6-070aafed10e6",
+            ),
+            [
+                "Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiaHR0cHM6Ly9hYmMuY2xvdWRmcm9udC5u"
+                "ZXQvNWFkNjhkYTYtMmNmYy0xMWVkLTg1ZDYtMDcwYWFmZWQxMGU2LyoiLCJDb25kaXRpb24iOns"
+                "iRGF0ZUxlc3NUaGFuIjp7IkFXUzpFcG9jaFRpbWUiOjE1MzM2OTM2MDB9fX1dfQ__",
+                "Signature=OpUX~RdC3qBhsmuynnmyS~H84edXyYJQ0jdG9KLIcJy3I~B7-ACWMDp~Vlc0ohnSX"
+                "6b99QwzTylIAzHeBmNT7b2kLkUpjEAzcH9BPu1A9UUnhArvPHAJ2qDKMTbf8Q2~cdEgDel2-znX"
+                "kAJO04ieb0lXchT5xItMpGycrLsFgbK-XNc7k8hPZyol3HDwIurdz-nx5afDSH2PsYlAyyOZJub"
+                "dc5iHzDjVdbtTffyRdsSSZt-l9O0GVs6d~FJbdEUZkVAA-T8hc-2eOglzvSqPK30fdBT8oAT8Hl"
+                "zdwiiDqN9B40dIwX~bXtyf8u6JZOOcmNPCkpNA59DHEOIM0fWEHw__",
+                "Key-Pair-Id=YourCloudfrontPublicKeyId",
+            ],
+        )

--- a/src/backend/marsha/core/tests/test_serializers_base.py
+++ b/src/backend/marsha/core/tests/test_serializers_base.py
@@ -11,6 +11,7 @@ from ..serializers import (
     get_video_cloudfront_url_params,
 )
 from ..utils.time_utils import to_timestamp
+from .utils import RSA_KEY_MOCK
 
 
 FIXED_TIME = datetime(2018, 8, 8, tzinfo=timezone.utc)

--- a/src/backend/marsha/core/tests/utils.py
+++ b/src/backend/marsha/core/tests/utils.py
@@ -12,6 +12,37 @@ from oauthlib import oauth1
 from marsha.core.factories import ConsumerSiteLTIPassportFactory
 
 
+RSA_KEY_MOCK = b"""
+-----BEGIN RSA PRIVATE KEY-----
+MIIEoQIBAAKCAQBNUKgvL8k3rd882JuuAwg/3102KEuOgJV47X+cEmaWDKZWbnIL
+1r+ondm8xtpLTDtYtZ2IYBZsrfa5DJjhllkIhtSOWpT/YnDJWnV9mHeuh1elfsB+
+szs/aCDezf3piNi4WdpDzNwmqcUBopn4rydKpADjup6zXoBXyh7pLtLyLk2Xdnt5
+LHlnRTgatBQmCcraLMRrvQfmscD0zA0TRlZyimWmktt/+eEli0bWgNwm2kPkcfG8
+SSdIp2GUMpV3rjILlWlybRDpNR0H7qO9Ea6JzjcNAAi+33pKDTJZ472TmetT51G/
+ZypymDNyh1wn3CIavQLMGBOp4HtoX0cX7x3/AgMBAAECggEAOsDffjRXOhvEeI23
+CK6/NyK7x+spN9qZPDNndSg6ky57vVTjEAIa1b1W+PE4dF4y/z/MvhUfFWnCA3AC
+QfQqJqOnpaJKdiTNxwYaIN6bnKK3RUmkaOQ1UwMDb62kljLrVnTZvApTBoKe9pYl
+Yelg94TYNDbeYTqgV5Z+lP+DSIx3dg+2Ow90scQt8ZQt20XsL9CANZye9bUwUcLn
+JQEjLIE3k+YpGSSDvJz+vbgozBvNfv0M4/BTLGvUvMRBinfqRJVXc09WTqqsDJb9
+GJHcP8TSdwm/6CHrkUkVjsDZvzUiVIp8R+DBmZfPO6KfS0ig5H/uA5NwaHhSMRi+
+6KSL+QKBgQCRMxdFjcCJFc5T/H3A/uJreAyuH8gn7jiK6pF3bplvnE6zpz9LzhNW
+5a+7F5rSZrRYRIQ6Rn67PpRd/T7N9wvMEItIp7cAGqfAwPwhaX/INkkVtmxFGrjg
+Muwpxi9zb8cmRYKL/j7WgwtzRsoR+BRqkAd+WqltRxq0dYqrAIExtQKBgQCIUD83
+WDoa8fguIj3VHeRnLBEg+5L7IUf7ldOhgzifhde/cEOlqFy7AQuLMnj4NJzmEwa8
+IKV+brcbAW1v7e3hElpFBFmVjcj9JSezuK3NS41iX5ZDPlLCGy0b1+3BS7ucMrHv
+CLWsDaTVacnD+vLzYk1ssppotAlFOMt4Z+hxYwKBgAw7Yp2AaJTj2mLm5W0py8dD
+8MWGdeUvQ2IoiqKmFZT6dQLbdxCaxrROWzSGs4tADbdV5lHGeIyro/IbEHxncH37
+ctBnGJqQpEsvts3VxmcGc7e5i3ty2dpBT/Xg9URjSUKnHm1OuNp3ZbKLZyCGZqnn
+gkoZtyY2lEBZmpn3S+r1AoGAY+CAYTnY4TNYB9149rU/TEUii8spB658Ap/l/5qZ
+G3FDAnbsae2xfCeo4KXrstlB+OYJ8j/tYnUW3set+uwXdukukRE93nGTyb+2ll2D
+oz9vaZvmCoEYvDaTV6pf/1hRL4KJkz4LdvRMST6I4nr2FlR5rGI09vCrNjgGBcQE
+sUcCgYBgICkGE5v7DltVOA1cT65bjyRh8xso+/LGTM2A6jORVZpC4DnqyxkVpJaA
+FjzCJG6LdHZH5df8TbqEz4dl2ddNT5wgYheLizH5YcJ+MyeMeGM+JHHAWyl2p016
+ASOu/Da3/eg8PI5Rsh6ubNVlEAMQdDFhL/TpfaHqSwim6mxbrQ==
+-----END RSA PRIVATE KEY-----
+"""
+
+
 def reload_urlconf():
     """
     Enforce URL configuration reload.


### PR DESCRIPTION
## Purpose

Allow other resources to generate the Cloudfront URL parameters.

## Proposal

Make the Cloudfront URL parameters function generic.

- [x] extract the generic part of `get_video_cloudfront_url_params` in another function
- [x] add tests

