### PR TITLE
✨(back) add management command clean_aws_elemental_stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - standalone website:
   - playlists page
 - install and configure drf-spectacular to serve a swagger ui
+- Management command clean_aws_elemental_stack
 
 ### Changed
 

--- a/src/backend/marsha/core/management/commands/clean_aws_elemental_stack.py
+++ b/src/backend/marsha/core/management/commands/clean_aws_elemental_stack.py
@@ -1,0 +1,81 @@
+"""Check every existing medialive channel and check if the related video is still usable."""
+from datetime import timedelta
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+from marsha.core.defaults import DELETED, ENDED
+from marsha.core.models import Video
+from marsha.core.utils.medialive_utils import (
+    delete_aws_element_stack,
+    delete_mediapackage_channel,
+    list_medialive_channels,
+)
+from marsha.core.utils.time_utils import to_datetime
+
+
+def generate_expired_date():
+    """Generate a datetime object NB_DAYS_BEFORE_DELETING_AWS_ELEMENTAL_STACK days in the past."""
+    return timezone.now() - timedelta(
+        days=settings.NB_DAYS_BEFORE_DELETING_AWS_ELEMENTAL_STACK
+    )
+
+
+class Command(BaseCommand):
+    """
+    Once a live started, all AWS elemental stack are created. Once stopped, the
+    instructor must do an action. Restart it and/or convert it in VOD. If
+    nothing is done, the AWS element resources are leaved unused and use the quota
+    we have on our AWS account.
+    These unused resources must be removed after several days of inactivity and the video
+    move in a DELETED state.
+    """
+
+    help = __doc__
+
+    def handle(self, *args, **options):
+        """Execute management command."""
+        expired_date = generate_expired_date()
+        for medialive_channel in list_medialive_channels():
+            # Don't work with stack not belonging to the current environment
+            if (
+                medialive_channel.get("Tags", {}).get("environment")
+                != settings.AWS_BASE_NAME
+            ):
+                continue
+
+            # If the live is not idle, skip it
+            if medialive_channel.get("State") != "IDLE":
+                continue
+            # the channel name contains the environment, the primary key and the created_at
+            # stamp. Here we want to use the primary key
+            _environment, pk, _stamp = medialive_channel["Name"].split("_")
+            live = Video.objects.get(pk=pk)
+            self.stdout.write(f"Checking video {live.id}")
+
+            if live.starting_at:
+                # Live was scheduled, we can use this schedule date.
+                if live.starting_at < expired_date:
+                    self._delete_live(live)
+            elif started_at := live.live_info.get("started_at"):
+                # Live has started_at info, we can use it.
+                started_at = to_datetime(started_at)
+                if started_at < expired_date:
+                    self._delete_live(live)
+
+    def _delete_live(self, live):
+        """
+        Set the live_state to ENDED, the upload_state to DELETED and delete
+        all AWS resources
+        """
+        self.stdout.write(f"deleting AWS resources for video {live.id}")
+        delete_aws_element_stack(live)
+        delete_mediapackage_channel(live.get_mediapackage_channel().get("id"))
+
+        self.stdout.write(f"Set video state to deleted for video {live.id}")
+        live.live_state = ENDED
+        live.upload_state = DELETED
+        live.live_info.pop("medialive")
+        live.live_info.pop("mediapackage")
+        live.save(update_fields=("live_state", "upload_state", "live_info"))

--- a/src/backend/marsha/core/tests/test_command_clean_aws_elemental_stack.py
+++ b/src/backend/marsha/core/tests/test_command_clean_aws_elemental_stack.py
@@ -1,0 +1,305 @@
+"""Test clean_aws_elemental_stack command."""
+from datetime import datetime, timezone
+from io import StringIO
+from unittest import mock
+import uuid
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from marsha.core.defaults import DELETED, ENDED, IDLE, JITSI, RUNNING, STOPPED
+from marsha.core.factories import VideoFactory
+from marsha.core.management.commands import clean_aws_elemental_stack
+from marsha.core.utils import time_utils
+
+
+class CleanAwsElementalStackCommandTest(TestCase):
+    """Test clean_aws_elemental_stack command."""
+
+    maxDiff = None
+
+    def test_clean_aws_elemental_stack(self):
+        """Test clean_aws_elemental_stack command."""
+        expiration_date = datetime(2022, 11, 1, 15, 00, tzinfo=timezone.utc)
+        # first live not started yet, should not be updated.
+        live1 = VideoFactory(
+            live_state=IDLE,
+            live_type=JITSI,
+            starting_at=datetime(2022, 12, 25, 13, 25, tzinfo=timezone.utc),
+            title="live one",
+            live_info=None,  # live has never been started
+        )
+
+        # Second live, started but still running, should not be updated
+        live2_id = uuid.uuid4()
+        live2 = VideoFactory(
+            id=live2_id,
+            live_state=RUNNING,
+            live_type=JITSI,
+            starting_at=datetime(2022, 11, 4, 13, 25, tzinfo=timezone.utc),
+            title="live two",
+            live_info={
+                "medialive": {
+                    "channel": {
+                        "arn": "arn:aws:medialive:eu-west-1:xxx:channel:2222222",
+                        "id": "2222222",
+                    },
+                    "input": {
+                        "endpoints": [
+                            f"rtmp://x.x.x.x:1935/{live2_id}_1667490961-primary",
+                            f"rtmp://x.x.x.x:1935/{live2_id}_1667490961-secondary",
+                        ],
+                        "id": "2222222",
+                    },
+                },
+                "mediapackage": {
+                    "channel": {"id": f"test_{live2_id}_1667490961"},
+                    "endpoints": {
+                        "hls": {
+                            "id": f"test_{live2_id}_1667490961_hls",
+                            "url": (
+                                "https://xxx.mediapackage.eu-west-1.amazonaws.com/out/v1/xxx/"
+                                f"test_{live2_id}_1667490961_hls.m3u8",
+                            ),
+                        }
+                    },
+                },
+            },
+        )
+
+        # Third live, started and stopped soon. Should not be updated
+        live3_id = uuid.uuid4()
+        live3 = VideoFactory(
+            id=live3_id,
+            live_state=STOPPED,
+            live_type=JITSI,
+            starting_at=datetime(2022, 11, 4, 13, 25, tzinfo=timezone.utc),
+            title="live three",
+            live_info={
+                "medialive": {
+                    "channel": {
+                        "arn": "arn:aws:medialive:eu-west-1:xxx:channel:3333333",
+                        "id": "3333333",
+                    },
+                    "input": {
+                        "endpoints": [
+                            f"rtmp://x.x.x.x:1935/{live3_id}_1667490961-primary",
+                            f"rtmp://x.x.x.x:1935/{live3_id}_1667490961-secondary",
+                        ],
+                        "id": "3333333",
+                    },
+                },
+                "mediapackage": {
+                    "channel": {"id": f"test_{live3_id}_1667490961"},
+                    "endpoints": {
+                        "hls": {
+                            "id": f"test_{live3_id}_1667490961_hls",
+                            "url": (
+                                "https://xxx.mediapackage.eu-west-1.amazonaws.com/out/v1/xxx/"
+                                f"test_{live3_id}_1667490961_hls.m3u8"
+                            ),
+                        }
+                    },
+                },
+                "started_at": time_utils.to_timestamp(
+                    datetime(2022, 11, 4, 13, 25, tzinfo=timezone.utc)
+                ),
+                "stopped_at": time_utils.to_timestamp(
+                    datetime(2022, 11, 4, 15, 25, tzinfo=timezone.utc)
+                ),
+            },
+        )
+
+        # Fourth live, started and stopped, without starting_at, but expired. Should be cleaned.
+        live4_id = uuid.uuid4()
+        live4 = VideoFactory(
+            id=live4_id,
+            live_state=STOPPED,
+            live_type=JITSI,
+            starting_at=None,
+            title="live four",
+            live_info={
+                "medialive": {
+                    "channel": {
+                        "arn": "arn:aws:medialive:eu-west-1:xxx:channel:4444444",
+                        "id": "4444444",
+                    },
+                    "input": {
+                        "endpoints": [
+                            f"rtmp://x.x.x.x:1935/{live4_id}_1667490961-primary",
+                            f"rtmp://x.x.x.x:1935/{live4_id}_1667490961-secondary",
+                        ],
+                        "id": "4444444",
+                    },
+                },
+                "mediapackage": {
+                    "channel": {"id": f"test_{live4_id}_1667490961"},
+                    "endpoints": {
+                        "hls": {
+                            "id": f"test_{live4_id}_1667490961_hls",
+                            "url": (
+                                "https://xxx.mediapackage.eu-west-1.amazonaws.com/out/v1/xxx/"
+                                f"test_{live4_id}_1667490961_hls.m3u8"
+                            ),
+                        }
+                    },
+                },
+                "started_at": time_utils.to_timestamp(
+                    datetime(2022, 10, 14, 13, 25, tzinfo=timezone.utc)
+                ),
+                "stopped_at": time_utils.to_timestamp(
+                    datetime(2022, 10, 14, 15, 25, tzinfo=timezone.utc)
+                ),
+            },
+        )
+
+        # Fifth live, started and stopped, with starting_at, but expired. Should be clean
+        live5_id = uuid.uuid4()
+        live5 = VideoFactory(
+            id=live5_id,
+            live_state=STOPPED,
+            live_type=JITSI,
+            starting_at=datetime(2022, 10, 14, 13, 25, tzinfo=timezone.utc),
+            title="live five",
+            live_info={
+                "medialive": {
+                    "channel": {
+                        "arn": "arn:aws:medialive:eu-west-1:xxx:channel:4444444",
+                        "id": "4444444",
+                    },
+                    "input": {
+                        "endpoints": [
+                            f"rtmp://x.x.x.x:1935/{live5_id}_1667490961-primary",
+                            f"rtmp://x.x.x.x:1935/{live5_id}_1667490961-secondary",
+                        ],
+                        "id": "4444444",
+                    },
+                },
+                "mediapackage": {
+                    "channel": {"id": f"test_{live5_id}_1667490961"},
+                    "endpoints": {
+                        "hls": {
+                            "id": f"test_{live5_id}_1667490961_hls",
+                            "url": (
+                                "https://xxx.mediapackage.eu-west-1.amazonaws.com/out/v1/xxx/"
+                                f"test_{live5_id}_1667490961_hls.m3u8"
+                            ),
+                        }
+                    },
+                },
+                "started_at": time_utils.to_timestamp(
+                    datetime(2022, 10, 14, 13, 25, tzinfo=timezone.utc)
+                ),
+                "stopped_at": time_utils.to_timestamp(
+                    datetime(2022, 10, 14, 15, 25, tzinfo=timezone.utc)
+                ),
+            },
+        )
+
+        # Run command
+        out = StringIO()
+        with mock.patch.object(
+            clean_aws_elemental_stack,
+            "generate_expired_date",
+            return_value=expiration_date,
+        ), mock.patch.object(
+            clean_aws_elemental_stack, "list_medialive_channels"
+        ) as list_medialive_channels_mock, mock.patch.object(
+            clean_aws_elemental_stack, "delete_aws_element_stack"
+        ) as delete_aws_element_stack_mock, mock.patch.object(
+            clean_aws_elemental_stack, "delete_mediapackage_channel"
+        ) as delete_mediapackage_channel_mock:
+            list_medialive_channels_mock.return_value = [
+                # medialive channels not in the same AWS_BASE_NAME environment
+                {
+                    "Name": f"foo_{uuid.uuid4()}_1667490961",
+                    "Tags": {"environment": "foo"},
+                    "State": "IDLE",
+                },
+                # live 2
+                {
+                    "Name": f"test_{live2_id}_1667490961",
+                    "Tags": {"environment": "test"},
+                    "State": "RUNNING",
+                },
+                # live 3
+                {
+                    "Name": f"test_{live3_id}_1667490961",
+                    "Tags": {"environment": "test"},
+                    "State": "IDLE",
+                },
+                # live 4
+                {
+                    "Name": f"test_{live4_id}_1667490961",
+                    "Tags": {"environment": "test"},
+                    "State": "IDLE",
+                },
+                # live 5
+                {
+                    "Name": f"test_{live5_id}_1667490961",
+                    "Tags": {"environment": "test"},
+                    "State": "IDLE",
+                },
+            ]
+
+            call_command("clean_aws_elemental_stack", stdout=out)
+            delete_aws_element_stack_mock.assert_any_call(live4)
+            delete_aws_element_stack_mock.assert_any_call(live5)
+            self.assertEqual(delete_aws_element_stack_mock.call_count, 2)
+
+            delete_mediapackage_channel_mock.assert_any_call(
+                live4.get_mediapackage_channel().get("id")
+            )
+            delete_mediapackage_channel_mock.assert_any_call(
+                live5.get_mediapackage_channel().get("id")
+            )
+            self.assertEqual(delete_mediapackage_channel_mock.call_count, 2)
+
+            self.assertNotIn(f"Checking video {live1.id}", out.getvalue())
+            self.assertNotIn(f"Checking video {live2.id}", out.getvalue())
+            self.assertIn(f"Checking video {live3.id}", out.getvalue())
+            self.assertIn(f"Checking video {live4.id}", out.getvalue())
+            self.assertIn(f"Checking video {live5.id}", out.getvalue())
+
+            # Refresh all video from db
+            live1.refresh_from_db()
+            live2.refresh_from_db()
+            live3.refresh_from_db()
+            live4.refresh_from_db()
+            live5.refresh_from_db()
+
+            # Live 1, 2 and 3 should not have been updated
+            self.assertEqual(live1.live_state, IDLE)
+            self.assertEqual(live2.live_state, RUNNING)
+            self.assertEqual(live3.live_state, STOPPED)
+
+            # Live 4 and 5 should have been updated
+            self.assertEqual(live4.live_state, ENDED)
+            self.assertEqual(live4.upload_state, DELETED)
+            self.assertEqual(
+                live4.live_info,
+                {
+                    "started_at": time_utils.to_timestamp(
+                        datetime(2022, 10, 14, 13, 25, tzinfo=timezone.utc)
+                    ),
+                    "stopped_at": time_utils.to_timestamp(
+                        datetime(2022, 10, 14, 15, 25, tzinfo=timezone.utc)
+                    ),
+                },
+            )
+
+            self.assertEqual(live5.live_state, ENDED)
+            self.assertEqual(live5.upload_state, DELETED)
+            self.assertEqual(
+                live5.live_info,
+                {
+                    "started_at": time_utils.to_timestamp(
+                        datetime(2022, 10, 14, 13, 25, tzinfo=timezone.utc)
+                    ),
+                    "stopped_at": time_utils.to_timestamp(
+                        datetime(2022, 10, 14, 15, 25, tzinfo=timezone.utc)
+                    ),
+                },
+            )
+
+        out.close()

--- a/src/backend/marsha/core/tests/test_command_clean_medialive_dev_stack.py
+++ b/src/backend/marsha/core/tests/test_command_clean_medialive_dev_stack.py
@@ -79,7 +79,6 @@ class CleanMedialigeDevStackCommandTest(TestCase):
                 "dev-bar_99d60314-20f2-4847-84a4-d2f47bf7fe38_1629982356"
             )
             medialive_client_stubber.assert_no_pending_responses()
-        print(out.getvalue())
 
         self.assertEqual(
             (

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -415,6 +415,7 @@ class Base(Configuration):
 
     # LIVE SETTINGS
     NB_DAYS_BEFORE_DELETING_LIVE_RECORDINGS = values.Value(14)
+    NB_DAYS_BEFORE_DELETING_AWS_ELEMENTAL_STACK = values.Value(14)
     NB_SECONDS_LIVING_DEV_STACK = values.PositiveIntegerValue(600)
     LIVE_PLAYLIST_WINDOW_SECONDS = values.PositiveIntegerValue(10)
     LIVE_SEGMENT_DURATION_SECONDS = values.PositiveIntegerValue(4)


### PR DESCRIPTION
## Purpose

Once a live started, all AWS elemental stack are created. Once stopped, the instructor must do an action. Restart it and/or convert it in VOD. If nothing is done, the AWS element resources are leaved unused and use the quota we have on our AWS account.
This resources unused must be removed after several days of inactivity and the video move in a DELETED state.

## Proposal

- [x] add management command clean_aws_elemental_stack

This PR is part of #1779
