### PR TITLE
🌐(front) split fileDespository string in translations sentences

### DIFF
--- a/src/aws/lambda-convert/src/scanDepositedFile.spec.js
+++ b/src/aws/lambda-convert/src/scanDepositedFile.spec.js
@@ -26,7 +26,7 @@ const objectKeyWithoutExtension =
   "630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/depositedfile/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1606230873";
 const objectKey = `${objectKeyWithoutExtension}.pdf`;
 
-jest.setTimeout(20000);
+jest.setTimeout(30000);
 
 describe("lambda-convert/src/scanDepositedFile", () => {
   beforeEach(() => {

--- a/src/backend/marsha/deposit/admin.py
+++ b/src/backend/marsha/deposit/admin.py
@@ -20,7 +20,7 @@ class DepositedFilesInline(admin.TabularInline):
 class FileDepositoryAdmin(admin.ModelAdmin):
     """Admin class for the FileDepository model."""
 
-    verbose_name = _("FileDepository")
+    verbose_name = _("File depository")
     list_display = (
         "id",
         "title",
@@ -58,7 +58,7 @@ class FileDepositoryAdmin(admin.ModelAdmin):
 class DepositedFileAdmin(admin.ModelAdmin):
     """Admin class for the DepositedFile model."""
 
-    verbose_name = _("DepositedFile")
+    verbose_name = _("Deposited file")
     list_display = (
         "id",
         "filename",

--- a/src/backend/marsha/deposit/models.py
+++ b/src/backend/marsha/deposit/models.py
@@ -26,7 +26,7 @@ class FileDepository(BaseModel):
         to=Playlist,
         related_name="%(class)ss",
         verbose_name=_("playlist"),
-        help_text=_("playlist to which this file_depository belongs"),
+        help_text=_("playlist to which this file depository belongs"),
         # don't allow hard deleting a playlist if it still contains file_depository
         on_delete=models.PROTECT,
     )
@@ -40,19 +40,19 @@ class FileDepository(BaseModel):
     title = models.CharField(
         max_length=255,
         verbose_name=_("title"),
-        help_text=_("title of the file_depository"),
+        help_text=_("title of the file depository"),
         null=True,
         blank=True,
     )
     description = models.TextField(
         verbose_name=_("description"),
-        help_text=_("description of the file_depository"),
+        help_text=_("description of the file depository"),
         null=True,
         blank=True,
     )
     position = models.PositiveIntegerField(
         verbose_name=_("position"),
-        help_text=_("position of this file_depository in the playlist"),
+        help_text=_("position of this file depository in the playlist"),
         default=0,
     )
 

--- a/src/frontend/apps/lti_site/apps/deposit/components/Dashboard/index.spec.tsx
+++ b/src/frontend/apps/lti_site/apps/deposit/components/Dashboard/index.spec.tsx
@@ -38,7 +38,7 @@ jest.mock('apps/deposit/data/depositAppData', () => ({
 jest.mock('./DashboardStudent', () => ({
   DashboardStudent: () => (
     <div>
-      <p>FileDepository loaded.</p>
+      <p>File depository loaded.</p>
       <p>Student view</p>
     </div>
   ),
@@ -47,7 +47,7 @@ jest.mock('./DashboardStudent', () => ({
 jest.mock('./DashboardInstructor', () => ({
   DashboardInstructor: () => (
     <div>
-      <p>FileDepository loaded.</p>
+      <p>File depository loaded.</p>
       <p>Instructor view</p>
     </div>
   ),
@@ -75,9 +75,9 @@ describe('<DashboardFileDepository />', () => {
     fetchMock.get('/api/filedepositories/1/', fileDepositoryDeferred.promise);
 
     render(<DashboardFileDepository />);
-    screen.getByText('Loading fileDepository...');
+    screen.getByText('Loading file depository...');
     fileDepositoryDeferred.resolve(fileDepository);
-    await screen.findByText('FileDepository loaded.');
+    await screen.findByText('File depository loaded.');
     screen.getByText('Student view');
   });
 
@@ -90,9 +90,9 @@ describe('<DashboardFileDepository />', () => {
     fetchMock.get('/api/filedepositories/1/', fileDepositoryDeferred.promise);
 
     render(<DashboardFileDepository />);
-    screen.getByText('Loading fileDepository...');
+    screen.getByText('Loading file depository...');
     fileDepositoryDeferred.resolve(fileDepository);
-    await screen.findByText('FileDepository loaded.');
+    await screen.findByText('File depository loaded.');
     screen.getByText('Instructor view');
   });
 
@@ -122,8 +122,8 @@ describe('<DashboardFileDepository />', () => {
     render(<DashboardFileDepository />, {
       queryOptions: { client: queryClient },
     });
-    screen.getByText('Loading fileDepository...');
+    screen.getByText('Loading file depository...');
     fileDepositoryDeferred.resolve(500);
-    await screen.findByText('FileDepository not loaded!');
+    await screen.findByText('File depository not loaded!');
   });
 });

--- a/src/frontend/apps/lti_site/apps/deposit/components/Dashboard/index.tsx
+++ b/src/frontend/apps/lti_site/apps/deposit/components/Dashboard/index.tsx
@@ -15,19 +15,19 @@ import { DashboardInstructor } from './DashboardInstructor';
 
 const messages = defineMessages({
   loadingFileDepository: {
-    defaultMessage: 'Loading fileDepository...',
+    defaultMessage: 'Loading file depository...',
     description:
-      'Accessible message for the spinner while loading the fileDepository in dashboard view.',
+      'Accessible message for the spinner while loading the file depository in dashboard view.',
     id: 'apps.deposit.components.Dashboard.loadingFileDepository',
   },
   loadFileDepositorySuccess: {
-    defaultMessage: 'FileDepository loaded.',
-    description: 'Message when fileDepository is loaded.',
+    defaultMessage: 'File depository loaded.',
+    description: 'Message when file depository is loaded.',
     id: 'apps.deposit.components.Dashboard.loadFileDepositorySuccess',
   },
   loadFileDepositoryError: {
-    defaultMessage: 'FileDepository not loaded!',
-    description: 'Message when fileDepository failed to load.',
+    defaultMessage: 'File depository not loaded!',
+    description: 'Message when file depository failed to load.',
     id: 'apps.deposit.components.Dashboard.loadFileDepositoryError',
   },
   tokenError: {

--- a/src/frontend/apps/lti_site/apps/deposit/components/SelectContentTab/index.tsx
+++ b/src/frontend/apps/lti_site/apps/deposit/components/SelectContentTab/index.tsx
@@ -20,19 +20,19 @@ import { FileDepository } from 'apps/deposit/types/models';
 
 const messages = defineMessages({
   loadingFileDepositories: {
-    defaultMessage: 'Loading fileDepositories...',
+    defaultMessage: 'Loading file depositories...',
     description:
-      'Accessible message for the spinner while loading the fileDepositories in lti select view.',
+      'Accessible message for the spinner while loading the file depositories in lti select view.',
     id: 'apps.deposit.SelectContent.loadingFileDepositories',
   },
   addFileDepository: {
     defaultMessage: 'Add a fileDepository',
-    description: `Text displayed on a button to add a new fileDepository.`,
+    description: `Text displayed on a button to add a new file depository.`,
     id: 'apps.deposit.SelectContent.addFileDepository',
   },
   select: {
     defaultMessage: 'Select {title}',
-    description: 'Accessible message for selecting a fileDepository.',
+    description: 'Accessible message for selecting a file depository.',
     id: 'apps.deposit.SelectContent.select',
   },
 });


### PR DESCRIPTION
## Purpose

The word fileDepository is used many times in string translations or in
the string description. We must split it in two words: file depository.

## Proposal

- [x] split fileDespository string in translations sentences
