### PR TITLE
⬇️(back) pin channels-redis to version <4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   a "not ready" resource which belongs to a playlist
   with portability.
 
+### Fixed
+
+- Downgrade channels-redis to version <4
+
 ## [4.0.0-beta.9] - 2022-10-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.0.0-beta.10] - 2022-10-19
+
 ### Changed
 
 - Administrators and teachers can now have access to
@@ -1283,7 +1285,8 @@ the video to the ViewersList in the right panel
 
 - Minor fixes and improvements on features and tests
 
-[unreleased]: https://github.com/openfun/marsha/compare/v4.0.0-beta.9...master
+[unreleased]: https://github.com/openfun/marsha/compare/v4.0.0-beta.10...master
+[4.0.0-beta.10]: https://github.com/openfun/marsha/compare/v4.0.0-beta.9...v4.0.0-beta.10
 [4.0.0-beta.9]: https://github.com/openfun/marsha/compare/v4.0.0-beta.8...v4.0.0-beta.9
 [4.0.0-beta.8]: https://github.com/openfun/marsha/compare/v4.0.0-beta.7...v4.0.0-beta.8
 [4.0.0-beta.7]: https://github.com/openfun/marsha/compare/v4.0.0-beta.6...v4.0.0-beta.7

--- a/renovate.json
+++ b/renovate.json
@@ -36,6 +36,17 @@
         "django"
       ],
       "allowedVersions": "<4.1"
+    },
+    {
+      "groupName": "allowed django channels version",
+      "matchManagers": [
+        "setup-cfg"
+      ],
+      "matchPackageNames": [
+        "channels",
+        "channels-redis"
+      ],
+      "allowedVersions": "<4"
     }
   ]
 }

--- a/src/aws/lambda-complete/package.json
+++ b/src/aws/lambda-complete/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-complete",
-  "version": "4.0.0-beta.9",
+  "version": "4.0.0-beta.10",
   "engines": {
     "node": "16"
   },

--- a/src/aws/lambda-configure/package.json
+++ b/src/aws/lambda-configure/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-configure",
-  "version": "4.0.0-beta.9",
+  "version": "4.0.0-beta.10",
   "engines": {
     "node": "16"
   },

--- a/src/aws/lambda-convert/package.json
+++ b/src/aws/lambda-convert/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-convert",
-  "version": "4.0.0-beta.9",
+  "version": "4.0.0-beta.10",
   "engines": {
     "node": "16"
   },

--- a/src/aws/lambda-elemental-routing/package.json
+++ b/src/aws/lambda-elemental-routing/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-elemental-routing",
-  "version": "4.0.0-beta.9",
+  "version": "4.0.0-beta.10",
   "engines": {
     "node": "16"
   },

--- a/src/aws/lambda-medialive/package.json
+++ b/src/aws/lambda-medialive/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-medialive",
-  "version": "4.0.0-beta.9",
+  "version": "4.0.0-beta.10",
   "engines": {
     "node": "16"
   },

--- a/src/aws/lambda-mediapackage/package.json
+++ b/src/aws/lambda-mediapackage/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-mediapackage",
-  "version": "4.0.0-beta.9",
+  "version": "4.0.0-beta.10",
   "engines": {
     "node": "16"
   },

--- a/src/aws/lambda-migrate/package.json
+++ b/src/aws/lambda-migrate/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-migrate",
-  "version": "4.0.0-beta.9",
+  "version": "4.0.0-beta.10",
   "engines": {
     "node": "16"
   },

--- a/src/aws/utils/update-state/package.json
+++ b/src/aws/utils/update-state/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-update-state",
-  "version": "4.0.0-beta.9",
+  "version": "4.0.0-beta.10",
   "engines": {
     "node": "16"
   },

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -29,8 +29,8 @@ requires-python = >=3.9
 install_requires =
     Brotli==1.0.9
     boto3==1.24.89
-    channels==3.0.5
-    channels-redis==4.0.0
+    channels<4
+    channels-redis<4
     chardet==5.0.0
     coreapi==2.3.3
     cryptography==38.0.1

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = marsha
 description = A FUN video provider for Open edX
-version = 4.0.0-beta.9
+version = 4.0.0-beta.10
 author = Open FUN (France Universite Numerique)
 author_email = fun.dev@fun-mooc.fr
 license = MIT

--- a/src/frontend/apps/lti_site/package.json
+++ b/src/frontend/apps/lti_site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marsha",
-  "version": "4.0.0-beta.9",
+  "version": "4.0.0-beta.10",
   "description": "🐠 a FUN LTI video provider",
   "main": "front/index.tsx",
   "scripts": {


### PR DESCRIPTION
## Purpose

Since we are using channels-redis 4, we have connection issues to redis. We must downgrade it to version <4 and block its upgrade, also django-channels upgrade, while this issue exists.
An issue is open on channels-redis repo lookink what we are experiencing https://github.com/django/channels_redis/issues/332

## Proposal

- [x] pin channels-redis to version <4

