### PR TITLE
Refactor playlist list action

### DIFF
--- a/src/backend/marsha/core/api/playlist.py
+++ b/src/backend/marsha/core/api/playlist.py
@@ -1,9 +1,11 @@
 """Declare API endpoints for playlist with Django RestFramework viewsets."""
+from django.db.models import Q
+
 from rest_framework import viewsets
 from rest_framework.response import Response
 
 from .. import permissions, serializers
-from ..models import Playlist
+from ..models import ADMINISTRATOR, Playlist
 from .base import APIViewMixin, ObjectPkMixin
 
 
@@ -63,7 +65,14 @@ class PlaylistViewSet(APIViewMixin, ObjectPkMixin, viewsets.ModelViewSet):
         playlists they have access to.
         """
         queryset = self.get_queryset().filter(
-            organization__users__id=self.request.user.id
+            Q(
+                organization__user_accesses__user_id=self.request.user.id,
+                organization__user_accesses__role=ADMINISTRATOR,
+            )
+            | Q(
+                user_accesses__user_id=self.request.user.id,
+                user_accesses__role=ADMINISTRATOR,
+            )
         )
 
         organization_id = self.request.query_params.get("organization")


### PR DESCRIPTION
## Purpose

The playlist list action results were not reflecting the permissions added on this viewset. The list action was returning the playlist belonging to organizations the user is member. But this is not true. First playlist can be "orphan", not belonging to an organization but also a user can be a playlist administrator without being an organization administrator. The queryset is modified this way.
Also filters backend have been adding, allowing to order and filter the list action. It is possible to order on `created_on` and `title`. And to filter the `organization`.

## Proposal

- [x] change playlist filter on list action to match permissions
- [x] enable ordering playlist list
- [x] configure DjangoFilterBackend on playlist view

