### PR TITLE
🔖(beta) bump release to 4.0.0-beta.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.0.0-beta.9] - 2022-10-18
+
 ### Added
 
 - standalone website:
@@ -1271,7 +1273,8 @@ the video to the ViewersList in the right panel
 
 - Minor fixes and improvements on features and tests
 
-[unreleased]: https://github.com/openfun/marsha/compare/v4.0.0-beta.8...master
+[unreleased]: https://github.com/openfun/marsha/compare/v4.0.0-beta.9...master
+[4.0.0-beta.9]: https://github.com/openfun/marsha/compare/v4.0.0-beta.8...v4.0.0-beta.9
 [4.0.0-beta.8]: https://github.com/openfun/marsha/compare/v4.0.0-beta.7...v4.0.0-beta.8
 [4.0.0-beta.7]: https://github.com/openfun/marsha/compare/v4.0.0-beta.6...v4.0.0-beta.7
 [4.0.0-beta.6]: https://github.com/openfun/marsha/compare/v4.0.0-beta.5...v4.0.0-beta.6

--- a/src/aws/lambda-complete/package.json
+++ b/src/aws/lambda-complete/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-complete",
-  "version": "4.0.0-beta.8",
+  "version": "4.0.0-beta.9",
   "engines": {
     "node": "16"
   },

--- a/src/aws/lambda-configure/package.json
+++ b/src/aws/lambda-configure/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-configure",
-  "version": "4.0.0-beta.8",
+  "version": "4.0.0-beta.9",
   "engines": {
     "node": "16"
   },

--- a/src/aws/lambda-convert/package.json
+++ b/src/aws/lambda-convert/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-convert",
-  "version": "4.0.0-beta.8",
+  "version": "4.0.0-beta.9",
   "engines": {
     "node": "16"
   },

--- a/src/aws/lambda-elemental-routing/package.json
+++ b/src/aws/lambda-elemental-routing/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-elemental-routing",
-  "version": "4.0.0-beta.8",
+  "version": "4.0.0-beta.9",
   "engines": {
     "node": "16"
   },

--- a/src/aws/lambda-medialive/package.json
+++ b/src/aws/lambda-medialive/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-medialive",
-  "version": "4.0.0-beta.8",
+  "version": "4.0.0-beta.9",
   "engines": {
     "node": "16"
   },

--- a/src/aws/lambda-mediapackage/package.json
+++ b/src/aws/lambda-mediapackage/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-mediapackage",
-  "version": "4.0.0-beta.8",
+  "version": "4.0.0-beta.9",
   "engines": {
     "node": "16"
   },

--- a/src/aws/lambda-migrate/package.json
+++ b/src/aws/lambda-migrate/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-migrate",
-  "version": "4.0.0-beta.8",
+  "version": "4.0.0-beta.9",
   "engines": {
     "node": "16"
   },

--- a/src/aws/utils/update-state/package.json
+++ b/src/aws/utils/update-state/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-update-state",
-  "version": "4.0.0-beta.8",
+  "version": "4.0.0-beta.9",
   "engines": {
     "node": "16"
   },

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = marsha
 description = A FUN video provider for Open edX
-version = 4.0.0-beta.8
+version = 4.0.0-beta.9
 author = Open FUN (France Universite Numerique)
 author_email = fun.dev@fun-mooc.fr
 license = MIT

--- a/src/frontend/apps/lti_site/package.json
+++ b/src/frontend/apps/lti_site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marsha",
-  "version": "4.0.0-beta.8",
+  "version": "4.0.0-beta.9",
   "description": "🐠 a FUN LTI video provider",
   "main": "front/index.tsx",
   "scripts": {


### PR DESCRIPTION
### Added

- standalone website:
  - Add router to the layout
  - Add menu interaction
  - Integrate internationalisation library (react-intl)
  - ESLint Fragment mandatory rule
  - ESlint better import order rule
- Integrate design Homepage in the standalone website:
  - Menu
  - Header
  - Homepage
- Catch and design error with react-error-boundary
- Enable visibility widget in VOD dashboard
- introduce initialized upload state
- Add BBB presentation upload
- Authenticate the user in the standalone site
- Allow to target a specific resource in LTI Select

### Changed

- move the lti data queries to the lib_components package
- call api update-state with an error when the timed text track format is not supported by @openfun/subsrt
- rename front application bbb in classroom
- rename lti/filedepositories in lti/deposits

### Fixed

- Fix deposit app translations
- Fix video dashboard translations
- Fix deposit app UI
- Use video title in creation wizard if it exists
- Skip screen choice between live and vod when coming back from LTI select
- Fix subtitles upload
- Fix debounce time too low in the classroom creation form
- Fix icons urls in LTI xml configuration


