### PR TITLE
📌(circle) pin python image to version 3.10.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,7 +216,7 @@ jobs:
   # Build backend development environment
   build-back:
     docker:
-      - image: cimg/python:3.10
+      - image: cimg/python:3.10.7
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -238,7 +238,7 @@ jobs:
   # Build backend translations
   build-back-i18n:
     docker:
-      - image: cimg/python:3.10
+      - image: cimg/python:3.10.7
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -289,7 +289,7 @@ jobs:
 
   lint-back:
     docker:
-      - image: cimg/python:3.10
+      - image: cimg/python:3.10.7
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -318,7 +318,7 @@ jobs:
 
   test-back:
     docker:
-      - image: cimg/python:3.10
+      - image: cimg/python:3.10.7
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS


### PR DESCRIPTION
## Purpose

After version 3.10.7 base image use by circle-ci to build their python images is updated and the dependencies installed are not matching the version from our docker image and basckend tests are failing.

## Proposal

- [x] pin python image to version 3.10.7

