### PR TITLE
Increase classroom form debounce time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Skip screen choice between live and vod when coming back from 
   LTI select
 - Fix subtitles upload
+- Fix debounce time too low in the classroom creation form
 
 ## [4.0.0-beta.8] - 2022-09-15
 

--- a/src/frontend/apps/lti_site/apps/classroom/components/DashboardClassroomForm/index.tsx
+++ b/src/frontend/apps/lti_site/apps/classroom/components/DashboardClassroomForm/index.tsx
@@ -15,6 +15,8 @@ import {
 } from 'apps/classroom/data/queries';
 import { Classroom } from 'apps/classroom/types/models';
 
+const DEBOUNCE_TIME_MS = 1500;
+
 const messages = defineMessages({
   createClassroomFail: {
     defaultMessage: 'Classroom not created!',
@@ -94,7 +96,7 @@ const DashboardClassroomForm = ({ classroom }: DashboardClassroomFormProps) => {
 
   const debounce = (
     fn: (updatedClassroom: Partial<Classroom>) => void,
-    ms = 500,
+    ms = DEBOUNCE_TIME_MS,
   ) => {
     return (updatedClassroom: Partial<Classroom>) => {
       window.clearTimeout(timeoutId.current);


### PR DESCRIPTION
## Purpose

The debounce time in the classroom creation form is too fast for a user-friendly use. By increasing it, the user-journey is more convenient.

## Proposal

- Increase the debounce time in the form

