### PR TITLE
🧑‍💻(frontend) configure site proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,3 +157,4 @@ transmuxed_video
 # ngrok
 .ngrok_url
 src/backend/marsha/core/templates/core/mail/
+*.local

--- a/src/frontend/apps/standalone_site/.eslintrc.js
+++ b/src/frontend/apps/standalone_site/.eslintrc.js
@@ -66,7 +66,7 @@ module.exports = {
     'react/react-in-jsx-scope': 0,
     'react/jsx-fragments': ['error', 'element'],
   },
-  ignorePatterns: ['node_modules/'],
+  ignorePatterns: ['node_modules/', '.eslintrc.js', 'src/setupProxy.js'],
   settings: {
     react: {
       version: 'detect',

--- a/src/frontend/apps/standalone_site/package.json
+++ b/src/frontend/apps/standalone_site/package.json
@@ -2,7 +2,6 @@
   "name": "standalone_site",
   "version": "0.1.0",
   "private": true,
-  "proxy": "http://localhost:8060",
   "devDependencies": {
     "@types/fetch-mock": "7.3.5",
     "@types/jest": "29.2.1",
@@ -24,6 +23,7 @@
   },
   "dependencies": {
     "grommet": "*",
+    "http-proxy-middleware": "2.0.6",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-query": "3.39.2",

--- a/src/frontend/apps/standalone_site/src/setupProxy.js
+++ b/src/frontend/apps/standalone_site/src/setupProxy.js
@@ -1,0 +1,11 @@
+const { createProxyMiddleware } = require('http-proxy-middleware');
+
+module.exports = function (app) {
+  app.use(
+    '/api',
+    createProxyMiddleware({
+      target: process.env.REACT_APP_BACKEND_API_BASE_URL,
+      changeOrigin: true,
+    }),
+  );
+};

--- a/src/frontend/yarn.lock
+++ b/src/frontend/yarn.lock
@@ -1956,9 +1956,9 @@
   integrity sha512-bO37brCPfteXQfFY0DyNDGB3+IMe4j150KFQcgJ5aBP295p9nBGeHEs/p0czrRbtlHq4Px/yoPXO/+dOCcF4uA==
 
 "@floating-ui/dom@^1.0.1":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.0.2.tgz#c5184c52c6f50abd11052d71204f4be2d9245237"
-  integrity sha512-5X9WSvZ8/fjy3gDu8yx9HAA4KG1lazUN2P4/VnaXLxTO9Dz53HI1oYoh1OlhqFNlHgGDiwFX5WhFCc2ljbW3yA==
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.0.3.tgz#b439c8a66436c2cae8d97e889f0b76cce757a6ec"
+  integrity sha512-6H1kwjkOZKabApNtXRiYHvMmYJToJ1DV7rQ3xc/WJpOABhQIOJJOdz2AOejj8X+gcybaFmBpisVTZxBZAM3V0w==
   dependencies:
     "@floating-ui/core" "^1.0.1"
 
@@ -8054,7 +8054,7 @@ http-proxy-agent@^5.0.0:
     agent-base "6"
     debug "4"
 
-http-proxy-middleware@^2.0.3:
+http-proxy-middleware@2.0.6, http-proxy-middleware@^2.0.3:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz#e1a4dd6979572c7ab5a4e4b55095d1f32a74963f"
   integrity sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==


### PR DESCRIPTION
## Purpose

Allow locale configuration to proxy backend (and later be able to deploy a backend on aws for dev purposes)

## Proposal

Use the configuration of the backend adress to configure the proxy.
You can override this config in your local environnement in the file .env.local and target the backend you wish.
