### PR TITLE
Add SharedLiveMedia to public and teach VOD Dashboards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Create lib-classroom package
+- Add SharedLiveMedia widget to public and teacher VOD Dashboard
 - Add new elements to the public VOD Dashboard :
   - Transcript reader
   - Video download

--- a/src/frontend/apps/lti_site/components/PublicVideoDashboard/PublicVODDashboard/index.spec.tsx
+++ b/src/frontend/apps/lti_site/components/PublicVideoDashboard/PublicVODDashboard/index.spec.tsx
@@ -8,6 +8,8 @@ import {
   useTimedTextTrack,
   timedTextMode,
   uploadState,
+  useSharedLiveMedia,
+  sharedLiveMediaMockFactory,
 } from 'lib-components';
 import React from 'react';
 
@@ -18,6 +20,7 @@ import render from 'utils/tests/render';
 import { wrapInVideo } from 'utils/tests/wrapInVideo';
 
 import { PublicVODDashboard } from '.';
+import faker from 'faker';
 
 jest.mock('lib-components', () => ({
   ...jest.requireActual('lib-components'),
@@ -75,6 +78,7 @@ describe('<PublicVODDashboard />', () => {
     const video = videoMockFactory({
       show_download: false,
       has_transcript: false,
+      shared_live_medias: [],
       urls: {
         manifests: {
           hls: 'https://example.com/hls.m3u8',
@@ -124,15 +128,22 @@ describe('<PublicVODDashboard />', () => {
     expect(screen.queryByText('Download video')).not.toBeInTheDocument();
   });
 
-  it('displays the video player, the download and transcripts widgets', async () => {
+  it('displays the video player, the download, SharedLiveMedia and transcripts widgets', async () => {
+    const videoId = faker.datatype.uuid();
     const timedTextTracks = [
       timedTextMockFactory({
         is_ready_to_show: true,
         mode: timedTextMode.TRANSCRIPT,
       }),
     ];
+    const mockedSharedLiveMedia = sharedLiveMediaMockFactory({
+      title: 'Title of the file',
+      video: videoId,
+    });
     useTimedTextTrack.getState().addMultipleResources(timedTextTracks);
+    useSharedLiveMedia.getState().addResource(mockedSharedLiveMedia);
     const video = videoMockFactory({
+      id: videoId,
       has_transcript: true,
       show_download: true,
       timed_text_tracks: timedTextTracks,
@@ -167,6 +178,7 @@ describe('<PublicVODDashboard />', () => {
 
     screen.getByText('Transcripts');
     screen.getByText('Download video');
+    screen.getByText('Supports sharing');
   });
 
   it('uses subtitles as transcripts', async () => {

--- a/src/frontend/apps/lti_site/components/VideoWidgetProvider/index.tsx
+++ b/src/frontend/apps/lti_site/components/VideoWidgetProvider/index.tsx
@@ -41,7 +41,9 @@ enum WidgetType {
   LIVE_PAIRING = 'LIVE_PAIRING',
   VOD_CREATION = 'VOD_CREATION',
   LIVE_JOIN_MODE = 'LIVE_JOIN_MODE',
-  SHARED_LIVE_MEDIA = 'SHARED_LIVE_MEDIA',
+  SHARED_MEDIA_LIVE_TEACHER = 'SHARED_MEDIA_LIVE_TEACHER',
+  SHARED_MEDIA_VOD_TEACHER = 'SHARED_MEDIA_VOD_TEACHER',
+  SHARED_MEDIA_VOD_PUBLIC = 'SHARED_MEDIA_VOD_PUBLIC',
   TRANSCRIPTS = 'TRANSCRIPTS',
 }
 
@@ -120,8 +122,24 @@ const widgetLoader: { [key in WidgetType]: WidgetProps } = {
     component: <LiveJoinMode key="live_join_mode" />,
     size: WidgetSize.DEFAULT,
   },
-  [WidgetType.SHARED_LIVE_MEDIA]: {
-    component: <SharedLiveMedia key="shared_live_media" />,
+  [WidgetType.SHARED_MEDIA_LIVE_TEACHER]: {
+    component: <SharedLiveMedia key="shared_live_media" isLive isTeacher />,
+    size: WidgetSize.DEFAULT,
+  },
+  [WidgetType.SHARED_MEDIA_VOD_TEACHER]: {
+    component: (
+      <SharedLiveMedia key="shared_live_media" isLive={false} isTeacher />
+    ),
+    size: WidgetSize.DEFAULT,
+  },
+  [WidgetType.SHARED_MEDIA_VOD_PUBLIC]: {
+    component: (
+      <SharedLiveMedia
+        key="shared_live_media"
+        isLive={false}
+        isTeacher={false}
+      />
+    ),
     size: WidgetSize.DEFAULT,
   },
   [WidgetType.TRANSCRIPTS]: {
@@ -139,7 +157,7 @@ const teacherLiveWidgets: WidgetType[] = [
   WidgetType.VOD_CREATION,
   WidgetType.LIVE_JOIN_MODE,
   WidgetType.THUMBNAIL_LIVE,
-  WidgetType.SHARED_LIVE_MEDIA,
+  WidgetType.SHARED_MEDIA_LIVE_TEACHER,
 ];
 const teacherVodWidgets: WidgetType[] = [
   WidgetType.TITLE_AND_DESCRIPTION,
@@ -150,11 +168,13 @@ const teacherVodWidgets: WidgetType[] = [
   WidgetType.UPLOAD_SUBTITLES,
   WidgetType.UPLOAD_TRANSCRIPTS,
   WidgetType.UPLOAD_CLOSED_CAPTATIONS,
+  WidgetType.SHARED_MEDIA_VOD_TEACHER,
 ];
 const publicLiveWidgets: WidgetType[] = [];
 const publicVodWidgets: WidgetType[] = [
   WidgetType.TRANSCRIPTS,
   WidgetType.DOWNLOAD_VOD_PUBLIC,
+  WidgetType.SHARED_MEDIA_VOD_PUBLIC,
 ];
 
 interface VideoWidgetProviderProps {

--- a/src/frontend/apps/lti_site/components/VideoWidgetProvider/widgets/SharedLiveMedia/SharedLiveMediaItem/index.spec.tsx
+++ b/src/frontend/apps/lti_site/components/VideoWidgetProvider/widgets/SharedLiveMedia/SharedLiveMediaItem/index.spec.tsx
@@ -72,6 +72,8 @@ describe('<SharedLiveMediaItem />', () => {
               onRetryFailedUpload={mockedOnRetryFailedUpload}
               sharedLiveMedia={mockedSharedLiveMedia}
               uploadingObject={mockedUploadingObject}
+              isLive
+              isTeacher
             />
           </DeleteSharedLiveMediaModalProvider>
         </UploadManagerContext.Provider>,
@@ -129,6 +131,8 @@ describe('<SharedLiveMediaItem />', () => {
               onRetryFailedUpload={mockedOnRetryFailedUpload}
               sharedLiveMedia={mockedSharedLiveMedia}
               uploadingObject={mockedUploadingObject}
+              isLive
+              isTeacher
             />
           </DeleteSharedLiveMediaModalProvider>
         </UploadManagerContext.Provider>,
@@ -176,6 +180,8 @@ describe('<SharedLiveMediaItem />', () => {
               isShared={null}
               onRetryFailedUpload={mockedOnRetryFailedUpload}
               sharedLiveMedia={mockedSharedLiveMedia}
+              isLive
+              isTeacher
             />
           </DeleteSharedLiveMediaModalProvider>
         </UploadManagerContext.Provider>,
@@ -219,6 +225,8 @@ describe('<SharedLiveMediaItem />', () => {
               isShared={null}
               onRetryFailedUpload={mockedOnRetryFailedUpload}
               sharedLiveMedia={mockedSharedLiveMedia}
+              isLive
+              isTeacher
             />
           </DeleteSharedLiveMediaModalProvider>
         </UploadManagerContext.Provider>,
@@ -264,6 +272,8 @@ describe('<SharedLiveMediaItem />', () => {
               isShared={true}
               onRetryFailedUpload={mockedOnRetryFailedUpload}
               sharedLiveMedia={mockedSharedLiveMedia}
+              isLive
+              isTeacher
             />
           </DeleteSharedLiveMediaModalProvider>
         </UploadManagerContext.Provider>,
@@ -306,6 +316,8 @@ describe('<SharedLiveMediaItem />', () => {
               isShared={null}
               onRetryFailedUpload={mockedOnRetryFailedUpload}
               sharedLiveMedia={mockedSharedLiveMedia}
+              isLive
+              isTeacher
             />
           </DeleteSharedLiveMediaModalProvider>
         </UploadManagerContext.Provider>,
@@ -356,6 +368,8 @@ describe('<SharedLiveMediaItem />', () => {
               isShared={null}
               onRetryFailedUpload={mockedOnRetryFailedUpload}
               sharedLiveMedia={mockedSharedLiveMedia}
+              isLive
+              isTeacher
             />
           </DeleteSharedLiveMediaModalProvider>
         </UploadManagerContext.Provider>,

--- a/src/frontend/apps/lti_site/components/VideoWidgetProvider/widgets/SharedLiveMedia/SharedLiveMediaItem/index.tsx
+++ b/src/frontend/apps/lti_site/components/VideoWidgetProvider/widgets/SharedLiveMedia/SharedLiveMediaItem/index.tsx
@@ -28,6 +28,8 @@ interface SharedLiveMediaItemProps {
   onRetryFailedUpload: (sharedLiveMediaId: SharedLiveMedia['id']) => void;
   sharedLiveMedia: SharedLiveMedia;
   uploadingObject?: UploadingObject;
+  isLive: boolean;
+  isTeacher: boolean;
 }
 
 export const SharedLiveMediaItem = ({
@@ -35,6 +37,8 @@ export const SharedLiveMediaItem = ({
   onRetryFailedUpload,
   sharedLiveMedia,
   uploadingObject,
+  isLive,
+  isTeacher,
 }: SharedLiveMediaItemProps) => {
   const intl = useIntl();
 
@@ -51,15 +55,18 @@ export const SharedLiveMediaItem = ({
       gap="medium"
       pad={{ horizontal: 'small', vertical: 'small' }}
     >
-      {sharedLiveMedia.show_download ? (
-        <AllowedDownloadButton sharedLiveMediaId={sharedLiveMedia.id} />
-      ) : (
-        <DisallowedDownloadButton sharedLiveMediaId={sharedLiveMedia.id} />
-      )}
+      {isTeacher &&
+        (sharedLiveMedia.show_download ? (
+          <AllowedDownloadButton sharedLiveMediaId={sharedLiveMedia.id} />
+        ) : (
+          <DisallowedDownloadButton sharedLiveMediaId={sharedLiveMedia.id} />
+        ))}
 
-      <Box direction="row" align="center" gap="small">
-        <DeleteSharedLiveMediaButton sharedLiveMedia={sharedLiveMedia} />
-      </Box>
+      {isTeacher && (
+        <Box direction="row" align="center" gap="small">
+          <DeleteSharedLiveMediaButton sharedLiveMedia={sharedLiveMedia} />
+        </Box>
+      )}
 
       <Box style={{ minWidth: '0' }}>
         <TitleDisplayer
@@ -68,48 +75,52 @@ export const SharedLiveMediaItem = ({
         />
       </Box>
 
-      <Box
-        align="center"
-        direction="row"
-        justify="center"
-        margin={{ left: 'auto' }}
-      >
-        {sharedLiveMedia.upload_state === uploadState.READY ? (
-          <Box justify="center" margin={{ left: 'auto' }}>
-            {!isShared ? (
-              <StartSharingButton sharedLiveMediaId={sharedLiveMedia.id} />
-            ) : (
-              <StopSharingButton />
-            )}
-          </Box>
-        ) : IS_UPLOAD_IN_PROGRESS ? (
-          <Text
-            color="blue-active"
-            size="0.9rem"
-            style={{ fontFamily: 'Roboto-Medium' }}
-            truncate
-          >
-            <ObjectStatusPicker object={sharedLiveMedia} />
-          </Text>
-        ) : (
-          <React.Fragment>
-            <Box>
-              <Text
-                color="red-active"
-                size="0.9rem"
-                style={{ fontFamily: 'Roboto-Medium' }}
-              >
-                {intl.formatMessage(messages.retryUploadFailedLabel)}
-              </Text>
-            </Box>
+      {isTeacher && (
+        <Box
+          align="center"
+          direction="row"
+          justify="center"
+          margin={{ left: 'auto' }}
+        >
+          {sharedLiveMedia.upload_state === uploadState.READY ? (
+            isLive && (
+              <Box justify="center" margin={{ left: 'auto' }}>
+                {!isShared ? (
+                  <StartSharingButton sharedLiveMediaId={sharedLiveMedia.id} />
+                ) : (
+                  <StopSharingButton />
+                )}
+              </Box>
+            )
+          ) : IS_UPLOAD_IN_PROGRESS ? (
+            <Text
+              color="blue-active"
+              size="0.9rem"
+              style={{ fontFamily: 'Roboto-Medium' }}
+              truncate
+            >
+              <ObjectStatusPicker object={sharedLiveMedia} />
+            </Text>
+          ) : (
+            <React.Fragment>
+              <Box>
+                <Text
+                  color="red-active"
+                  size="0.9rem"
+                  style={{ fontFamily: 'Roboto-Medium' }}
+                >
+                  {intl.formatMessage(messages.retryUploadFailedLabel)}
+                </Text>
+              </Box>
 
-            <RetryUploadButton
-              color="red-active"
-              onClick={() => onRetryFailedUpload(sharedLiveMedia.id)}
-            />
-          </React.Fragment>
-        )}
-      </Box>
+              <RetryUploadButton
+                color="red-active"
+                onClick={() => onRetryFailedUpload(sharedLiveMedia.id)}
+              />
+            </React.Fragment>
+          )}
+        </Box>
+      )}
     </Box>
   );
 };

--- a/src/frontend/apps/lti_site/components/VideoWidgetProvider/widgets/SharedLiveMedia/index.spec.tsx
+++ b/src/frontend/apps/lti_site/components/VideoWidgetProvider/widgets/SharedLiveMedia/index.spec.tsx
@@ -67,7 +67,7 @@ describe('<SharedLiveMedia />', () => {
           <InfoWidgetModalProvider value={null}>
             <DeleteSharedLiveMediaModalProvider value={null}>
               <SharedLiveMediaModalWrapper />
-              <SharedLiveMedia />
+              <SharedLiveMedia isLive isTeacher />
             </DeleteSharedLiveMediaModalProvider>
           </InfoWidgetModalProvider>
         </UploadManagerContext.Provider>,
@@ -111,7 +111,7 @@ describe('<SharedLiveMedia />', () => {
           <InfoWidgetModalProvider value={null}>
             <DeleteSharedLiveMediaModalProvider value={null}>
               <SharedLiveMediaModalWrapper />
-              <SharedLiveMedia />
+              <SharedLiveMedia isLive isTeacher />
             </DeleteSharedLiveMediaModalProvider>
           </InfoWidgetModalProvider>
         </UploadManagerContext.Provider>,
@@ -176,7 +176,7 @@ describe('<SharedLiveMedia />', () => {
           <InfoWidgetModalProvider value={null}>
             <DeleteSharedLiveMediaModalProvider value={null}>
               <SharedLiveMediaModalWrapper />
-              <SharedLiveMedia />
+              <SharedLiveMedia isLive isTeacher />
             </DeleteSharedLiveMediaModalProvider>
           </InfoWidgetModalProvider>
         </UploadManagerContext.Provider>,
@@ -249,7 +249,7 @@ describe('<SharedLiveMedia />', () => {
           <InfoWidgetModalProvider value={null}>
             <DeleteSharedLiveMediaModalProvider value={null}>
               <SharedLiveMediaModalWrapper />
-              <SharedLiveMedia />
+              <SharedLiveMedia isLive isTeacher />
             </DeleteSharedLiveMediaModalProvider>
           </InfoWidgetModalProvider>
         </UploadManagerContext.Provider>,
@@ -331,7 +331,7 @@ describe('<SharedLiveMedia />', () => {
           <InfoWidgetModalProvider value={null}>
             <DeleteSharedLiveMediaModalProvider value={null}>
               <SharedLiveMediaModalWrapper />
-              <SharedLiveMedia />
+              <SharedLiveMedia isLive isTeacher />
             </DeleteSharedLiveMediaModalProvider>
           </InfoWidgetModalProvider>
         </UploadManagerContext.Provider>,
@@ -355,7 +355,7 @@ describe('<SharedLiveMedia />', () => {
 
     userEvent.click(retryButton);
     const hiddenInput = screen.getByTestId('input-file-test-id');
-    const file = new File(['(⌐□_□)'], 'sharedMedia.pdf', {
+    const file = new File(['(⌐□_□)'], 'SharedLiveMedia.pdf', {
       type: 'application/pdf',
     });
     userEvent.upload(hiddenInput, file);
@@ -367,5 +367,243 @@ describe('<SharedLiveMedia />', () => {
       mockedSharedLiveMedia.id,
       file,
     );
+  });
+
+  it('renders the component in teacher VOD mode', () => {
+    const videoId = faker.datatype.uuid();
+    const mockedSharedLiveMedia = sharedLiveMediaMockFactory({
+      title: 'Title of the file',
+      video: videoId,
+    });
+    const mockedVideo = videoMockFactory({
+      id: videoId,
+      shared_live_medias: [mockedSharedLiveMedia],
+    });
+    mockUseUploadManager.mockReturnValue({
+      addUpload: jest.fn(),
+      resetUpload: jest.fn(),
+      uploadManagerState: {},
+    });
+    useSharedLiveMedia.getState().addResource(mockedSharedLiveMedia);
+
+    render(
+      wrapInVideo(
+        <InfoWidgetModalProvider value={null}>
+          <DeleteSharedLiveMediaModalProvider value={null}>
+            <SharedLiveMediaModalWrapper />
+            <SharedLiveMedia isLive={false} isTeacher />
+          </DeleteSharedLiveMediaModalProvider>
+        </InfoWidgetModalProvider>,
+        mockedVideo,
+      ),
+    );
+
+    screen.getByRole('button', { name: 'Upload a presentation support' });
+    screen.getByRole('button', {
+      name: 'Click on this button to stop allowing students to download this media.',
+    });
+    screen.getByRole('button', {
+      name: 'Click on this button to delete the media.',
+    });
+
+    expect(
+      screen.queryByRole('button', { name: 'Share' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders the component in student VOD mode', () => {
+    const videoId = faker.datatype.uuid();
+    const mockedSharedLiveMedia = sharedLiveMediaMockFactory({
+      title: 'Title of the file',
+      video: videoId,
+    });
+    const mockedVideo = videoMockFactory({
+      id: videoId,
+      shared_live_medias: [mockedSharedLiveMedia],
+    });
+    mockUseUploadManager.mockReturnValue({
+      addUpload: jest.fn(),
+      resetUpload: jest.fn(),
+      uploadManagerState: {},
+    });
+    useSharedLiveMedia.getState().addResource(mockedSharedLiveMedia);
+
+    render(
+      wrapInVideo(
+        <InfoWidgetModalProvider value={null}>
+          <DeleteSharedLiveMediaModalProvider value={null}>
+            <SharedLiveMediaModalWrapper />
+            <SharedLiveMedia isLive={false} isTeacher={false} />
+          </DeleteSharedLiveMediaModalProvider>
+        </InfoWidgetModalProvider>,
+        mockedVideo,
+      ),
+    );
+
+    expect(
+      screen.queryByRole('button', { name: 'Upload a presentation support' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {
+        name: 'Click on this button to stop allowing students to download this media.',
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Share' }),
+    ).not.toBeInTheDocument();
+    screen.getByRole('button', { name: 'Download all available supports' });
+    screen.getByRole('link', { name: 'Title of the file' });
+  });
+
+  it('does not show the media if show_donwload is set to false', () => {
+    const videoId = faker.datatype.uuid();
+    const mockedSharedLiveMedia = sharedLiveMediaMockFactory({
+      title: 'Title of the file',
+      video: videoId,
+      show_download: true,
+    });
+    const secondMockedSharedLiveMedia = sharedLiveMediaMockFactory({
+      title: 'Title of the file 2',
+      video: videoId,
+      show_download: false,
+    });
+    const mockedVideo = videoMockFactory({
+      id: videoId,
+      shared_live_medias: [mockedSharedLiveMedia, secondMockedSharedLiveMedia],
+    });
+    mockUseUploadManager.mockReturnValue({
+      addUpload: jest.fn(),
+      resetUpload: jest.fn(),
+      uploadManagerState: {},
+    });
+    useSharedLiveMedia.getState().addResource(mockedSharedLiveMedia);
+
+    render(
+      wrapInVideo(
+        <InfoWidgetModalProvider value={null}>
+          <DeleteSharedLiveMediaModalProvider value={null}>
+            <SharedLiveMediaModalWrapper />
+            <SharedLiveMedia isLive={false} isTeacher={false} />
+          </DeleteSharedLiveMediaModalProvider>
+        </InfoWidgetModalProvider>,
+        mockedVideo,
+      ),
+    );
+    expect(
+      screen.queryByRole('link', { name: 'Title of the file 2' }),
+    ).not.toBeInTheDocument();
+    screen.getByRole('button', { name: 'Download all available supports' });
+    screen.getByRole('link', { name: 'Title of the file' });
+  });
+
+  it('does not show the media if show_donwload is set to false', () => {
+    const videoId = faker.datatype.uuid();
+    const mockedSharedLiveMedia = sharedLiveMediaMockFactory({
+      title: 'Title of the file',
+      video: videoId,
+      show_download: true,
+    });
+    const secondMockedSharedLiveMedia = sharedLiveMediaMockFactory({
+      title: 'Title of the file 2',
+      video: videoId,
+      show_download: false,
+    });
+    const mockedVideo = videoMockFactory({
+      id: videoId,
+      shared_live_medias: [mockedSharedLiveMedia, secondMockedSharedLiveMedia],
+    });
+    mockUseUploadManager.mockReturnValue({
+      addUpload: jest.fn(),
+      resetUpload: jest.fn(),
+      uploadManagerState: {},
+    });
+    useSharedLiveMedia.getState().addResource(mockedSharedLiveMedia);
+
+    render(
+      wrapInVideo(
+        <InfoWidgetModalProvider value={null}>
+          <DeleteSharedLiveMediaModalProvider value={null}>
+            <SharedLiveMediaModalWrapper />
+            <SharedLiveMedia isLive={false} isTeacher={false} />
+          </DeleteSharedLiveMediaModalProvider>
+        </InfoWidgetModalProvider>,
+        mockedVideo,
+      ),
+    );
+    expect(
+      screen.queryByRole('link', { name: 'Title of the file 2' }),
+    ).not.toBeInTheDocument();
+    screen.getByRole('button', { name: 'Download all available supports' });
+    screen.getByRole('link', { name: 'Title of the file' });
+  });
+
+  it('does not show anything in public is there is no media to downoad', () => {
+    const videoId = faker.datatype.uuid();
+    const mockedSharedLiveMedia = sharedLiveMediaMockFactory({
+      title: 'Title of the file',
+      video: videoId,
+      show_download: false,
+    });
+    const mockedVideo = videoMockFactory({
+      id: videoId,
+      shared_live_medias: [mockedSharedLiveMedia],
+    });
+    mockUseUploadManager.mockReturnValue({
+      addUpload: jest.fn(),
+      resetUpload: jest.fn(),
+      uploadManagerState: {},
+    });
+    useSharedLiveMedia.getState().addResource(mockedSharedLiveMedia);
+
+    render(
+      wrapInVideo(
+        <InfoWidgetModalProvider value={null}>
+          <DeleteSharedLiveMediaModalProvider value={null}>
+            <SharedLiveMediaModalWrapper />
+            <SharedLiveMedia isLive={false} isTeacher={false} />
+          </DeleteSharedLiveMediaModalProvider>
+        </InfoWidgetModalProvider>,
+        mockedVideo,
+      ),
+    );
+    expect(
+      screen.queryByRole('link', { name: 'Title of the file' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Download all available supports' }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText('Supports sharing')).not.toBeInTheDocument();
+  });
+
+  it('shows the compoment in teacher view even if is there is no media to downoad', () => {
+    const videoId = faker.datatype.uuid();
+    const mockedSharedLiveMedia = sharedLiveMediaMockFactory({
+      title: 'Title of the file',
+      video: videoId,
+      show_download: false,
+    });
+    const mockedVideo = videoMockFactory({
+      id: videoId,
+      shared_live_medias: [mockedSharedLiveMedia],
+    });
+    mockUseUploadManager.mockReturnValue({
+      addUpload: jest.fn(),
+      resetUpload: jest.fn(),
+      uploadManagerState: {},
+    });
+    useSharedLiveMedia.getState().addResource(mockedSharedLiveMedia);
+
+    render(
+      wrapInVideo(
+        <InfoWidgetModalProvider value={null}>
+          <DeleteSharedLiveMediaModalProvider value={null}>
+            <SharedLiveMediaModalWrapper />
+            <SharedLiveMedia isLive={false} isTeacher />
+          </DeleteSharedLiveMediaModalProvider>
+        </InfoWidgetModalProvider>,
+        mockedVideo,
+      ),
+    );
+    screen.getByRole('link', { name: 'Title of the file' });
   });
 });

--- a/src/frontend/yarn.lock
+++ b/src/frontend/yarn.lock
@@ -1589,7 +1589,7 @@
     "@codemirror/language" "^6.0.0"
     "@codemirror/legacy-modes" "^6.1.0"
 
-"@codemirror/language@6.3.0", "@codemirror/language@^6.0.0", "@codemirror/language@^6.3.0":
+"@codemirror/language@6.3.0", "@codemirror/language@^0.19.0", "@codemirror/language@^6.0.0", "@codemirror/language@^6.3.0":
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/@codemirror/language/-/language-6.3.0.tgz#141c715e1fce5f6dcca3b1b984ed8f03f583dd5c"
   integrity sha512-6jOE5DEt6sKD46SXhn3xPbBehn+l48ACcA6Uxs2k+E2YNH9XGF5WdGMTYr2DlggfK4h0QZBK6zEb5S7lkTriWA==
@@ -1600,17 +1600,6 @@
     "@lezer/highlight" "^1.0.0"
     "@lezer/lr" "^1.0.0"
     style-mod "^4.0.0"
-
-"@codemirror/language@^0.19.0":
-  version "0.19.10"
-  resolved "https://registry.yarnpkg.com/@codemirror/language/-/language-0.19.10.tgz#c3d1330fa5de778c6b6b5177af5572a3d9d596b5"
-  integrity sha512-yA0DZ3RYn2CqAAGW62VrU8c4YxscMQn45y/I9sjBlqB1e2OTQLg4CCkMBuMSLXk4xaqjlsgazeOQWaJQOKfV8Q==
-  dependencies:
-    "@codemirror/state" "^0.19.0"
-    "@codemirror/text" "^0.19.0"
-    "@codemirror/view" "^0.19.0"
-    "@lezer/common" "^0.15.5"
-    "@lezer/lr" "^0.15.0"
 
 "@codemirror/legacy-modes@^6.1.0":
   version "6.2.0"
@@ -1638,7 +1627,7 @@
     "@codemirror/view" "^0.19.0"
     "@lezer/common" "^0.15.0"
 
-"@codemirror/rangeset@^0.19.0", "@codemirror/rangeset@^0.19.5":
+"@codemirror/rangeset@^0.19.0":
   version "0.19.9"
   resolved "https://registry.yarnpkg.com/@codemirror/rangeset/-/rangeset-0.19.9.tgz#e80895de93c39dc7899f5be31d368c9d88aa4efc"
   integrity sha512-V8YUuOvK+ew87Xem+71nKcqu1SXd5QROMRLMS/ljT5/3MCxtgrRie1Cvild0G/Z2f1fpWxzX78V0U4jjXBorBQ==
@@ -1672,40 +1661,22 @@
     "@codemirror/view" "^6.0.0"
     crelt "^1.0.5"
 
-"@codemirror/state@6.1.2", "@codemirror/state@^6.0.0":
+"@codemirror/state@6.1.2", "@codemirror/state@^0.19.0", "@codemirror/state@^0.19.2", "@codemirror/state@^0.19.3", "@codemirror/state@^0.19.9", "@codemirror/state@^6.0.0":
   version "6.1.2"
   resolved "https://registry.yarnpkg.com/@codemirror/state/-/state-6.1.2.tgz#182d46eabcc17c95508984d6add5a5a641dcd517"
   integrity sha512-Mxff85Hp5va+zuj+H748KbubXjrinX/k28lj43H14T2D0+4kuvEFIEIO7hCEcvBT8ubZyIelt9yGOjj2MWOEQA==
-
-"@codemirror/state@^0.19.0", "@codemirror/state@^0.19.2", "@codemirror/state@^0.19.3", "@codemirror/state@^0.19.9":
-  version "0.19.9"
-  resolved "https://registry.yarnpkg.com/@codemirror/state/-/state-0.19.9.tgz#b797f9fbc204d6dc7975485e231693c09001b0dd"
-  integrity sha512-psOzDolKTZkx4CgUqhBQ8T8gBc0xN5z4gzed109aF6x7D7umpDRoimacI/O6d9UGuyl4eYuDCZmDFr2Rq7aGOw==
-  dependencies:
-    "@codemirror/text" "^0.19.0"
 
 "@codemirror/text@^0.19.0", "@codemirror/text@^0.19.4":
   version "0.19.6"
   resolved "https://registry.yarnpkg.com/@codemirror/text/-/text-0.19.6.tgz#9adcbd8137f69b75518eacd30ddb16fd67bbac45"
   integrity sha512-T9jnREMIygx+TPC1bOuepz18maGq/92q2a+n4qTqObKwvNMg+8cMTslb8yxeEDEq7S3kpgGWxgO1UWbQRij0dA==
 
-"@codemirror/view@6.4.0", "@codemirror/view@^6.0.0", "@codemirror/view@^6.2.2":
+"@codemirror/view@6.4.0", "@codemirror/view@^0.19.0", "@codemirror/view@^0.19.22", "@codemirror/view@^0.19.23", "@codemirror/view@^0.19.39", "@codemirror/view@^0.19.44", "@codemirror/view@^0.19.48", "@codemirror/view@^6.0.0", "@codemirror/view@^6.2.2":
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/@codemirror/view/-/view-6.4.0.tgz#f8c213ab6dfec56048b372d2c378213428e2b4e5"
   integrity sha512-Kv32b6Tn7QVwFbj/EDswTLSocjk5kgggF6zzBFAL4o4hZ/vmtFD155+EjH1pVlbfoDyVC2M6SedPsMrwYscgNg==
   dependencies:
     "@codemirror/state" "^6.0.0"
-    style-mod "^4.0.0"
-    w3c-keyname "^2.2.4"
-
-"@codemirror/view@^0.19.0", "@codemirror/view@^0.19.22", "@codemirror/view@^0.19.23", "@codemirror/view@^0.19.39", "@codemirror/view@^0.19.44", "@codemirror/view@^0.19.48":
-  version "0.19.48"
-  resolved "https://registry.yarnpkg.com/@codemirror/view/-/view-0.19.48.tgz#1c657e2b0f8ed896ac6448d6e2215ab115e2a0fc"
-  integrity sha512-0eg7D2Nz4S8/caetCTz61rK0tkHI17V/d15Jy0kLOT8dTLGGNJUponDnW28h2B6bERmPlVHKh8MJIr5OCp1nGw==
-  dependencies:
-    "@codemirror/rangeset" "^0.19.5"
-    "@codemirror/state" "^0.19.3"
-    "@codemirror/text" "^0.19.0"
     style-mod "^4.0.0"
     w3c-keyname "^2.2.4"
 
@@ -2624,7 +2595,7 @@
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz#b2ac626d6cb9c8718ab459166d4bb405b8ffa78b"
   integrity sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==
 
-"@lezer/common@^0.15.0", "@lezer/common@^0.15.5":
+"@lezer/common@^0.15.0":
   version "0.15.12"
   resolved "https://registry.yarnpkg.com/@lezer/common/-/common-0.15.12.tgz#2f21aec551dd5fd7d24eb069f90f54d5bc6ee5e9"
   integrity sha512-edfwCxNLnzq5pBA/yaIhwJ3U3Kz8VAUOTRg0hhxaizaI1N+qxV7EXDv/kLCkLeq2RzSFvxexlaj5Mzfn2kY0Ig==
@@ -2689,13 +2660,6 @@
   dependencies:
     "@lezer/highlight" "^1.0.0"
     "@lezer/lr" "^1.0.0"
-
-"@lezer/lr@^0.15.0":
-  version "0.15.8"
-  resolved "https://registry.yarnpkg.com/@lezer/lr/-/lr-0.15.8.tgz#1564a911e62b0a0f75ca63794a6aa8c5dc63db21"
-  integrity sha512-bM6oE6VQZ6hIFxDNKk8bKPa14hqFrV07J/vHGOeiAbJReIaQXmkVb6xQu4MR+JBTLa5arGRyAAjJe1qaQt3Uvg==
-  dependencies:
-    "@lezer/common" "^0.15.0"
 
 "@lezer/lr@^1.0.0":
   version "1.2.3"
@@ -3488,7 +3452,7 @@
   resolved "https://registry.yarnpkg.com/@types/mathjax/-/mathjax-0.0.37.tgz#31a0076ced55c2e12da75edb44db45098b6feed6"
   integrity sha512-y0WSZBtBNQwcYipTU/BhgeFu1EZNlFvUNCmkMXV9kBQZq7/o5z82dNVyH3yy2Xv5zzeNeQoHSL4Xm06+EQiH+g==
 
-"@types/mdast@^3.0.0":
+"@types/mdast@3.0.10", "@types/mdast@^3.0.0":
   version "3.0.10"
   resolved "https://registry.yarnpkg.com/@types/mdast/-/mdast-3.0.10.tgz#4724244a82a4598884cbbe9bcfd73dff927ee8af"
   integrity sha512-W864tg/Osz1+9f4lrGTZpCSO5/z4608eUp19tbozkq2HJK6i3z1kT0H9tlADXuYIb1YYOBByU4Jsqkk75q48qA==
@@ -6764,7 +6728,7 @@ escodegen@^2.0.0:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-prettier@*:
+eslint-config-prettier@*, eslint-config-prettier@8.5.0:
   version "8.5.0"
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz#5a81680ec934beca02c7b1a61cf8ca34b66feab1"
   integrity sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==
@@ -6812,7 +6776,7 @@ eslint-plugin-flowtype@^8.0.3:
     lodash "^4.17.21"
     string-natural-compare "^3.0.1"
 
-eslint-plugin-import@*, eslint-plugin-import@^2.25.3:
+eslint-plugin-import@*, eslint-plugin-import@2.26.0, eslint-plugin-import@^2.25.3:
   version "2.26.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz#f812dc47be4f2b72b478a021605a59fc6fe8b88b"
   integrity sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==
@@ -6857,26 +6821,19 @@ eslint-plugin-jsx-a11y@^6.5.1:
     minimatch "^3.1.2"
     semver "^6.3.0"
 
-eslint-plugin-prettier@*:
+eslint-plugin-prettier@*, eslint-plugin-prettier@3.1.0, eslint-plugin-prettier@4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz#651cbb88b1dab98bfd42f017a12fa6b2d993f94b"
   integrity sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
-eslint-plugin-prettier@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.0.tgz#8695188f95daa93b0dc54b249347ca3b79c4686d"
-  integrity sha512-XWX2yVuwVNLOUhQijAkXz+rMPPoCr7WFiAl8ig6I7Xn+pPVhDhzg4DxHpmbeb0iqjO9UronEA3Tb09ChnFVHHA==
-  dependencies:
-    prettier-linter-helpers "^1.0.0"
-
-eslint-plugin-react-hooks@*, eslint-plugin-react-hooks@^4.3.0:
+eslint-plugin-react-hooks@*, eslint-plugin-react-hooks@4.6.0, eslint-plugin-react-hooks@^4.3.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz#4c3e697ad95b77e93f8646aaa1630c1ba607edd3"
   integrity sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==
 
-eslint-plugin-react@*, eslint-plugin-react@^7.27.1:
+eslint-plugin-react@*, eslint-plugin-react@7.31.10, eslint-plugin-react@^7.27.1:
   version "7.31.10"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.31.10.tgz#6782c2c7fe91c09e715d536067644bbb9491419a"
   integrity sha512-e4N/nc6AAlg4UKW/mXeYWd3R++qUano5/o+t+wnWxIf+bLsOaH3a4q74kX3nDjYym3VBN4HyO9nEn1GcAqgQOA==
@@ -6947,7 +6904,7 @@ eslint-webpack-plugin@^3.1.1:
     normalize-path "^3.0.0"
     schema-utils "^4.0.0"
 
-eslint@*, eslint@^8.3.0:
+eslint@*, eslint@8.26.0, eslint@^8.3.0:
   version "8.26.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.26.0.tgz#2bcc8836e6c424c4ac26a5674a70d44d84f2181d"
   integrity sha512-kzJkpaw1Bfwheq4VXUezFriD1GxszX6dUekM7Z3aC2o4hju+tsR/XyTC3RcoSD7jmy9VkPU3+N6YjVU2e96Oyg==
@@ -7730,7 +7687,7 @@ grommet-styles@^0.2.0:
   resolved "https://registry.yarnpkg.com/grommet-styles/-/grommet-styles-0.2.0.tgz#b2eac2b7e2747cb523434d21728ce5234f8ce4f4"
   integrity sha512-0OMSYuGeyifYKpg4Gv2HzL8rUdd0ddnJ5LbCBKgDuloC71XIwr9g/Fxa6rs737MbPV7OZ4pEm4wvrjH4epzf1A==
 
-grommet@*:
+grommet@*, grommet@2.27.0:
   version "2.27.0"
   resolved "https://registry.yarnpkg.com/grommet/-/grommet-2.27.0.tgz#f2396155cb8d871d3c4ec6a0ab47c2ee0fe90939"
   integrity sha512-VAk1sNPagLJX4d9wLEZbAt1NU+AMzwtnX5eFy6ZkINKpvKcHOhO05E/RW7i7a4RBTGz2w251Y4xGTmPieCDxOA==
@@ -14199,7 +14156,7 @@ unist-util-visit-parents@^5.1.1:
     "@types/unist" "^2.0.0"
     unist-util-is "^5.0.0"
 
-unist-util-visit@^4.0.0:
+unist-util-visit@4.1.1, unist-util-visit@^4.0.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-4.1.1.tgz#1c4842d70bd3df6cc545276f5164f933390a9aad"
   integrity sha512-n9KN3WV9k4h1DxYR1LoajgN93wpEi/7ZplVe02IoB4gH5ctI1AaF2670BLHQYbwj+pY83gFtyeySFiyMHJklrg==


### PR DESCRIPTION
## Purpose

This PR updates the existing `SharedLiveMedia` widget, originally designed to fit in the Live section of the app, to make it compatible with the VOD views. 

## Proposal

To do so we introduce `isTeacher` and `isLive` parameters and build the component regarding to them.

- [x] add the new parameters to the component
- [x] add the new widget to the expected pages (Teacher VOD and Public VOD)

Teacher view :
![Screenshot from 2022-10-27 16-45-20](https://user-images.githubusercontent.com/9515777/198320984-8339ce77-784b-47b2-a72a-85a7c174686f.png)

Student view :
![Screenshot from 2022-10-27 16-45-04](https://user-images.githubusercontent.com/9515777/198320992-bbb81757-f1e2-4137-af49-7652fc49108f.png)

