### PR TITLE
🐛(circle) fix standalone_site i18n path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -423,7 +423,7 @@ jobs:
           root: ~/marsha
           paths:
             - src/frontend/apps/lti_site/i18n/frontend.json
-            - src/frontend/apps/standalone/i18n/frontend.json
+            - src/frontend/apps/standalone_site/i18n/frontend.json
             - src/frontend/packages/i18n/frontend.json
       - save_cache:
           paths:


### PR DESCRIPTION
## Purpose

The path used to attach the frontend.json file in marsha workspace is wrong. The job i18n file because it doesn't found this file.

## Proposal

- fix standalone_site i18n path

