### PR TITLE
✨(backend) allow site users to use classroom api

### DIFF
--- a/src/backend/marsha/bbb/api.py
+++ b/src/backend/marsha/bbb/api.py
@@ -60,8 +60,15 @@ class ClassroomViewSet(
         """
         if self.action in ["create"]:
             permission_classes = [
-                core_permissions.HasPlaylistToken
-                & (core_permissions.IsTokenInstructor | core_permissions.IsTokenAdmin)
+                (
+                    core_permissions.HasPlaylistToken
+                    & (
+                        core_permissions.IsTokenInstructor
+                        | core_permissions.IsTokenAdmin
+                    )
+                )
+                | IsClassroomOrganizationAdmin
+                | IsClassroomPlaylistAdmin
             ]
         elif self.action in ["retrieve"]:
             permission_classes = [

--- a/src/backend/marsha/bbb/api.py
+++ b/src/backend/marsha/bbb/api.py
@@ -19,7 +19,7 @@ from ..core.utils.s3_utils import create_presigned_post
 from ..core.utils.time_utils import to_timestamp
 from .forms import ClassroomForm
 from .models import Classroom, ClassroomDocument
-from .permissions import IsClassroomOrganizationAdmin, IsClassroomPlaylistAdmin
+from .permissions import IsClassroomPlaylistOrOrganizationAdmin
 
 
 class ClassroomFilter(django_filters.FilterSet):
@@ -51,8 +51,7 @@ class ClassroomViewSet(
             core_permissions.IsTokenResourceRouteObject
             & (core_permissions.IsTokenInstructor | core_permissions.IsTokenAdmin)
         )
-        | IsClassroomOrganizationAdmin
-        | IsClassroomPlaylistAdmin
+        | IsClassroomPlaylistOrOrganizationAdmin
     ]
 
     def get_permissions(self):
@@ -71,26 +70,11 @@ class ClassroomViewSet(
                         | core_permissions.IsTokenAdmin
                     )
                 )
-                | IsClassroomOrganizationAdmin
-                | IsClassroomPlaylistAdmin
+                | IsClassroomPlaylistOrOrganizationAdmin
             ]
         elif self.action in ["retrieve"]:
             permission_classes = [
-                ResourceIsAuthenticated
-                | IsClassroomOrganizationAdmin
-                | IsClassroomPlaylistAdmin
-            ]
-        elif self.action in ["update", "partial_update"]:
-            permission_classes = [
-                (
-                    core_permissions.IsTokenResourceRouteObject
-                    & (
-                        core_permissions.IsTokenInstructor
-                        | core_permissions.IsTokenAdmin
-                    )
-                )
-                | IsClassroomOrganizationAdmin
-                | IsClassroomPlaylistAdmin
+                ResourceIsAuthenticated | IsClassroomPlaylistOrOrganizationAdmin
             ]
         elif self.action in ["list"]:
             permission_classes = [core_permissions.UserIsAuthenticated]
@@ -174,7 +158,7 @@ class ClassroomViewSet(
         permission_classes=[
             core_permissions.IsTokenInstructor
             | core_permissions.IsTokenAdmin
-            | IsClassroomOrganizationAdmin
+            | IsClassroomPlaylistOrOrganizationAdmin
         ],
     )
     # pylint: disable=unused-argument
@@ -242,9 +226,7 @@ class ClassroomViewSet(
         detail=True,
         url_path="join",
         permission_classes=[
-            ResourceIsAuthenticated
-            | IsClassroomOrganizationAdmin
-            | IsClassroomPlaylistAdmin
+            ResourceIsAuthenticated | IsClassroomPlaylistOrOrganizationAdmin
         ],
     )
     def service_join(self, request, *args, **kwargs):

--- a/src/backend/marsha/bbb/api.py
+++ b/src/backend/marsha/bbb/api.py
@@ -69,6 +69,18 @@ class ClassroomViewSet(
                 | IsClassroomOrganizationAdmin
                 | IsClassroomPlaylistAdmin
             ]
+        elif self.action in ["update", "partial_update"]:
+            permission_classes = [
+                (
+                    core_permissions.IsTokenResourceRouteObject
+                    & (
+                        core_permissions.IsTokenInstructor
+                        | core_permissions.IsTokenAdmin
+                    )
+                )
+                | IsClassroomOrganizationAdmin
+                | IsClassroomPlaylistAdmin
+            ]
         elif self.action in ["list"]:
             permission_classes = [core_permissions.UserIsAuthenticated]
         else:

--- a/src/backend/marsha/bbb/permissions.py
+++ b/src/backend/marsha/bbb/permissions.py
@@ -80,3 +80,24 @@ class IsClassroomPlaylistAdmin(permissions.BasePermission):
             playlist__classrooms__id=view.get_object_pk(),
             user__id=request.user.id,
         ).exists()
+
+
+class IsClassroomPlaylistOrOrganizationAdmin(permissions.BasePermission):
+    """
+    Allow a request to proceed. Permission class.
+
+    Permission to allow a request to proceed only if the user is an admin for the playlist
+    the classroom is a part of or admin of the linked organization.
+    """
+
+    def has_permission(self, request, view):
+        """
+        Allow the request.
+
+        Allow the request only if there is a classroom id in the path of the request, which exists,
+        and if the current user is an admin for the playlist this video is a part of or
+        admin of the linked organization.
+        """
+        return IsClassroomPlaylistAdmin().has_permission(
+            request, view
+        ) or IsClassroomOrganizationAdmin().has_permission(request, view)

--- a/src/backend/marsha/bbb/tests/api/classroom/test_service_end.py
+++ b/src/backend/marsha/bbb/tests/api/classroom/test_service_end.py
@@ -6,9 +6,16 @@ from django.test import TestCase, override_settings
 from marsha.bbb import api
 from marsha.bbb.factories import ClassroomFactory
 from marsha.core import factories as core_factories
+from marsha.core.factories import (
+    OrganizationAccessFactory,
+    PlaylistAccessFactory,
+    PlaylistFactory,
+)
+from marsha.core.models import ADMINISTRATOR
 from marsha.core.simple_jwt.factories import (
     InstructorOrAdminLtiTokenFactory,
     StudentLtiTokenFactory,
+    UserAccessTokenFactory,
 )
 from marsha.core.tests.utils import reload_urlconf
 
@@ -88,6 +95,81 @@ class ClassroomServiceEndAPITest(TestCase):
         }
 
         jwt_token = InstructorOrAdminLtiTokenFactory(resource=classroom)
+
+        response = self.client.patch(
+            f"/api/classrooms/{classroom.id}/end/",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertDictEqual(
+            {
+                "returncode": "SUCCESS",
+                "message": "A request to end the classroom was sent.",
+                "messageKey": "sentEndClassroomRequest",
+            },
+            response.data,
+        )
+
+    @mock.patch.object(api, "end")
+    def test_api_bbb_end_classroom_user_access_token(self, mock_end_request):
+        """A user with UserAccessToken should not be able to end a classroom."""
+        organization_access = OrganizationAccessFactory()
+        playlist = PlaylistFactory(organization=organization_access.organization)
+        classroom = ClassroomFactory(playlist=playlist)
+
+        jwt_token = UserAccessTokenFactory(user=organization_access.user)
+
+        response = self.client.patch(
+            f"/api/classrooms/{classroom.id}/end/",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+        self.assertEqual(response.status_code, 403)
+        mock_end_request.assert_not_called()
+
+    @mock.patch.object(api, "end")
+    def test_api_bbb_end_classroom_user_access_token_organization_admin(
+        self, mock_end_request
+    ):
+        """An organization administrator should be able to end a classroom."""
+        organization_access = OrganizationAccessFactory(role=ADMINISTRATOR)
+        playlist = PlaylistFactory(organization=organization_access.organization)
+        classroom = ClassroomFactory(playlist=playlist)
+        mock_end_request.return_value = {
+            "message": "A request to end the classroom was sent.",
+            "messageKey": "sentEndClassroomRequest",
+            "returncode": "SUCCESS",
+        }
+
+        jwt_token = UserAccessTokenFactory(user=organization_access.user)
+
+        response = self.client.patch(
+            f"/api/classrooms/{classroom.id}/end/",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertDictEqual(
+            {
+                "returncode": "SUCCESS",
+                "message": "A request to end the classroom was sent.",
+                "messageKey": "sentEndClassroomRequest",
+            },
+            response.data,
+        )
+
+    @mock.patch.object(api, "end")
+    def test_api_bbb_end_classroom_user_access_token_playlist_admin(
+        self, mock_end_request
+    ):
+        """A playlist administrator should be able to join a classroom."""
+        playlist_access = PlaylistAccessFactory(role=ADMINISTRATOR)
+        classroom = ClassroomFactory(playlist=playlist_access.playlist)
+        mock_end_request.return_value = {
+            "message": "A request to end the classroom was sent.",
+            "messageKey": "sentEndClassroomRequest",
+            "returncode": "SUCCESS",
+        }
+
+        jwt_token = UserAccessTokenFactory(user=playlist_access.user)
 
         response = self.client.patch(
             f"/api/classrooms/{classroom.id}/end/",

--- a/src/backend/marsha/bbb/tests/api/classroom/test_service_join.py
+++ b/src/backend/marsha/bbb/tests/api/classroom/test_service_join.py
@@ -8,9 +8,16 @@ from django.test import TestCase, override_settings
 from marsha.bbb import api, serializers
 from marsha.bbb.factories import ClassroomFactory
 from marsha.core import factories as core_factories
+from marsha.core.factories import (
+    OrganizationAccessFactory,
+    PlaylistAccessFactory,
+    PlaylistFactory,
+)
+from marsha.core.models import ADMINISTRATOR
 from marsha.core.simple_jwt.factories import (
     InstructorOrAdminLtiTokenFactory,
     StudentLtiTokenFactory,
+    UserAccessTokenFactory,
 )
 from marsha.core.tests.utils import reload_urlconf
 
@@ -141,4 +148,67 @@ class ClassroomServiceJoinAPITest(TestCase):
         self.assertDictEqual(
             {"message": "missing fullname parameter"},
             response.data,
+        )
+
+    @mock.patch.object(api, "join")
+    def test_api_bbb_join_user_access_token(self, mock_join_request):
+        """A user with UserAccessToken should not be able to join a classroom."""
+        organization_access = OrganizationAccessFactory()
+        playlist = PlaylistFactory(organization=organization_access.organization)
+        classroom = ClassroomFactory(playlist=playlist)
+
+        jwt_token = UserAccessTokenFactory(user=organization_access.user)
+
+        response = self.client.patch(
+            f"/api/classrooms/{classroom.id}/join/",
+            data=json.dumps({"fullname": "John Doe"}),
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+        self.assertEqual(response.status_code, 403)
+        mock_join_request.assert_not_called()
+
+    def test_api_bbb_join_user_access_token_organization_admin(self):
+        """An organization administrator should be able to join a classroom."""
+        organization_access = OrganizationAccessFactory(role=ADMINISTRATOR)
+        playlist = PlaylistFactory(organization=organization_access.organization)
+        classroom = ClassroomFactory(playlist=playlist)
+
+        jwt_token = UserAccessTokenFactory(user=organization_access.user)
+
+        response = self.client.patch(
+            f"/api/classrooms/{classroom.id}/join/",
+            data=json.dumps({"fullname": "John Doe"}),
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(
+            "https://10.7.7.1/bigbluebutton/api/join?"
+            f"fullName=John+Doe&meetingID={classroom.meeting_id}&"
+            f"password={quote_plus(classroom.moderator_password)}&"
+            f"userID={organization_access.user_id}&redirect=true",
+            response.data.get("url"),
+        )
+
+    def test_api_bbb_join_user_access_token_playlist_admin(self):
+        """A playlist administrator should be able to join a classroom."""
+        playlist_access = PlaylistAccessFactory(role=ADMINISTRATOR)
+        classroom = ClassroomFactory(playlist=playlist_access.playlist)
+
+        jwt_token = UserAccessTokenFactory(user=playlist_access.user)
+
+        response = self.client.patch(
+            f"/api/classrooms/{classroom.id}/join/",
+            data=json.dumps({"fullname": "John Doe"}),
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(
+            "https://10.7.7.1/bigbluebutton/api/join?"
+            f"fullName=John+Doe&meetingID={classroom.meeting_id}&"
+            f"password={quote_plus(classroom.moderator_password)}&"
+            f"userID={playlist_access.user_id}&redirect=true",
+            response.data.get("url"),
         )


### PR DESCRIPTION

## Purpose

We want the site users to use classroom api.

## Proposal

Open classroom update api to site users.

- [x] update
- [x] create
- [x] service_create
- [x] service_join
- [x] service_end

