### PR TITLE
✨(back) resource not ready and portability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Administrators and teachers can now have access to
+  a "not ready" resource which belongs to a playlist
+  with portability.
+
 ## [4.0.0-beta.9] - 2022-10-18
 
 ### Added

--- a/src/backend/marsha/core/lti/utils.py
+++ b/src/backend/marsha/core/lti/utils.py
@@ -94,21 +94,17 @@ def get_or_create_resource(model, lti):
             Q(playlist__lti_id=lti.context_id, playlist__consumer_site=consumer_site)
             # The resource exists in another playlist of the same consumer site and is portable
             | Q(
-                model.get_ready_clause(),
                 playlist__is_portable_to_playlist=True,
                 playlist__consumer_site=consumer_site,
             )
             # The resource exists in another consumer site to which it is portable because:
             # 1. its playlist is portable to all consumer sites
-            | Q(model.get_ready_clause(), playlist__is_portable_to_consumer_site=True)
+            | Q(playlist__is_portable_to_consumer_site=True)
             # 2. its playlist is portable to the requested playlist
-            | Q(model.get_ready_clause(), playlist__in=playlist_reachable_from)
+            | Q(playlist__in=playlist_reachable_from)
             # 3. all playlists in the consumer site of the resource are portable to the
             #    requesting consumer site
-            | Q(
-                model.get_ready_clause(),
-                playlist__consumer_site__in=consumer_site.reachable_from.all(),
-            ),
+            | Q(playlist__consumer_site__in=consumer_site.reachable_from.all()),
             pk=lti.resource_id,
         )
     except model.DoesNotExist:

--- a/src/backend/marsha/core/tests/test_lti_utils.py
+++ b/src/backend/marsha/core/tests/test_lti_utils.py
@@ -630,8 +630,8 @@ class PortabilityLTITestCase(TestCase):
     ):
         """Above case 1-2-1-2-1.
 
-        A PortabilityError should be raised if an instructor tries to retrieve a resource that
-        is already existing for a consumer site but not ready, even if it is portable to another
+        The resource should be returned if an instructor tries to retrieve a resource that
+        is already existing for a consumer site but not ready and it is portable to another
         consumer site.
         """
         passport = factories.ConsumerSiteLTIPassportFactory(
@@ -652,16 +652,10 @@ class PortabilityLTITestCase(TestCase):
         request = self.factory.post("/", data, HTTP_REFERER="https://example.com/route")
         lti = LTI(request, resource.pk)
         lti.verify()
-        with self.assertRaises(PortabilityError) as context:
-            get_or_create_resource(model, lti)
-        self.assertEqual(
-            context.exception.args[0],
-            (
-                f"The {model.__name__} ID 77fbf317-3e99-41bd-819c-130531313139 already exists but "
-                "is not portable to your playlist (a-playlist) and/or consumer site "
-                "(example.com)."
-            ),
-        )
+        retrieved_resource = get_or_create_resource(model, lti)
+        self.assertIsInstance(retrieved_resource, model)
+        self.assertEqual(retrieved_resource, resource)
+
         # No new playlist or resource are created
         self.assertEqual(models.Playlist.objects.count(), 1)
         self.assertEqual(model.objects.count(), 1)
@@ -672,8 +666,8 @@ class PortabilityLTITestCase(TestCase):
     ):
         """Above case 1-2-1-2-1.
 
-        An LTI Exception should be raised if an instructor tries to retrieve a video that is
-        already existing for a consumer site but not ready, even if it is portable to another
+        The resource should be returned if an instructor tries to retrieve a resource that
+        is already existing for a consumer site but not ready and it is portable to another
         consumer site.
         """
         self._test_lti_get_resource_other_site_playlist_portable_not_ready_to_show_instructor(
@@ -692,8 +686,8 @@ class PortabilityLTITestCase(TestCase):
     ):
         """Above case 1-2-1-2-1.
 
-        An LTI Exception should be raised if an instructor tries to retrieve a document that is
-        already existing for a consumer site but not ready, even if it is portable to another
+        The resource should be returned if an instructor tries to retrieve a resource that
+        is already existing for a consumer site but not ready and it is portable to another
         consumer site.
         """
         self._test_lti_get_resource_other_site_playlist_portable_not_ready_to_show_instructor(
@@ -959,15 +953,10 @@ class PortabilityLTITestCase(TestCase):
         request = self.factory.post("/", data, HTTP_REFERER="https://example.com/route")
         lti = LTI(request, resource.pk)
         lti.verify()
-        with self.assertRaises(PortabilityError) as context:
-            get_or_create_resource(model, lti)
-        self.assertEqual(
-            context.exception.args[0],
-            (
-                f"The {model.__name__} ID 77fbf317-3e99-41bd-819c-130531313139 already exists but "
-                "is not portable to your playlist (a-playlist) and/or consumer site (example.com)."
-            ),
-        )
+        retrieved_resource = get_or_create_resource(model, lti)
+        self.assertIsInstance(retrieved_resource, model)
+        self.assertEqual(retrieved_resource, resource)
+
         # No new playlist or resource are created
         self.assertEqual(models.Playlist.objects.count(), 1)
         self.assertEqual(model.objects.count(), 1)
@@ -1927,8 +1916,8 @@ class PortabilityLTITestCase(TestCase):
     ):
         """Above case 1-3-1-2-1.
 
-        A PortabilityError should be raised if an instructor tries to retrieve a video that is
-        already existing in a playlist but not ready, even if it is portable to another
+        The resource should be returned if an instructor tries to retrieve a video that is
+        already existing in a playlist but not ready, and if it is portable to another
         playlist.
         """
         passport = factories.ConsumerSiteLTIPassportFactory(
@@ -1950,16 +1939,9 @@ class PortabilityLTITestCase(TestCase):
         request = self.factory.post("/", data, HTTP_REFERER="https://example.com/route")
         lti = LTI(request, resource.pk)
         lti.verify()
-        with self.assertRaises(PortabilityError) as context:
-            get_or_create_resource(model, lti)
-        self.assertEqual(
-            context.exception.args[0],
-            (
-                f"The {model.__name__} ID 77fbf317-3e99-41bd-819c-130531313139 already exists but "
-                "is not portable to your playlist (another-playlist) and/or consumer site "
-                "(example.com)."
-            ),
-        )
+        retrieved_resource = get_or_create_resource(model, lti)
+        self.assertIsInstance(retrieved_resource, model)
+        self.assertEqual(retrieved_resource, resource)
 
     @mock.patch.object(LTIOAuthServer, "verify_request", return_value=True)
     def test_lti_get_video_other_pl_portable_not_ready_to_show_instructor(
@@ -1967,8 +1949,8 @@ class PortabilityLTITestCase(TestCase):
     ):
         """Above case 1-3-1-2-1 for Video.
 
-        A PortabilityError should be raised if an instructor tries to retrieve a video that
-        is already existing in a playlist but not ready, even if it is portable to another
+        The resource should be returned if an instructor tries to retrieve a video that is
+        already existing in a playlist but not ready, and if it is portable to another
         playlist.
         """
         self._test_lti_get_resource_other_pl_portable_not_ready_to_show_instructor(
@@ -1987,8 +1969,8 @@ class PortabilityLTITestCase(TestCase):
     ):
         """Above case 1-3-1-2-1 for Document.
 
-        A PortabilityError should be raised if an instructor tries to retrieve a document that
-        is already existing in a playlist but not ready, even if it is portable to another
+        The resource should be returned if an instructor tries to retrieve a video that is
+        already existing in a playlist but not ready, and if it is portable to another
         playlist.
         """
         self._test_lti_get_resource_other_pl_portable_not_ready_to_show_instructor(
@@ -2531,8 +2513,8 @@ class PortabilityLTITestCase(TestCase):
     ):
         """Above case 1-4-1-1-2-1.
 
-        A PortabilityError should be raised if an instructor tries to retrieve a resource that is
-        already existing in a playlist on another consumer site but not ready, even if it is
+        The resource should be returned if an instructor tries to retrieve a resource that is
+        already existing in a playlist on another consumer site but not ready, and if it is
         portable to another playlist AND to another consumer site.
         """
         passport = factories.ConsumerSiteLTIPassportFactory(
@@ -2554,16 +2536,10 @@ class PortabilityLTITestCase(TestCase):
         request = self.factory.post("/", data, HTTP_REFERER="https://example.com/route")
         lti = LTI(request, resource.pk)
         lti.verify()
-        with self.assertRaises(PortabilityError) as context:
-            get_or_create_resource(model, lti)
-        self.assertEqual(
-            context.exception.args[0],
-            (
-                f"The {model.__name__} ID 77fbf317-3e99-41bd-819c-130531313139 already exists but "
-                "is not portable to your playlist (another-playlist) and/or consumer site "
-                "(example.com)."
-            ),
-        )
+        retrieved_resource = get_or_create_resource(model, lti)
+        self.assertIsInstance(retrieved_resource, model)
+        self.assertEqual(retrieved_resource, resource)
+
         # No new playlist or resource are created
         self.assertEqual(models.Playlist.objects.count(), 1)
         self.assertEqual(model.objects.count(), 1)
@@ -2574,8 +2550,8 @@ class PortabilityLTITestCase(TestCase):
     ):
         """Above case 1-4-1-1-2-1 for Video.
 
-        A PortabilityError should be raised if an instructor tries to retrieve a video that is
-        already existing in a playlist on another consumer site but not ready, even if it is
+        The resource should be returned if an instructor tries to retrieve a resource that is
+        already existing in a playlist on another consumer site but not ready, and if it is
         portable to another playlist AND to another consumer site.
         """
         self._test_lti_get_resource_other_pl_site_portable_not_ready_to_show_instructor(
@@ -2594,8 +2570,8 @@ class PortabilityLTITestCase(TestCase):
     ):
         """Above case 1-4-1-1-2-1 for Document.
 
-        A PortabilityError should be raised if an instructor tries to retrieve a document that is
-        already existing in a playlist on another consumer site but not ready, even if it is
+        The resource should be returned if an instructor tries to retrieve a resource that is
+        already existing in a playlist on another consumer site but not ready, and if it is
         portable to another playlist AND to another consumer site.
         """
         self._test_lti_get_resource_other_pl_site_portable_not_ready_to_show_instructor(
@@ -2870,16 +2846,10 @@ class PortabilityLTITestCase(TestCase):
         request = self.factory.post("/", data, HTTP_REFERER="https://example.com/route")
         lti = LTI(request, resource.pk)
         lti.verify()
-        with self.assertRaises(PortabilityError) as context:
-            get_or_create_resource(model, lti)
-        self.assertEqual(
-            context.exception.args[0],
-            (
-                f"The {model.__name__} ID 77fbf317-3e99-41bd-819c-130531313139 already exists but "
-                "is not portable to your playlist (another-playlist) and/or consumer site "
-                "(example.com)."
-            ),
-        )
+        retrieved_resource = get_or_create_resource(model, lti)
+        self.assertIsInstance(retrieved_resource, model)
+        self.assertEqual(retrieved_resource, resource)
+
         # No new playlist or resource are created
         self.assertEqual(models.Playlist.objects.count(), 1)
         self.assertEqual(model.objects.count(), 1)
@@ -3188,16 +3158,10 @@ class PortabilityLTITestCase(TestCase):
         request = self.factory.post("/", data, HTTP_REFERER="https://example.com/route")
         lti = LTI(request, resource.pk)
         lti.verify()
-        with self.assertRaises(PortabilityError) as context:
-            get_or_create_resource(model, lti)
-        self.assertEqual(
-            context.exception.args[0],
-            (
-                f"The {model.__name__} ID 77fbf317-3e99-41bd-819c-130531313139 already exists but "
-                f"is not portable to your playlist ({playlist.lti_id}) and/or consumer site "
-                "(example.com)."
-            ),
-        )
+        retrieved_resource = get_or_create_resource(model, lti)
+        self.assertIsInstance(retrieved_resource, model)
+        self.assertEqual(retrieved_resource, resource)
+
         # No new playlist or resource are created
         self.assertEqual(models.Playlist.objects.count(), 2)
         self.assertEqual(model.objects.count(), 1)

--- a/src/frontend/apps/lti_site/apps/markdown/components/RedirectOnLoad/index.spec.tsx
+++ b/src/frontend/apps/lti_site/apps/markdown/components/RedirectOnLoad/index.spec.tsx
@@ -73,7 +73,7 @@ describe('<RedirectOnLoad />', () => {
     getByText('Feature disabled');
   });
 
-  it('shows editor for instructor', async () => {
+  it('shows editor for instructor who can update', async () => {
     mockedUseAppConfig.mockReturnValue({
       flags: { markdown: true },
     } as any);
@@ -99,39 +99,13 @@ describe('<RedirectOnLoad />', () => {
     getByText('Markdown editor');
   });
 
-  it('shows viewer for instructor without editing permission', async () => {
+  it('shows viewer for student or instructor who cannot update', async () => {
     mockedUseAppConfig.mockReturnValue({
       flags: { markdown: true },
     } as any);
     mockedGetDecodedJwt.mockReturnValue({
       permissions: {
         can_update: false,
-      },
-      roles: [OrganizationAccessRole.INSTRUCTOR],
-      consumer_site: 'consumer_site',
-    } as any);
-
-    const { getByText } = render(<RedirectOnLoad />, {
-      routerOptions: {
-        routes: [
-          {
-            path: MARKDOWN_VIEWER_ROUTE(),
-            render: () => <span>Markdown viewer</span>,
-          },
-        ],
-      },
-    });
-
-    getByText('Markdown viewer');
-  });
-
-  it('shows viewer for student', async () => {
-    mockedUseAppConfig.mockReturnValue({
-      flags: { markdown: true },
-    } as any);
-    mockedGetDecodedJwt.mockReturnValue({
-      permissions: {
-        can_update: true, // or false
       },
       roles: [OrganizationAccessRole.STUDENT],
       consumer_site: 'consumer_site',

--- a/src/frontend/apps/lti_site/apps/markdown/components/RedirectOnLoad/index.tsx
+++ b/src/frontend/apps/lti_site/apps/markdown/components/RedirectOnLoad/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Redirect } from 'react-router-dom';
 
-import { OrganizationAccessRole, useJwt } from 'lib-components';
+import { useJwt } from 'lib-components';
 
 import { FULL_SCREEN_ERROR_ROUTE } from 'components/ErrorComponents/route';
 import { useIsFeatureEnabled } from 'data/hooks/useIsFeatureEnabled';
@@ -34,12 +34,8 @@ export const RedirectOnLoad = () => {
   }
 
   const decodedJwt = useJwt.getState().getDecodedJwt();
-  const userHasEditionRole =
-    (decodedJwt.roles.includes(OrganizationAccessRole.ADMINISTRATOR) ||
-      decodedJwt.roles.includes(OrganizationAccessRole.INSTRUCTOR)) &&
-    decodedJwt.permissions.can_update;
 
-  if (userHasEditionRole) {
+  if (decodedJwt.permissions.can_update) {
     return <Redirect push to={MARKDOWN_EDITOR_ROUTE()} />;
   } else {
     return <Redirect push to={MARKDOWN_VIEWER_ROUTE()} />;


### PR DESCRIPTION
## Purpose

When a resource is not ready, it should not raise a portability error for intructors or administrators when playlist is ported.

This will prevent the future case where an instructor uploads many videos from the standalone site and copy links in the LMS, request portability, accept it while the video are still uploading.

## Proposal

- [x] Return the resource when the playlist is ported and the LTI request authenticates an instructor or administrator, even if the resource is not ready yet.
- [x] Fix the markdown document frontend to display only the reader when the JWT does not contain the `can_update`permission.

