### PR TITLE
🐛(front) use video title in creation wizard if it exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Fix deposit app translations
 - Fix video dashboard translations
 - Fix deposit app UI
+- Use video title in creation wizard if it exists
 
 ## [4.0.0-beta.8] - 2022-09-15
 

--- a/src/frontend/apps/lti_site/components/VideoWizard/CreateVOD/index.tsx
+++ b/src/frontend/apps/lti_site/components/VideoWizard/CreateVOD/index.tsx
@@ -79,7 +79,7 @@ const CreateVOD = ({ video }: CreateVODProps) => {
   const intl = useIntl();
   const size = useContext(ResponsiveContext);
   const [wizardedVideo, setWizardedVideo] = useState<WizardedVideo>({
-    title: null,
+    title: currentVideo.title,
     videoFile: null,
     license: null,
   });


### PR DESCRIPTION
## Purpose

When the video title is already set and we are in the VOD creation wizard this existing title should be set in the textbox. This specific case occurs when the video is not created with a classic LTI request but in the LTI select process.

## Proposal

- [x] use video title in creation wizard if it exists

Fixes #1713 

