### PR TITLE
♻️(frontend) use redirect on load for apps

### DIFF
--- a/bin/generate_frontend_lti_app
+++ b/bin/generate_frontend_lti_app
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-docker-compose run --rm -w /app/src/frontend/apps app cookiecutter .cookiecutter/ "$@"
+docker-compose run --rm -w /app/src/frontend/apps/lti_site/apps app cookiecutter .cookiecutter/ "$@"

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -420,7 +420,7 @@ flag [ASSIGNMENTS]:
 
 Don't forget to configure assignments in core:
 
-src/frontend/types/AppData.ts
+src/frontend/apps/lti_site/types/AppData.ts
     export enum appNames {
       […]
 +     ASSIGNMENTS = 'assignments',
@@ -433,7 +433,7 @@ src/frontend/types/AppData.ts
       […]
     }
 
-src/frontend/data/appConfigs.ts
+src/frontend/apps/lti_site/data/appConfigs.ts
     export const appConfigs: { [key in appNames]?: { flag?: flags } } = {
       […]
 +     [appNames.ASSIGNMENTS]: { flag: flags.ASSIGNMENTS },
@@ -445,7 +445,7 @@ src/frontend/data/appConfigs.ts
 The generated app will be available in the `src/frontend/apps` directory. 
 
 ```
-src/frontend/apps/assignments/
+src/frontend/apps/lti_site/apps/assignments/
 ├── DashboardSubmission
 │   ├── index.spec.tsx
 │   └── index.tsx

--- a/src/frontend/apps/lti_site/apps/.cookiecutter/hooks/post_gen_project.sh
+++ b/src/frontend/apps/lti_site/apps/.cookiecutter/hooks/post_gen_project.sh
@@ -5,7 +5,7 @@ chown -R 1000:1000 .
 echo -e "\n\e[34mDon't forget to configure {{ cookiecutter.app_name }} in core:\e[0m"
 cat << EOF
 
-src/frontend/types/AppData.ts
+src/frontend/apps/lti_site/types/AppData.ts
     export enum appNames {
       […]
 +     {{ cookiecutter.flag }} = '{{ cookiecutter.app_name }}',
@@ -18,7 +18,7 @@ src/frontend/types/AppData.ts
       […]
     }
 
-src/frontend/data/appConfigs.ts
+src/frontend/apps/lti_site/data/appConfigs.ts
     export const appConfigs: { [key in appNames]?: { flag?: flags } } = {
       […]
 +     [appNames.{{ cookiecutter.flag }}]: { flag: flags.{{ cookiecutter.flag }} },

--- a/src/frontend/apps/lti_site/apps/.cookiecutter/{{cookiecutter.app_name}}/components/Dashboard{{cookiecutter.model}}/index.tsx
+++ b/src/frontend/apps/lti_site/apps/.cookiecutter/{{cookiecutter.app_name}}/components/Dashboard{{cookiecutter.model}}/index.tsx
@@ -2,8 +2,7 @@ import { Box, Spinner, Text, ThemeContext, ThemeType } from 'grommet';
 import React, { Suspense, useRef } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 
-import { useJwt } from 'lib-components';
-import { Loader } from 'components/Loader';
+import { Loader, useJwt } from 'lib-components';
 
 import { {{cookiecutter.app_name}}AppData } from 'apps/{{cookiecutter.app_name}}/data/{{cookiecutter.app_name}}AppData';
 import { use{{cookiecutter.model}} } from 'apps/{{cookiecutter.app_name}}/data/queries';

--- a/src/frontend/apps/lti_site/apps/.cookiecutter/{{cookiecutter.app_name}}/components/Dashboard{{cookiecutter.model}}/route.ts
+++ b/src/frontend/apps/lti_site/apps/.cookiecutter/{{cookiecutter.app_name}}/components/Dashboard{{cookiecutter.model}}/route.ts
@@ -1,0 +1,4 @@
+/**
+ * Route for the `<Dashboard{{cookiecutter.model}} />` component.
+ */
+export const DASHBOARD_{{ cookiecutter.app_name|upper }}_ROUTE = () => '/dashboard/{{cookiecutter.model}}';

--- a/src/frontend/apps/lti_site/apps/.cookiecutter/{{cookiecutter.app_name}}/components/RedirectOnLoad/index.spec.tsx
+++ b/src/frontend/apps/lti_site/apps/.cookiecutter/{{cookiecutter.app_name}}/components/RedirectOnLoad/index.spec.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+
+import { FULL_SCREEN_ERROR_ROUTE } from 'components/ErrorComponents/route';
+import { useAppConfig } from 'data/stores/useAppConfig';
+import { appState } from 'types/AppData';
+import render from 'utils/tests/render';
+
+import { RedirectOnLoad } from '.';
+import { DASHBOARD_{{ cookiecutter.app_name|upper }}_ROUTE } from '../Dashboard{{cookiecutter.model}}/route';
+
+jest.mock('data/stores/useAppConfig', () => ({
+  useAppConfig: jest.fn(),
+}));
+const mockedUseAppConfig = useAppConfig as jest.MockedFunction<
+  typeof useAppConfig
+>;
+
+describe('<RedirectOnLoad />', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('redirects users to the error view on LTI error', () => {
+    mockedUseAppConfig.mockReturnValue({
+      state: appState.ERROR,
+      flags: { {{ cookiecutter.app_name }}: true },
+    } as any);
+
+    const { getByText } = render(<RedirectOnLoad />, {
+      routerOptions: {
+        routes: [
+          {
+            path: FULL_SCREEN_ERROR_ROUTE(),
+            render: ({ match }) => (
+              <span>{`Error Component: ${match.params.code}`}</span>
+            ),
+          },
+        ],
+      },
+    });
+
+    getByText('Error Component: lti');
+  });
+
+  it('shows not found error when feature is disabled', () => {
+    mockedUseAppConfig.mockReturnValue({
+      flags: { {{ cookiecutter.app_name }}: false },
+    } as any);
+
+    const { getByText } = render(<RedirectOnLoad />, {
+      routerOptions: {
+        routes: [
+          {
+            path: FULL_SCREEN_ERROR_ROUTE(),
+            render: ({ match }) => (
+              <span>{`Error Component: ${match.params.code}`}</span>
+            ),
+          },
+        ],
+      },
+    });
+
+    getByText('Error Component: notFound');
+  });
+
+  it('shows dashboard', async () => {
+    mockedUseAppConfig.mockReturnValue({
+      flags: { {{ cookiecutter.app_name }}: true },
+    } as any);
+
+    const { getByText } = render(<RedirectOnLoad />, {
+      routerOptions: {
+        routes: [
+          {
+            path: DASHBOARD_{{ cookiecutter.app_name|upper }}_ROUTE(),
+            render: () => <span>Dashboard</span>,
+          },
+        ],
+      },
+    });
+
+    getByText('Dashboard');
+  });
+});

--- a/src/frontend/apps/lti_site/apps/.cookiecutter/{{cookiecutter.app_name}}/components/RedirectOnLoad/index.tsx
+++ b/src/frontend/apps/lti_site/apps/.cookiecutter/{{cookiecutter.app_name}}/components/RedirectOnLoad/index.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { Redirect } from 'react-router-dom';
+
+import { FULL_SCREEN_ERROR_ROUTE } from 'components/ErrorComponents/route';
+import { useIsFeatureEnabled } from 'data/hooks/useIsFeatureEnabled';
+import { useAppConfig } from 'data/stores/useAppConfig';
+
+import { appState, flags } from 'types/AppData';
+
+import { DASHBOARD_{{ cookiecutter.app_name|upper }}_ROUTE } from '../Dashboard{{cookiecutter.model}}/route';
+
+// RedirectOnLoad assesses the initial state of the application using appData and determines the proper
+// route to load in the Router
+export const RedirectOnLoad = () => {
+  const appData = useAppConfig();
+  const isFeatureEnabled = useIsFeatureEnabled();
+
+  // Get LTI errors out of the way
+  if (appData.state === appState.ERROR) {
+    return <Redirect push to={FULL_SCREEN_ERROR_ROUTE('lti')} />;
+  }
+
+  if (!isFeatureEnabled(flags.{{ cookiecutter.flag }})) {
+    return <Redirect push to={FULL_SCREEN_ERROR_ROUTE('notFound')} />;
+  }
+
+  return <Redirect push to={DASHBOARD_{{ cookiecutter.app_name|upper }}_ROUTE()} />;
+};

--- a/src/frontend/apps/lti_site/apps/.cookiecutter/{{cookiecutter.app_name}}/components/RedirectOnLoad/route.ts
+++ b/src/frontend/apps/lti_site/apps/.cookiecutter/{{cookiecutter.app_name}}/components/RedirectOnLoad/route.ts
@@ -1,0 +1,4 @@
+/**
+ * Route for the `<RedirectOnLoad />` component.
+ */
+export const REDIRECT_ON_LOAD_ROUTE = () => '/';

--- a/src/frontend/apps/lti_site/apps/.cookiecutter/{{cookiecutter.app_name}}/components/Routes.tsx
+++ b/src/frontend/apps/lti_site/apps/.cookiecutter/{{cookiecutter.app_name}}/components/Routes.tsx
@@ -1,12 +1,13 @@
 import React, { lazy, Suspense } from 'react';
 import { MemoryRouter, Route } from 'react-router-dom';
 
+import { Loader } from 'lib-components';
+
 import {
   ErrorComponentsProps,
   FullScreenError,
 } from 'components/ErrorComponents';
 import { FULL_SCREEN_ERROR_ROUTE } from 'components/ErrorComponents/route';
-import { Loader } from 'components/Loader';
 import {DASHBOARD_{{ cookiecutter.app_name|upper }}_ROUTE} from "./Dashboard{{cookiecutter.model}}/route";
 import {RedirectOnLoad} from "./RedirectOnLoad";
 import {REDIRECT_ON_LOAD_ROUTE} from "./RedirectOnLoad/route";

--- a/src/frontend/apps/lti_site/apps/.cookiecutter/{{cookiecutter.app_name}}/components/Routes.tsx
+++ b/src/frontend/apps/lti_site/apps/.cookiecutter/{{cookiecutter.app_name}}/components/Routes.tsx
@@ -1,5 +1,5 @@
 import React, { lazy, Suspense } from 'react';
-import { MemoryRouter, Redirect, Route } from 'react-router-dom';
+import { MemoryRouter, Route } from 'react-router-dom';
 
 import {
   ErrorComponentsProps,
@@ -7,21 +7,22 @@ import {
 } from 'components/ErrorComponents';
 import { FULL_SCREEN_ERROR_ROUTE } from 'components/ErrorComponents/route';
 import { Loader } from 'components/Loader';
-import { useIsFeatureEnabled } from 'data/hooks/useIsFeatureEnabled';
-import { flags } from 'types/AppData';
+import {DASHBOARD_{{ cookiecutter.app_name|upper }}_ROUTE} from "./Dashboard{{cookiecutter.model}}/route";
+import {RedirectOnLoad} from "./RedirectOnLoad";
+import {REDIRECT_ON_LOAD_ROUTE} from "./RedirectOnLoad/route";
 
 const Dashboard{{cookiecutter.model}} = lazy(() => import('./Dashboard{{cookiecutter.model}}'));
 
 export const Routes = () => {
-  const isFeatureEnabled = useIsFeatureEnabled();
   return (
     <Suspense fallback={<Loader />}>
       <MemoryRouter>
-        {isFeatureEnabled(flags.{{cookiecutter.flag}}) ? (
-          <Route path="/" render={() => <Dashboard{{cookiecutter.model}} />} />
-        ) : (
-          <Redirect push to={FULL_SCREEN_ERROR_ROUTE('notFound')} />
-        )}
+        <Route
+          exact
+          path={DASHBOARD_{{ cookiecutter.app_name|upper }}_ROUTE()}
+          render={() => <Dashboard{{cookiecutter.model}} />}
+        />
+
         <Route
           exact
           path={FULL_SCREEN_ERROR_ROUTE()}
@@ -31,6 +32,8 @@ export const Routes = () => {
             />
           )}
         />
+
+        <Route path={REDIRECT_ON_LOAD_ROUTE()} component={RedirectOnLoad} />
       </MemoryRouter>
     </Suspense>
   );

--- a/src/frontend/apps/lti_site/apps/bbb/components/DashboardClassroom/route.ts
+++ b/src/frontend/apps/lti_site/apps/bbb/components/DashboardClassroom/route.ts
@@ -1,0 +1,4 @@
+/**
+ * Route for the `<Dashboard />` component.
+ */
+export const DASHBOARD_CLASSROOM_ROUTE = () => '/dashboard/classroom';

--- a/src/frontend/apps/lti_site/apps/bbb/components/RedirectOnLoad/index.spec.tsx
+++ b/src/frontend/apps/lti_site/apps/bbb/components/RedirectOnLoad/index.spec.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+
+import { FULL_SCREEN_ERROR_ROUTE } from 'components/ErrorComponents/route';
+import { useAppConfig } from 'data/stores/useAppConfig';
+import { appState } from 'types/AppData';
+import render from 'utils/tests/render';
+
+import { RedirectOnLoad } from '.';
+import { DASHBOARD_CLASSROOM_ROUTE } from '../DashboardClassroom/route';
+
+jest.mock('data/stores/useAppConfig', () => ({
+  useAppConfig: jest.fn(),
+}));
+const mockedUseAppConfig = useAppConfig as jest.MockedFunction<
+  typeof useAppConfig
+>;
+
+describe('<RedirectOnLoad />', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('redirects users to the error view on LTI error', () => {
+    mockedUseAppConfig.mockReturnValue({
+      state: appState.ERROR,
+      flags: { BBB: true },
+    } as any);
+
+    const { getByText } = render(<RedirectOnLoad />, {
+      routerOptions: {
+        routes: [
+          {
+            path: FULL_SCREEN_ERROR_ROUTE(),
+            render: ({ match }) => (
+              <span>{`Error Component: ${match.params.code}`}</span>
+            ),
+          },
+        ],
+      },
+    });
+
+    getByText('Error Component: lti');
+  });
+
+  it('shows not found error when feature is disabled', () => {
+    mockedUseAppConfig.mockReturnValue({
+      flags: { BBB: false },
+    } as any);
+
+    const { getByText } = render(<RedirectOnLoad />, {
+      routerOptions: {
+        routes: [
+          {
+            path: FULL_SCREEN_ERROR_ROUTE(),
+            render: ({ match }) => (
+              <span>{`Error Component: ${match.params.code}`}</span>
+            ),
+          },
+        ],
+      },
+    });
+
+    getByText('Error Component: notFound');
+  });
+
+  it('shows dashboard', async () => {
+    mockedUseAppConfig.mockReturnValue({
+      flags: { BBB: true },
+    } as any);
+
+    const { getByText } = render(<RedirectOnLoad />, {
+      routerOptions: {
+        routes: [
+          {
+            path: DASHBOARD_CLASSROOM_ROUTE(),
+            render: () => <span>Dashboard</span>,
+          },
+        ],
+      },
+    });
+
+    getByText('Dashboard');
+  });
+});

--- a/src/frontend/apps/lti_site/apps/bbb/components/RedirectOnLoad/index.tsx
+++ b/src/frontend/apps/lti_site/apps/bbb/components/RedirectOnLoad/index.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { Redirect } from 'react-router-dom';
+
+import { FULL_SCREEN_ERROR_ROUTE } from 'components/ErrorComponents/route';
+import { useIsFeatureEnabled } from 'data/hooks/useIsFeatureEnabled';
+import { useAppConfig } from 'data/stores/useAppConfig';
+
+import { appState, flags } from 'types/AppData';
+
+import { DASHBOARD_CLASSROOM_ROUTE } from '../DashboardClassroom/route';
+
+// RedirectOnLoad assesses the initial state of the application using appData and determines the proper
+// route to load in the Router
+export const RedirectOnLoad = () => {
+  const appData = useAppConfig();
+  const isFeatureEnabled = useIsFeatureEnabled();
+
+  // Get LTI errors out of the way
+  if (appData.state === appState.ERROR) {
+    return <Redirect push to={FULL_SCREEN_ERROR_ROUTE('lti')} />;
+  }
+
+  if (!isFeatureEnabled(flags.BBB)) {
+    return <Redirect push to={FULL_SCREEN_ERROR_ROUTE('notFound')} />;
+  }
+
+  return <Redirect push to={DASHBOARD_CLASSROOM_ROUTE()} />;
+};

--- a/src/frontend/apps/lti_site/apps/bbb/components/RedirectOnLoad/route.ts
+++ b/src/frontend/apps/lti_site/apps/bbb/components/RedirectOnLoad/route.ts
@@ -1,0 +1,4 @@
+/**
+ * Route for the `<RedirectOnLoad />` component.
+ */
+export const REDIRECT_ON_LOAD_ROUTE = () => '/';

--- a/src/frontend/apps/lti_site/apps/bbb/components/Routes.tsx
+++ b/src/frontend/apps/lti_site/apps/bbb/components/Routes.tsx
@@ -1,12 +1,17 @@
 import React, { lazy, Suspense } from 'react';
-import { MemoryRouter, Redirect, Route, Switch } from 'react-router-dom';
+import { MemoryRouter, Route } from 'react-router-dom';
 
+import {
+  ErrorComponentsProps,
+  FullScreenError,
+} from 'components/ErrorComponents';
 import { FULL_SCREEN_ERROR_ROUTE } from 'components/ErrorComponents/route';
 import { Loader } from 'lib-components';
-import { useIsFeatureEnabled } from 'data/hooks/useIsFeatureEnabled';
-import { flags } from 'types/AppData';
 
 import { bbbAppData } from 'apps/bbb/data/bbbAppData';
+import { DASHBOARD_CLASSROOM_ROUTE } from './DashboardClassroom/route';
+import { REDIRECT_ON_LOAD_ROUTE } from './RedirectOnLoad/route';
+import { RedirectOnLoad } from './RedirectOnLoad';
 
 const DashboardClassroom = lazy(() => import('./DashboardClassroom'));
 
@@ -17,25 +22,31 @@ const Wrappers = ({ children }: React.PropsWithChildren<{}>) => (
 );
 
 const Routes = () => {
-  const isFeatureEnabled = useIsFeatureEnabled();
+  return (
+    <Wrappers>
+      <Suspense fallback={<Loader />}>
+        <MemoryRouter>
+          <Route
+            exact
+            path={DASHBOARD_CLASSROOM_ROUTE()}
+            render={() => <DashboardClassroom />}
+          />
 
-  if (isFeatureEnabled(flags.BBB)) {
-    return (
-      <Wrappers>
-        <Suspense fallback={<Loader />}>
-          <Switch>
-            <Route exact path="/" render={() => <DashboardClassroom />} />
-          </Switch>
-        </Suspense>
-      </Wrappers>
-    );
-  } else {
-    return (
-      <Wrappers>
-        <Redirect push to={FULL_SCREEN_ERROR_ROUTE('notFound')} />
-      </Wrappers>
-    );
-  }
+          <Route
+            exact
+            path={FULL_SCREEN_ERROR_ROUTE()}
+            render={({ match }) => (
+              <FullScreenError
+                code={match.params.code as ErrorComponentsProps['code']}
+              />
+            )}
+          />
+
+          <Route path={REDIRECT_ON_LOAD_ROUTE()} component={RedirectOnLoad} />
+        </MemoryRouter>
+      </Suspense>
+    </Wrappers>
+  );
 };
 
 export default Routes;

--- a/src/frontend/apps/lti_site/apps/deposit/components/Dashboard/route.ts
+++ b/src/frontend/apps/lti_site/apps/deposit/components/Dashboard/route.ts
@@ -1,0 +1,4 @@
+/**
+ * Route for the `<Dashboard />` component.
+ */
+export const DASHBOARD_ROUTE = () => '/dashboard';

--- a/src/frontend/apps/lti_site/apps/deposit/components/RedirectOnLoad/index.spec.tsx
+++ b/src/frontend/apps/lti_site/apps/deposit/components/RedirectOnLoad/index.spec.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+
+import { FULL_SCREEN_ERROR_ROUTE } from 'components/ErrorComponents/route';
+import { useAppConfig } from 'data/stores/useAppConfig';
+import { appState } from 'types/AppData';
+import render from 'utils/tests/render';
+
+import { RedirectOnLoad } from '.';
+import { DASHBOARD_ROUTE } from '../Dashboard/route';
+
+jest.mock('data/stores/useAppConfig', () => ({
+  useAppConfig: jest.fn(),
+}));
+const mockedUseAppConfig = useAppConfig as jest.MockedFunction<
+  typeof useAppConfig
+>;
+
+describe('<RedirectOnLoad />', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('redirects users to the error view on LTI error', () => {
+    mockedUseAppConfig.mockReturnValue({
+      state: appState.ERROR,
+      flags: { deposit: true },
+    } as any);
+
+    const { getByText } = render(<RedirectOnLoad />, {
+      routerOptions: {
+        routes: [
+          {
+            path: FULL_SCREEN_ERROR_ROUTE(),
+            render: ({ match }) => (
+              <span>{`Error Component: ${match.params.code}`}</span>
+            ),
+          },
+        ],
+      },
+    });
+
+    getByText('Error Component: lti');
+  });
+
+  it('shows not found error when feature is disabled', () => {
+    mockedUseAppConfig.mockReturnValue({
+      flags: { deposit: false },
+    } as any);
+
+    const { getByText } = render(<RedirectOnLoad />, {
+      routerOptions: {
+        routes: [
+          {
+            path: FULL_SCREEN_ERROR_ROUTE(),
+            render: ({ match }) => (
+              <span>{`Error Component: ${match.params.code}`}</span>
+            ),
+          },
+        ],
+      },
+    });
+
+    getByText('Error Component: notFound');
+  });
+
+  it('shows dashboard', async () => {
+    mockedUseAppConfig.mockReturnValue({
+      flags: { deposit: true },
+    } as any);
+
+    const { getByText } = render(<RedirectOnLoad />, {
+      routerOptions: {
+        routes: [
+          {
+            path: DASHBOARD_ROUTE(),
+            render: () => <span>Dashboard</span>,
+          },
+        ],
+      },
+    });
+
+    getByText('Dashboard');
+  });
+});

--- a/src/frontend/apps/lti_site/apps/deposit/components/RedirectOnLoad/index.tsx
+++ b/src/frontend/apps/lti_site/apps/deposit/components/RedirectOnLoad/index.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { Redirect } from 'react-router-dom';
+
+import { FULL_SCREEN_ERROR_ROUTE } from 'components/ErrorComponents/route';
+import { useIsFeatureEnabled } from 'data/hooks/useIsFeatureEnabled';
+import { useAppConfig } from 'data/stores/useAppConfig';
+
+import { appState, flags } from 'types/AppData';
+
+import { DASHBOARD_ROUTE } from '../Dashboard/route';
+
+// RedirectOnLoad assesses the initial state of the application using appData and determines the proper
+// route to load in the Router
+export const RedirectOnLoad = () => {
+  const appData = useAppConfig();
+  const isFeatureEnabled = useIsFeatureEnabled();
+
+  // Get LTI errors out of the way
+  if (appData.state === appState.ERROR) {
+    return <Redirect push to={FULL_SCREEN_ERROR_ROUTE('lti')} />;
+  }
+
+  if (!isFeatureEnabled(flags.DEPOSIT)) {
+    return <Redirect push to={FULL_SCREEN_ERROR_ROUTE('notFound')} />;
+  }
+
+  return <Redirect push to={DASHBOARD_ROUTE()} />;
+};

--- a/src/frontend/apps/lti_site/apps/deposit/components/RedirectOnLoad/route.ts
+++ b/src/frontend/apps/lti_site/apps/deposit/components/RedirectOnLoad/route.ts
@@ -1,0 +1,4 @@
+/**
+ * Route for the `<RedirectOnLoad />` component.
+ */
+export const REDIRECT_ON_LOAD_ROUTE = () => '/';

--- a/src/frontend/apps/lti_site/apps/deposit/components/Routes.tsx
+++ b/src/frontend/apps/lti_site/apps/deposit/components/Routes.tsx
@@ -1,5 +1,5 @@
 import React, { lazy, Suspense } from 'react';
-import { MemoryRouter, Redirect, Route } from 'react-router-dom';
+import { MemoryRouter, Route } from 'react-router-dom';
 
 import {
   ErrorComponentsProps,
@@ -7,21 +7,19 @@ import {
 } from 'components/ErrorComponents';
 import { FULL_SCREEN_ERROR_ROUTE } from 'components/ErrorComponents/route';
 import { Loader } from 'lib-components';
-import { useIsFeatureEnabled } from 'data/hooks/useIsFeatureEnabled';
-import { flags } from 'types/AppData';
+
+import { DASHBOARD_ROUTE } from './Dashboard/route';
+import { RedirectOnLoad } from './RedirectOnLoad';
+import { REDIRECT_ON_LOAD_ROUTE } from './RedirectOnLoad/route';
 
 const Dashboard = lazy(() => import('./Dashboard'));
 
 const Routes = () => {
-  const isFeatureEnabled = useIsFeatureEnabled();
   return (
     <Suspense fallback={<Loader />}>
       <MemoryRouter>
-        {isFeatureEnabled(flags.DEPOSIT) ? (
-          <Route path="/" render={() => <Dashboard />} />
-        ) : (
-          <Redirect push to={FULL_SCREEN_ERROR_ROUTE('notFound')} />
-        )}
+        <Route exact path={DASHBOARD_ROUTE()} render={() => <Dashboard />} />
+
         <Route
           exact
           path={FULL_SCREEN_ERROR_ROUTE()}
@@ -31,6 +29,8 @@ const Routes = () => {
             />
           )}
         />
+
+        <Route path={REDIRECT_ON_LOAD_ROUTE()} component={RedirectOnLoad} />
       </MemoryRouter>
     </Suspense>
   );


### PR DESCRIPTION
## Purpose

Add different checks on the app root route to behave more like the `LTISite` and allow to easily add checks on the `app_data.state`.

## Proposal

Add a `RedirectOnLoad` component which purpose is to make verification then redirect to the corresponding route.

