### PR TITLE
🐛(frontend) fix classroom file upload

### DIFF
--- a/src/frontend/apps/lti_site/apps/classroom/components/UploadDocuments/index.spec.tsx
+++ b/src/frontend/apps/lti_site/apps/classroom/components/UploadDocuments/index.spec.tsx
@@ -132,7 +132,16 @@ describe('<UploadDocuments />', () => {
   it('shows the upload progress when the file is uploading', async () => {
     const file = new File(['(⌐□_□)'], 'course.mp4', { type: 'video/mp4' });
     const classroomDocument = classroomDocumentMockFactory({
+      filename: file.name,
       upload_state: PENDING,
+      uploaded_on: '2020-01-01T00:00:00Z',
+      url: 'https://example.com/file.txt',
+    });
+    fetchMock.get('/api/classrooms/1/classroomdocuments/?limit=999', {
+      count: 1,
+      next: null,
+      previous: null,
+      results: [classroomDocument],
     });
 
     mockUseUploadManager.mockReturnValue({
@@ -150,6 +159,10 @@ describe('<UploadDocuments />', () => {
     });
     render(<UploadDocuments />);
 
+    await waitFor(() => expect(fetchMock.calls()).toHaveLength(1));
+    // file exist in both uploadmanager and classrooms.classroomdocuments,
+    // but only the uploadmanager one is rendered.
+    await screen.findByText(file.name);
     await screen.findByText('20%');
     await screen.findByText(
       'Upload in progress... Please do not close or reload this page.',

--- a/src/frontend/apps/lti_site/apps/classroom/components/UploadDocuments/index.tsx
+++ b/src/frontend/apps/lti_site/apps/classroom/components/UploadDocuments/index.tsx
@@ -1,4 +1,4 @@
-import { Anchor, Box, Button, Paragraph, Text } from 'grommet';
+import { Anchor, Box, Button, Grid, Paragraph, Text } from 'grommet';
 import Dropzone from 'react-dropzone';
 import React, { useEffect, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
@@ -89,46 +89,61 @@ const UploadDocumentsRow = ({
   }
 
   return (
-    <Box fill background="#F9FBFD" pad="small" round="small" direction="row">
-      <Box justify="start" flex>
-        <Text weight="bold">{truncateFilename(filename, 40)}</Text>
-      </Box>
-      {uploadingObjectId && (
-        <React.Fragment>
-          <UploadableObjectProgress objectId={uploadingObjectId} />
-          {intl.formatMessage(messages.uploadingFile)}
-        </React.Fragment>
-      )}
-      {uploadState && (
-        <Box justify="end" flex="shrink" direction="row">
-          {uploadState === 'ready' ? (
-            <Box direction="row" align="center" gap="small">
-              {isDefault ? (
-                <ValidSVG iconColor="brand" height="20px" width="20px" />
-              ) : (
-                <Button
-                  alignSelf="start"
-                  onClick={setDefaultDocument}
-                  title={intl.formatMessage(messages.setDefaultDocument)}
-                >
-                  <ValidSVG iconColor="light-5" height="20px" width="20px" />
-                </Button>
-              )}
-              <Anchor
-                download
-                a11yTitle={intl.formatMessage(messages.downloadButtonLabel)}
-                label={intl.formatMessage(messages.downloadButtonLabel)}
-                style={{ fontFamily: 'Roboto-Medium' }}
-                title={intl.formatMessage(messages.downloadButtonLabel)}
-                href={url}
-              />
-            </Box>
-          ) : (
-            <Text>{uploadState}</Text>
-          )}
+    <Grid fill>
+      <Box
+        fill
+        background="#F9FBFD"
+        pad="small"
+        round="small"
+        direction={uploadingObjectId ? 'column' : 'row'}
+      >
+        <Box
+          justify={uploadingObjectId ? 'center' : 'start'}
+          flex={!uploadingObjectId}
+        >
+          <Text as="div" weight="bold">
+            {truncateFilename(filename, 40)}
+          </Text>
         </Box>
-      )}
-    </Box>
+        {uploadingObjectId && (
+          <React.Fragment>
+            <UploadableObjectProgress objectId={uploadingObjectId} />
+            <Text alignSelf="center">
+              {intl.formatMessage(messages.uploadingFile)}
+            </Text>
+          </React.Fragment>
+        )}
+        {uploadState && (
+          <Box justify="end" flex="shrink" direction="row">
+            {uploadState === 'ready' ? (
+              <Box direction="row" align="center" gap="small">
+                {isDefault ? (
+                  <ValidSVG iconColor="brand" height="20px" width="20px" />
+                ) : (
+                  <Button
+                    alignSelf="start"
+                    onClick={setDefaultDocument}
+                    title={intl.formatMessage(messages.setDefaultDocument)}
+                  >
+                    <ValidSVG iconColor="light-5" height="20px" width="20px" />
+                  </Button>
+                )}
+                <Anchor
+                  download
+                  a11yTitle={intl.formatMessage(messages.downloadButtonLabel)}
+                  label={intl.formatMessage(messages.downloadButtonLabel)}
+                  style={{ fontFamily: 'Roboto-Medium' }}
+                  title={intl.formatMessage(messages.downloadButtonLabel)}
+                  href={url}
+                />
+              </Box>
+            ) : (
+              <Text>{uploadState}</Text>
+            )}
+          </Box>
+        )}
+      </Box>
+    </Grid>
   );
 };
 
@@ -211,16 +226,23 @@ export const UploadDocuments = () => {
         margin={{ top: 'medium' }}
         round="xsmall"
       >
-        {classroomDocuments?.results.map((classroomDocument) => (
-          <UploadDocumentsRow
-            key={classroomDocument.id}
-            filename={classroomDocument.filename}
-            isDefault={classroomDocument.is_default}
-            documentId={classroomDocument.id}
-            uploadState={classroomDocument.upload_state}
-            url={classroomDocument.url}
-          />
-        ))}
+        {classroomDocuments?.results
+          .filter(
+            (classroomDocument) =>
+              uploadsInProgress.find(
+                (upload) => upload.objectId === classroomDocument.id,
+              ) === undefined,
+          )
+          .map((classroomDocument) => (
+            <UploadDocumentsRow
+              key={classroomDocument.id}
+              filename={classroomDocument.filename}
+              isDefault={classroomDocument.is_default}
+              documentId={classroomDocument.id}
+              uploadState={classroomDocument.upload_state}
+              url={classroomDocument.url}
+            />
+          ))}
 
         {uploadsInProgress.map((state, index) => (
           <UploadDocumentsRow


### PR DESCRIPTION


## Purpose

While uploading, a file was rendered twice. One time in the uploadmanager, and one other in the existing classroomdocuments. Also, the progressbar and the filename were wrongly displayed.

Fixes #1751 

## Proposal

- [x] rework the compnents for clean display
- [x] exclude pending uploads from existing classroom documents

![image](https://user-images.githubusercontent.com/720491/194516277-739f109e-05c1-46a7-b918-91322979d6c0.png)


