### PR TITLE
✨(back) install and configure drf-spectacular to serve a swagger ui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   - Video download
 - standalone website:
   - playlists page
+- install and configure drf-spectacular to serve a swagger ui
 
 ### Changed
 

--- a/src/backend/marsha/core/api/video.py
+++ b/src/backend/marsha/core/api/video.py
@@ -113,7 +113,7 @@ class VideoViewSet(APIViewMixin, ObjectPkMixin, viewsets.ModelViewSet):
         """Extra context provided to the serializer class."""
         context = super().get_serializer_context()
 
-        if self.request.resource:
+        if self.request and self.request.resource:
             context.update(self.request.resource.token.payload)
             admin_role_permission = permissions.IsTokenAdmin()
             instructor_role_permission = permissions.IsTokenInstructor()

--- a/src/backend/marsha/core/tests/test_api_schema.py
+++ b/src/backend/marsha/core/tests/test_api_schema.py
@@ -1,6 +1,4 @@
 """Tests for the Schema endpoint on the API of the Marsha project."""
-import json
-
 from django.test import TestCase
 
 
@@ -9,6 +7,11 @@ class SchemaAPITest(TestCase):
 
     def test_api_schema(self):
         """The API has a schema route that answers."""
-        response = self.client.get("/api/schema")
+        response = self.client.get("/api/schema/")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(json.loads(response.content)["info"]["title"], "Marsha API")
+        self.assertEqual(
+            response.get("Content-Type"), "application/vnd.oai.openapi; charset=utf-8"
+        )
+        self.assertEqual(
+            response.get("Content-Disposition"), 'inline; filename="Marsha API.yaml"'
+        )

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -117,6 +117,7 @@ class Base(Configuration):
         "dockerflow.django",
         "waffle",
         "rest_framework",
+        "drf_spectacular",
         "corsheaders",
         "channels",
         "parler",  # django-parler, for translated models
@@ -217,6 +218,13 @@ class Base(Configuration):
                 "3/minute", environ_name="REST_FRAMEWORK_LIVE_SESSION_THROTTLE_RATE"
             ),
         },
+        "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
+    }
+
+    # DRF SPECTACULAR
+    SPECTACULAR_SETTINGS = {
+        "TITLE": "Marsha API",
+        "SERVE_INCLUDE_SCHEMA": False,
     }
 
     # WAFFLE

--- a/src/backend/marsha/urls.py
+++ b/src/backend/marsha/urls.py
@@ -5,9 +5,8 @@ from django.contrib import admin
 from django.urls import include, path, re_path
 from django.views.decorators.cache import cache_page
 
-from rest_framework.renderers import CoreJSONRenderer
+from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 from rest_framework.routers import DefaultRouter
-from rest_framework.schemas import get_schema_view
 
 from marsha.core import models
 from marsha.core.api import (
@@ -107,10 +106,11 @@ urlpatterns = [
         recording_slices_state,
         name="recording_slices_state",
     ),
+    path("api/schema/", SpectacularAPIView.as_view(), name="schema"),
     path(
-        "api/schema",
-        get_schema_view(title="Marsha API", renderer_classes=[CoreJSONRenderer]),
-        name="schema",
+        "api/schema/swagger-ui/",
+        SpectacularSwaggerView.as_view(url_name="schema"),
+        name="swagger-ui",
     ),
     path("api/", include(router.urls)),
     path(

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -47,6 +47,7 @@ install_requires =
     django-storages==1.13.1
     django-waffle==3.0.0
     dockerflow==2022.8.0
+    drf-spectacular==0.24.2
     gunicorn==20.1.0
     logging-ldp==0.0.6
     oauthlib==3.2.2


### PR DESCRIPTION
## Purpose

To ease the use of Marsha API, we would like to have a page serving swagger listing all available routes for the API. For this, we are using drf-spectacular.

## Proposal

- [x] install and configure drf-spectacular to serve a swagger ui

