### PR TITLE
🐛(back) cast started_at in int in check_live_state command

### DIFF
--- a/src/backend/marsha/core/management/commands/check_live_state.py
+++ b/src/backend/marsha/core/management/commands/check_live_state.py
@@ -67,7 +67,7 @@ class Command(BaseCommand):
             live_info = video.live_info
             logs = logs_client.filter_log_events(
                 logGroupName=live_info["cloudwatch"]["logGroupName"],
-                startTime=int(video.live_info.get("started_at") * 1000),
+                startTime=int(int(video.live_info.get("started_at")) * 1000),
                 filterPattern=(
                     "{"
                     '($.detail-type = "MediaLive Channel Alert") && '

--- a/src/backend/marsha/core/tests/test_command_check_live_state.py
+++ b/src/backend/marsha/core/tests/test_command_check_live_state.py
@@ -40,7 +40,7 @@ class CheckLiveStateTest(TestCase):
                 "medialive": {
                     "channel": {"arn": "medialive:channel:arn", "id": "123456"}
                 },
-                "started_at": 1598313600,  # 25 aug 2020 00:00:00 UTC
+                "started_at": "1598313600",  # 25 aug 2020 00:00:00 UTC
             },
             live_type=RAW,
         )
@@ -136,7 +136,7 @@ class CheckLiveStateTest(TestCase):
                 "medialive": {
                     "channel": {"arn": "medialive:channel:arn", "id": "123456"}
                 },
-                "started_at": 1598313600,  # 25 aug 2020 00:00:00 UTC
+                "started_at": "1598313600",  # 25 aug 2020 00:00:00 UTC
             },
             live_type=RAW,
         )
@@ -221,7 +221,7 @@ class CheckLiveStateTest(TestCase):
                 "medialive": {
                     "channel": {"arn": "medialive:channel:arn", "id": "123456"}
                 },
-                "started_at": 1598313600,  # 25 aug 2020 00:00:00 UTC
+                "started_at": "1598313600",  # 25 aug 2020 00:00:00 UTC
             },
             live_type=RAW,
         )


### PR DESCRIPTION
## Purpose

In the management command, live_info.started_at is used but stored as a string instead of an integer in database. We must cast it first in integer and then multiple it by 1000 to obtain a timestamp in milliseconds.

## Proposal

- [x] cast started_at in int in check_live_state command

