### PR TITLE
fix bug on subtitles upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Use video title in creation wizard if it exists
 - Skip screen choice between live and vod when coming back from 
   LTI select
+- Fix subtitles upload
 
 ## [4.0.0-beta.8] - 2022-09-15
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -19,6 +19,7 @@
 - [Ronan Le Viennesse](https://github.com/roro-lv) <ronan.le-viennesse@polyconseil.fr>
 - [Quentin Bey](https://github.com/qbey) <quentin.bey@polyconseil.fr>
 - [Anthony Le Courric](https://github.com/AntoLC) <freelance.anthony@gmail.com>
+- [Alfred Pichard](https://github.com/AlfredPichard) <alfred.pichard@polyconseil.fr>
 
 - [Renovate Bot](https://renovatebot.com) <bot@renovateapp.com>
 - [Renovate Bot](https://renovatebot.com) <29139614+renovate[bot]@users.noreply.github.com>

--- a/src/frontend/apps/lti_site/components/LocalizedTimedTextTrackUpload/index.tsx
+++ b/src/frontend/apps/lti_site/components/LocalizedTimedTextTrackUpload/index.tsx
@@ -72,6 +72,7 @@ export const LocalizedTimedTextTrackUpload = ({
 
   const handleChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
     let timedTextTrackId;
+    const nativeEvent = event.nativeEvent.target as HTMLInputElement;
     if (event.target.files && event.target.files[0] && selectedLanguage) {
       if (!retryUploadIdRef.current) {
         const response = await createTimedTextTrack(
@@ -89,6 +90,10 @@ export const LocalizedTimedTextTrackUpload = ({
         event.target.files[0],
       );
     }
+    // We reset this value to allow handleChange to be triggered again on a new file upload
+    // if it has the same name. More on this issue :
+    // https://stackoverflow.com/questions/39484895/how-to-allow-input-type-file-to-select-the-same-file-in-react-component
+    nativeEvent.value = '';
   };
 
   const onRetryFailedUpload = (timedTextTrackId: string) => {


### PR DESCRIPTION
turns out that uploading the same file again doesn't trigger the handleChange method on chromium based browsers, and reseting the nativeEvent value solves this bug



