### PR TITLE
♻️(front) rework frontend translations workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -406,7 +406,7 @@ jobs:
           command: yarn install --frozen-lockfile
       - run:
           name: Compile translations
-          command: yarn workspace marsha run compile-translations
+          command: yarn compile-translations
       - run:
           name: Build lib_tests
           command: yarn build-tests
@@ -417,12 +417,14 @@ jobs:
           name: Build front-end standalone application
           command: yarn build-site
       - run:
-          name: Use formatjs cli to generate frontend.json file
-          command: yarn workspace marsha run extract-translations
+          name: Extract all translations
+          command: yarn extract-translations
       - persist_to_workspace:
           root: ~/marsha
           paths:
             - src/frontend/apps/lti_site/i18n/frontend.json
+            - src/frontend/apps/standalone/i18n/frontend.json
+            - src/frontend/packages/i18n/frontend.json
       - save_cache:
           paths:
             - ./node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -127,7 +127,7 @@ __diff_output__/
 node_modules
 src/frontend/coverage
 src/frontend/apps/**/translations/*.json
-src/frontend/apps/**/i18n/frontend.json
+src/frontend/**/i18n/frontend.json
 src/backend/marsha/static/css
 src/backend/marsha/static/js
 src/backend/marsha/static/media

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ COPY ./src/frontend /app/
 COPY ./src/.prettierrc.js /app/
 
 RUN yarn install --frozen-lockfile && \
-    yarn workspace marsha run compile-translations && \
+    yarn compile-translations && \
     yarn workspace marsha run sass scss/_main.scss /app/marsha/static/css/main.css --style=compressed --load-path=../../node_modules  && \
     mkdir -p /app/marsha/static/css/fonts && cp node_modules/katex/dist/fonts/* /app/marsha/static/css/fonts && \
     yarn build-libs && \

--- a/Makefile
+++ b/Makefile
@@ -378,7 +378,7 @@ i18n-compile-back:
 .PHONY: i18n-compile-back
 
 i18n-compile-front:
-	@$(YARN) workspace marsha run compile-translations
+	@$(YARN) compile-translations
 .PHONY: i18n-compile-front
 
 i18n-generate: ## Generate source translations files for all applications
@@ -393,7 +393,7 @@ i18n-generate-back:
 
 i18n-generate-front:
 	@$(YARN) workspace marsha run build
-	@$(YARN) workspace marsha run extract-translations
+	@$(YARN) extract-translations
 .PHONY: i18n-generate-front
 
 

--- a/crowdin/config.yml
+++ b/crowdin/config.yml
@@ -22,7 +22,17 @@ files: [
  },
  {
   "source" : "/frontend/apps/lti_site/i18n/frontend.json",
-  "dest": "/frontend.json",
+  "dest": "/lti_site.json",
   "translation" : "/frontend/apps/lti_site/i18n/%locale_with_underscore%.json",
+ },
+ {
+  "source" : "/frontend/apps/standalone_site/i18n/frontend.json",
+  "dest": "/standalone_site.json",
+  "translation" : "/frontend/apps/standalone_site/i18n/%locale_with_underscore%.json",
+ },
+ {
+  "source" : "/frontend/packages/i18n/frontend.json",
+  "dest": "/packages.json",
+  "translation" : "/frontend/packages/i18n/%locale_with_underscore%.json",
  }
 ]

--- a/src/frontend/apps/lti_site/package.json
+++ b/src/frontend/apps/lti_site/package.json
@@ -6,8 +6,6 @@
   "scripts": {
     "build": "tsc --noEmit && webpack",
     "build-dev": "yarn copy-iframe-resizer; yarn copy-katex-fonts; yarn build",
-    "extract-translations": "formatjs extract './**/*.ts*' --ignore ./node_modules --ignore './**/*.d.ts' --out-file i18n/frontend.json --id-interpolation-pattern '[sha512:contenthash:base64:6]' --format crowdin",
-    "compile-translations": "formatjs compile-folder --format crowdin ./i18n ./translations",
     "copy-iframe-resizer": "cp ../../node_modules/iframe-resizer/js/*.min.js ../../../backend/marsha/static/js",
     "copy-katex-fonts": "mkdir -p ../../../backend/marsha/static/css/fonts && cp ../../node_modules/katex/dist/fonts/* ../../../backend/marsha/static/css/fonts",
     "lint": "tslint -c tslint.json \"**/*.ts?(x)\" -e \"node_modules/**/*\"",

--- a/src/frontend/compile-translations.js
+++ b/src/frontend/compile-translations.js
@@ -1,0 +1,81 @@
+#! /usr/bin/env node
+const path = require('path');
+const fs = require('fs');
+const yargs = require('yargs');
+const glob = require('glob');
+const { merge } = require('cljs-merge');
+
+/**
+ * compile-translations
+ * 
+ * Adapt from [Richie](https://github.com/openfun/richie) project
+ * 
+ * formatjs/cli compile and compile-folder methods do not allow merge.
+ * So we need your own compile method.
+ * 
+ * 
+ * You must provide a search pattern to include translation sources. If several files have the
+ * same name, they will be merged.
+ * 
+ * Usage: ./compile-translations.js [search_patterns] [--ignore] [--outDir <path_to_output_files]
+ * 
+ * 
+ * ARGUMENTS:
+ *  search_pattern      list of patterns to search additional translation files (support only json)
+ *  --ignore            a pattern to ignore a path where search files (e.g ./node_modules)
+ *  --outDir            output directory
+ * 
+ */
+
+
+// Output directory
+const OUT_DIR = yargs.argv.outDir;
+
+(async () => {
+  const { ignore, _: patterns } = yargs.argv
+  const filesPattern = patterns.map((filepath) => path.resolve(process.cwd(), filepath));
+
+  // Search files and group paths found by filename
+  const files = await Promise.all(filesPattern.map((pattern) => new Promise((resolve, reject) => {
+    glob(pattern, { nodir: true, ignore }, (error, matches) => {
+      if (error) reject(error);
+      resolve(matches);
+    })
+  }))).then((matches) => matches.flat().reduce((outputs, filePath) => {
+    const matchCutter = /.*\/(?<filename>.*)\.(?<ext>.{2,4})$/;
+    const [, filename, ext] = filePath.match(matchCutter);
+    if (ext !== 'json') throw new Error('Only JSON files are supported!');
+
+    if (filename in outputs) {
+      return {
+        ...outputs,
+        [filename]: [...outputs[filename], filePath]
+      }
+    }
+
+    return {
+      ...outputs,
+      [filename]: [filePath],
+    }
+  }, {}));
+
+  Object.entries(files).forEach(([filename, paths]) => {
+    // Get file content
+    const jsons = paths.map((filePath) => require(path.join(filePath)));
+    let translations = jsons.shift();
+
+    // If a translation contains several objects, we merged them
+    if (jsons.length > 0) {
+      translations = jsons.reduce((src, target) => {
+        return merge({ src, target });
+      }, translations);
+    }
+
+    // Write json files into output directory with format required by react-intl
+    fs.writeFile(
+      path.join(OUT_DIR, `${filename}.json`),
+      JSON.stringify(Object.entries(translations).reduce((acc, [key, { message }]) => ({ ...acc, [key]: message }), {})),
+      (error) => { if (error) throw new Error(error) }
+    );
+  })
+})();

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -17,6 +17,13 @@
     ]
   },
   "scripts": {
+    "extract-packages-translations": "formatjs extract './packages/lib_*/src/**/*.{ts,tsx}' --ignore ./packages/lib_*/node_modules --ignore ./packages/lib_*/lib --ignore ./node_modules --ignore './**/*.d.ts' --out-file packages/i18n/frontend.json --id-interpolation-pattern '[sha512:contenthash:base64:6]' --format crowdin",
+    "extract-lti_site_translations": "formatjs extract './apps/lti_site/**/*.ts*' --ignore ./node_modules --ignore ./apps/lti_site/node_modules --ignore './apps/lti_site/**/*.d.ts' --out-file apps/lti_site/i18n/frontend.json --id-interpolation-pattern '[sha512:contenthash:base64:6]' --format crowdin",
+    "extract-standalone_site_translations": "formatjs extract './apps/standalone_site/src/**/*.ts*' --ignore ./node_modules --ignore ./apps/standalone_site/node_modules --ignore './apps/standalone_site/src/**/*.d.ts' --out-file apps/standalone_site/i18n/frontend.json --id-interpolation-pattern '[sha512:contenthash:base64:6]' --format crowdin",
+    "extract-translations": "yarn extract-packages-translations && yarn extract-lti_site_translations && yarn extract-standalone_site_translations",
+    "compile-lti_site-translations": "node compile-translations.js packages/i18n/* apps/lti_site/i18n/* --outDir=apps/lti_site/translations",
+    "compile-standalone_site-translations": "node compile-translations.js packages/i18n/* apps/standalone_site/i18n/* --outDir=apps/standalone_site/src/translations",
+    "compile-translations": "yarn compile-lti_site-translations && yarn compile-standalone_site-translations",
     "lint": "yarn build-tests && yarn workspaces run lint",
     "test-libs": "yarn build-tests && yarn workspace lib-components run test",
     "test-lib-classroom": "yarn build-tests && yarn workspace lib-classroom run test",
@@ -47,5 +54,9 @@
     "eslint-plugin-react-hooks": "4.6.0",
     "grommet": "2.27.0",
     "unist-util-visit": "4.1.1"
+  },
+  "dependencies": {
+    "cljs-merge": "1.1.1",
+    "yargs": "17.6.0"
   }
 }

--- a/src/frontend/yarn.lock
+++ b/src/frontend/yarn.lock
@@ -5156,6 +5156,20 @@ cliui@^7.0.2:
     strip-ansi "^6.0.0"
     wrap-ansi "^7.0.0"
 
+cliui@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-8.0.1.tgz#0c04b075db02cbfe60dc8e6cf2f5486b1a3608aa"
+  integrity sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.1"
+    wrap-ansi "^7.0.0"
+
+cljs-merge@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/cljs-merge/-/cljs-merge-1.1.1.tgz#b0c6657219ec0ce34c22ca8fe6f71f89a087a07b"
+  integrity sha512-EnSi+cgaul+L9RrRtY0D+UzkCwKDjwyyJ+Cg1Lho7T3WWuG+Rr1cdK28OFmCrn+wEl7BLkBuCXbc0W4YxQI9wg==
+
 clone-deep@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/clone-deep/-/clone-deep-4.0.1.tgz#c19fd9bdbbf85942b4fd979c84dcf7d5f07c2387"
@@ -15075,6 +15089,19 @@ yargs-parser@^21.0.0, yargs-parser@^21.0.1:
   version "21.1.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
+
+yargs@17.6.0:
+  version "17.6.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.6.0.tgz#e134900fc1f218bc230192bdec06a0a5f973e46c"
+  integrity sha512-8H/wTDqlSwoSnScvV2N/JHfLWOKuh5MVla9hqLjK3nsfyy6Y4kDSYSvkU5YCUEPOSnRXfIyx3Sq+B/IWudTo4g==
+  dependencies:
+    cliui "^8.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.0.0"
 
 yargs@^16.2.0:
   version "16.2.0"


### PR DESCRIPTION
## Purpose

Translations are only for now in the lti_site apps. We have to rework all
the translation workflow to be able to translate standalone_site app and
all packages.
To avoid to translate multiple times the same translation or group them
in only one file, source translations are split in 3 files. One for the
lti_site, one for standalone_site and one for all packages containing
translations (This is all extract-* commands).
Then, to compile them, we use the compile-translations.js script to
merge the packages translations with the lti_site or the
standalone_site.

The `compile-translations.js` script is imported from [Richie](https://github.com/openfun/richie) project.

## Proposal

- [x] add compile-translations script
- [x] rework frontend translations workflow
