### PR TITLE
🎨(front) install and configure import/order eslint plugin

### DIFF
--- a/src/frontend/packages/lib_common/.eslintrc.js
+++ b/src/frontend/packages/lib_common/.eslintrc.js
@@ -15,6 +15,7 @@ module.exports = {
     tsconfigRootDir: __dirname,
     project: ['./tsconfig.json'],
   },
+  plugins: ['import'],
   rules: {
     '@typescript-eslint/no-unused-vars': ['error', { varsIgnorePattern: '^_' }],
     '@typescript-eslint/explicit-function-return-type': 0,
@@ -24,6 +25,14 @@ module.exports = {
     curly: 2,
     'default-case': 'error',
     eqeqeq: 2,
+    'import/order': [
+      'error',
+      {
+        alphabetize: {
+          order: 'asc',
+        },
+      },
+    ],
     'no-alert': 1,
     'react/prop-types': 0,
   },

--- a/src/frontend/packages/lib_common/package.json
+++ b/src/frontend/packages/lib_common/package.json
@@ -39,6 +39,7 @@
     "babel-preset-react": "7.0.0-beta.3",
     "eslint": "8.23.0",
     "eslint-config-prettier": "8.5.0",
+    "eslint-plugin-import": "2.26.0",
     "eslint-plugin-prettier": "4.2.1",
     "eslint-plugin-react": "7.31.6",
     "grommet": "2.25.0",

--- a/src/frontend/packages/lib_components/.eslintrc.js
+++ b/src/frontend/packages/lib_components/.eslintrc.js
@@ -15,6 +15,7 @@ module.exports = {
     tsconfigRootDir: __dirname,
     project: ['./tsconfig.json'],
   },
+  plugins: ['import'],
   rules: {
     '@typescript-eslint/no-unused-vars': ['error', { varsIgnorePattern: '^_' }],
     '@typescript-eslint/explicit-function-return-type': 0,
@@ -24,6 +25,14 @@ module.exports = {
     curly: 2,
     'default-case': 'error',
     eqeqeq: 2,
+    'import/order': [
+      'error',
+      {
+        alphabetize: {
+          order: 'asc',
+        },
+      },
+    ],
     'no-alert': 1,
     'react/prop-types': 0,
   },

--- a/src/frontend/packages/lib_components/package.json
+++ b/src/frontend/packages/lib_components/package.json
@@ -17,18 +17,18 @@
     "prettier": "prettier --list-different '**/*.+(ts|tsx|json|js|jsx)' --ignore-path ../../../.prettierignore"
   },
   "peerDependencies": {
+    "@testing-library/react": "*",
     "grommet": "*",
+    "jest-image-snapshot": "*",
+    "jest-matchmedia-mock": "*",
+    "jsdom-screenshot": "*",
     "react": "*",
     "react-dom": "*",
-    "styled-components": "*",
-    "react-test-renderer": "*",
-    "jest-image-snapshot": "*",
-    "jsdom-screenshot": "*",
-    "react-query": "*",
-    "@testing-library/react": "*",
     "react-hot-toast": "*",
-    "jest-matchmedia-mock": "*",
-    "react-intl": "*"
+    "react-intl": "*",
+    "react-query": "*",
+    "react-test-renderer": "*",
+    "styled-components": "*"
   },
   "devDependencies": {
     "@babel/core": "7.19.0",
@@ -71,6 +71,7 @@
     "css-loader": "6.7.1",
     "eslint": "8.23.0",
     "eslint-config-prettier": "8.5.0",
+    "eslint-plugin-import": "2.26.0",
     "eslint-plugin-prettier": "4.2.1",
     "eslint-plugin-react": "7.31.6",
     "faker": "5.5.3",
@@ -97,8 +98,8 @@
     "rollup-plugin-typescript2": "0.26.0",
     "sinon": "14.0.0",
     "source-map-loader": "4.0.0",
-    "styled-components": "5.3.5",
     "style-loader": "3.3.1",
+    "styled-components": "5.3.5",
     "ts-jest": "28.0.8",
     "typescript": "4.8.2",
     "xhr-mock": "2.5.1"

--- a/src/frontend/packages/lib_components/src/common/BreadCrumbs/index.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/BreadCrumbs/index.spec.tsx
@@ -1,8 +1,7 @@
 import { fireEvent, screen } from '@testing-library/react';
+import { render } from 'lib-tests';
 import React, { Fragment } from 'react';
 import { Link, Route, Switch } from 'react-router-dom';
-
-import { render } from 'lib-tests';
 
 import { BreadCrumbs, Crumb } from '.';
 

--- a/src/frontend/packages/lib_components/src/common/BreadCrumbs/index.tsx
+++ b/src/frontend/packages/lib_components/src/common/BreadCrumbs/index.tsx
@@ -1,10 +1,9 @@
 import { Box } from 'grommet';
+import { BreadCrumbsContext, Crumb as CrumbType } from 'lib-common';
 import React, { useContext, useEffect } from 'react';
 import { Link, useRouteMatch } from 'react-router-dom';
 import styled from 'styled-components';
 import { v4 as uuidv4 } from 'uuid';
-
-import { BreadCrumbsContext, Crumb as CrumbType } from 'lib-common';
 
 const BreadCrumbLink = styled(Link)`
   color: black;

--- a/src/frontend/packages/lib_components/src/common/Button/ButtonLayout/Badge/index.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/Button/ButtonLayout/Badge/index.spec.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
 import { screen } from '@testing-library/react';
 
 import { imageSnapshot, render } from 'lib-tests';
+import React from 'react';
 
 import { Badge } from '.';
 

--- a/src/frontend/packages/lib_components/src/common/Button/ButtonLayout/index.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/Button/ButtonLayout/index.spec.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
 import { screen } from '@testing-library/react';
 
 import { render } from 'lib-tests';
+import React from 'react';
 
 import { ButtonLayout } from '.';
 

--- a/src/frontend/packages/lib_components/src/common/Button/ButtonLayout/index.tsx
+++ b/src/frontend/packages/lib_components/src/common/Button/ButtonLayout/index.tsx
@@ -1,8 +1,7 @@
-import React, { useContext } from 'react';
 import { Box, Text, ResponsiveContext } from 'grommet';
-import styled from 'styled-components';
-
+import React, { useContext } from 'react';
 import { SvgProps } from 'src/common/SVGIcons';
+import styled from 'styled-components';
 
 import { Badge } from './Badge';
 

--- a/src/frontend/packages/lib_components/src/common/Button/index.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/Button/index.spec.tsx
@@ -1,7 +1,6 @@
 import { screen, fireEvent } from '@testing-library/react';
-import React from 'react';
-
 import { render } from 'lib-tests';
+import React from 'react';
 
 import { Button } from '.';
 

--- a/src/frontend/packages/lib_components/src/common/SVGIcons/AppsSVG.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/SVGIcons/AppsSVG.spec.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { renderIconSnapshot } from 'lib-tests';
+import React from 'react';
 
 import { AppsSVG } from './AppsSVG';
 

--- a/src/frontend/packages/lib_components/src/common/SVGIcons/BinSVG.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/SVGIcons/BinSVG.spec.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { renderIconSnapshot } from 'lib-tests';
+import React from 'react';
 
 import { BinSVG } from './BinSVG';
 

--- a/src/frontend/packages/lib_components/src/common/SVGIcons/CameraOffSVG.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/SVGIcons/CameraOffSVG.spec.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { renderIconSnapshot } from 'lib-tests';
+import React from 'react';
 
 import { CameraOffSVG } from './CameraOffSVG';
 

--- a/src/frontend/packages/lib_components/src/common/SVGIcons/CameraOnSVG.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/SVGIcons/CameraOnSVG.spec.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { renderIconSnapshot } from 'lib-tests';
+import React from 'react';
 
 import { CameraOnSVG } from './CameraOnSVG';
 

--- a/src/frontend/packages/lib_components/src/common/SVGIcons/ChannelSVG.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/SVGIcons/ChannelSVG.spec.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { renderIconSnapshot } from 'lib-tests';
+import React from 'react';
 
 import { ChannelSVG } from './ChannelSVG';
 

--- a/src/frontend/packages/lib_components/src/common/SVGIcons/ChatSVG.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/SVGIcons/ChatSVG.spec.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { renderIconSnapshot } from 'lib-tests';
+import React from 'react';
 
 import { ChatSVG } from './ChatSVG';
 

--- a/src/frontend/packages/lib_components/src/common/SVGIcons/ChronometerSVG.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/SVGIcons/ChronometerSVG.spec.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { renderIconSnapshot } from 'lib-tests';
+import React from 'react';
 
 import { ChronometerSVG } from './ChronometerSVG';
 

--- a/src/frontend/packages/lib_components/src/common/SVGIcons/CopySVG.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/SVGIcons/CopySVG.spec.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { renderIconSnapshot } from 'lib-tests';
+import React from 'react';
 
 import { CopySVG } from './CopySVG';
 

--- a/src/frontend/packages/lib_components/src/common/SVGIcons/DoubleArrowResizerSVG.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/SVGIcons/DoubleArrowResizerSVG.spec.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { renderIconSnapshot } from 'lib-tests';
+import React from 'react';
 
 import { DoubleArrowResizerSVG } from './DoubleArrowResizerSVG';
 

--- a/src/frontend/packages/lib_components/src/common/SVGIcons/DownArrowSVG.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/SVGIcons/DownArrowSVG.spec.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { renderIconSnapshot } from 'lib-tests';
+import React from 'react';
 
 import { DownArrowSVG } from './DownArrowSVG';
 

--- a/src/frontend/packages/lib_components/src/common/SVGIcons/DownloadSVG.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/SVGIcons/DownloadSVG.spec.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { renderIconSnapshot } from 'lib-tests';
+import React from 'react';
 
 import { DownloadSVG } from './DownloadSVG';
 

--- a/src/frontend/packages/lib_components/src/common/SVGIcons/ExitCrossSVG.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/SVGIcons/ExitCrossSVG.spec.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { renderIconSnapshot } from 'lib-tests';
+import React from 'react';
 
 import { ExitCrossSVG } from './ExitCrossSVG';
 

--- a/src/frontend/packages/lib_components/src/common/SVGIcons/InfoCircleSVG.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/SVGIcons/InfoCircleSVG.spec.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { renderIconSnapshot } from 'lib-tests';
+import React from 'react';
 
 import { InfoCircleSVG } from './InfoCircleSVG';
 

--- a/src/frontend/packages/lib_components/src/common/SVGIcons/JoinDiscussionSVG.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/SVGIcons/JoinDiscussionSVG.spec.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { renderIconSnapshot } from 'lib-tests';
+import React from 'react';
 
 import { JoinDiscussionSVG } from './JoinDiscussionSVG';
 

--- a/src/frontend/packages/lib_components/src/common/SVGIcons/MicrophoneOffSVG.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/SVGIcons/MicrophoneOffSVG.spec.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { renderIconSnapshot } from 'lib-tests';
+import React from 'react';
 
 import { MicrophoneOffSVG } from './MicrophoneOffSVG';
 

--- a/src/frontend/packages/lib_components/src/common/SVGIcons/MicrophoneOnSVG.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/SVGIcons/MicrophoneOnSVG.spec.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { renderIconSnapshot } from 'lib-tests';
+import React from 'react';
 
 import { MicrophoneOnSVG } from './MicrophoneOnSVG';
 

--- a/src/frontend/packages/lib_components/src/common/SVGIcons/MoreOptionSVG.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/SVGIcons/MoreOptionSVG.spec.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { renderIconSnapshot } from 'lib-tests';
+import React from 'react';
 
 import { MoreOptionSVG } from './MoreOptionSVG';
 

--- a/src/frontend/packages/lib_components/src/common/SVGIcons/NoDownloadSVG.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/SVGIcons/NoDownloadSVG.spec.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { renderIconSnapshot } from 'lib-tests';
+import React from 'react';
 
 import { NoDownloadSVG } from './NoDownloadSVG';
 

--- a/src/frontend/packages/lib_components/src/common/SVGIcons/OpenClosePanelSVG.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/SVGIcons/OpenClosePanelSVG.spec.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { renderIconSnapshot } from 'lib-tests';
+import React from 'react';
 
 import { OpenClosePanelSVG } from './OpenClosePanelSVG';
 

--- a/src/frontend/packages/lib_components/src/common/SVGIcons/PauseSVG.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/SVGIcons/PauseSVG.spec.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { renderIconSnapshot } from 'lib-tests';
+import React from 'react';
 
 import { PauseSVG } from './PauseSVG';
 

--- a/src/frontend/packages/lib_components/src/common/SVGIcons/PictureSVG.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/SVGIcons/PictureSVG.spec.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { renderIconSnapshot } from 'lib-tests';
+import React from 'react';
 
 import { PictureSVG } from './PictureSVG';
 

--- a/src/frontend/packages/lib_components/src/common/SVGIcons/PlaySVG.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/SVGIcons/PlaySVG.spec.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { renderIconSnapshot } from 'lib-tests';
+import React from 'react';
 
 import { PlaySVG } from './PlaySVG';
 

--- a/src/frontend/packages/lib_components/src/common/SVGIcons/QuestionMarkSVG.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/SVGIcons/QuestionMarkSVG.spec.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { renderIconSnapshot } from 'lib-tests';
+import React from 'react';
 
 import { QuestionMarkSVG } from './QuestionMarkSVG';
 

--- a/src/frontend/packages/lib_components/src/common/SVGIcons/RecordSVG.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/SVGIcons/RecordSVG.spec.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { renderIconSnapshot } from 'lib-tests';
+import React from 'react';
 
 import { RecordSVG } from './RecordSVG';
 

--- a/src/frontend/packages/lib_components/src/common/SVGIcons/RingingBellSVG.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/SVGIcons/RingingBellSVG.spec.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { renderIconSnapshot } from 'lib-tests';
+import React from 'react';
 
 import { RingingBellSVG } from './RingingBellSVG';
 

--- a/src/frontend/packages/lib_components/src/common/SVGIcons/RoundCrossSVG.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/SVGIcons/RoundCrossSVG.spec.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { renderIconSnapshot } from 'lib-tests';
+import React from 'react';
 
 import { RoundCrossSVG } from './RoundCrossSVG';
 

--- a/src/frontend/packages/lib_components/src/common/SVGIcons/RoundPlus.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/SVGIcons/RoundPlus.spec.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { renderIconSnapshot } from 'lib-tests';
+import React from 'react';
 
 import { RoundPlusSVG } from './RoundPlusSVG';
 

--- a/src/frontend/packages/lib_components/src/common/SVGIcons/SendButtonSVG.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/SVGIcons/SendButtonSVG.spec.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { renderIconSnapshot } from 'lib-tests';
+import React from 'react';
 
 import { SendButtonSVG } from './SendButtonSVG';
 

--- a/src/frontend/packages/lib_components/src/common/SVGIcons/SpeakerSVG.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/SVGIcons/SpeakerSVG.spec.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { renderIconSnapshot } from 'lib-tests';
+import React from 'react';
 
 import { SpeakerSVG } from './SpeakerSVG';
 

--- a/src/frontend/packages/lib_components/src/common/SVGIcons/StopSVG.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/SVGIcons/StopSVG.spec.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { renderIconSnapshot } from 'lib-tests';
+import React from 'react';
 
 import { StopSVG } from './StopSVG';
 

--- a/src/frontend/packages/lib_components/src/common/SVGIcons/SwitchToDocumentSVG.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/SVGIcons/SwitchToDocumentSVG.spec.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { renderIconSnapshot } from 'lib-tests';
+import React from 'react';
 
 import { SwitchToDocumentSVG } from './SwitchToDocumentSVG';
 

--- a/src/frontend/packages/lib_components/src/common/SVGIcons/SwitchToPlayerSVG.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/SVGIcons/SwitchToPlayerSVG.spec.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { renderIconSnapshot } from 'lib-tests';
+import React from 'react';
 
 import { SwitchToPlayerSVG } from './SwitchToPlayerSVG';
 

--- a/src/frontend/packages/lib_components/src/common/SVGIcons/Valid.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/SVGIcons/Valid.spec.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { renderIconSnapshot } from 'lib-tests';
+import React from 'react';
 
 import { ValidSVG } from './ValidSVG';
 

--- a/src/frontend/packages/lib_components/src/common/SVGIcons/ViewDocumentSVG.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/SVGIcons/ViewDocumentSVG.spec.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { renderIconSnapshot } from 'lib-tests';
+import React from 'react';
 
 import { ViewDocumentSVG } from './ViewDocumentSVG';
 

--- a/src/frontend/packages/lib_components/src/common/SVGIcons/ViewersSVG.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/SVGIcons/ViewersSVG.spec.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { renderIconSnapshot } from 'lib-tests';
+import React from 'react';
 
 import { ViewersSVG } from './ViewersSVG';
 

--- a/src/frontend/packages/lib_components/src/common/SVGIcons/WaitingJoinDiscussionSVG.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/SVGIcons/WaitingJoinDiscussionSVG.spec.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { renderIconSnapshot } from 'lib-tests';
+import React from 'react';
 
 import { WaitingJoinDiscussionSVG } from './WaitingJoinDiscussionSVG';
 

--- a/src/frontend/packages/lib_components/src/common/SVGIcons/index.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/SVGIcons/index.spec.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { renderIconSnapshot } from 'lib-tests';
+import React from 'react';
 
 import SVGIcon from '.';
 

--- a/src/frontend/packages/lib_components/src/common/SVGIcons/index.tsx
+++ b/src/frontend/packages/lib_components/src/common/SVGIcons/index.tsx
@@ -1,8 +1,7 @@
+import { ThemeContext } from 'grommet';
+import { normalizeColor } from 'grommet/utils';
 import React, { useContext } from 'react';
 import styled, { CSSProperties } from 'styled-components';
-import { normalizeColor } from 'grommet/utils';
-
-import { ThemeContext } from 'grommet';
 
 interface ComponentWithTheme {
   grommetTheme: object;

--- a/src/frontend/packages/lib_tests/.eslintrc.js
+++ b/src/frontend/packages/lib_tests/.eslintrc.js
@@ -15,6 +15,7 @@ module.exports = {
     tsconfigRootDir: __dirname,
     project: ['./tsconfig.json'],
   },
+  plugins: ['import'],
   rules: {
     '@typescript-eslint/no-explicit-any': 0,
     '@typescript-eslint/no-empty-function': 0,
@@ -29,6 +30,14 @@ module.exports = {
     curly: 2,
     'default-case': 'error',
     eqeqeq: 2,
+    'import/order': [
+      'error',
+      {
+        alphabetize: {
+          order: 'asc',
+        },
+      },
+    ],
     'no-alert': 1,
     'react/prop-types': 0,
   },

--- a/src/frontend/packages/lib_tests/package.json
+++ b/src/frontend/packages/lib_tests/package.json
@@ -14,18 +14,18 @@
     "prettier": "prettier --list-different '**/*.+(ts|tsx|json|js|jsx)' --ignore-path ../../../.prettierignore"
   },
   "peerDependencies": {
+    "@testing-library/react": "*",
     "grommet": "*",
+    "jest-image-snapshot": "*",
+    "jest-matchmedia-mock": "*",
+    "jsdom-screenshot": "*",
     "react": "*",
     "react-dom": "*",
-    "styled-components": "*",
-    "react-test-renderer": "*",
-    "jest-image-snapshot": "*",
-    "jsdom-screenshot": "*",
-    "react-query": "*",
-    "@testing-library/react": "*",
     "react-hot-toast": "*",
-    "jest-matchmedia-mock": "*",
-    "react-intl": "*"
+    "react-intl": "*",
+    "react-query": "*",
+    "react-test-renderer": "*",
+    "styled-components": "*"
   },
   "devDependencies": {
     "@babel/core": "7.19.0",
@@ -68,6 +68,7 @@
     "css-loader": "6.7.1",
     "eslint": "8.23.0",
     "eslint-config-prettier": "8.5.0",
+    "eslint-plugin-import": "2.26.0",
     "eslint-plugin-prettier": "4.2.1",
     "eslint-plugin-react": "7.31.6",
     "faker": "5.5.3",
@@ -94,8 +95,8 @@
     "rollup-plugin-typescript2": "0.26.0",
     "sinon": "14.0.0",
     "source-map-loader": "4.0.0",
-    "styled-components": "5.3.5",
     "style-loader": "3.3.1",
+    "styled-components": "5.3.5",
     "ts-jest": "28.0.8",
     "typescript": "4.8.2",
     "xhr-mock": "2.5.1"

--- a/src/frontend/packages/lib_tests/src/imageSnapshot.tsx
+++ b/src/frontend/packages/lib_tests/src/imageSnapshot.tsx
@@ -1,10 +1,9 @@
-import { cleanup, render } from '@testing-library/react';
-import { generateImage, GenerateImageOptions } from 'jsdom-screenshot';
-import { Grommet } from 'grommet';
-import React from 'react';
 import path from 'path';
-
+import { cleanup, render } from '@testing-library/react';
+import { Grommet } from 'grommet';
+import { generateImage, GenerateImageOptions } from 'jsdom-screenshot';
 import { GlobalStyles, theme } from 'lib-common';
+import React from 'react';
 
 import { wrapInIntlProvider } from './intl';
 import { wrapInRouter } from './router';

--- a/src/frontend/packages/lib_tests/src/render.tsx
+++ b/src/frontend/packages/lib_tests/src/render.tsx
@@ -7,11 +7,10 @@ import {
 } from '@testing-library/react';
 import { Grommet, ResponsiveContext, ThemeType } from 'grommet';
 import MatchMediaMock from 'jest-matchmedia-mock';
+import { BreadCrumbsProvider, GlobalStyles, theme } from 'lib-common';
 import React, { CSSProperties, ReactElement } from 'react';
 import toast, { Toast, Toaster, useToaster } from 'react-hot-toast';
 import { QueryClient, QueryClientProvider } from 'react-query';
-
-import { BreadCrumbsProvider, GlobalStyles, theme } from 'lib-common';
 
 import { wrapInIntlProvider } from './intl';
 import { wrapInRouter } from './router';

--- a/src/frontend/packages/lib_tests/src/router.tsx
+++ b/src/frontend/packages/lib_tests/src/router.tsx
@@ -1,7 +1,6 @@
+import { Maybe } from 'lib-common';
 import React from 'react';
 import { MemoryRouter, Route, Switch } from 'react-router-dom';
-
-import { Maybe } from 'lib-common';
 
 export const wrapInRouter = (
   Component: JSX.Element,

--- a/src/frontend/yarn.lock
+++ b/src/frontend/yarn.lock
@@ -2515,6 +2515,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
   integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
 
+"@types/json5@^0.0.29":
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
+  integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
+
 "@types/katex@0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@types/katex/-/katex-0.14.0.tgz#b84c0afc3218069a5ad64fe2a95321881021b5fe"
@@ -3209,7 +3214,7 @@ aria-query@^5.0.0:
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.0.2.tgz#0b8a744295271861e1d933f8feca13f9b70cfdc1"
   integrity sha512-eigU3vhqSO+Z8BKDnVLN/ompjhf3pYzecKXz8+whRy+9gZu8n1TCGfwzQUUPnqdHl9ax1Hr9031orZ+UOEYr7Q==
 
-array-includes@^3.1.5:
+array-includes@^3.1.4, array-includes@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.1.5.tgz#2c320010db8d31031fd2a5f6b3bbd4b1aad31bdb"
   integrity sha512-iSDYZMMyTPkiFasVqfuAQnWAYcvO/SeBSCGKePoEthjp4LEMTe4uLc7b025o4jAZpHhihh8xPo99TNWUWWkGDQ==
@@ -3224,6 +3229,16 @@ array-union@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
+
+array.prototype.flat@^1.2.5:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.3.0.tgz#0b0c1567bf57b38b56b4c97b8aa72ab45e4adc7b"
+  integrity sha512-12IUEkHsAhA4DY5s0FPgNXIdc8VRSqD9Zp78a5au9abH/SOBrsp082JOWFNTjkMozh8mqcdiKuaLGhPeYztxSw==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+    es-abstract "^1.19.2"
+    es-shim-unscopables "^1.0.0"
 
 array.prototype.flatmap@^1.3.0:
   version "1.3.0"
@@ -4518,7 +4533,7 @@ debug@4, debug@^4.0.0, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
   dependencies:
     ms "2.1.2"
 
-debug@^3.1.0:
+debug@^3.1.0, debug@^3.2.7:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
@@ -4846,6 +4861,40 @@ eslint-config-prettier@8.5.0:
   version "8.5.0"
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz#5a81680ec934beca02c7b1a61cf8ca34b66feab1"
   integrity sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==
+
+eslint-import-resolver-node@^0.3.6:
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz#4048b958395da89668252001dbd9eca6b83bacbd"
+  integrity sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==
+  dependencies:
+    debug "^3.2.7"
+    resolve "^1.20.0"
+
+eslint-module-utils@^2.7.3:
+  version "2.7.4"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.7.4.tgz#4f3e41116aaf13a20792261e61d3a2e7e0583974"
+  integrity sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==
+  dependencies:
+    debug "^3.2.7"
+
+eslint-plugin-import@2.26.0:
+  version "2.26.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz#f812dc47be4f2b72b478a021605a59fc6fe8b88b"
+  integrity sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==
+  dependencies:
+    array-includes "^3.1.4"
+    array.prototype.flat "^1.2.5"
+    debug "^2.6.9"
+    doctrine "^2.1.0"
+    eslint-import-resolver-node "^0.3.6"
+    eslint-module-utils "^2.7.3"
+    has "^1.0.3"
+    is-core-module "^2.8.1"
+    is-glob "^4.0.3"
+    minimatch "^3.1.2"
+    object.values "^1.1.5"
+    resolve "^1.22.0"
+    tsconfig-paths "^3.14.1"
 
 eslint-plugin-prettier@3.1.0:
   version "3.1.0"
@@ -5989,7 +6038,7 @@ is-callable@^1.1.4, is-callable@^1.2.4:
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.4.tgz#47301d58dd0259407865547853df6d61fe471945"
   integrity sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==
 
-is-core-module@^2.9.0:
+is-core-module@^2.8.1, is-core-module@^2.9.0:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.10.0.tgz#9012ede0a91c69587e647514e1d5277019e728ed"
   integrity sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==
@@ -6838,6 +6887,13 @@ json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
+
+json5@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
+  integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
+  dependencies:
+    minimist "^1.2.0"
 
 json5@^2.1.2, json5@^2.2.1:
   version "2.2.1"
@@ -7694,7 +7750,7 @@ minimatch@^3.0.4, minimatch@^3.1.1, minimatch@^3.1.2:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.2.6:
+minimist@^1.2.0, minimist@^1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
@@ -8889,7 +8945,7 @@ resolve@1.15.1:
   dependencies:
     path-parse "^1.0.6"
 
-resolve@^1.14.2, resolve@^1.17.0, resolve@^1.19.0, resolve@^1.20.0, resolve@^1.3.2, resolve@^1.9.0:
+resolve@^1.14.2, resolve@^1.17.0, resolve@^1.19.0, resolve@^1.20.0, resolve@^1.22.0, resolve@^1.3.2, resolve@^1.9.0:
   version "1.22.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.1.tgz#27cb2ebb53f91abb49470a928bba7558066ac177"
   integrity sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==
@@ -9399,6 +9455,11 @@ strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   dependencies:
     ansi-regex "^5.0.1"
 
+strip-bom@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
+  integrity sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==
+
 strip-bom@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-4.0.0.tgz#9c3505c1db45bcedca3d9cf7a16f5c5aa3901878"
@@ -9660,6 +9721,16 @@ ts-jest@28.0.8:
     make-error "1.x"
     semver "7.x"
     yargs-parser "^21.0.1"
+
+tsconfig-paths@^3.14.1:
+  version "3.14.1"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz#ba0734599e8ea36c862798e920bcf163277b137a"
+  integrity sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==
+  dependencies:
+    "@types/json5" "^0.0.29"
+    json5 "^1.0.1"
+    minimist "^1.2.6"
+    strip-bom "^3.0.0"
 
 tslib@1.10.0:
   version "1.10.0"


### PR DESCRIPTION
## Purpose

In the project we use to order our import by groups and then alphabetically. Since now we didn't have a linter enforcing this rule. Now we are using eslint, we can install the eslint-plugin-import package to configure the import/order rules.

## Proposal

- [x] install and configure import/order eslint plugin

