### PR TITLE
Update frontend i18n path 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -906,7 +906,7 @@ jobs:
   # translation management tool
   i18n:
     docker:
-      - image: crowdin/cli:3.2.1
+      - image: crowdin/cli:3.7.10
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS

--- a/.dockerignore
+++ b/.dockerignore
@@ -44,7 +44,7 @@ renovate.json
 # Assets
 data
 src/backend/marsha/static/js
-src/frontend/i18n/frontend.json
+src/frontend/apps/**/i18n/frontend.json
 
 # Front-end
 **/node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -65,7 +65,7 @@ coverage.xml
 # Translations
 *.mo
 *.pot
-src/frontend/translations/*.json
+
 
 # Django stuff:
 *.log
@@ -126,7 +126,8 @@ venv.bak/
 __diff_output__/
 node_modules
 src/frontend/coverage
-src/frontend/i18n/frontend.json
+src/frontend/apps/**/translations/*.json
+src/frontend/apps/**/i18n/frontend.json
 src/backend/marsha/static/css
 src/backend/marsha/static/js
 storybook-static

--- a/Makefile
+++ b/Makefile
@@ -231,7 +231,7 @@ build-sass: ## Build Sass file to CSS
 
 build-ts: ### Build TypeScript application
 	@$(YARN) workspace marsha run compile-translations
-	@$(YARN) build
+	@$(YARN) build-lti
 .PHONY: build-ts
 
 watch-front: ## Build front application and activate watch mode

--- a/Makefile
+++ b/Makefile
@@ -388,12 +388,12 @@ i18n-generate: \
 .PHONY: i18n-generate
 
 i18n-generate-back:
-	@$(COMPOSE_RUN_APP) python manage.py makemessages --ignore "venv/**/*" --keep-pot
+	@$(COMPOSE_RUN_APP) python manage.py makemessages --ignore "venv/**/*" --keep-pot --all
 .PHONY: i18n-generate-back
 
 i18n-generate-front:
 	@$(YARN) workspace marsha run build
-	@$(YARN) extract-translations
+	@$(YARN) workspace marsha run extract-translations
 .PHONY: i18n-generate-front
 
 

--- a/crowdin/config.yml
+++ b/crowdin/config.yml
@@ -21,8 +21,8 @@ files: [
   "translation" : "/backend/locale/%locale_with_underscore%/LC_MESSAGES/django.po",
  },
  {
-  "source" : "/frontend/i18n/frontend.json",
+  "source" : "/frontend/apps/lti_site/i18n/frontend.json",
   "dest": "/frontend.json",
-  "translation" : "/frontend/i18n/%locale_with_underscore%.json",
+  "translation" : "/frontend/apps/lti_site/i18n/%locale_with_underscore%.json",
  }
 ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,7 +76,7 @@ services:
       - 4040:4040
 
   crowdin:
-    image: crowdin/cli:3.2.1
+    image: crowdin/cli:3.7.10
     volumes:
       - ".:/app"
     env_file:

--- a/src/frontend/apps/lti_site/components/VideoWidgetProvider/widgets/TitleAndDescriptionWidget/index.tsx
+++ b/src/frontend/apps/lti_site/components/VideoWidgetProvider/widgets/TitleAndDescriptionWidget/index.tsx
@@ -18,41 +18,41 @@ const messages = defineMessages({
       'This widget allows you to set the title of your video and its description',
     description:
       'Info of the widget used for setting title and live recording.',
-    id: 'components.GeneralTitle.info',
+    id: 'components.TitleAndDescriptionWidget.info',
   },
   title: {
     defaultMessage: 'General',
     description:
       'Title of the widget used for setting VOD title and activate recording.',
-    id: 'components.GeneralTitle.title',
+    id: 'components.TitleAndDescriptionWidget.title',
   },
   placeholderTitleInput: {
     defaultMessage: 'Enter title of your VOD here',
     description:
       'A placeholder text indicating the purpose of the input and what it is supposed to received.',
-    id: 'components.GeneralTitle.placeholderTitleInput',
+    id: 'components.TitleAndDescriptionWidget.placeholderTitleInput',
   },
   updateVideoSucces: {
     defaultMessage: 'Video updated.',
     description: 'Message displayed when video is successfully updated.',
-    id: 'component.GeneralTitle.updateVideoSuccess',
+    id: 'component.TitleAndDescriptionWidget.updateVideoSuccess',
   },
   updateVideoFail: {
     defaultMessage: 'Video update has failed !',
     description: 'Message displayed when video update has failed.',
-    id: 'component.GeneralTitle.updateVideoFail',
+    id: 'component.TitleAndDescriptionWidget.updateVideoFail',
   },
   updateTitleBlank: {
     defaultMessage: "Title can't be blank !",
     description:
       'Message displayed when the user tried to enter a blank title.',
-    id: 'component.GeneralTitle.updateTitleBlank',
+    id: 'component.TitleAndDescriptionWidget.updateTitleBlank',
   },
   placeholderDescriptionInput: {
     defaultMessage: 'Description...',
     description:
       'A placeholder text indicating the purpose of the input and what it is supposed to received.',
-    id: 'components.GeneralTitle.placeholderDescriptionInput',
+    id: 'components.TitleAndDescriptionWidget.placeholderDescriptionInput',
   },
 });
 

--- a/src/frontend/apps/lti_site/components/VideoWidgetProvider/widgets/TitleAndRecordConfigWidget/index.tsx
+++ b/src/frontend/apps/lti_site/components/VideoWidgetProvider/widgets/TitleAndRecordConfigWidget/index.tsx
@@ -18,41 +18,41 @@ const messages = defineMessages({
       'This widget allows you to set the title of your live, alongside activate / deactivate recording of it.',
     description:
       'Info of the widget used for setting title and live recording.',
-    id: 'components.GeneralTitle.info',
+    id: 'components.TitleAndRecordConfigWidget.info',
   },
   title: {
     defaultMessage: 'General',
     description:
       'Title of the widget used for setting live title and activate recording.',
-    id: 'components.GeneralTitle.title',
+    id: 'components.TitleAndRecordConfigWidget.title',
   },
   placeholderTitleInput: {
     defaultMessage: 'Enter title of your live here',
     description:
       'A placeholder text indicating the purpose of the input and what it is supposed to received.',
-    id: 'components.GeneralTitle.placeholderTitleInput',
+    id: 'components.TitleAndRecordConfigWidget.placeholderTitleInput',
   },
   updateVideoSucces: {
     defaultMessage: 'Video updated.',
     description: 'Message displayed when video is successfully updated.',
-    id: 'component.GeneralTitle.updateVideoSuccess',
+    id: 'component.TitleAndRecordConfigWidget.updateVideoSuccess',
   },
   updateVideoFail: {
     defaultMessage: 'Video update has failed !',
     description: 'Message displayed when video update has failed.',
-    id: 'component.GeneralTitle.updateVideoFail',
+    id: 'component.TitleAndRecordConfigWidget.updateVideoFail',
   },
   updateTitleBlank: {
     defaultMessage: "Title can't be blank !",
     description:
       'Message displayed when the user tried to enter a blank title.',
-    id: 'component.GeneralTitle.updateTitleBlank',
+    id: 'component.TitleAndRecordConfigWidget.updateTitleBlank',
   },
   recordingToggleLabel: {
     defaultMessage: 'Activate live recording',
     description:
       'The label associated to the toggle button reponsible of live recording activation / deactivation.',
-    id: 'components.GeneralTitle.liveRecordingToggleLabel',
+    id: 'components.TitleAndRecordConfigWidget.liveRecordingToggleLabel',
   },
 });
 


### PR DESCRIPTION
## Purpose

The frontend i18n directory has been moved to the `apps/lti_site` directory. This change must be reflect on the config of tooling using i18n like crowdin

## Proposal

- [x] upgrade crowdin to version 3.7.10
- [x] update frontend i18n in tooling config
- [x] fix duplicated translation message id

