### PR TITLE
update state with an error when TTT format is not supported 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -821,7 +821,7 @@ jobs:
           command: yarn install --frozen-lockfile
       - run:
           name: lint code
-          command: yarn prettier --write --list-different '**/*.+(json|js)'
+          command: yarn prettier --list-different '**/*.+(json|js)'
 
   lint-lambda-convert:
     docker:
@@ -840,7 +840,7 @@ jobs:
           command: yarn install --frozen-lockfile
       - run:
           name: lint code
-          command: yarn prettier --write --list-different '**/*.+(json|js)'
+          command: yarn prettier --list-different '**/*.+(json|js)'
 
   lint-lambda-complete:
     docker:
@@ -862,7 +862,7 @@ jobs:
           command: yarn install --frozen-lockfile
       - run:
           name: lint code
-          command: yarn prettier --write --list-different '**/*.+(json|js)'
+          command: yarn prettier --list-different '**/*.+(json|js)'
 
   lint-lambda-medialive:
     docker:
@@ -884,7 +884,7 @@ jobs:
           command: yarn install --frozen-lockfile
       - run:
           name: lint code
-          command: yarn prettier --write --list-different '**/*.+(json|js)'
+          command: yarn prettier --list-different '**/*.+(json|js)'
 
   lint-lambda-mediapackage:
     docker:
@@ -906,7 +906,7 @@ jobs:
           command: yarn install --frozen-lockfile
       - run:
           name: lint code
-          command: yarn prettier --write --list-different '**/*.+(json|js)'
+          command: yarn prettier --list-different '**/*.+(json|js)'
 
   lint-lambda-elemental-routing:
     docker:
@@ -928,7 +928,7 @@ jobs:
           command: yarn install --frozen-lockfile
       - run:
           name: lint code
-          command: yarn prettier --write --list-different '**/*.+(json|js)'
+          command: yarn prettier --list-different '**/*.+(json|js)'
 
   # Restore django and front POT files containing strings to translate and upload them to our
   # translation management tool

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- call api update-state with an error when the
+  timed text track format is not supported by
+  @openfun/subsrt
+
 ### Fixed
 
 - Fix deposit app translations

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,6 +119,7 @@ services:
     volumes:
       - "./src/aws/lambda-convert:/var/task/lambda-convert"
       - "./src/aws/utils:/var/task/utils"
+      - "./src/.prettierrc.js:/var/task/.prettierrc.js"
     depends_on:
       - lambda_base
 
@@ -133,7 +134,7 @@ services:
     volumes:
       - "./src/aws/lambda-complete:/var/task/lambda-complete"
       - "./src/aws/utils:/var/task/utils"
-      - "./src/.prettierrc:/var/task/.prettierrc"
+      - "./src/.prettierrc.js:/var/task/.prettierrc.js"
     depends_on:
       - lambda_base
 
@@ -147,7 +148,7 @@ services:
       - env.d/lambda
     volumes:
       - "./src/aws/lambda-configure:/var/task/lambda-configure"
-      - "./src/.prettierrc:/var/task/.prettierrc"
+      - "./src/.prettierrc.js:/var/task/.prettierrc.js"
     depends_on:
       - lambda_base
 
@@ -162,7 +163,7 @@ services:
     volumes:
       - "./src/aws/lambda-medialive:/var/task/lambda-medialive"
       - "./src/aws/utils:/var/task/utils"
-      - "./src/.prettierrc:/var/task/.prettierrc"
+      - "./src/.prettierrc.js:/var/task/.prettierrc.js"
     depends_on:
       - lambda_base
 
@@ -177,7 +178,7 @@ services:
     volumes:
       - "./src/aws/lambda-mediapackage:/var/task/lambda-mediapackage"
       - "./src/aws/utils:/var/task/utils"
-      - "./src/.prettierrc:/var/task/.prettierrc"
+      - "./src/.prettierrc.js:/var/task/.prettierrc.js"
       - "./transmuxed_video:/mnt/transmuxed_video"
     depends_on:
       - lambda_base
@@ -195,7 +196,7 @@ services:
     volumes:
       - "./src/aws/lambda-elemental-routing:/var/task/lambda-elemental-routing"
       - "./src/aws/utils:/var/task/utils"
-      - "./src/.prettierrc:/var/task/.prettierrc"
+      - "./src/.prettierrc.js:/var/task/.prettierrc.js"
     depends_on:
       - lambda_base
 
@@ -210,7 +211,7 @@ services:
     volumes:
       - "./src/aws/lambda-migrate:/var/task/lambda-migrate"
       - "./src/aws/utils:/var/task/utils"
-      - "./src/.prettierrc:/var/task/.prettierrc"
+      - "./src/.prettierrc.js:/var/task/.prettierrc.js"
     depends_on:
       - lambda_base
 

--- a/src/aws/lambda-convert/index.js
+++ b/src/aws/lambda-convert/index.js
@@ -8,7 +8,7 @@ const resizeThumbnails = require('./src/resizeThumbnails');
 const convertSharedLiveMedia = require('./src/convertSharedLiveMedia');
 const copyDocument = require('./src/copyDocument');
 const copyMarkdownImage = require('./src/copyMarkdownImage');
-const scanDepositedFile = require("./src/scanDepositedFile");
+const scanDepositedFile = require('./src/scanDepositedFile');
 
 const READY = 'ready';
 const PROCESSING = 'processing';
@@ -37,7 +37,7 @@ exports.handler = async (event, context, callback) => {
     switch (kind) {
       case ResourceKindEnum.DEPOSITED_FILE_KIND:
         error =
-          "Source depositedfile should be uploaded to a folder of the form " +
+          'Source depositedfile should be uploaded to a folder of the form ' +
           '"{file-deposit_id}/depositedfile/{depositedfile_id}/{stamp}".';
         break;
       case ResourceKindEnum.DOCUMENT_KIND:
@@ -88,7 +88,7 @@ exports.handler = async (event, context, callback) => {
         return callback(error);
       }
       console.log(
-        `Successfully received and copy deposited file ${objectKey} from ${sourceBucket}.`
+        `Successfully received and copy deposited file ${objectKey} from ${sourceBucket}.`,
       );
       break;
     case ResourceKindEnum.DOCUMENT_KIND:
@@ -145,11 +145,7 @@ exports.handler = async (event, context, callback) => {
 
     case ResourceKindEnum.TIMED_TEXT_TRACK_KIND:
       try {
-        await encodeTimedTextTrack(
-          objectKey,
-          sourceBucket,
-          extendedStamp,
-        );
+        await encodeTimedTextTrack(objectKey, sourceBucket, extendedStamp);
       } catch (error) {
         return callback(error);
       }

--- a/src/aws/lambda-convert/index.js
+++ b/src/aws/lambda-convert/index.js
@@ -145,12 +145,11 @@ exports.handler = async (event, context, callback) => {
 
     case ResourceKindEnum.TIMED_TEXT_TRACK_KIND:
       try {
-        const extension = await encodeTimedTextTrack(
+        await encodeTimedTextTrack(
           objectKey,
           sourceBucket,
           extendedStamp,
         );
-        await updateState(objectKey, READY, { extension });
       } catch (error) {
         return callback(error);
       }

--- a/src/aws/lambda-convert/index.spec.js
+++ b/src/aws/lambda-convert/index.spec.js
@@ -166,19 +166,14 @@ describe("lambda", () => {
       ],
     };
 
-    it("delegates to encodeTimedTextTrack and calls updateState when it succeeds", async () => {
-      mockEncodeTimedTextTrack.mockImplementation(() => Promise.resolve("srt"));
+    it("delegates to encodeTimedTextTrack", async () => {
+      mockEncodeTimedTextTrack.mockImplementation(() => Promise.resolve());
       await lambda(event, null, callback);
 
       expect(mockEncodeTimedTextTrack).toHaveBeenCalledWith(
         "630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/timedtexttrack/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1542967735_fr_st",
         "source bucket",
         "1542967735_fr_st"
-      );
-      expect(mockUpdateState).toHaveBeenCalledWith(
-        "630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/timedtexttrack/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1542967735_fr_st",
-        "ready",
-        { extension: "srt" }
       );
     });
 
@@ -379,7 +374,7 @@ describe("lambda", () => {
       );
       expect(mockUpdateState).toHaveBeenCalledWith(
         "ed08da34-7447-4141-96ff-5740315d7b99/sharedlivemedia/c5cad053-111a-4e0e-8f78-fe43dec11512/1638403200.pdf",
-        "processing",
+        "processing"
       );
       expect(mockUpdateState).toHaveBeenCalledWith(
         "ed08da34-7447-4141-96ff-5740315d7b99/sharedlivemedia/c5cad053-111a-4e0e-8f78-fe43dec11512/1638403200.pdf",
@@ -442,11 +437,10 @@ describe("lambda", () => {
     });
 
     it("delegates to copyDepositFile and reports an error when thrown", async () => {
-      const error = new Error("Something went wrong")
+      const error = new Error("Something went wrong");
       mockScanDepositedFile.mockImplementation(() => {
-          throw error;
-        }
-      );
+        throw error;
+      });
 
       await lambda(
         {

--- a/src/aws/lambda-convert/index.spec.js
+++ b/src/aws/lambda-convert/index.spec.js
@@ -1,443 +1,443 @@
-process.env.DISABLE_SSL_VALIDATION = "false";
+process.env.DISABLE_SSL_VALIDATION = 'false';
 
 // Don't pollute tests with logs intended for CloudWatch
-jest.spyOn(console, "log");
+jest.spyOn(console, 'log');
 
 // Mock our own sub-modules to simplify our tests
 const mockEncodeTimedTextTrack = jest.fn();
-jest.doMock("./src/encodeTimedTextTrack", () => mockEncodeTimedTextTrack);
+jest.doMock('./src/encodeTimedTextTrack', () => mockEncodeTimedTextTrack);
 
 const mockEncodeVideo = jest.fn();
-jest.doMock("./src/encodeVideo", () => mockEncodeVideo);
+jest.doMock('./src/encodeVideo', () => mockEncodeVideo);
 
 const mockUpdateState = jest.fn();
-jest.doMock("update-state", () => mockUpdateState);
+jest.doMock('update-state', () => mockUpdateState);
 
 const mockResizeThumbnails = jest.fn();
-jest.doMock("./src/resizeThumbnails", () => mockResizeThumbnails);
+jest.doMock('./src/resizeThumbnails', () => mockResizeThumbnails);
 
 const mockCopyDocument = jest.fn();
-jest.doMock("./src/copyDocument", () => mockCopyDocument);
+jest.doMock('./src/copyDocument', () => mockCopyDocument);
 
 const mockConvertSharedLiveMedia = jest.fn();
-jest.doMock("./src/convertSharedLiveMedia", () => mockConvertSharedLiveMedia);
+jest.doMock('./src/convertSharedLiveMedia', () => mockConvertSharedLiveMedia);
 
 const mockScanDepositedFile = jest.fn();
-jest.doMock("./src/scanDepositedFile", () => mockScanDepositedFile);
+jest.doMock('./src/scanDepositedFile', () => mockScanDepositedFile);
 
-const lambda = require("./index.js").handler;
+const lambda = require('./index.js').handler;
 
 const callback = jest.fn();
 
-describe("lambda", () => {
+describe('lambda', () => {
   beforeEach(() => {
     console.log.mockReset();
     jest.resetAllMocks();
   });
 
-  it("reports a specific error when a video object key has an unexpected format", () => {
+  it('reports a specific error when a video object key has an unexpected format', () => {
     lambda(
       {
         Records: [
           {
             s3: {
-              bucket: { name: "some bucket" },
+              bucket: { name: 'some bucket' },
               object: {
-                key: "630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/video/dba1512e-d0b3-40cc-ae44-722fbe8cba6a",
+                key: '630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/video/dba1512e-d0b3-40cc-ae44-722fbe8cba6a',
               },
             },
           },
         ],
       },
       null,
-      callback
+      callback,
     );
     expect(mockUpdateState).not.toHaveBeenCalled();
     expect(callback).toHaveBeenCalledWith(
-      'Source videos should be uploaded in a folder of the form "{video_id}/video/{video_id}/{stamp}".'
+      'Source videos should be uploaded in a folder of the form "{video_id}/video/{video_id}/{stamp}".',
     );
   });
 
-  it("reports a specific error when a timed text object key has an unexpected format", () => {
+  it('reports a specific error when a timed text object key has an unexpected format', () => {
     lambda(
       {
         Records: [
           {
             s3: {
-              bucket: { name: "some bucket" },
+              bucket: { name: 'some bucket' },
               object: {
-                key: "630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/timedtexttrack/dba1512e-d0b3-40cc-ae44-722fbe8cba6a",
+                key: '630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/timedtexttrack/dba1512e-d0b3-40cc-ae44-722fbe8cba6a',
               },
             },
           },
         ],
       },
       null,
-      callback
+      callback,
     );
     expect(mockUpdateState).not.toHaveBeenCalled();
     expect(callback).toHaveBeenCalledWith(
-      "Source timed text files should be uploaded to a folder of the form " +
-        '"{playlist_id}/timedtexttrack/{timedtext_id}/{stamp}_{language}[_{has_closed_caption}]".'
+      'Source timed text files should be uploaded to a folder of the form ' +
+        '"{playlist_id}/timedtexttrack/{timedtext_id}/{stamp}_{language}[_{has_closed_caption}]".',
     );
   });
 
-  it("reports an error when the kind of object is unexpected", () => {
+  it('reports an error when the kind of object is unexpected', () => {
     lambda(
       {
         Records: [
           {
             s3: {
-              bucket: { name: "some bucket" },
+              bucket: { name: 'some bucket' },
               object: {
-                key: "630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/subtitletrack/dba1512e-d0b3-40cc-ae44-722fbe8cba6a",
+                key: '630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/subtitletrack/dba1512e-d0b3-40cc-ae44-722fbe8cba6a',
               },
             },
           },
         ],
       },
       null,
-      callback
+      callback,
     );
     expect(mockUpdateState).not.toHaveBeenCalled();
     expect(callback).toHaveBeenCalledWith(
-      "Unrecognized kind subtitletrack in key " +
-        '"630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/subtitletrack/dba1512e-d0b3-40cc-ae44-722fbe8cba6a".'
+      'Unrecognized kind subtitletrack in key ' +
+        '"630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/subtitletrack/dba1512e-d0b3-40cc-ae44-722fbe8cba6a".',
     );
   });
 
-  it("reports an error when the object key has an unexpected format", () => {
+  it('reports an error when the object key has an unexpected format', () => {
     lambda(
       {
         Records: [
           {
             s3: {
-              bucket: { name: "some bucket" },
-              object: { key: "invalid key" },
+              bucket: { name: 'some bucket' },
+              object: { key: 'invalid key' },
             },
           },
         ],
       },
       null,
-      callback
+      callback,
     );
     expect(mockUpdateState).not.toHaveBeenCalled();
     expect(callback).toHaveBeenCalledWith(
-      'Unrecognized key format "invalid key"'
+      'Unrecognized key format "invalid key"',
     );
   });
 
-  it("reports an error when a thumbnail has an unexpected format", () => {
+  it('reports an error when a thumbnail has an unexpected format', () => {
     lambda(
       {
         Records: [
           {
             s3: {
-              bucket: { name: "source bucket" },
+              bucket: { name: 'source bucket' },
               object: {
-                key: "630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/thumbnail/dba1512e-d0b3-40cc-ae44-722fbe8cba6a",
+                key: '630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/thumbnail/dba1512e-d0b3-40cc-ae44-722fbe8cba6a',
               },
             },
           },
         ],
       },
       null,
-      callback
+      callback,
     );
     expect(callback).toHaveBeenCalledWith(
-      "Source thumbnails should be uploaded in a folder of the form " +
-        '"{playlist_id}/thumbnail/{thumbnail_id}/{stamp}".'
+      'Source thumbnails should be uploaded in a folder of the form ' +
+        '"{playlist_id}/thumbnail/{thumbnail_id}/{stamp}".',
     );
   });
 
-  describe("called with a timed text object", () => {
+  describe('called with a timed text object', () => {
     const event = {
       Records: [
         {
           s3: {
             bucket: {
-              name: "source bucket",
+              name: 'source bucket',
             },
             object: {
-              key: "630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/timedtexttrack/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1542967735_fr_st",
+              key: '630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/timedtexttrack/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1542967735_fr_st',
             },
           },
         },
       ],
     };
 
-    it("delegates to encodeTimedTextTrack", async () => {
+    it('delegates to encodeTimedTextTrack', async () => {
       mockEncodeTimedTextTrack.mockImplementation(() => Promise.resolve());
       await lambda(event, null, callback);
 
       expect(mockEncodeTimedTextTrack).toHaveBeenCalledWith(
-        "630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/timedtexttrack/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1542967735_fr_st",
-        "source bucket",
-        "1542967735_fr_st"
+        '630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/timedtexttrack/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1542967735_fr_st',
+        'source bucket',
+        '1542967735_fr_st',
       );
     });
 
-    it("delegates to encodeTimedTextTrack and reports the error when it fails", async () => {
+    it('delegates to encodeTimedTextTrack and reports the error when it fails', async () => {
       mockEncodeTimedTextTrack.mockImplementation(
-        () => new Promise((resolve, reject) => reject("Failed!"))
+        () => new Promise((resolve, reject) => reject('Failed!')),
       );
 
       await lambda(event, null, callback);
 
       expect(mockEncodeTimedTextTrack).toHaveBeenCalledWith(
-        "630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/timedtexttrack/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1542967735_fr_st",
-        "source bucket",
-        "1542967735_fr_st"
+        '630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/timedtexttrack/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1542967735_fr_st',
+        'source bucket',
+        '1542967735_fr_st',
       );
       expect(mockUpdateState).not.toHaveBeenCalled();
-      expect(callback).toHaveBeenCalledWith("Failed!");
+      expect(callback).toHaveBeenCalledWith('Failed!');
     });
   });
 
-  describe("called with a video object", () => {
+  describe('called with a video object', () => {
     const event = {
       Records: [
         {
           s3: {
             bucket: {
-              name: "source bucket",
+              name: 'source bucket',
             },
             object: {
-              key: "630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/video/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1542967735_fr",
+              key: '630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/video/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1542967735_fr',
             },
           },
         },
       ],
     };
 
-    it("delegates to encodeVideo and calls updateState & callback when it succeeds", async () => {
-      mockEncodeVideo.mockReturnValue(Promise.resolve({ Job: { Id: "42" } }));
+    it('delegates to encodeVideo and calls updateState & callback when it succeeds', async () => {
+      mockEncodeVideo.mockReturnValue(Promise.resolve({ Job: { Id: '42' } }));
       await lambda(event, null, callback);
 
       expect(mockEncodeVideo).toHaveBeenCalledWith(
-        "630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/video/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1542967735_fr",
-        "source bucket"
+        '630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/video/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1542967735_fr',
+        'source bucket',
       );
       expect(mockUpdateState).toHaveBeenCalledWith(
-        "630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/video/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1542967735_fr",
-        "processing"
+        '630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/video/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1542967735_fr',
+        'processing',
       );
     });
 
-    it("delegates to encodeVideo and reports the error when it fails", async () => {
+    it('delegates to encodeVideo and reports the error when it fails', async () => {
       mockEncodeVideo.mockImplementation(
-        () => new Promise((resolve, reject) => reject("Failed!"))
+        () => new Promise((resolve, reject) => reject('Failed!')),
       );
 
       await lambda(event, null, callback);
 
       expect(mockEncodeVideo).toHaveBeenCalledWith(
-        "630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/video/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1542967735_fr",
-        "source bucket"
+        '630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/video/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1542967735_fr',
+        'source bucket',
       );
       expect(mockUpdateState).not.toHaveBeenCalled();
-      expect(callback).toHaveBeenCalledWith("Failed!");
+      expect(callback).toHaveBeenCalledWith('Failed!');
     });
   });
 
-  describe("called with a thumbnail object", () => {
-    it("delegates to resizeThumbnails and call updateState", async () => {
+  describe('called with a thumbnail object', () => {
+    it('delegates to resizeThumbnails and call updateState', async () => {
       await lambda(
         {
           Records: [
             {
               s3: {
-                bucket: { name: "source bucket" },
+                bucket: { name: 'source bucket' },
                 object: {
-                  key: "630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/thumbnail/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1542967735",
+                  key: '630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/thumbnail/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1542967735',
                 },
               },
             },
           ],
         },
         null,
-        callback
+        callback,
       );
 
       expect(mockResizeThumbnails).toHaveBeenCalledWith(
-        "630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/thumbnail/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1542967735",
-        "source bucket"
+        '630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/thumbnail/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1542967735',
+        'source bucket',
       );
       expect(mockUpdateState).toHaveBeenCalledWith(
-        "630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/thumbnail/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1542967735",
-        "ready"
+        '630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/thumbnail/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1542967735',
+        'ready',
       );
     });
   });
 
-  describe("called with a document object", () => {
-    it("reports an error when a document has an unexpected format", () => {
+  describe('called with a document object', () => {
+    it('reports an error when a document has an unexpected format', () => {
       lambda(
         {
           Records: [
             {
               s3: {
-                bucket: { name: "source bucket" },
+                bucket: { name: 'source bucket' },
                 object: {
-                  key: "630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/document/dba1512e-d0b3-40cc-ae44-722fbe8cba6a",
+                  key: '630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/document/dba1512e-d0b3-40cc-ae44-722fbe8cba6a',
                 },
               },
             },
           ],
         },
         null,
-        callback
+        callback,
       );
       expect(callback).toHaveBeenCalledWith(
-        "Source document should be uploaded to a folder of the form " +
-          '"{document_id}/document/{document_id}/{stamp}".'
+        'Source document should be uploaded to a folder of the form ' +
+          '"{document_id}/document/{document_id}/{stamp}".',
       );
     });
 
-    it("delegates to copyDocument and call updateState", async () => {
+    it('delegates to copyDocument and call updateState', async () => {
       await lambda(
         {
           Records: [
             {
               s3: {
-                bucket: { name: "source bucket" },
+                bucket: { name: 'source bucket' },
                 object: {
-                  key: "630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/document/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1542967735",
+                  key: '630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/document/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1542967735',
                 },
               },
             },
           ],
         },
         null,
-        callback
+        callback,
       );
 
       expect(mockCopyDocument).toHaveBeenCalledWith(
-        "630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/document/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1542967735",
-        "source bucket"
+        '630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/document/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1542967735',
+        'source bucket',
       );
       expect(mockUpdateState).toHaveBeenCalledWith(
-        "630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/document/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1542967735",
-        "ready"
+        '630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/document/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1542967735',
+        'ready',
       );
     });
   });
 
-  describe("called with a sharedlivemedia object", () => {
-    it("reports an error when a sharedlivemedia has an unexpected format", () => {
+  describe('called with a sharedlivemedia object', () => {
+    it('reports an error when a sharedlivemedia has an unexpected format', () => {
       lambda(
         {
           Records: [
             {
               s3: {
-                bucket: { name: "source bucket" },
+                bucket: { name: 'source bucket' },
                 object: {
-                  key: "ed08da34-7447-4141-96ff-5740315d7b99/sharedlivemedia/c5cad053-111a-4e0e-8f78-fe43dec11512",
+                  key: 'ed08da34-7447-4141-96ff-5740315d7b99/sharedlivemedia/c5cad053-111a-4e0e-8f78-fe43dec11512',
                 },
               },
             },
           ],
         },
         null,
-        callback
+        callback,
       );
       expect(callback).toHaveBeenCalledWith(
-        "Source sharedlivemedia should be uploaded to a folder of the form " +
-          '"{video_id}/sharedlivemedia/{sharedlivemedia_id}/{stamp}.{extension}".'
+        'Source sharedlivemedia should be uploaded to a folder of the form ' +
+          '"{video_id}/sharedlivemedia/{sharedlivemedia_id}/{stamp}.{extension}".',
       );
     });
 
-    it("delegates to convertSharedLiveMedia and call updateState", async () => {
+    it('delegates to convertSharedLiveMedia and call updateState', async () => {
       mockConvertSharedLiveMedia.mockImplementation(() =>
-        Promise.resolve({ nbPages: 3, extension: "pdf" })
+        Promise.resolve({ nbPages: 3, extension: 'pdf' }),
       );
       await lambda(
         {
           Records: [
             {
               s3: {
-                bucket: { name: "source bucket" },
+                bucket: { name: 'source bucket' },
                 object: {
-                  key: "ed08da34-7447-4141-96ff-5740315d7b99/sharedlivemedia/c5cad053-111a-4e0e-8f78-fe43dec11512/1638403200.pdf",
+                  key: 'ed08da34-7447-4141-96ff-5740315d7b99/sharedlivemedia/c5cad053-111a-4e0e-8f78-fe43dec11512/1638403200.pdf',
                 },
               },
             },
           ],
         },
         null,
-        callback
+        callback,
       );
 
       expect(mockConvertSharedLiveMedia).toHaveBeenCalledWith(
-        "ed08da34-7447-4141-96ff-5740315d7b99/sharedlivemedia/c5cad053-111a-4e0e-8f78-fe43dec11512/1638403200.pdf",
-        "source bucket"
+        'ed08da34-7447-4141-96ff-5740315d7b99/sharedlivemedia/c5cad053-111a-4e0e-8f78-fe43dec11512/1638403200.pdf',
+        'source bucket',
       );
       expect(mockUpdateState).toHaveBeenCalledWith(
-        "ed08da34-7447-4141-96ff-5740315d7b99/sharedlivemedia/c5cad053-111a-4e0e-8f78-fe43dec11512/1638403200.pdf",
-        "processing"
+        'ed08da34-7447-4141-96ff-5740315d7b99/sharedlivemedia/c5cad053-111a-4e0e-8f78-fe43dec11512/1638403200.pdf',
+        'processing',
       );
       expect(mockUpdateState).toHaveBeenCalledWith(
-        "ed08da34-7447-4141-96ff-5740315d7b99/sharedlivemedia/c5cad053-111a-4e0e-8f78-fe43dec11512/1638403200.pdf",
-        "ready",
-        { extension: "pdf", nbPages: 3 }
+        'ed08da34-7447-4141-96ff-5740315d7b99/sharedlivemedia/c5cad053-111a-4e0e-8f78-fe43dec11512/1638403200.pdf',
+        'ready',
+        { extension: 'pdf', nbPages: 3 },
       );
       expect(mockUpdateState).toHaveBeenCalledTimes(2);
     });
   });
 
-  describe("called with a depositedfile object", () => {
-    it("reports an error when a depositedfile has an unexpected format", () => {
+  describe('called with a depositedfile object', () => {
+    it('reports an error when a depositedfile has an unexpected format', () => {
       lambda(
         {
           Records: [
             {
               s3: {
-                bucket: { name: "source bucket" },
+                bucket: { name: 'source bucket' },
                 object: {
-                  key: "630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/depositedfile/dba1512e-d0b3-40cc-ae44-722fbe8cba6a",
+                  key: '630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/depositedfile/dba1512e-d0b3-40cc-ae44-722fbe8cba6a',
                 },
               },
             },
           ],
         },
         null,
-        callback
+        callback,
       );
       expect(callback).toHaveBeenCalledWith(
-        "Source depositedfile should be uploaded to a folder of the form " +
-          '"{file-deposit_id}/depositedfile/{depositedfile_id}/{stamp}".'
+        'Source depositedfile should be uploaded to a folder of the form ' +
+          '"{file-deposit_id}/depositedfile/{depositedfile_id}/{stamp}".',
       );
     });
 
-    it("delegates to copyDepositFile", async () => {
+    it('delegates to copyDepositFile', async () => {
       mockScanDepositedFile.mockImplementation(() =>
-        Promise.resolve({ extension: "pdf" })
+        Promise.resolve({ extension: 'pdf' }),
       );
       await lambda(
         {
           Records: [
             {
               s3: {
-                bucket: { name: "source bucket" },
+                bucket: { name: 'source bucket' },
                 object: {
-                  key: "630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/depositedfile/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1542967735",
+                  key: '630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/depositedfile/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1542967735',
                 },
               },
             },
           ],
         },
         null,
-        callback
+        callback,
       );
 
       expect(mockScanDepositedFile).toHaveBeenCalledWith(
-        "630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/depositedfile/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1542967735",
-        "source bucket"
+        '630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/depositedfile/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1542967735',
+        'source bucket',
       );
     });
 
-    it("delegates to copyDepositFile and reports an error when thrown", async () => {
-      const error = new Error("Something went wrong");
+    it('delegates to copyDepositFile and reports an error when thrown', async () => {
+      const error = new Error('Something went wrong');
       mockScanDepositedFile.mockImplementation(() => {
         throw error;
       });
@@ -447,21 +447,21 @@ describe("lambda", () => {
           Records: [
             {
               s3: {
-                bucket: { name: "source bucket" },
+                bucket: { name: 'source bucket' },
                 object: {
-                  key: "630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/depositedfile/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1542967735",
+                  key: '630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/depositedfile/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1542967735',
                 },
               },
             },
           ],
         },
         null,
-        callback
+        callback,
       );
 
       expect(mockScanDepositedFile).toHaveBeenCalledWith(
-        "630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/depositedfile/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1542967735",
-        "source bucket"
+        '630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/depositedfile/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1542967735',
+        'source bucket',
       );
       expect(callback).toHaveBeenCalledWith(error);
     });

--- a/src/aws/lambda-convert/src/convertSharedLiveMedia.js
+++ b/src/aws/lambda-convert/src/convertSharedLiveMedia.js
@@ -1,7 +1,7 @@
 // Convert a sharedlivemedia from a source to a destination bucket
-const AWS = require("aws-sdk");
-const s3 = new AWS.S3({ apiVersion: "2006-03-01" });
-const { Poppler } = require("node-poppler");
+const AWS = require('aws-sdk');
+const s3 = new AWS.S3({ apiVersion: '2006-03-01' });
+const { Poppler } = require('node-poppler');
 
 module.exports = async (objectKey, sourceBucket) => {
   const destinationBucket = process.env.S3_DESTINATION_BUCKET;
@@ -12,15 +12,15 @@ module.exports = async (objectKey, sourceBucket) => {
     .getObject({ Bucket: sourceBucket, Key: objectKey })
     .promise();
 
-  const poppler = new Poppler("/usr/local/bin");
+  const poppler = new Poppler('/usr/local/bin');
   const pdfInfos = await poppler.pdfInfo(sourceSharedliveMedia.Body, {
     printAsJson: true,
   });
   const nbPages = parseInt(pdfInfos.pages);
-  const parts = objectKey.split("/");
+  const parts = objectKey.split('/');
   const videoId = parts[0];
   const sharedliveMediaId = parts[2];
-  const [stamp, extension] = parts[3].split(".");
+  const [stamp, extension] = parts[3].split('.');
 
   return Promise.all(
     Array.from({ length: nbPages }, (_, i) => i + 1).map(async (page) => {
@@ -33,7 +33,7 @@ module.exports = async (objectKey, sourceBucket) => {
       const outputBuffer = await poppler.pdfToCairo(
         sourceSharedliveMedia.Body,
         undefined,
-        options
+        options,
       );
       await s3
         .putObject({
@@ -43,7 +43,7 @@ module.exports = async (objectKey, sourceBucket) => {
           Key: `${videoId}/sharedlivemedia/${sharedliveMediaId}/${stamp}_${page}.svg`,
         })
         .promise();
-    })
+    }),
   )
     .then(() => {
       return s3

--- a/src/aws/lambda-convert/src/convertSharedLiveMedia.spec.js
+++ b/src/aws/lambda-convert/src/convertSharedLiveMedia.spec.js
@@ -1,6 +1,6 @@
-const fs = require("fs");
+const fs = require('fs');
 
-process.env.S3_DESTINATION_BUCKET = "destination_bucket";
+process.env.S3_DESTINATION_BUCKET = 'destination_bucket';
 
 const testDirectory = `${__dirname}/../testfiles/`;
 const pdfFile = `${testDirectory}sample.pdf`;
@@ -11,13 +11,13 @@ const svgFiles = [
 ];
 
 // Don't pollute tests with logs intended for CloudWatch
-jest.spyOn(console, "log");
+jest.spyOn(console, 'log');
 
 // Mock the AWS SDK calls used in convertSharedLiveMedia
 const mockGetObject = jest.fn();
 const mockPutObject = jest.fn();
 const mockCopyObject = jest.fn();
-jest.mock("aws-sdk", () => ({
+jest.mock('aws-sdk', () => ({
   S3: function () {
     this.copyObject = mockCopyObject;
     this.getObject = mockGetObject;
@@ -25,14 +25,14 @@ jest.mock("aws-sdk", () => ({
   },
 }));
 
-const convertSharedLiveMedia = require("./convertSharedLiveMedia");
+const convertSharedLiveMedia = require('./convertSharedLiveMedia');
 
-describe("lambda-convert/src/convertSharedLiveMedia", () => {
+describe('lambda-convert/src/convertSharedLiveMedia', () => {
   beforeEach(() => {
     console.log.mockReset();
     jest.resetAllMocks();
   });
-  it("converts uploaded sharedlivemedia", async () => {
+  it('converts uploaded sharedlivemedia', async () => {
     mockGetObject.mockReturnValue({
       promise: () =>
         new Promise((resolve) => resolve({ Body: fs.readFileSync(pdfFile) })),
@@ -45,36 +45,36 @@ describe("lambda-convert/src/convertSharedLiveMedia", () => {
     });
 
     const { nbPages, extension } = await convertSharedLiveMedia(
-      "ed08da34-7447-4141-96ff-5740315d7b99/sharedlivemedia/c5cad053-111a-4e0e-8f78-fe43dec11512/1638403200.pdf",
-      "source_bucket"
+      'ed08da34-7447-4141-96ff-5740315d7b99/sharedlivemedia/c5cad053-111a-4e0e-8f78-fe43dec11512/1638403200.pdf',
+      'source_bucket',
     );
 
     expect(nbPages).toBe(3);
-    expect(extension).toBe("pdf");
+    expect(extension).toBe('pdf');
     expect(mockPutObject).toHaveBeenCalledTimes(nbPages);
     expect(mockPutObject).toHaveBeenCalledWith({
       Body: fs.readFileSync(svgFiles[0]),
       ContentType: 'image/svg+xml',
-      Key: "ed08da34-7447-4141-96ff-5740315d7b99/sharedlivemedia/c5cad053-111a-4e0e-8f78-fe43dec11512/1638403200_1.svg",
-      Bucket: "destination_bucket",
+      Key: 'ed08da34-7447-4141-96ff-5740315d7b99/sharedlivemedia/c5cad053-111a-4e0e-8f78-fe43dec11512/1638403200_1.svg',
+      Bucket: 'destination_bucket',
     });
     expect(mockPutObject).toHaveBeenCalledWith({
       Body: fs.readFileSync(svgFiles[1]),
       ContentType: 'image/svg+xml',
-      Key: "ed08da34-7447-4141-96ff-5740315d7b99/sharedlivemedia/c5cad053-111a-4e0e-8f78-fe43dec11512/1638403200_2.svg",
-      Bucket: "destination_bucket",
+      Key: 'ed08da34-7447-4141-96ff-5740315d7b99/sharedlivemedia/c5cad053-111a-4e0e-8f78-fe43dec11512/1638403200_2.svg',
+      Bucket: 'destination_bucket',
     });
     expect(mockPutObject).toHaveBeenCalledWith({
       Body: fs.readFileSync(svgFiles[2]),
       ContentType: 'image/svg+xml',
-      Key: "ed08da34-7447-4141-96ff-5740315d7b99/sharedlivemedia/c5cad053-111a-4e0e-8f78-fe43dec11512/1638403200_3.svg",
-      Bucket: "destination_bucket",
+      Key: 'ed08da34-7447-4141-96ff-5740315d7b99/sharedlivemedia/c5cad053-111a-4e0e-8f78-fe43dec11512/1638403200_3.svg',
+      Bucket: 'destination_bucket',
     });
     expect(mockCopyObject).toHaveBeenCalledWith({
-      Bucket: "destination_bucket",
-      Key: "ed08da34-7447-4141-96ff-5740315d7b99/sharedlivemedia/c5cad053-111a-4e0e-8f78-fe43dec11512/1638403200.pdf",
+      Bucket: 'destination_bucket',
+      Key: 'ed08da34-7447-4141-96ff-5740315d7b99/sharedlivemedia/c5cad053-111a-4e0e-8f78-fe43dec11512/1638403200.pdf',
       CopySource:
-        "source_bucket/ed08da34-7447-4141-96ff-5740315d7b99/sharedlivemedia/c5cad053-111a-4e0e-8f78-fe43dec11512/1638403200.pdf",
+        'source_bucket/ed08da34-7447-4141-96ff-5740315d7b99/sharedlivemedia/c5cad053-111a-4e0e-8f78-fe43dec11512/1638403200.pdf',
     });
   });
 });

--- a/src/aws/lambda-convert/src/copyDocument.js
+++ b/src/aws/lambda-convert/src/copyDocument.js
@@ -1,13 +1,13 @@
 // Copy a document from a source to a destination bucket
-const AWS = require("aws-sdk");
-const s3 = new AWS.S3({ apiVersion: "2006-03-01" });
+const AWS = require('aws-sdk');
+const s3 = new AWS.S3({ apiVersion: '2006-03-01' });
 
 module.exports = async (objectKey, sourceBucket) => {
   const destinationBucket = process.env.S3_DESTINATION_BUCKET;
 
   console.log(`Copying document ${objectKey} to destination bucket.`);
 
-  const parts = objectKey.split("/");
+  const parts = objectKey.split('/');
   return s3
     .copyObject({
       Bucket: destinationBucket,

--- a/src/aws/lambda-convert/src/copyDocument.spec.js
+++ b/src/aws/lambda-convert/src/copyDocument.spec.js
@@ -1,37 +1,37 @@
-process.env.S3_DESTINATION_BUCKET = "destination_bucket";
+process.env.S3_DESTINATION_BUCKET = 'destination_bucket';
 
 // Don't pollute tests with logs intended for CloudWatch
-jest.spyOn(console, "log");
+jest.spyOn(console, 'log');
 
 // Mock the AWS SDK calls used in encodeTimedTextTrack
 const mockCopyObject = jest.fn();
-jest.mock("aws-sdk", () => ({
+jest.mock('aws-sdk', () => ({
   S3: function () {
     this.copyObject = mockCopyObject;
   },
 }));
 
-const copyDocument = require("./copyDocument");
+const copyDocument = require('./copyDocument');
 
-describe("lambda-encore/src/copyDocument", () => {
+describe('lambda-encore/src/copyDocument', () => {
   beforeEach(() => {
     console.log.mockReset();
     jest.resetAllMocks();
   });
 
-  it("copy a document from a source to a destination bucket", async () => {
+  it('copy a document from a source to a destination bucket', async () => {
     mockCopyObject.mockReturnValue({
       promise: () => new Promise((resolve) => resolve()),
     });
 
     await copyDocument(
-      "a3e213a7-9c56-4bd3-b71c-fe567b0cfe12/document/a3e213a7-9c56-4bd3-b71c-fe567b0cfe12/1606230873.zip",
-      "source_bucket"
+      'a3e213a7-9c56-4bd3-b71c-fe567b0cfe12/document/a3e213a7-9c56-4bd3-b71c-fe567b0cfe12/1606230873.zip',
+      'source_bucket',
     );
 
     expect(mockCopyObject).toHaveBeenCalledWith({
-      Bucket: "destination_bucket",
-      Key: "a3e213a7-9c56-4bd3-b71c-fe567b0cfe12/document/1606230873.zip",
+      Bucket: 'destination_bucket',
+      Key: 'a3e213a7-9c56-4bd3-b71c-fe567b0cfe12/document/1606230873.zip',
       CopySource: `source_bucket/a3e213a7-9c56-4bd3-b71c-fe567b0cfe12/document/a3e213a7-9c56-4bd3-b71c-fe567b0cfe12/1606230873.zip`,
     });
   });

--- a/src/aws/lambda-convert/src/encodeTimedTextTrack.js
+++ b/src/aws/lambda-convert/src/encodeTimedTextTrack.js
@@ -1,12 +1,12 @@
-const AWS = require("aws-sdk");
+const AWS = require('aws-sdk');
 const s3 = new AWS.S3();
 
-const subsrt = require("@openfun/subsrt");
-const he = require("he");
+const subsrt = require('@openfun/subsrt');
+const he = require('he');
 const updateState = require('update-state');
 
-const READY = "ready";
-const ERROR = "error";
+const READY = 'ready';
+const ERROR = 'error';
 
 /**
  * Convert any uploaded timed text track to `.vtt`.
@@ -29,8 +29,8 @@ module.exports = async (objectKey, sourceBucket, filename) => {
   let encodedVttTimedText;
   try {
     switch (mode) {
-      case "st":
-      case "cc":
+      case 'st':
+      case 'cc':
         encodedVttTimedText = convertTimedTextTrack(timedTextFile, objectKey);
         break;
       default:
@@ -45,12 +45,12 @@ module.exports = async (objectKey, sourceBucket, filename) => {
     .putObject({
       Body: encodedVttTimedText,
       Bucket: destinationBucket,
-      ContentType: "text/vtt",
+      ContentType: 'text/vtt',
       // Transform the source key to the format expected for destination keys:
       // 630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/timedtexttrack/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1542967735_fr
       // 👆 becomes 👇
       // 630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/timedtext/1542967735_fr.vtt
-      Key: `${objectKey.replace(/\/timedtexttrack\/.*\//, "/timedtext/")}.vtt`,
+      Key: `${objectKey.replace(/\/timedtexttrack\/.*\//, '/timedtext/')}.vtt`,
     })
     .promise();
 
@@ -59,7 +59,7 @@ module.exports = async (objectKey, sourceBucket, filename) => {
       Bucket: destinationBucket,
       Key: `${objectKey.replace(
         /\/timedtexttrack\/.*\//,
-        "/timedtext/source/"
+        '/timedtext/source/',
       )}`,
       CopySource: `${sourceBucket}/${objectKey}`,
     })
@@ -73,7 +73,7 @@ module.exports = async (objectKey, sourceBucket, filename) => {
 const convertTimedTextTrack = (timedTextFile, objectKey) => {
   try {
     return subsrt.convert(timedTextFile.Body.toString(), {
-      format: "vtt",
+      format: 'vtt',
     });
   } catch (e) {
     // Log the file as read from S3 to ease debugging
@@ -87,7 +87,7 @@ const encodeTranscript = (timedTextFile, objectKey) => {
   let captions;
   try {
     captions = subsrt.parse(timedTextFile.Body.toString(), {
-      format: "vtt",
+      format: 'vtt',
     });
   } catch (e) {
     // Log the file as read from S3 to ease debugging
@@ -97,7 +97,7 @@ const encodeTranscript = (timedTextFile, objectKey) => {
 
   const encodedCaptions = captions.map((caption) => {
     // meta caption does not have data, nothing to encode here we directly return it
-    if (caption.type == "meta") {
+    if (caption.type == 'meta') {
       return caption;
     }
 
@@ -113,5 +113,5 @@ const encodeTranscript = (timedTextFile, objectKey) => {
     return caption;
   });
 
-  return subsrt.build(encodedCaptions, { format: "vtt" });
+  return subsrt.build(encodedCaptions, { format: 'vtt' });
 };

--- a/src/aws/lambda-convert/src/encodeTimedTextTrack.spec.js
+++ b/src/aws/lambda-convert/src/encodeTimedTextTrack.spec.js
@@ -1,10 +1,10 @@
-process.env.S3_DESTINATION_BUCKET = "destination_bucket";
+process.env.S3_DESTINATION_BUCKET = 'destination_bucket';
 
 // Mock the AWS SDK calls used in encodeTimedTextTrack
 const mockGetObject = jest.fn();
 const mockPutObject = jest.fn();
 const mockCopyObject = jest.fn();
-jest.mock("aws-sdk", () => ({
+jest.mock('aws-sdk', () => ({
   S3: function () {
     this.getObject = mockGetObject;
     this.putObject = mockPutObject;
@@ -13,27 +13,27 @@ jest.mock("aws-sdk", () => ({
 }));
 
 const mockUpdateState = jest.fn();
-jest.doMock("update-state", () => mockUpdateState);
+jest.doMock('update-state', () => mockUpdateState);
 
-const encodeTimedTextTrack = require("./encodeTimedTextTrack");
+const encodeTimedTextTrack = require('./encodeTimedTextTrack');
 
-describe("lambda-convert/src/encodeTimedTextTrack", () => {
+describe('lambda-convert/src/encodeTimedTextTrack', () => {
   beforeEach(() => {
     mockGetObject.mockReset();
     mockPutObject.mockReset();
     mockCopyObject.mockReset();
   });
 
-  const eol = "\r\n";
+  const eol = '\r\n';
   const rawSubstitles = `1${eol}00:00:17,000 --> 00:00:19,000${eol}<script>alert("foo");</script>${eol}${eol}2${eol}00:00:19,750 --> 00:00:23,500${eol}doit être placé entre &lt;script&gt; et &lt;/script&gt;`;
 
-  it("reads the source transcript, parses it, encodes it and then builds it in VTT and writes it to destination", async () => {
+  it('reads the source transcript, parses it, encodes it and then builds it in VTT and writes it to destination', async () => {
     const expectedEncodedSubtitles = `WEBVTT${eol}${eol}1${eol}00:00:17.000 --> 00:00:19.000${eol}&lt;script&gt;alert(&quot;foo&quot;);&lt;/script&gt;${eol}${eol}2${eol}00:00:19.750 --> 00:00:23.500${eol}doit être placé entre &lt;script&gt; et &lt;/script&gt;${eol}${eol}`;
 
     mockGetObject.mockReturnValue({
       promise: () =>
         new Promise((resolve) =>
-          resolve({ Body: { toString: () => rawSubstitles } })
+          resolve({ Body: { toString: () => rawSubstitles } }),
         ),
     });
     mockPutObject.mockReturnValue({
@@ -44,42 +44,42 @@ describe("lambda-convert/src/encodeTimedTextTrack", () => {
     });
 
     await encodeTimedTextTrack(
-      "a3e213a7-9c56-4bd3-b71c-fe567b0cfeb9/timedtexttrack/91d397b2-ea37-451c-8d76-8d2f1dd20e4b/1605887889_fr_ts",
-      "source_bucket",
-      "1605887889_fr_ts"
+      'a3e213a7-9c56-4bd3-b71c-fe567b0cfeb9/timedtexttrack/91d397b2-ea37-451c-8d76-8d2f1dd20e4b/1605887889_fr_ts',
+      'source_bucket',
+      '1605887889_fr_ts',
     );
 
     expect(mockGetObject).toHaveBeenCalledWith({
-      Bucket: "source_bucket",
-      Key: "a3e213a7-9c56-4bd3-b71c-fe567b0cfeb9/timedtexttrack/91d397b2-ea37-451c-8d76-8d2f1dd20e4b/1605887889_fr_ts",
+      Bucket: 'source_bucket',
+      Key: 'a3e213a7-9c56-4bd3-b71c-fe567b0cfeb9/timedtexttrack/91d397b2-ea37-451c-8d76-8d2f1dd20e4b/1605887889_fr_ts',
     });
     expect(mockPutObject).toHaveBeenCalledWith({
       Body: expectedEncodedSubtitles,
-      Bucket: "destination_bucket",
-      ContentType: "text/vtt",
-      Key: "a3e213a7-9c56-4bd3-b71c-fe567b0cfeb9/timedtext/1605887889_fr_ts.vtt",
+      Bucket: 'destination_bucket',
+      ContentType: 'text/vtt',
+      Key: 'a3e213a7-9c56-4bd3-b71c-fe567b0cfeb9/timedtext/1605887889_fr_ts.vtt',
     });
     expect(mockCopyObject).toHaveBeenCalledWith({
-      Bucket: "destination_bucket",
-      Key: "a3e213a7-9c56-4bd3-b71c-fe567b0cfeb9/timedtext/source/1605887889_fr_ts",
+      Bucket: 'destination_bucket',
+      Key: 'a3e213a7-9c56-4bd3-b71c-fe567b0cfeb9/timedtext/source/1605887889_fr_ts',
       CopySource:
-        "source_bucket/a3e213a7-9c56-4bd3-b71c-fe567b0cfeb9/timedtexttrack/91d397b2-ea37-451c-8d76-8d2f1dd20e4b/1605887889_fr_ts",
+        'source_bucket/a3e213a7-9c56-4bd3-b71c-fe567b0cfeb9/timedtexttrack/91d397b2-ea37-451c-8d76-8d2f1dd20e4b/1605887889_fr_ts',
     });
 
     expect(mockUpdateState).toHaveBeenCalledWith(
-      "a3e213a7-9c56-4bd3-b71c-fe567b0cfeb9/timedtexttrack/91d397b2-ea37-451c-8d76-8d2f1dd20e4b/1605887889_fr_ts",
-      "ready",
-      { extension: "srt" }
+      'a3e213a7-9c56-4bd3-b71c-fe567b0cfeb9/timedtexttrack/91d397b2-ea37-451c-8d76-8d2f1dd20e4b/1605887889_fr_ts',
+      'ready',
+      { extension: 'srt' },
     );
   });
 
-  it("timed text tracks without known mode should be encoded", async () => {
+  it('timed text tracks without known mode should be encoded', async () => {
     const expectedEncodedSubtitles = `WEBVTT${eol}${eol}1${eol}00:00:17.000 --> 00:00:19.000${eol}&lt;script&gt;alert(&quot;foo&quot;);&lt;/script&gt;${eol}${eol}2${eol}00:00:19.750 --> 00:00:23.500${eol}doit être placé entre &lt;script&gt; et &lt;/script&gt;${eol}${eol}`;
 
     mockGetObject.mockReturnValue({
       promise: () =>
         new Promise((resolve) =>
-          resolve({ Body: { toString: () => rawSubstitles } })
+          resolve({ Body: { toString: () => rawSubstitles } }),
         ),
     });
     mockPutObject.mockReturnValue({
@@ -90,42 +90,42 @@ describe("lambda-convert/src/encodeTimedTextTrack", () => {
     });
 
     await encodeTimedTextTrack(
-      "a3e213a7-9c56-4bd3-b71c-fe567b0cfeb9/timedtexttrack/91d397b2-ea37-451c-8d76-8d2f1dd20e4b/1605887889_fr",
-      "source_bucket",
-      "1605887889_fr"
+      'a3e213a7-9c56-4bd3-b71c-fe567b0cfeb9/timedtexttrack/91d397b2-ea37-451c-8d76-8d2f1dd20e4b/1605887889_fr',
+      'source_bucket',
+      '1605887889_fr',
     );
 
     expect(mockGetObject).toHaveBeenCalledWith({
-      Bucket: "source_bucket",
-      Key: "a3e213a7-9c56-4bd3-b71c-fe567b0cfeb9/timedtexttrack/91d397b2-ea37-451c-8d76-8d2f1dd20e4b/1605887889_fr",
+      Bucket: 'source_bucket',
+      Key: 'a3e213a7-9c56-4bd3-b71c-fe567b0cfeb9/timedtexttrack/91d397b2-ea37-451c-8d76-8d2f1dd20e4b/1605887889_fr',
     });
     expect(mockPutObject).toHaveBeenCalledWith({
       Body: expectedEncodedSubtitles,
-      Bucket: "destination_bucket",
-      ContentType: "text/vtt",
-      Key: "a3e213a7-9c56-4bd3-b71c-fe567b0cfeb9/timedtext/1605887889_fr.vtt",
+      Bucket: 'destination_bucket',
+      ContentType: 'text/vtt',
+      Key: 'a3e213a7-9c56-4bd3-b71c-fe567b0cfeb9/timedtext/1605887889_fr.vtt',
     });
     expect(mockCopyObject).toHaveBeenCalledWith({
-      Bucket: "destination_bucket",
-      Key: "a3e213a7-9c56-4bd3-b71c-fe567b0cfeb9/timedtext/source/1605887889_fr",
+      Bucket: 'destination_bucket',
+      Key: 'a3e213a7-9c56-4bd3-b71c-fe567b0cfeb9/timedtext/source/1605887889_fr',
       CopySource:
-        "source_bucket/a3e213a7-9c56-4bd3-b71c-fe567b0cfeb9/timedtexttrack/91d397b2-ea37-451c-8d76-8d2f1dd20e4b/1605887889_fr",
+        'source_bucket/a3e213a7-9c56-4bd3-b71c-fe567b0cfeb9/timedtexttrack/91d397b2-ea37-451c-8d76-8d2f1dd20e4b/1605887889_fr',
     });
 
     expect(mockUpdateState).toHaveBeenCalledWith(
-      "a3e213a7-9c56-4bd3-b71c-fe567b0cfeb9/timedtexttrack/91d397b2-ea37-451c-8d76-8d2f1dd20e4b/1605887889_fr",
-      "ready",
-      { extension: "srt" }
+      'a3e213a7-9c56-4bd3-b71c-fe567b0cfeb9/timedtexttrack/91d397b2-ea37-451c-8d76-8d2f1dd20e4b/1605887889_fr',
+      'ready',
+      { extension: 'srt' },
     );
   });
 
-  it("reads the source timed text, converts it without escaping to VTT and writes it to destination", async () => {
+  it('reads the source timed text, converts it without escaping to VTT and writes it to destination', async () => {
     const expectedEncodedSubtitles = `WEBVTT${eol}${eol}1${eol}00:00:17.000 --> 00:00:19.000${eol}alert("foo");${eol}${eol}2${eol}00:00:19.750 --> 00:00:23.500${eol}doit être placé entre &lt;script&gt; et &lt;/script&gt;${eol}${eol}`;
 
     mockGetObject.mockReturnValue({
       promise: () =>
         new Promise((resolve) =>
-          resolve({ Body: { toString: () => rawSubstitles } })
+          resolve({ Body: { toString: () => rawSubstitles } }),
         ),
     });
     mockPutObject.mockReturnValue({
@@ -136,89 +136,89 @@ describe("lambda-convert/src/encodeTimedTextTrack", () => {
     });
 
     await encodeTimedTextTrack(
-      "a3e213a7-9c56-4bd3-b71c-fe567b0cfeb9/timedtexttrack/91d397b2-ea37-451c-8d76-8d2f1dd20e4b/1605887889_fr_st",
-      "source_bucket",
-      "1605887889_fr_st"
+      'a3e213a7-9c56-4bd3-b71c-fe567b0cfeb9/timedtexttrack/91d397b2-ea37-451c-8d76-8d2f1dd20e4b/1605887889_fr_st',
+      'source_bucket',
+      '1605887889_fr_st',
     );
 
     expect(mockGetObject).toHaveBeenCalledWith({
-      Bucket: "source_bucket",
-      Key: "a3e213a7-9c56-4bd3-b71c-fe567b0cfeb9/timedtexttrack/91d397b2-ea37-451c-8d76-8d2f1dd20e4b/1605887889_fr_st",
+      Bucket: 'source_bucket',
+      Key: 'a3e213a7-9c56-4bd3-b71c-fe567b0cfeb9/timedtexttrack/91d397b2-ea37-451c-8d76-8d2f1dd20e4b/1605887889_fr_st',
     });
     expect(mockPutObject).toHaveBeenCalledWith({
       Body: expectedEncodedSubtitles,
-      Bucket: "destination_bucket",
-      ContentType: "text/vtt",
-      Key: "a3e213a7-9c56-4bd3-b71c-fe567b0cfeb9/timedtext/1605887889_fr_st.vtt",
+      Bucket: 'destination_bucket',
+      ContentType: 'text/vtt',
+      Key: 'a3e213a7-9c56-4bd3-b71c-fe567b0cfeb9/timedtext/1605887889_fr_st.vtt',
     });
     expect(mockCopyObject).toHaveBeenCalledWith({
-      Bucket: "destination_bucket",
-      Key: "a3e213a7-9c56-4bd3-b71c-fe567b0cfeb9/timedtext/source/1605887889_fr_st",
+      Bucket: 'destination_bucket',
+      Key: 'a3e213a7-9c56-4bd3-b71c-fe567b0cfeb9/timedtext/source/1605887889_fr_st',
       CopySource:
-        "source_bucket/a3e213a7-9c56-4bd3-b71c-fe567b0cfeb9/timedtexttrack/91d397b2-ea37-451c-8d76-8d2f1dd20e4b/1605887889_fr_st",
+        'source_bucket/a3e213a7-9c56-4bd3-b71c-fe567b0cfeb9/timedtexttrack/91d397b2-ea37-451c-8d76-8d2f1dd20e4b/1605887889_fr_st',
     });
 
     expect(mockUpdateState).toHaveBeenCalledWith(
-      "a3e213a7-9c56-4bd3-b71c-fe567b0cfeb9/timedtexttrack/91d397b2-ea37-451c-8d76-8d2f1dd20e4b/1605887889_fr",
-      "ready",
-      { extension: "srt" }
+      'a3e213a7-9c56-4bd3-b71c-fe567b0cfeb9/timedtexttrack/91d397b2-ea37-451c-8d76-8d2f1dd20e4b/1605887889_fr',
+      'ready',
+      { extension: 'srt' },
     );
   });
 
-  it("throws when it fails to convert the source timed text to VTT", async () => {
+  it('throws when it fails to convert the source timed text to VTT', async () => {
     mockGetObject.mockReturnValue({
       promise: () =>
         new Promise((resolve) =>
           // no subtitles handler support number.
-          resolve({ Body: { toString: () => 42 } })
+          resolve({ Body: { toString: () => 42 } }),
         ),
     });
 
     await encodeTimedTextTrack(
-      "a3e213a7-9c56-4bd3-b71c-fe567b0cfeb9/timedtexttrack/91d397b2-ea37-451c-8d76-8d2f1dd20e4b/1605887889_fr_st",
-      "source_bucket",
-      "1605887889_fr_st"
+      'a3e213a7-9c56-4bd3-b71c-fe567b0cfeb9/timedtexttrack/91d397b2-ea37-451c-8d76-8d2f1dd20e4b/1605887889_fr_st',
+      'source_bucket',
+      '1605887889_fr_st',
     );
 
     expect(mockUpdateState).toHaveBeenCalledWith(
-      "a3e213a7-9c56-4bd3-b71c-fe567b0cfeb9/timedtexttrack/91d397b2-ea37-451c-8d76-8d2f1dd20e4b/1605887889_fr_st",
-      "error",
+      'a3e213a7-9c56-4bd3-b71c-fe567b0cfeb9/timedtexttrack/91d397b2-ea37-451c-8d76-8d2f1dd20e4b/1605887889_fr_st',
+      'error',
     );
   });
 
-  it("throws when it fails to get the timed text file from the source bucket", async () => {
+  it('throws when it fails to get the timed text file from the source bucket', async () => {
     mockGetObject.mockReturnValue({
       promise: () =>
-        new Promise((resolve, reject) => reject(new Error("Failed!"))),
+        new Promise((resolve, reject) => reject(new Error('Failed!'))),
     });
 
     await expect(
       encodeTimedTextTrack(
-        "a3e213a7-9c56-4bd3-b71c-fe567b0cfeb9/timedtexttrack/91d397b2-ea37-451c-8d76-8d2f1dd20e4b/1605887889_fr_st",
-        "source_bucket",
-        "1605887889_fr_st"
-      )
-    ).rejects.toEqual(new Error("Failed!"));
+        'a3e213a7-9c56-4bd3-b71c-fe567b0cfeb9/timedtexttrack/91d397b2-ea37-451c-8d76-8d2f1dd20e4b/1605887889_fr_st',
+        'source_bucket',
+        '1605887889_fr_st',
+      ),
+    ).rejects.toEqual(new Error('Failed!'));
   });
 
-  it("throws when it fails to put the timed text file to the destination bucket", async () => {
+  it('throws when it fails to put the timed text file to the destination bucket', async () => {
     mockGetObject.mockReturnValue({
       promise: () =>
         new Promise((resolve) =>
-          resolve({ Body: { toString: () => rawSubstitles } })
+          resolve({ Body: { toString: () => rawSubstitles } }),
         ),
     });
     mockPutObject.mockReturnValue({
       promise: () =>
-        new Promise((resolve, reject) => reject(new Error("Failed!"))),
+        new Promise((resolve, reject) => reject(new Error('Failed!'))),
     });
 
     await expect(
       encodeTimedTextTrack(
-        "a3e213a7-9c56-4bd3-b71c-fe567b0cfeb9/timedtexttrack/91d397b2-ea37-451c-8d76-8d2f1dd20e4b/1605887889_fr_st",
-        "source_bucket",
-        "1605887889_fr_st"
-      )
-    ).rejects.toEqual(new Error("Failed!"));
+        'a3e213a7-9c56-4bd3-b71c-fe567b0cfeb9/timedtexttrack/91d397b2-ea37-451c-8d76-8d2f1dd20e4b/1605887889_fr_st',
+        'source_bucket',
+        '1605887889_fr_st',
+      ),
+    ).rejects.toEqual(new Error('Failed!'));
   });
 });

--- a/src/aws/lambda-convert/src/encodeTimedTextTrack.spec.js
+++ b/src/aws/lambda-convert/src/encodeTimedTextTrack.spec.js
@@ -12,6 +12,9 @@ jest.mock("aws-sdk", () => ({
   },
 }));
 
+const mockUpdateState = jest.fn();
+jest.doMock("update-state", () => mockUpdateState);
+
 const encodeTimedTextTrack = require("./encodeTimedTextTrack");
 
 describe("lambda-convert/src/encodeTimedTextTrack", () => {
@@ -40,13 +43,11 @@ describe("lambda-convert/src/encodeTimedTextTrack", () => {
       promise: () => new Promise((resolve) => resolve()),
     });
 
-    const extension = await encodeTimedTextTrack(
+    await encodeTimedTextTrack(
       "a3e213a7-9c56-4bd3-b71c-fe567b0cfeb9/timedtexttrack/91d397b2-ea37-451c-8d76-8d2f1dd20e4b/1605887889_fr_ts",
       "source_bucket",
       "1605887889_fr_ts"
     );
-
-    expect(extension).toEqual("srt");
 
     expect(mockGetObject).toHaveBeenCalledWith({
       Bucket: "source_bucket",
@@ -64,6 +65,12 @@ describe("lambda-convert/src/encodeTimedTextTrack", () => {
       CopySource:
         "source_bucket/a3e213a7-9c56-4bd3-b71c-fe567b0cfeb9/timedtexttrack/91d397b2-ea37-451c-8d76-8d2f1dd20e4b/1605887889_fr_ts",
     });
+
+    expect(mockUpdateState).toHaveBeenCalledWith(
+      "a3e213a7-9c56-4bd3-b71c-fe567b0cfeb9/timedtexttrack/91d397b2-ea37-451c-8d76-8d2f1dd20e4b/1605887889_fr_ts",
+      "ready",
+      { extension: "srt" }
+    );
   });
 
   it("timed text tracks without known mode should be encoded", async () => {
@@ -104,6 +111,12 @@ describe("lambda-convert/src/encodeTimedTextTrack", () => {
       CopySource:
         "source_bucket/a3e213a7-9c56-4bd3-b71c-fe567b0cfeb9/timedtexttrack/91d397b2-ea37-451c-8d76-8d2f1dd20e4b/1605887889_fr",
     });
+
+    expect(mockUpdateState).toHaveBeenCalledWith(
+      "a3e213a7-9c56-4bd3-b71c-fe567b0cfeb9/timedtexttrack/91d397b2-ea37-451c-8d76-8d2f1dd20e4b/1605887889_fr",
+      "ready",
+      { extension: "srt" }
+    );
   });
 
   it("reads the source timed text, converts it without escaping to VTT and writes it to destination", async () => {
@@ -144,6 +157,12 @@ describe("lambda-convert/src/encodeTimedTextTrack", () => {
       CopySource:
         "source_bucket/a3e213a7-9c56-4bd3-b71c-fe567b0cfeb9/timedtexttrack/91d397b2-ea37-451c-8d76-8d2f1dd20e4b/1605887889_fr_st",
     });
+
+    expect(mockUpdateState).toHaveBeenCalledWith(
+      "a3e213a7-9c56-4bd3-b71c-fe567b0cfeb9/timedtexttrack/91d397b2-ea37-451c-8d76-8d2f1dd20e4b/1605887889_fr",
+      "ready",
+      { extension: "srt" }
+    );
   });
 
   it("throws when it fails to convert the source timed text to VTT", async () => {
@@ -155,16 +174,15 @@ describe("lambda-convert/src/encodeTimedTextTrack", () => {
         ),
     });
 
-    await expect(
-      encodeTimedTextTrack(
-        "a3e213a7-9c56-4bd3-b71c-fe567b0cfeb9/timedtexttrack/91d397b2-ea37-451c-8d76-8d2f1dd20e4b/1605887889_fr_st",
-        "source_bucket",
-        "1605887889_fr_st"
-      )
-    ).rejects.toEqual(
-      new Error(
-        "Invalid timed text format for a3e213a7-9c56-4bd3-b71c-fe567b0cfeb9/timedtexttrack/91d397b2-ea37-451c-8d76-8d2f1dd20e4b/1605887889_fr_st."
-      )
+    await encodeTimedTextTrack(
+      "a3e213a7-9c56-4bd3-b71c-fe567b0cfeb9/timedtexttrack/91d397b2-ea37-451c-8d76-8d2f1dd20e4b/1605887889_fr_st",
+      "source_bucket",
+      "1605887889_fr_st"
+    );
+
+    expect(mockUpdateState).toHaveBeenCalledWith(
+      "a3e213a7-9c56-4bd3-b71c-fe567b0cfeb9/timedtexttrack/91d397b2-ea37-451c-8d76-8d2f1dd20e4b/1605887889_fr_st",
+      "error",
     );
   });
 

--- a/src/aws/lambda-convert/src/encodeVideo.js
+++ b/src/aws/lambda-convert/src/encodeVideo.js
@@ -1,9 +1,9 @@
-const AWS = require("aws-sdk");
-const util = require("util");
-const execFile = util.promisify(require("child_process").execFile);
-const framerateConverter = require("./utils/framerateConverter");
+const AWS = require('aws-sdk');
+const util = require('util');
+const execFile = util.promisify(require('child_process').execFile);
+const framerateConverter = require('./utils/framerateConverter');
 
-const s3 = new AWS.S3({ apiVersion: "2006-03-01", signatureVersion: "v4" });
+const s3 = new AWS.S3({ apiVersion: '2006-03-01', signatureVersion: 'v4' });
 
 /**
  * Build the appropriate parameters object using our presets and pass it along
@@ -15,15 +15,15 @@ module.exports = async (objectKey, sourceBucket) => {
   const envType = process.env.ENV_TYPE;
   const destinationBucket = process.env.S3_DESTINATION_BUCKET;
 
-  const signedUrl = await s3.getSignedUrlPromise("getObject", {
+  const signedUrl = await s3.getSignedUrlPromise('getObject', {
     Bucket: sourceBucket,
     Expires: 1200,
     Key: objectKey,
   });
 
-  const { stdout, stderr } = await execFile("mediainfo", [
-    "--full",
-    "--output=JSON",
+  const { stdout, stderr } = await execFile('mediainfo', [
+    '--full',
+    '--output=JSON',
     signedUrl,
   ]);
 
@@ -42,32 +42,32 @@ module.exports = async (objectKey, sourceBucket) => {
     const mediainfos = JSON.parse(stdout);
 
     const videoInfo = mediainfos.media.track.find(
-      (track) => track["@type"] === "Video"
+      (track) => track['@type'] === 'Video',
     );
     const audioInfo = mediainfos.media.track.find(
-      (track) => track["@type"] === "Audio"
+      (track) => track['@type'] === 'Audio',
     );
 
     if (videoInfo) {
-      if (videoInfo.hasOwnProperty("Height")) {
+      if (videoInfo.hasOwnProperty('Height')) {
         videoSizes = videoSizesDefinition.filter(
-          (size) => size <= videoInfo.Height
+          (size) => size <= videoInfo.Height,
         );
         if (videoSizes.length === 0) {
           videoSizes.push(videoSizesDefinition[0]);
         }
       }
 
-      if (videoInfo.hasOwnProperty("FrameRate")) {
+      if (videoInfo.hasOwnProperty('FrameRate')) {
         const convertedFramerate = framerateConverter(videoInfo.FrameRate);
         framerateSettings.FramerateDenominator = convertedFramerate.denominator;
         framerateSettings.FramerateNumerator = convertedFramerate.numerator;
       }
     }
 
-    if (audioInfo && audioInfo.hasOwnProperty("BitRate")) {
+    if (audioInfo && audioInfo.hasOwnProperty('BitRate')) {
       audioBitrates = audioBitratesDefinition.filter(
-        (bitrate) => bitrate <= audioInfo.BitRate
+        (bitrate) => bitrate <= audioInfo.BitRate,
       );
       if (audioBitrates.length === 0) {
         audioBitrates.push(audioBitratesDefinition[0]);
@@ -85,19 +85,19 @@ module.exports = async (objectKey, sourceBucket) => {
       AdAvailOffset: 0,
       Inputs: [
         {
-          FilterEnable: "AUTO",
-          PsiControl: "USE_PSI",
+          FilterEnable: 'AUTO',
+          PsiControl: 'USE_PSI',
           FilterStrength: 0,
-          DeblockFilter: "DISABLED",
-          DenoiseFilter: "DISABLED",
-          TimecodeSource: "EMBEDDED",
+          DeblockFilter: 'DISABLED',
+          DenoiseFilter: 'DISABLED',
+          TimecodeSource: 'EMBEDDED',
           VideoSelector: {
-            ColorSpace: "FOLLOW",
+            ColorSpace: 'FOLLOW',
           },
           AudioSelectors: {
-            "Audio Selector 1": {
+            'Audio Selector 1': {
               Offset: 0,
-              DefaultSelection: "DEFAULT",
+              DefaultSelection: 'DEFAULT',
               ProgramSelection: 1,
             },
           },
@@ -106,14 +106,14 @@ module.exports = async (objectKey, sourceBucket) => {
       ],
       OutputGroups: [
         {
-          CustomName: "Video MP4 outputs",
-          Name: "File Group",
+          CustomName: 'Video MP4 outputs',
+          Name: 'File Group',
           OutputGroupSettings: {
-            Type: "FILE_GROUP_SETTINGS",
+            Type: 'FILE_GROUP_SETTINGS',
             FileGroupSettings: {
               Destination: `s3://${destinationBucket}/${objectKey.replace(
                 /\/video\/.*\//,
-                "/mp4/"
+                '/mp4/',
               )}`,
             },
           },
@@ -131,19 +131,19 @@ module.exports = async (objectKey, sourceBucket) => {
           })),
         },
         {
-          CustomName: "Video CMAF outputs",
-          Name: "CMAF",
+          CustomName: 'Video CMAF outputs',
+          Name: 'CMAF',
           OutputGroupSettings: {
-            Type: "CMAF_GROUP_SETTINGS",
+            Type: 'CMAF_GROUP_SETTINGS',
             CmafGroupSettings: {
-              WriteDashManifest: "ENABLED",
-              WriteHlsManifest: "ENABLED",
+              WriteDashManifest: 'ENABLED',
+              WriteHlsManifest: 'ENABLED',
               FragmentLength: 2,
               SegmentLength: 14,
-              SegmentControl: "SEGMENTED_FILES",
+              SegmentControl: 'SEGMENTED_FILES',
               Destination: `s3://${destinationBucket}/${objectKey.replace(
                 /\/video\/.*\//,
-                "/cmaf/"
+                '/cmaf/',
               )}`,
             },
           },
@@ -172,14 +172,14 @@ module.exports = async (objectKey, sourceBucket) => {
           ],
         },
         {
-          CustomName: "Thumbnails outputs",
-          Name: "File Group",
+          CustomName: 'Thumbnails outputs',
+          Name: 'File Group',
           OutputGroupSettings: {
-            Type: "FILE_GROUP_SETTINGS",
+            Type: 'FILE_GROUP_SETTINGS',
             FileGroupSettings: {
               Destination: `s3://${destinationBucket}/${objectKey.replace(
                 /\/video\/.*\//,
-                "/thumbnails/"
+                '/thumbnails/',
               )}`,
             },
           },
@@ -189,21 +189,21 @@ module.exports = async (objectKey, sourceBucket) => {
           })),
         },
         {
-          CustomName: "Previews outputs",
-          Name: "File Group",
+          CustomName: 'Previews outputs',
+          Name: 'File Group',
           OutputGroupSettings: {
-            Type: "FILE_GROUP_SETTINGS",
+            Type: 'FILE_GROUP_SETTINGS',
             FileGroupSettings: {
               Destination: `s3://${destinationBucket}/${objectKey.replace(
                 /\/video\/.*\//,
-                "/previews/"
+                '/previews/',
               )}`,
             },
           },
           Outputs: [
             {
               Preset: `${envType}_marsha_preview_jpeg_100`,
-              NameModifier: "_100",
+              NameModifier: '_100',
             },
           ],
         },

--- a/src/aws/lambda-convert/src/resizeThumbnails.js
+++ b/src/aws/lambda-convert/src/resizeThumbnails.js
@@ -1,6 +1,6 @@
-const AWS = require("aws-sdk");
-const s3 = new AWS.S3({ apiVersion: "2006-03-01" });
-const Jimp = require("jimp");
+const AWS = require('aws-sdk');
+const s3 = new AWS.S3({ apiVersion: '2006-03-01' });
+const Jimp = require('jimp');
 
 module.exports = async (objectKey, sourceBucket) => {
   const destinationBucket = process.env.S3_DESTINATION_BUCKET;
@@ -16,7 +16,7 @@ module.exports = async (objectKey, sourceBucket) => {
     const jimpInstance = await Jimp.read(sourceImage.Body);
     const resizedImage = jimpInstance.resize(Jimp.AUTO, size);
 
-    const parts = objectKey.split("/");
+    const parts = objectKey.split('/');
     await s3
       .putObject({
         Body: await resizedImage.getBufferAsync(Jimp.MIME_JPEG),

--- a/src/aws/lambda-convert/src/resizeThumbnails.spec.js
+++ b/src/aws/lambda-convert/src/resizeThumbnails.spec.js
@@ -1,12 +1,12 @@
-process.env.S3_DESTINATION_BUCKET = "destination bucket";
+process.env.S3_DESTINATION_BUCKET = 'destination bucket';
 
 // Don't pollute tests with logs intended for CloudWatch
-jest.spyOn(console, "log");
+jest.spyOn(console, 'log');
 
 // Mock the AWS SDK calls used in encodeTimedTextTrack
 const mockGetObject = jest.fn();
 const mockPutObject = jest.fn();
-jest.mock("aws-sdk", () => ({
+jest.mock('aws-sdk', () => ({
   S3: function () {
     this.getObject = mockGetObject;
     this.putObject = mockPutObject;
@@ -17,21 +17,21 @@ const mockGetBufferAsync = jest.fn();
 const mockResize = jest.fn();
 const mockRead = jest.fn();
 
-jest.mock("jimp", () => ({
+jest.mock('jimp', () => ({
   read: mockRead,
 }));
 
-const resizeThumbnails = require("./resizeThumbnails");
+const resizeThumbnails = require('./resizeThumbnails');
 
-describe("lambda-convert/src/resizeThumbnails", () => {
+describe('lambda-convert/src/resizeThumbnails', () => {
   beforeEach(() => {
     console.log.mockReset();
     jest.resetAllMocks();
   });
-  it("resizes uploaded image", async () => {
+  it('resizes uploaded image', async () => {
     mockGetObject.mockReturnValue({
       promise: () =>
-        new Promise((resolve) => resolve({ Body: "input timed text" })),
+        new Promise((resolve) => resolve({ Body: 'input timed text' })),
     });
     mockPutObject.mockReturnValue({
       promise: () => new Promise((resolve) => resolve()),
@@ -39,14 +39,14 @@ describe("lambda-convert/src/resizeThumbnails", () => {
     mockRead.mockReturnValue(
       Promise.resolve({
         resize: mockResize,
-      })
+      }),
     );
-    mockGetBufferAsync.mockReturnValue(Promise.resolve("resized_image"));
+    mockGetBufferAsync.mockReturnValue(Promise.resolve('resized_image'));
     mockResize.mockReturnValue({
       getBufferAsync: mockGetBufferAsync,
     });
 
-    await resizeThumbnails("foo/thumbnail/bar/baz", "source bucket");
+    await resizeThumbnails('foo/thumbnail/bar/baz', 'source bucket');
 
     expect(mockResize).toHaveBeenCalledTimes(5);
     expect(mockGetBufferAsync).toHaveBeenCalledTimes(5);

--- a/src/aws/lambda-convert/src/scanDepositedFile.js
+++ b/src/aws/lambda-convert/src/scanDepositedFile.js
@@ -1,26 +1,26 @@
 // Copy a document from a source to a destination bucket
-const AWS = require("aws-sdk");
-const { writeFileSync } = require("fs");
-const NodeClam = require("clamscan");
+const AWS = require('aws-sdk');
+const { writeFileSync } = require('fs');
+const NodeClam = require('clamscan');
 
-const updateState = require("update-state");
+const updateState = require('update-state');
 
-const s3 = new AWS.S3({ apiVersion: "2006-03-01" });
+const s3 = new AWS.S3({ apiVersion: '2006-03-01' });
 
-const COPYING = "copying";
-const ERROR = "error";
-const INFECTED = "infected";
-const READY = "ready";
-const SCANNING = "scanning";
+const COPYING = 'copying';
+const ERROR = 'error';
+const INFECTED = 'infected';
+const READY = 'ready';
+const SCANNING = 'scanning';
 
 module.exports = async (objectKey, sourceBucket) => {
   const destinationBucket = process.env.S3_DESTINATION_BUCKET;
 
-  const parts = objectKey.split("/");
+  const parts = objectKey.split('/');
   const fileDepositId = parts[0];
   const depositedFileId = parts[2];
   const depositedFilename = parts[3];
-  const extension = depositedFilename.split(".")[1] || null;
+  const extension = depositedFilename.split('.')[1] || null;
 
   console.log(`Scanning depositedfile ${objectKey} for viruses.`);
 
@@ -36,10 +36,10 @@ module.exports = async (objectKey, sourceBucket) => {
     // Get instance by resolving ClamScan promise object
     const clamscan = await new NodeClam().init({
       debugMode: true,
-      preference: "clamscan",
+      preference: 'clamscan',
     });
     const { isInfected, file, viruses } = await clamscan.isInfected(
-      `/tmp/${depositedFilename}`
+      `/tmp/${depositedFilename}`,
     );
     if (isInfected) {
       console.log(`${file} is infected with ${viruses}!`);

--- a/src/aws/lambda-convert/src/scanDepositedFile.spec.js
+++ b/src/aws/lambda-convert/src/scanDepositedFile.spec.js
@@ -1,123 +1,125 @@
-process.env.S3_DESTINATION_BUCKET = "destination_bucket";
+process.env.S3_DESTINATION_BUCKET = 'destination_bucket';
 
 // Don't pollute tests with logs intended for CloudWatch
-jest.spyOn(console, "log");
+jest.spyOn(console, 'log');
 
 const mockUpdateState = jest.fn();
-jest.doMock("update-state", () => mockUpdateState);
+jest.doMock('update-state', () => mockUpdateState);
 
 // Mock the AWS SDK calls used in scanDepositedFile
 const mockGetObject = jest.fn();
 const mockCopyObject = jest.fn();
-jest.mock("aws-sdk", () => ({
+jest.mock('aws-sdk', () => ({
   S3: function () {
     this.copyObject = mockCopyObject;
     this.getObject = mockGetObject;
   },
 }));
 
-const fs = require("fs");
-const scanDepositedFile = require("./scanDepositedFile");
+const fs = require('fs');
+const scanDepositedFile = require('./scanDepositedFile');
 const testDirectory = `${__dirname}/../testfiles`;
 const cleanPdfFile = `${testDirectory}/sample.pdf`;
 const infectedPdfFile = `${testDirectory}/pdf-doc-vba-eicar-dropper.pdf`;
 
 const objectKeyWithoutExtension =
-  "630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/depositedfile/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1606230873";
+  '630dfaaa-8b1c-4d2e-b708-c9a2d715cf59/depositedfile/dba1512e-d0b3-40cc-ae44-722fbe8cba6a/1606230873';
 const objectKey = `${objectKeyWithoutExtension}.pdf`;
 
 jest.setTimeout(30000);
 
-describe("lambda-convert/src/scanDepositedFile", () => {
+describe('lambda-convert/src/scanDepositedFile', () => {
   beforeEach(() => {
     console.log.mockReset();
     jest.resetAllMocks();
   });
 
-  it("copy a clean deposited file from a source to a destination bucket", async () => {
+  it('copy a clean deposited file from a source to a destination bucket', async () => {
     mockGetObject.mockReturnValue({
       promise: () =>
         new Promise((resolve) =>
-          resolve({ Body: fs.readFileSync(cleanPdfFile) })
+          resolve({ Body: fs.readFileSync(cleanPdfFile) }),
         ),
     });
     mockCopyObject.mockReturnValue({
       promise: () => new Promise((resolve) => resolve()),
     });
 
-    await scanDepositedFile(objectKey, "source_bucket");
+    await scanDepositedFile(objectKey, 'source_bucket');
 
-    expect(mockUpdateState).toHaveBeenCalledWith(objectKey, "scanning");
+    expect(mockUpdateState).toHaveBeenCalledWith(objectKey, 'scanning');
 
-    expect(mockUpdateState).toHaveBeenCalledWith(objectKey, "copying");
+    expect(mockUpdateState).toHaveBeenCalledWith(objectKey, 'copying');
 
-    expect(mockUpdateState).toHaveBeenCalledWith(objectKey, "ready", {extension: "pdf"});
+    expect(mockUpdateState).toHaveBeenCalledWith(objectKey, 'ready', {
+      extension: 'pdf',
+    });
 
     expect(mockCopyObject).toHaveBeenCalledWith({
-      Bucket: "destination_bucket",
+      Bucket: 'destination_bucket',
       Key: objectKey,
       CopySource: `source_bucket/${objectKey}`,
     });
   });
 
-  it("copy a clean deposited file without extension from a source to a destination bucket", async () => {
+  it('copy a clean deposited file without extension from a source to a destination bucket', async () => {
     mockGetObject.mockReturnValue({
       promise: () =>
         new Promise((resolve) =>
-          resolve({ Body: fs.readFileSync(cleanPdfFile) })
+          resolve({ Body: fs.readFileSync(cleanPdfFile) }),
         ),
     });
     mockCopyObject.mockReturnValue({
       promise: () => new Promise((resolve) => resolve()),
     });
 
-    await scanDepositedFile(
+    await scanDepositedFile(objectKeyWithoutExtension, 'source_bucket');
+
+    expect(mockUpdateState).toHaveBeenCalledWith(
       objectKeyWithoutExtension,
-      "source_bucket"
+      'scanning',
     );
 
     expect(mockUpdateState).toHaveBeenCalledWith(
       objectKeyWithoutExtension,
-      "scanning"
+      'copying',
     );
 
     expect(mockUpdateState).toHaveBeenCalledWith(
       objectKeyWithoutExtension,
-      "copying"
+      'ready',
     );
-
-    expect(mockUpdateState).toHaveBeenCalledWith(objectKeyWithoutExtension, "ready");
 
     expect(mockCopyObject).toHaveBeenCalledWith({
-      Bucket: "destination_bucket",
+      Bucket: 'destination_bucket',
       Key: objectKeyWithoutExtension,
       CopySource: `source_bucket/${objectKeyWithoutExtension}`,
     });
   });
 
-  it("copy an infected deposited file from a source to a destination bucket", async () => {
+  it('copy an infected deposited file from a source to a destination bucket', async () => {
     mockGetObject.mockReturnValue({
       promise: () =>
         new Promise((resolve) =>
-          resolve({ Body: fs.readFileSync(infectedPdfFile) })
+          resolve({ Body: fs.readFileSync(infectedPdfFile) }),
         ),
     });
     mockCopyObject.mockReturnValue({
       promise: () => new Promise((resolve) => resolve()),
     });
 
-    await scanDepositedFile(objectKey, "source_bucket");
+    await scanDepositedFile(objectKey, 'source_bucket');
 
-    expect(mockUpdateState).toHaveBeenCalledWith(objectKey, "scanning");
+    expect(mockUpdateState).toHaveBeenCalledWith(objectKey, 'scanning');
 
-    expect(mockUpdateState).toHaveBeenCalledWith(objectKey, "infected", {
-      error: ["Doc.Dropper.Agent-1540415"],
+    expect(mockUpdateState).toHaveBeenCalledWith(objectKey, 'infected', {
+      error: ['Doc.Dropper.Agent-1540415'],
     });
 
-    expect(mockUpdateState).not.toHaveBeenCalledWith(objectKey, "copying");
+    expect(mockUpdateState).not.toHaveBeenCalledWith(objectKey, 'copying');
 
     expect(mockCopyObject).not.toHaveBeenCalledWith({
-      Bucket: "destination_bucket",
+      Bucket: 'destination_bucket',
       Key: objectKey,
       CopySource: `source_bucket/${objectKey}`,
     });

--- a/src/aws/lambda-convert/src/utils/framerateConverter.js
+++ b/src/aws/lambda-convert/src/utils/framerateConverter.js
@@ -1,7 +1,7 @@
 module.exports = (framerate) => {
   const roundedFramerate = Math.round(framerate);
   const denominator = Math.round(
-    ((1000 * roundedFramerate) / Math.round(framerate * 1000)) * 1000
+    ((1000 * roundedFramerate) / Math.round(framerate * 1000)) * 1000,
   );
   const numerator = 1000 * roundedFramerate;
 

--- a/src/aws/lambda-convert/src/utils/framerateConverter.spec.js
+++ b/src/aws/lambda-convert/src/utils/framerateConverter.spec.js
@@ -1,31 +1,31 @@
-const framerateConverter = require("./framerateConverter");
+const framerateConverter = require('./framerateConverter');
 
-describe("src/utils/framerateConverter", () => {
-  it("converts fps to denominator and numerator", () => {
+describe('src/utils/framerateConverter', () => {
+  it('converts fps to denominator and numerator', () => {
     const fpsMapping = [
       {
-        fps: "24",
+        fps: '24',
         expectedConverted: {
           numerator: 24000,
           denominator: 1000,
         },
       },
       {
-        fps: "25",
+        fps: '25',
         expectedConverted: {
           numerator: 25000,
           denominator: 1000,
         },
       },
       {
-        fps: "23.976",
+        fps: '23.976',
         expectedConverted: {
           numerator: 24000,
           denominator: 1001,
         },
       },
       {
-        fps: "29.970",
+        fps: '29.970',
         expectedConverted: {
           numerator: 30000,
           denominator: 1001,

--- a/src/aws/lambda-elemental-routing/src/mediapackage.spec.js
+++ b/src/aws/lambda-elemental-routing/src/mediapackage.spec.js
@@ -32,8 +32,7 @@ describe('mediapackage', () => {
       detail: {
         harvest_job: {
           id: 'test_762f3681-43dd-446c-81a0-29a6fb6edfe1_1609943219',
-          arn:
-            'arn:aws:mediapackage-vod:eu-west-1:aws_account_id:harvest_jobs/test_762f3681-43dd-446c-81a0-29a6fb6edfe1_1609943219',
+          arn: 'arn:aws:mediapackage-vod:eu-west-1:aws_account_id:harvest_jobs/test_762f3681-43dd-446c-81a0-29a6fb6edfe1_1609943219',
           status: 'COMPLETED',
           origin_endpoint_id: 'endpoint_id',
           start_time: '2019-06-26T20:30:00-08:00',

--- a/src/aws/lambda-mediapackage/index.spec.js
+++ b/src/aws/lambda-mediapackage/index.spec.js
@@ -60,8 +60,7 @@ describe('lambda mediapackage', () => {
       detail: {
         harvest_job: {
           id: 'harvest_job_id',
-          arn:
-            'arn:aws:mediapackage-vod:us-east-1:aws_account_id:harvest_jobs/harvest_job_id',
+          arn: 'arn:aws:mediapackage-vod:us-east-1:aws_account_id:harvest_jobs/harvest_job_id',
           status: 'SUCCEEDED',
           origin_endpoint_id: 'endpoint_id',
           start_time: '2019-06-26T20:30:00-08:00',

--- a/src/aws/lambda-mediapackage/src/check.spec.js
+++ b/src/aws/lambda-mediapackage/src/check.spec.js
@@ -74,8 +74,7 @@ describe('check', () => {
 
     expect(mockHeadObject).toHaveBeenCalledWith({
       Bucket: 'test-marsha-destination',
-      Key:
-        'a3e213a7-9c56-4bd3-b71c-fe567b0cfe19/mp4/a3e213a7-9c56-4bd3-b71c-fe567b0cfe19_540.mp4',
+      Key: 'a3e213a7-9c56-4bd3-b71c-fe567b0cfe19/mp4/a3e213a7-9c56-4bd3-b71c-fe567b0cfe19_540.mp4',
     });
 
     expect(mockSendRequest).not.toHaveBeenCalled();
@@ -127,23 +126,19 @@ describe('check', () => {
 
     expect(mockHeadObject).toHaveBeenCalledWith({
       Bucket: 'test-marsha-destination',
-      Key:
-        'a3e213a7-9c56-4bd3-b71c-fe567b0cfe19/mp4/a3e213a7-9c56-4bd3-b71c-fe567b0cfe19_540.mp4',
+      Key: 'a3e213a7-9c56-4bd3-b71c-fe567b0cfe19/mp4/a3e213a7-9c56-4bd3-b71c-fe567b0cfe19_540.mp4',
     });
     expect(mockHeadObject).toHaveBeenCalledWith({
       Bucket: 'test-marsha-destination',
-      Key:
-        'a3e213a7-9c56-4bd3-b71c-fe567b0cfe19/thumbnails/a3e213a7-9c56-4bd3-b71c-fe567b0cfe19_540.0000000.jpg',
+      Key: 'a3e213a7-9c56-4bd3-b71c-fe567b0cfe19/thumbnails/a3e213a7-9c56-4bd3-b71c-fe567b0cfe19_540.0000000.jpg',
     });
     expect(mockHeadObject).toHaveBeenCalledWith({
       Bucket: 'test-marsha-destination',
-      Key:
-        'a3e213a7-9c56-4bd3-b71c-fe567b0cfe19/mp4/a3e213a7-9c56-4bd3-b71c-fe567b0cfe19_720.mp4',
+      Key: 'a3e213a7-9c56-4bd3-b71c-fe567b0cfe19/mp4/a3e213a7-9c56-4bd3-b71c-fe567b0cfe19_720.mp4',
     });
     expect(mockHeadObject).toHaveBeenCalledWith({
       Bucket: 'test-marsha-destination',
-      Key:
-        'a3e213a7-9c56-4bd3-b71c-fe567b0cfe19/thumbnails/a3e213a7-9c56-4bd3-b71c-fe567b0cfe19_720.0000000.jpg',
+      Key: 'a3e213a7-9c56-4bd3-b71c-fe567b0cfe19/thumbnails/a3e213a7-9c56-4bd3-b71c-fe567b0cfe19_720.0000000.jpg',
     });
 
     const expectedBody = {

--- a/src/aws/lambda-mediapackage/src/harvest.spec.js
+++ b/src/aws/lambda-mediapackage/src/harvest.spec.js
@@ -75,8 +75,7 @@ describe('harvest', () => {
       detail: {
         harvest_job: {
           id: 'harvest_job_id',
-          arn:
-            'arn:aws:mediapackage-vod:eu-west-1:aws_account_id:harvest_jobs/harvest_job_id',
+          arn: 'arn:aws:mediapackage-vod:eu-west-1:aws_account_id:harvest_jobs/harvest_job_id',
           status: 'STARTING',
           origin_endpoint_id: 'endpoint_id',
           start_time: '2019-06-26T20:30:00-08:00',
@@ -110,8 +109,7 @@ describe('harvest', () => {
       detail: {
         harvest_job: {
           id: 'test_a3e213a7-9c56-4bd3-b71c-fe567b0cfe22_1610546271',
-          arn:
-            'arn:aws:mediapackage-vod:eu-west-1:aws_account_id:harvest_jobs/test_a3e213a7-9c56-4bd3-b71c-fe567b0cfe22_1610546271',
+          arn: 'arn:aws:mediapackage-vod:eu-west-1:aws_account_id:harvest_jobs/test_a3e213a7-9c56-4bd3-b71c-fe567b0cfe22_1610546271',
           status: 'SUCCEEDED',
           origin_endpoint_id:
             'test_a3e213a7-9c56-4bd3-b71c-fe567b0cfe22_1610546271_hls',

--- a/src/aws/lambda-mediapackage/src/utils/recordSlicesState/index.spec.js
+++ b/src/aws/lambda-mediapackage/src/utils/recordSlicesState/index.spec.js
@@ -77,9 +77,9 @@ describe('lambda/mediapackage/src/utils/recordSlicesState()', () => {
       () => new Promise((resolve, reject) => reject('Failed!')),
     );
 
-    await expect(
-      recordSlicesState('failed object key'),
-    ).rejects.toEqual('Failed!');
+    await expect(recordSlicesState('failed object key')).rejects.toEqual(
+      'Failed!',
+    );
 
     expect(requestStub).toHaveBeenCalledWith({
       body: {

--- a/src/aws/lambda-migrate/src/migrations/0001_encode_timed_text_tracks.spec.js
+++ b/src/aws/lambda-migrate/src/migrations/0001_encode_timed_text_tracks.spec.js
@@ -55,8 +55,7 @@ describe('0001_encode_timed_text_tracks', () => {
           {
             s3: {
               object: {
-                key:
-                  '80c43d43-4ed0-4695-ac64-8318f59d04ec/timedtexttrack/1_st_fr',
+                key: '80c43d43-4ed0-4695-ac64-8318f59d04ec/timedtexttrack/1_st_fr',
               },
               bucket: {
                 name: 'test-marsha-source',
@@ -73,8 +72,7 @@ describe('0001_encode_timed_text_tracks', () => {
           {
             s3: {
               object: {
-                key:
-                  '80c43d43-4ed0-4695-ac64-8318f59d04ec/timedtexttrack/2_st_en',
+                key: '80c43d43-4ed0-4695-ac64-8318f59d04ec/timedtexttrack/2_st_en',
               },
               bucket: {
                 name: 'test-marsha-source',
@@ -137,8 +135,7 @@ describe('0001_encode_timed_text_tracks', () => {
           {
             s3: {
               object: {
-                key:
-                  '80c43d43-4ed0-4695-ac64-8318f59d04ec/timedtexttrack/1_st_fr',
+                key: '80c43d43-4ed0-4695-ac64-8318f59d04ec/timedtexttrack/1_st_fr',
               },
               bucket: {
                 name: 'test-marsha-source',
@@ -155,8 +152,7 @@ describe('0001_encode_timed_text_tracks', () => {
           {
             s3: {
               object: {
-                key:
-                  '80c43d43-4ed0-4695-ac64-8318f59d04ec/timedtexttrack/2_st_en',
+                key: '80c43d43-4ed0-4695-ac64-8318f59d04ec/timedtexttrack/2_st_en',
               },
               bucket: {
                 name: 'test-marsha-source',
@@ -173,8 +169,7 @@ describe('0001_encode_timed_text_tracks', () => {
           {
             s3: {
               object: {
-                key:
-                  '80c43d43-4ed0-4695-ac64-8318f59d04ec/timedtexttrack/3_ts_fr',
+                key: '80c43d43-4ed0-4695-ac64-8318f59d04ec/timedtexttrack/3_ts_fr',
               },
               bucket: {
                 name: 'test-marsha-source',


### PR DESCRIPTION
## Purpose

When a timed text track format is not supported, we want to update the
state with an error and stop the lambda. There is no need to throw an
error and launch the retry lambda strategy.

Also, I added in this PR a fix about how lambda are linted. The usage or prettier was wrong.

## Proposal

- [x] update state with an error when TTT format is not supported 
- [x] fix usage of prettier with all lambda

Fixes #1700 

