### PR TITLE
♻️(front) allow to not truncate ToggleInput label

### DIFF
--- a/src/frontend/apps/lti_site/components/VideoWidgetProvider/widgets/DownloadVideo/index.tsx
+++ b/src/frontend/apps/lti_site/components/VideoWidgetProvider/widgets/DownloadVideo/index.tsx
@@ -158,6 +158,7 @@ export const DownloadVideo = () => {
         checked={toggleAllowDownload}
         onChange={onToggleChange}
         label={intl.formatMessage(messages.allowDownloadToggleLabel)}
+        truncateLabel={false}
       />
       <Box direction="column" gap="small" style={{ marginTop: '0.75rem' }}>
         <Select

--- a/src/frontend/apps/lti_site/components/VideoWidgetProvider/widgets/UploadSubtitles/ToggleSubtitlesAsTranscript/index.tsx
+++ b/src/frontend/apps/lti_site/components/VideoWidgetProvider/widgets/UploadSubtitles/ToggleSubtitlesAsTranscript/index.tsx
@@ -112,6 +112,7 @@ export const ToggleSubtitlesAsTranscript = () => {
       checked={toggleUseTranscript}
       onChange={onToggleChange}
       label={intl.formatMessage(messages.useTranscriptToggleLabel)}
+      truncateLabel={false}
     />
   );
 };

--- a/src/frontend/apps/lti_site/components/graphicals/ToggleInput/index.spec.tsx
+++ b/src/frontend/apps/lti_site/components/graphicals/ToggleInput/index.spec.tsx
@@ -1,5 +1,6 @@
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { Box } from 'grommet';
 import React from 'react';
 
 import render from 'utils/tests/render';
@@ -68,5 +69,38 @@ describe('<ToggleInput />', () => {
     userEvent.click(toggleInput);
 
     expect(onChangeToggleMock).toHaveBeenCalledTimes(0);
+  });
+  it('renders a truncated label', () => {
+    render(
+      <Box width="10px">
+        <ToggleInput
+          checked={true}
+          disabled
+          label={'An example title'}
+          onChange={onChangeToggleMock}
+        />
+        ,
+      </Box>,
+    );
+
+    const text = screen.getByText('An example title');
+    expect(text).toHaveStyleRule('text-overflow', 'ellipsis');
+  });
+  it('renders a non truncated label', () => {
+    render(
+      <Box width="10px">
+        <ToggleInput
+          checked={true}
+          disabled
+          label={'An example title'}
+          onChange={onChangeToggleMock}
+          truncateLabel={false}
+        />
+        ,
+      </Box>,
+    );
+
+    const text = screen.getByText('An example title');
+    expect(text).not.toHaveStyleRule('text-overflow', 'ellipsis');
   });
 });

--- a/src/frontend/apps/lti_site/components/graphicals/ToggleInput/index.tsx
+++ b/src/frontend/apps/lti_site/components/graphicals/ToggleInput/index.tsx
@@ -13,6 +13,7 @@ interface ToggleInputProps extends CheckBoxExtendedProps {
   disabled?: boolean;
   label: string;
   onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  truncateLabel?: boolean;
 }
 
 export const ToggleInput = ({
@@ -20,6 +21,7 @@ export const ToggleInput = ({
   disabled,
   label,
   onChange,
+  truncateLabel = true,
   ...props
 }: ToggleInputProps) => {
   return (
@@ -39,7 +41,7 @@ export const ToggleInput = ({
         title={label}
         {...props}
       />
-      <StyledText color="blue-active" size="1rem" truncate>
+      <StyledText color="blue-active" size="1rem" truncate={truncateLabel}>
         {label}
       </StyledText>
     </Box>


### PR DESCRIPTION
## Purpose

The ToggleInput component label is always truncated. In some specific cases we don't want to truncate it to fully display the label linke in the DownloadVideo and ToggleSubtitlesAsTranscript components.

## Proposal

- [x] allow to not truncate ToggleInput label

