### PR TITLE
💄(frontend) stylegrommet components

### DIFF
--- a/src/frontend/apps/standalone_site/src/features/Menu/components/Menu.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Menu/components/Menu.tsx
@@ -1,31 +1,29 @@
-import { Box, Text } from 'grommet';
 import { normalizeColor } from 'grommet/utils';
 import { theme } from 'lib-common';
 import React from 'react';
-import styled from 'styled-components';
+import { defineMessages, useIntl } from 'react-intl';
 
 import { Route, routes } from 'routes';
+import { Text, Box } from 'styles/StyledGrommet';
 
 import { useMenu } from '../store/menuStore';
 
 import MenuItem from './MenuItem';
 
+const messages = defineMessages({
+  typeContentLabel: {
+    defaultMessage: 'Types of content',
+    description: 'Label for the types of content in the menu',
+    id: 'features.Menu.typeContentLabel',
+  },
+});
+
 const colorMenu = normalizeColor('blue-active', theme);
-const sizeMenu = '18.75rem';
-
-interface PropsExtended {
-  isMenuOpen: boolean;
-}
-
-const MenuBox = styled(Box)<PropsExtended>`
-  box-shadow: 0px 0px 4px 0px rgba(104, 111, 122, 0.3);
-  z-index: 1;
-  transition: margin-left 0.6s;
-  ${(props) => (props.isMenuOpen ? `` : `margin-left: -${sizeMenu};`)}
-`;
 
 function Menu() {
+  const intl = useIntl();
   const { isMenuOpen } = useMenu();
+  const sizeMenu = '18.75rem';
   const topRoutes: Route[] = [
     routes.HomePage,
     routes.Favorites,
@@ -38,7 +36,7 @@ function Menu() {
   ];
 
   return (
-    <MenuBox
+    <Box
       role="menu"
       width={`${sizeMenu}`}
       pad={{
@@ -47,7 +45,12 @@ function Menu() {
         right: '3.75rem',
         top: '6.75rem',
       }}
-      isMenuOpen={isMenuOpen}
+      css={`
+        box-shadow: 0px 0px 4px 0px rgba(104, 111, 122, 0.3);
+        z-index: 1;
+        transition: margin-left 0.6s;
+        ${isMenuOpen ? `` : `margin-left: -${sizeMenu};`}
+      `}
     >
       <Box role="group">
         {topRoutes.map((route, index) => (
@@ -60,8 +63,13 @@ function Menu() {
         margin={{ vertical: 'medium', horizontal: 'xxsmall' }}
       />
       <Box role="group">
-        <Text size="small" weight="bold" margin={{ left: '1rem' }}>
-          TYPES DE CONTENUS
+        <Text
+          size="small"
+          weight="bold"
+          margin={{ left: '1rem' }}
+          css="text-transform: 'uppercase';"
+        >
+          {intl.formatMessage(messages.typeContentLabel)}
         </Text>
         {contents.map((content, index) => (
           <MenuItem key={`menuItemContent-${index}`} route={content}>
@@ -78,7 +86,7 @@ function Menu() {
           </MenuItem>
         ))}
       </Box>
-    </MenuBox>
+    </Box>
   );
 }
 

--- a/src/frontend/apps/standalone_site/src/styles/StyledGrommet.tsx
+++ b/src/frontend/apps/standalone_site/src/styles/StyledGrommet.tsx
@@ -1,0 +1,33 @@
+import {
+  Box as BoxGrommet,
+  BoxExtendedProps,
+  Text as TextGrommet,
+  TextExtendedProps,
+} from 'grommet';
+import styled from 'styled-components';
+
+interface StyledProps {
+  css?: string;
+}
+
+/**
+ * @description: Text component with styled-components
+ */
+const TextStyled = styled(TextGrommet)<StyledProps>`
+  ${(props) => props.css || ''};
+`;
+interface TextProps extends StyledProps, TextExtendedProps {}
+export const Text = (props: TextProps) => {
+  return <TextStyled {...props} />;
+};
+
+/**
+ * @description: Box component with styled-components
+ */
+const BoxStyled = styled(BoxGrommet)<StyledProps>`
+  ${(props) => props.css || ''};
+`;
+interface BoxProps extends StyledProps, BoxExtendedProps {}
+export const Box = (props: BoxProps) => {
+  return <BoxStyled {...props} />;
+};


### PR DESCRIPTION
Components to have the full feature of Grommet
combine with the css feature of styled-components.

## Problem

As it is now, we have to extend a Grommet component (Box / Text ...) with styled-component every time we need a small css property, we have as well to extend an interface if we want to pass props, on the big pictures it takes time. We can use the inline style directly on the component but it is not best way to do it.

## Proposal

When we need extra css property:
 -  Small extension of Grommet components with a css property to add directly our css.

Example of use:
```
 <Box
    width="15px;"
    css={`
      box-shadow: 0px 0px 4px 0px rgba(104, 111, 122, 0.3);
      transition: margin-left 0.6s;
      ${isMenuOpen ? `` : `transform:  translateX(-15px);`}
   `}
  >
```

## Solve

- [x] Don't need to think about component naming 
- [x] Less code: Don't have to create new component from styled component
- [x] Easy access to parent components variable
- [x] No use of inline style
