### PR TITLE
✨(frontend) toggle to use subtitle as transcript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Add toggle to use subtitle as transcript
 - Add toggle to allow download or not on the VOD dashboard.
 - Display total amount of participants in the title panel
 - Display amount of participants in the viewers panel

--- a/src/frontend/apps/lti_site/components/LocalizedTimedTextTrackUpload/index.tsx
+++ b/src/frontend/apps/lti_site/components/LocalizedTimedTextTrackUpload/index.tsx
@@ -99,7 +99,7 @@ export const LocalizedTimedTextTrackUpload = ({
   };
 
   return (
-    <Box direction="column" gap="small">
+    <Box direction="column" gap="small" margin={{ top: 'small' }}>
       <LanguageSelect
         onChange={(option) => setSelectedLanguage(option)}
         timedTextModeWidget={timedTextModeWidget}

--- a/src/frontend/apps/lti_site/components/VideoWidgetProvider/widgets/UploadSubtitles/ToggleSubtitlesAsTranscript/index.spec.tsx
+++ b/src/frontend/apps/lti_site/components/VideoWidgetProvider/widgets/UploadSubtitles/ToggleSubtitlesAsTranscript/index.spec.tsx
@@ -1,0 +1,201 @@
+import { act, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import fetchMock from 'fetch-mock';
+import React, { PropsWithChildren } from 'react';
+
+import { ToggleSubtitlesAsTranscript } from '.';
+import { useJwt } from 'data/stores/useJwt';
+import { useTimedTextTrack } from 'data/stores/useTimedTextTrack';
+import { timedTextMode } from 'types/tracks';
+import { timedTextMockFactory, videoMockFactory } from 'utils/tests/factories';
+import render from 'utils/tests/render';
+import { wrapInVideo } from 'utils/tests/wrapInVideo';
+
+const mockSetInfoWidgetModal = jest.fn();
+const mockedVideo = videoMockFactory();
+const toggleLabel = 'Use subtitles as transcripts';
+const mockedTimedTextTrackSubtitle = timedTextMockFactory({
+  language: 'fr-FR',
+  is_ready_to_show: true,
+  mode: timedTextMode.SUBTITLE,
+});
+
+jest.mock('data/stores/useInfoWidgetModal', () => ({
+  useInfoWidgetModal: () => [
+    { isVisible: false, text: null, title: null },
+    mockSetInfoWidgetModal,
+  ],
+  InfoWidgetModalProvider: ({ children }: PropsWithChildren<{}>) => children,
+}));
+
+jest.mock('utils/errors/report', () => ({
+  report: jest.fn(),
+}));
+
+describe('<ToggleSubtitlesAsTranscript />', () => {
+  beforeEach(() => {
+    useJwt.setState({
+      jwt: 'json web token',
+    });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    fetchMock.reset();
+  });
+
+  it('check component render depend the timedTextTrack state', async () => {
+    const mockedTimedTextTrackTranscript = timedTextMockFactory({
+      language: 'fr-FR',
+      is_ready_to_show: true,
+      mode: timedTextMode.TRANSCRIPT,
+    });
+
+    render(wrapInVideo(<ToggleSubtitlesAsTranscript />, mockedVideo));
+
+    expect(
+      screen.queryByRole('checkbox', {
+        name: toggleLabel,
+      }),
+    ).not.toBeInTheDocument();
+
+    // Update the state with a timed text track in subtitle mode
+    act(() => {
+      useTimedTextTrack.getState().addResource(mockedTimedTextTrackSubtitle);
+    });
+
+    expect(
+      screen.getByRole('checkbox', {
+        name: toggleLabel,
+      }),
+    ).toBeInTheDocument();
+
+    // Update the state with a timed text track in transcript mode
+    act(() => {
+      useTimedTextTrack.getState().addResource(mockedTimedTextTrackTranscript);
+    });
+
+    expect(
+      screen.queryByRole('checkbox', {
+        name: toggleLabel,
+      }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('check disable attribute', async () => {
+    const toggleFailLabel = 'Update failed, try again.';
+
+    render(wrapInVideo(<ToggleSubtitlesAsTranscript />, mockedVideo));
+
+    // Update the state with a timed text track in subtitle mode
+    act(() => {
+      useTimedTextTrack.getState().addResource(mockedTimedTextTrackSubtitle);
+    });
+
+    const toggle = screen.getByRole('checkbox', {
+      name: toggleLabel,
+    });
+
+    userEvent.click(toggle);
+
+    await waitFor(() => {
+      expect(toggle).toBeDisabled();
+    });
+
+    expect(await screen.findByText(toggleFailLabel)).toBeInTheDocument();
+
+    expect(toggle).not.toBeDisabled();
+  });
+
+  it('check failed update', async () => {
+    const toggleFailLabel = 'Update failed, try again.';
+
+    render(wrapInVideo(<ToggleSubtitlesAsTranscript />, mockedVideo));
+
+    // Update the state with a timed text track in subtitle mode
+    act(() => {
+      useTimedTextTrack.getState().addResource(mockedTimedTextTrackSubtitle);
+    });
+
+    const toggle = screen.getByRole('checkbox', {
+      name: toggleLabel,
+    });
+
+    expect(screen.queryByText(toggleFailLabel)).not.toBeInTheDocument();
+
+    userEvent.click(toggle);
+
+    expect(await screen.findByText(toggleFailLabel)).toBeInTheDocument();
+  });
+
+  it('check toggle success use subtitle as transcript', async () => {
+    const toggleSuccessLabel = 'Use subtitles as transcripts activated.';
+    fetchMock.patch(`/api/videos/${mockedVideo.id}/`, {
+      ...mockedVideo,
+      should_use_subtitle_as_transcript: true,
+    });
+
+    render(wrapInVideo(<ToggleSubtitlesAsTranscript />, mockedVideo));
+
+    // Update the state with a timed text track in subtitle mode
+    act(() => {
+      useTimedTextTrack.getState().addResource(mockedTimedTextTrackSubtitle);
+    });
+
+    const toggle = screen.getByRole('checkbox', {
+      name: toggleLabel,
+    });
+
+    expect(screen.queryByText(toggleSuccessLabel)).not.toBeInTheDocument();
+
+    userEvent.click(toggle);
+
+    expect(await screen.findByText(toggleSuccessLabel)).toBeInTheDocument();
+
+    expect(fetchMock.lastCall()![1]).toEqual({
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer json web token',
+      },
+      method: 'PATCH',
+      body: '{"should_use_subtitle_as_transcript":true}',
+    });
+  });
+
+  it('check toggle success unuse subtitle as transcript', async () => {
+    const mockedVideoSubAsTrans = videoMockFactory({
+      should_use_subtitle_as_transcript: true,
+    });
+    const toggleSuccessLabel = 'Use subtitles as transcripts deactivated.';
+    fetchMock.patch(`/api/videos/${mockedVideoSubAsTrans.id}/`, {
+      ...mockedVideoSubAsTrans,
+      should_use_subtitle_as_transcript: false,
+    });
+
+    render(wrapInVideo(<ToggleSubtitlesAsTranscript />, mockedVideoSubAsTrans));
+
+    // Update the state with a timed text track in subtitle mode
+    act(() => {
+      useTimedTextTrack.getState().addResource(mockedTimedTextTrackSubtitle);
+    });
+
+    const toggle = screen.getByRole('checkbox', {
+      name: toggleLabel,
+    });
+
+    expect(screen.queryByText(toggleSuccessLabel)).not.toBeInTheDocument();
+
+    userEvent.click(toggle);
+
+    expect(await screen.findByText(toggleSuccessLabel)).toBeInTheDocument();
+
+    expect(fetchMock.lastCall()![1]).toEqual({
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer json web token',
+      },
+      method: 'PATCH',
+      body: '{"should_use_subtitle_as_transcript":false}',
+    });
+  });
+});

--- a/src/frontend/apps/lti_site/components/VideoWidgetProvider/widgets/UploadSubtitles/ToggleSubtitlesAsTranscript/index.tsx
+++ b/src/frontend/apps/lti_site/components/VideoWidgetProvider/widgets/UploadSubtitles/ToggleSubtitlesAsTranscript/index.tsx
@@ -1,0 +1,117 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import toast from 'react-hot-toast';
+import { defineMessages, useIntl } from 'react-intl';
+
+import { ToggleInput } from 'components/graphicals/ToggleInput';
+import { useUpdateVideo } from 'data/queries';
+import { useCurrentVideo } from 'data/stores/useCurrentRessource/useCurrentVideo';
+import { useTimedTextTrack } from 'data/stores/useTimedTextTrack';
+import { timedTextMode, Video } from 'types/tracks';
+import { report } from 'utils/errors/report';
+
+const messages = defineMessages({
+  useTranscriptToggleLabel: {
+    defaultMessage: 'Use subtitles as transcripts',
+    description: 'Label of the toggle used to use subtitles as transcripts.',
+    id: 'component.DashboardVideoPaneTranscriptOption.useTranscript',
+  },
+  useTranscriptToggleSuccess: {
+    defaultMessage: 'Use subtitles as transcripts activated.',
+    description:
+      'Message displayed when use subtitles as transcripts succeded.',
+    id: 'components.DownloadVideo.enableDownloadToggleSuccess',
+  },
+  unuseTranscriptToggleSuccess: {
+    defaultMessage: 'Use subtitles as transcripts deactivated.',
+    description:
+      'Message displayed when unuse subtitles as transcripts succeded.',
+    id: 'components.DownloadVideo.disallowDownloadToggleSuccess',
+  },
+  useTranscriptoggleFail: {
+    defaultMessage: 'Update failed, try again.',
+    description:
+      'Message displayed when use subtitles as transcripts has failed.',
+    id: 'components.DownloadVideo.allowDownloadToggleFail',
+  },
+});
+
+export const ToggleSubtitlesAsTranscript = () => {
+  const intl = useIntl();
+
+  const timedTextTracks = useTimedTextTrack((state) =>
+    state.getTimedTextTracks(),
+  );
+
+  const video = useCurrentVideo();
+
+  const [toggleUseTranscript, setToggleUseTranscript] = useState(
+    video.should_use_subtitle_as_transcript,
+  );
+
+  useEffect(() => {
+    setToggleUseTranscript(video.should_use_subtitle_as_transcript);
+  }, [video.should_use_subtitle_as_transcript]);
+
+  const [disabledToggle, setDisabledToggle] = useState(false);
+
+  const videoMutation = useUpdateVideo(video.id, {
+    onSuccess: (videoUpdated: Video) => {
+      setToggleUseTranscript(videoUpdated.should_use_subtitle_as_transcript);
+      toast.success(
+        intl.formatMessage(
+          videoUpdated.should_use_subtitle_as_transcript
+            ? messages.useTranscriptToggleSuccess
+            : messages.unuseTranscriptToggleSuccess,
+        ),
+        {
+          position: 'bottom-center',
+        },
+      );
+    },
+    onError: (err) => {
+      report(err);
+      toast.error(intl.formatMessage(messages.useTranscriptoggleFail), {
+        position: 'bottom-center',
+      });
+    },
+    onMutate: () => {
+      setDisabledToggle(true);
+    },
+    onSettled: () => {
+      setDisabledToggle(false);
+    },
+  });
+
+  const onToggleChange = useCallback(() => {
+    videoMutation.mutate({
+      should_use_subtitle_as_transcript:
+        !video.should_use_subtitle_as_transcript,
+    });
+  }, [video.should_use_subtitle_as_transcript, videoMutation]);
+
+  // if there is no timed text track, do not display this component.
+  if (timedTextTracks.length === 0) {
+    return null;
+  }
+
+  const transcripts = timedTextTracks
+    .filter((track) => track.is_ready_to_show)
+    .filter((track) => timedTextMode.TRANSCRIPT === track.mode);
+
+  const subtitles = timedTextTracks
+    .filter((track) => track.is_ready_to_show)
+    .filter((track) => timedTextMode.SUBTITLE === track.mode);
+
+  if (transcripts.length > 0 || subtitles.length === 0) {
+    return null;
+  }
+
+  return (
+    <ToggleInput
+      disabled={disabledToggle}
+      checked={toggleUseTranscript}
+      onChange={onToggleChange}
+      label={intl.formatMessage(messages.useTranscriptToggleLabel)}
+    />
+  );
+};

--- a/src/frontend/apps/lti_site/components/VideoWidgetProvider/widgets/UploadSubtitles/index.spec.tsx
+++ b/src/frontend/apps/lti_site/components/VideoWidgetProvider/widgets/UploadSubtitles/index.spec.tsx
@@ -2,11 +2,13 @@ import { act, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
+import { UploadSubtitles } from '.';
 import { useInfoWidgetModal } from 'data/stores/useInfoWidgetModal';
 import { useJwt } from 'data/stores/useJwt';
 import { useTimedTextTrackLanguageChoices } from 'data/stores/useTimedTextTrackLanguageChoices';
+import { videoMockFactory } from 'utils/tests/factories';
 import render from 'utils/tests/render';
-import { UploadSubtitles } from '.';
+import { wrapInVideo } from 'utils/tests/wrapInVideo';
 
 jest.mock('data/stores/useInfoWidgetModal', () => ({
   useInfoWidgetModal: jest.fn(),
@@ -35,12 +37,13 @@ describe('<UploadSubtitles />', () => {
       null,
       mockSetInfoWidgetModalProvider,
     ]);
+    const mockedVideo = videoMockFactory();
 
     useTimedTextTrackLanguageChoices.setState({
       choices: languageChoices,
     });
 
-    render(<UploadSubtitles />);
+    render(wrapInVideo(<UploadSubtitles />, mockedVideo));
 
     screen.getByText('Subtitles');
 

--- a/src/frontend/apps/lti_site/components/VideoWidgetProvider/widgets/UploadSubtitles/index.tsx
+++ b/src/frontend/apps/lti_site/components/VideoWidgetProvider/widgets/UploadSubtitles/index.tsx
@@ -4,6 +4,7 @@ import { defineMessages, useIntl } from 'react-intl';
 import { FoldableItem } from 'components/graphicals/FoldableItem';
 import { LocalizedTimedTextTrackUpload } from 'components/LocalizedTimedTextTrackUpload';
 import { timedTextMode } from 'types/tracks';
+import { ToggleSubtitlesAsTranscript } from './ToggleSubtitlesAsTranscript';
 
 const messages = defineMessages({
   info: {
@@ -27,6 +28,7 @@ export const UploadSubtitles = () => {
       initialOpenValue
       title={intl.formatMessage(messages.title)}
     >
+      <ToggleSubtitlesAsTranscript />
       <LocalizedTimedTextTrackUpload
         timedTextModeWidget={timedTextMode.SUBTITLE}
       />


### PR DESCRIPTION
## Purpose

Implement the toggle to use subtitle as transcript, in the Subtitles widget on the dashboard.
The toggle appears if the video has subtitles and no transcripts. 
When the toggle is on, the subtitles will be the transcript.

## Proposal

Create a new component, child of [UploadSubtitles](https://github.com/openfun/marsha/blob/feature/anthony/toggle_allowing_subtitle/src/frontend/apps/lti_site/components/VideoWidgetProvider/widgets/UploadSubtitles/index.tsx).


