### PR TITLE
♻️(back) rename lti filedepositories route in deposits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   timed text track format is not supported by
   @openfun/subsrt
 - rename front application bbb in classroom
+- rename lti/filedepositories in lti/deposits
 
 ### Fixed
 

--- a/src/backend/marsha/core/templates/core/lti_development.html
+++ b/src/backend/marsha/core/templates/core/lti_development.html
@@ -241,7 +241,7 @@
             <option value="documents">document</option>
             <option value="classrooms">classroom</option>
             <option value="markdown-documents">Markdown document</option>
-            <option value="filedepositories">File depository</option>
+            <option value="deposits">File depository</option>
           </select>
         </div>
         <div class="input-group">
@@ -344,7 +344,7 @@
             <option value="documents">document</option>
             <option value="classrooms">classroom</option>
             <option value="markdown-documents">Markdown document</option>
-            <option value="filedepositories">File depository</option>
+            <option value="deposits">File depository</option>
           </select>
         </div>
         <div class="input-group">

--- a/src/backend/marsha/deposit/urls.py
+++ b/src/backend/marsha/deposit/urls.py
@@ -16,6 +16,13 @@ router.register("depositedfiles", DepositedFileViewSet, basename="deposited_file
 
 urlpatterns = [
     path(
+        "lti/deposits/<uuid:uuid>",
+        FileDepositoryLTIView.as_view(),
+        name="file_depository_lti_view",
+    ),
+    # The following URL pattern is used to support legacy model name.
+    # It must be removed in the future.
+    path(
         "lti/filedepositories/<uuid:uuid>",
         FileDepositoryLTIView.as_view(),
         name="file_depository_lti_view",

--- a/src/backend/marsha/development/views.py
+++ b/src/backend/marsha/development/views.py
@@ -96,10 +96,10 @@ class DevelopmentLTIView(TemplateView):
                 "videos": Video.objects.order_by("-updated_on")[:5],
                 "documents": Document.objects.order_by("-updated_on")[:5],
                 "classrooms": Classroom.objects.order_by("-updated_on")[:5],
-                "markdown_documents": MarkdownDocument.objects.order_by("-updated_on")[
+                "markdown-documents": MarkdownDocument.objects.order_by("-updated_on")[
                     :5
                 ],
-                "filedepositories": FileDepository.objects.order_by("-updated_on")[:5],
+                "deposits": FileDepository.objects.order_by("-updated_on")[:5],
             },
         }
 


### PR DESCRIPTION
## Purpose

The route to use the deposit app in lti was /lti/filedepositories and we want to rename it in /lti/deposits to understand more the resource we are working on. The api routes are leave unchanged.

## Proposal

- [x] rename lti filedepositories route in deposits

