### PR TITLE
Fix/qbey/specify docker port for saml fake idp

### DIFF
--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -789,6 +789,7 @@ class Development(Base):
             # Metadata is fetched from inside the docker, hence the 8000 port
             "http://localhost:8000/account/saml/idp/metadata/"
         )
+        cls.SOCIAL_AUTH_SAML_FER_IDP_FAKER_DOCKER_PORT = 8060
 
         # Call setup afterward
         super().setup()

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -58,7 +58,7 @@ install_requires =
     requests==2.28.1
     social-auth-app-django==5.0.0
     social-auth-core[saml]==4.3.0
-    social-edu-federation==1.0.0
+    social-edu-federation==1.0.1
     urllib3==1.26.12
     uvicorn[standard]==0.18.3
     whitenoise==6.2.0

--- a/src/frontend/apps/lti_site/components/App/AppContentLoader/index.tsx
+++ b/src/frontend/apps/lti_site/components/App/AppContentLoader/index.tsx
@@ -73,17 +73,22 @@ const intl = createIntl(
   cache,
 );
 
-const appsContent: Record<string, LazyExoticComponent<ComponentType<any>>> = {};
+const appsContent: Record<string, LazyExoticComponent<ComponentType<any>>> = {
+  LTI: lazy(() => import('components/LTIRoutes')),
+  Site: lazy(() => import('components/SiteRoutes')),
+};
 Object.values(appNames).forEach((app) => {
   appsContent[app] = lazy(() => import(`apps/${app}/components/Routes`));
 });
-const ltiSite = lazy(() => import('components/LTIRoutes'));
 
 const AppContentLoader = () => {
   const appConfig = useAppConfig();
   const queryClient = useMemo(() => new QueryClient(), []);
 
-  const Content = appConfig.appName ? appsContent[appConfig.appName] : ltiSite;
+  let Content: LazyExoticComponent<ComponentType<any>>;
+  if (appConfig.appName) Content = appsContent[appConfig.appName];
+  else if (appConfig.frontend) Content = appsContent[appConfig.frontend];
+  else throw new Error('application and frontend are not properly set');
 
   return (
     <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
## Purpose

Fix the fake SAML IdP provider to be used to login locally on Marsha

## Proposal

- [x] Use the latest version of `social-edu-federation`
- [x] Set the port overriding for marsha
- [x] Make the "site" available again

