### PR TITLE
Upgrade terraform and AWS provider

### DIFF
--- a/src/aws/.terraform.lock.hcl
+++ b/src/aws/.terraform.lock.hcl
@@ -2,21 +2,22 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "3.63.0"
-  constraints = "~> 3.63"
+  version     = "4.29.0"
+  constraints = "~> 4.29"
   hashes = [
-    "h1:v9aPF3aaBpk0uSO5pfggYJKGgP/Ur28hZRJs1jS+ttI=",
-    "zh:42c6c98b294953a4e1434a331251e539f5372bf6779bd61ab5df84cac0545287",
-    "zh:5493773762a470889c9a23db97582d3a82035847c8d3bd13323b4c3012abf325",
-    "zh:550d22ff9fed4d817a922e7b84bd9d1f2ef8d3afa00832cf66b8cd5f0e6dc748",
-    "zh:632cb5e2d9d5041875f57174236eafe5b05dbf26750c1041ab57eb08c5369fe2",
-    "zh:7cfeaf5bde1b28bd010415af1f3dc494680a8374f1a26ec19db494d99938cc4e",
-    "zh:99d871606b67c8aefce49007315de15736b949c09a9f8f29ad8af1e9ce383ed3",
-    "zh:c4fc8539ffe90df5c7ae587fde495fac6bc0186fec2f2713a8988a619cef265f",
-    "zh:d0a26493206575c99ca221d78fe64f96a8fbcebe933af92eea6b39168c1f1c1d",
-    "zh:e156fdc964fdd4a7586ec15629e20d2b06295b46b4962428006e088145db07d6",
-    "zh:eb04fc80f652b5c92f76822f0fec1697581543806244068506aed69e1bb9b2af",
-    "zh:f5638a533cf9444f7d02b5527446cdbc3b2eab8bcc4ec4b0ca32035fe6f479d3",
+    "h1:cpTUwXfdtmmUqsnYwXFQ5gZjnfz5cgvydmcGxrv+BeA=",
+    "zh:091615c6dddd556b8cc1cd54e1c5c1fe71b593acebacd0b274a2fed7fc4ca802",
+    "zh:4cc11d7252813b2d7cb52e78b24af8eaf377cc242d1d672a7f8bf680758a4976",
+    "zh:565f46308d6e96a21c273e84e0f73d3f39fd8159fc5aaf41bf65c0b0dd6f1de3",
+    "zh:627b6a5574262b5f07c0e012bcb5c73afd97d90b75389c0ab154b5ae4c0dce8f",
+    "zh:91622572d311c28504fbf14e9364120fbafb3adf8e2d49bfdf014752dac9dac0",
+    "zh:98f37f07628b7c2960335b772a544de6bb90f0f390b9d5fdcc3ac211b9cd7def",
+    "zh:9a6338478ba0e7ca75c5b43e0f91dde12d17273b1dc9934c8ff4d631b8bb837a",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a1cc1fc49e406cba1e98250bc04a47be0b6babf5bb42f23baa40f2dc7f8b90f7",
+    "zh:a251e933412036426e2f7b090000c198feee114270d5724bcc8dd9d674d43689",
+    "zh:b0ef3b92947cc8cea75634139dfbfcae2207a9cb5c31d827cd34e523ca04e919",
+    "zh:fb9ede02c9291e7677877bc21ec5c094da38e3cd44df91da5af36f504be399be",
   ]
 }
 

--- a/src/aws/bin/terraform
+++ b/src/aws/bin/terraform
@@ -3,7 +3,7 @@
 set -eo pipefail
 
 declare MARSHA_TERRAFORM_ENV_FILE
-declare -r TERRAFORM_VERSION="1.0.9"
+declare -r TERRAFORM_VERSION="1.2.8"
 
 function _check_workspace() {
     current_workspace=$(

--- a/src/aws/provider.tf
+++ b/src/aws/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.63"
+      version = "~> 4.29"
     }
     tls = {
       source = "hashicorp/tls"

--- a/src/aws/s3.tf
+++ b/src/aws/s3.tf
@@ -1,14 +1,6 @@
 # Create source S3 Bucket for uploaded videos to be converted
 resource "aws_s3_bucket" "marsha_source" {
   bucket = "${terraform.workspace}-marsha-source${var.s3_bucket_unique_suffix}"
-  acl    = "private"
-
-  cors_rule {
-    allowed_headers = ["*"]
-    allowed_methods = ["POST"]
-    allowed_origins = ["*"]
-    max_age_seconds = 3600
-  }
 
   tags = {
     Name        = "marsha-source"
@@ -16,17 +8,25 @@ resource "aws_s3_bucket" "marsha_source" {
   }
 }
 
-# Create destination S3 Bucket for converted videos and images
-resource "aws_s3_bucket" "marsha_destination" {
-  bucket = "${terraform.workspace}-marsha-destination${var.s3_bucket_unique_suffix}"
-  acl    = "private"
+resource "aws_s3_bucket_cors_configuration" "marsha_source_cors_rule" {
+  bucket = aws_s3_bucket.marsha_source.id
 
   cors_rule {
     allowed_headers = ["*"]
-    allowed_methods = ["GET"]
+    allowed_methods = ["POST"]
     allowed_origins = ["*"]
     max_age_seconds = 3600
   }
+}
+
+resource "aws_s3_bucket_acl" "marsha_source_acl" {
+  bucket = aws_s3_bucket.marsha_source.id
+  acl    = "private"
+}
+
+# Create destination S3 Bucket for converted videos and images
+resource "aws_s3_bucket" "marsha_destination" {
+  bucket = "${terraform.workspace}-marsha-destination${var.s3_bucket_unique_suffix}"
 
   tags = {
     Name        = "marsha-destination"
@@ -34,10 +34,8 @@ resource "aws_s3_bucket" "marsha_destination" {
   }
 }
 
-# Create S3 Bucket for static files
-resource "aws_s3_bucket" "marsha_static" {
-  bucket = "${terraform.workspace}-marsha-static${var.s3_bucket_unique_suffix}"
-  acl    = "private"
+resource "aws_s3_bucket_cors_configuration" "marsha_destination_cors_rule" {
+  bucket = aws_s3_bucket.marsha_destination.id
 
   cors_rule {
     allowed_headers = ["*"]
@@ -45,11 +43,38 @@ resource "aws_s3_bucket" "marsha_static" {
     allowed_origins = ["*"]
     max_age_seconds = 3600
   }
+}
+
+resource "aws_s3_bucket_acl" "marsha_destination_acl" {
+  bucket = aws_s3_bucket.marsha_destination.id
+  acl    = "private"
+}
+
+
+# Create S3 Bucket for static files
+resource "aws_s3_bucket" "marsha_static" {
+  bucket = "${terraform.workspace}-marsha-static${var.s3_bucket_unique_suffix}"
 
   tags = {
     Name        = "marsha-static"
     Environment = terraform.workspace
   }
+}
+
+resource "aws_s3_bucket_cors_configuration" "marsha_static_cors_rule" {
+  bucket = aws_s3_bucket.marsha_static.id
+
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["GET"]
+    allowed_origins = ["*"]
+    max_age_seconds = 3600
+  }
+}
+
+resource "aws_s3_bucket_acl" "marsha_static_acl" {
+  bucket = aws_s3_bucket.marsha_static.id
+  acl    = "private"
 }
 
 # Add notification invoking Lambda to convert video files each time a video is


### PR DESCRIPTION
## Purpose

We need to use a more recent version of AWS provider to use some new properties introduction on the lambda function like the ephemeral storage.

## Proposal

- [x] Upgrade terraform to version 1.2.8
- [x] Upgrade AWS provider to version 4.29.0

