### PR TITLE
🐛(frontend) fix translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Fix deposit app translations
+- Fix video dashboard translations
 
 ## [4.0.0-beta.8] - 2022-09-15
 

--- a/src/frontend/apps/lti_site/components/VideoWidgetProvider/widgets/UploadSubtitles/ToggleSubtitlesAsTranscript/index.tsx
+++ b/src/frontend/apps/lti_site/components/VideoWidgetProvider/widgets/UploadSubtitles/ToggleSubtitlesAsTranscript/index.tsx
@@ -13,25 +13,25 @@ const messages = defineMessages({
   useTranscriptToggleLabel: {
     defaultMessage: 'Use subtitles as transcripts',
     description: 'Label of the toggle used to use subtitles as transcripts.',
-    id: 'component.DashboardVideoPaneTranscriptOption.useTranscript',
+    id: 'component.ToggleSubtitlesAsTranscript.useTranscriptToggleLabel',
   },
   useTranscriptToggleSuccess: {
     defaultMessage: 'Use subtitles as transcripts activated.',
     description:
       'Message displayed when use subtitles as transcripts succeded.',
-    id: 'components.DownloadVideo.enableDownloadToggleSuccess',
+    id: 'components.ToggleSubtitlesAsTranscript.useTranscriptToggleSuccess',
   },
   unuseTranscriptToggleSuccess: {
     defaultMessage: 'Use subtitles as transcripts deactivated.',
     description:
       'Message displayed when unuse subtitles as transcripts succeded.',
-    id: 'components.DownloadVideo.disallowDownloadToggleSuccess',
+    id: 'components.ToggleSubtitlesAsTranscript.unuseTranscriptToggleSuccess',
   },
   useTranscriptoggleFail: {
     defaultMessage: 'Update failed, try again.',
     description:
       'Message displayed when use subtitles as transcripts has failed.',
-    id: 'components.DownloadVideo.allowDownloadToggleFail',
+    id: 'components.ToggleSubtitlesAsTranscript.useTranscriptoggleFail',
   },
 });
 


### PR DESCRIPTION
## Purpose

Translations ids were wrong in ToggleSubtitlesAsTranscript components.

```
[@formatjs/cli] [WARN] [FormatJS CLI] Duplicate message id: "components.DownloadVideo.enableDownloadToggleSuccess", but the `description` and/or `defaultMessage` are different.
[@formatjs/cli] [WARN] [FormatJS CLI] Duplicate message id: "components.DownloadVideo.disallowDownloadToggleSuccess", but the `description` and/or `defaultMessage` are different.
[@formatjs/cli] [WARN] [FormatJS CLI] Duplicate message id: "components.DownloadVideo.allowDownloadToggleFail", but the `description` and/or `defaultMessage` are different.
```

