### PR TITLE
✨(frontend) add toggle to allow download on new VOD dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Add toggle to allow download or not on the VOD dashboard.
 - Display total amount of participants in the title panel
 - Display amount of participants in the viewers panel
 - Add missing ended webinar screens when live is stopped 


### PR DESCRIPTION
## Purpose

Added a toggle to allow download or not on the VOD dashboard. 
The toggle is located in the download video widget.

## Proposal

I updated the component [DownloadVideo](https://github.com/openfun/marsha/blob/feature/anthony/download_toggle_vod/src/frontend/apps/lti_site/components/VideoWidgetProvider/widgets/DownloadVideo/index.tsx), I was hesitating by creating a new component instead; let me know.

