### PR TITLE
♻️(front) remove refetch interval for markdown select-content tab

### DIFF
--- a/src/frontend/apps/lti_site/apps/markdown/components/SelectContentTab/index.tsx
+++ b/src/frontend/apps/lti_site/apps/markdown/components/SelectContentTab/index.tsx
@@ -238,7 +238,7 @@ const SelectContentTab = ({
   const {
     data: selectMarkdownDocument,
     status: useSelectMarkdownDocumentStatus,
-  } = useSelectMarkdownDocument({ refetchInterval: 10000 }); // refresh every 10 s
+  } = useSelectMarkdownDocument();
 
   const useCreateMarkdownDocumentMutation = useCreateMarkdownDocument({
     onSuccess: (markdownDocument) =>


### PR DESCRIPTION
## Purpose

In the markdown select content tab, the data was refreshed every 10 seconds. This is not necessary. React-query will already refetch the data when the user will switch between tabs.

## Proposal

- [x] remove refetch interval for markdown select-content tab

