### PR TITLE
👽️(frontend) update jitsi default config

### DIFF
--- a/src/frontend/apps/lti_site/components/DashboardLiveJitsi/utils.spec.ts
+++ b/src/frontend/apps/lti_site/components/DashboardLiveJitsi/utils.spec.ts
@@ -88,7 +88,9 @@ describe('DashboardLiveJitsi/utils', () => {
         doNotStoreRoom: true,
         hideConferenceSubject: true,
         hideConferenceTimer: true,
-        prejoinPageEnabled: false,
+        prejoinConfig: {
+          enabled: false,
+        },
         resolution: 720,
         toolbarButtons,
       },
@@ -171,7 +173,9 @@ describe('DashboardLiveJitsi/utils', () => {
         doNotStoreRoom: true,
         hideConferenceSubject: true,
         hideConferenceTimer: true,
-        prejoinPageEnabled: false,
+        prejoinConfig: {
+          enabled: false,
+        },
         resolution: 720,
         toolbarButtons,
       },
@@ -254,7 +258,9 @@ describe('DashboardLiveJitsi/utils', () => {
         doNotStoreRoom: true,
         hideConferenceSubject: true,
         hideConferenceTimer: true,
-        prejoinPageEnabled: false,
+        prejoinConfig: {
+          enabled: false,
+        },
         resolution: 720,
         toolbarButtons,
       },
@@ -360,7 +366,9 @@ describe('DashboardLiveJitsi/utils', () => {
         doNotStoreRoom: true,
         hideConferenceSubject: true,
         hideConferenceTimer: true,
-        prejoinPageEnabled: false,
+        prejoinConfig: {
+          enabled: false,
+        },
         resolution: 720,
         toolbarButtons,
       },
@@ -449,7 +457,9 @@ describe('DashboardLiveJitsi/utils', () => {
         doNotStoreRoom: true,
         hideConferenceSubject: true,
         hideConferenceTimer: true,
-        prejoinPageEnabled: false,
+        prejoinConfig: {
+          enabled: false,
+        },
         resolution: 720,
         toolbarButtons,
       },
@@ -474,7 +484,9 @@ describe('DashboardLiveJitsi/utils', () => {
           external_api_url: 'external api url',
           domain: 'domain',
           config_overwrite: {
-            prejoinPageEnabled: true,
+            prejoinConfig: {
+              enabled: true,
+            },
           },
           interface_config_overwrite: {},
           room_name: 'room name',
@@ -541,7 +553,9 @@ describe('DashboardLiveJitsi/utils', () => {
         doNotStoreRoom: true,
         hideConferenceSubject: true,
         hideConferenceTimer: true,
-        prejoinPageEnabled: false,
+        prejoinConfig: {
+          enabled: false,
+        },
         resolution: 720,
         toolbarButtons,
       },
@@ -566,7 +580,9 @@ describe('DashboardLiveJitsi/utils', () => {
           external_api_url: 'external api url',
           domain: 'domain',
           config_overwrite: {
-            prejoinPageEnabled: true,
+            prejoinConfig: {
+              enabled: true,
+            },
           },
           interface_config_overwrite: {},
           room_name: 'room name',
@@ -633,7 +649,9 @@ describe('DashboardLiveJitsi/utils', () => {
         doNotStoreRoom: true,
         hideConferenceSubject: true,
         hideConferenceTimer: true,
-        prejoinPageEnabled: true,
+        prejoinConfig: {
+          enabled: true,
+        },
         resolution: 720,
         toolbarButtons,
       },

--- a/src/frontend/apps/lti_site/components/DashboardLiveJitsi/utils.ts
+++ b/src/frontend/apps/lti_site/components/DashboardLiveJitsi/utils.ts
@@ -91,14 +91,19 @@ export const initializeJitsi = async (
     hideConferenceSubject: true,
     // Hides the conference timer.
     hideConferenceTimer: true,
-    prejoinPageEnabled: false,
+    prejoinConfig: {
+      enabled: false,
+    },
     resolution: 720,
     toolbarButtons,
     ...live.live_info.jitsi.config_overwrite,
   };
 
   if (live.join_mode === JoinMode.FORCED && !isInstructor) {
-    configOverwrite.prejoinPageEnabled = false;
+    configOverwrite.prejoinConfig = {
+      ...(configOverwrite.prejoinConfig || {}),
+      enabled: false,
+    };
   }
 
   return new window.JitsiMeetExternalAPI(live.live_info.jitsi.domain, {

--- a/src/frontend/apps/lti_site/types/libs/JitsiMeetExternalAPI/index.d.ts
+++ b/src/frontend/apps/lti_site/types/libs/JitsiMeetExternalAPI/index.d.ts
@@ -69,7 +69,11 @@ declare namespace JitsiMeetExternalAPI {
     hideConferenceSubject?: boolean;
     hideConferenceTimer?: boolean;
     doNotStoreRoom?: boolean;
-    prejoinPageEnabled?: boolean;
+    prejoinConfig?: {
+      enabled?: boolean;
+      hideDisplayName?: boolean;
+      hideExtraJoinButtons?: string[];
+    };
     resolution?: number;
     toolbarButtons?: string[];
   };


### PR DESCRIPTION
## Purpose

As Jitsi config has been updated, we want to align our type with it.

Fixes #1754 

## Proposal

First I tried to replace our type with @types/gjitsi/meet, but it not seems ap to date (ie: conferenceInfo is missing here)

So I checked every item, `prejoinConfig` is the only one that changed.
