### PR TITLE
Manage permissions for classroom, deposit and markdown creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Refactor check_live_state management command to use the live started_at
   timestamp to filter logs instead of using video creation date.
 
+### Fixed
+
+- fix permission for classroom creation
+
 ## [4.0.0-beta.10] - 2022-10-19
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - fix permission for classroom creation
 - fix permission for filedepository creation
+- fix permission for markdown document creation
 
 ## [4.0.0-beta.10] - 2022-10-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - fix permission for classroom creation
+- fix permission for filedepository creation
 
 ## [4.0.0-beta.10] - 2022-10-19
 

--- a/src/backend/marsha/bbb/api.py
+++ b/src/backend/marsha/bbb/api.py
@@ -74,7 +74,13 @@ class ClassroomViewSet(
                         | core_permissions.IsTokenAdmin
                     )
                 )
-                | IsClassroomPlaylistOrOrganizationAdmin
+                | (
+                    core_permissions.UserIsAuthenticated  # asserts request.resource is None
+                    & (
+                        core_permissions.IsParamsPlaylistAdmin
+                        | core_permissions.IsParamsPlaylistAdminThroughOrganization
+                    )
+                )
             ]
         elif self.action in ["retrieve"]:
             permission_classes = [

--- a/src/backend/marsha/bbb/permissions.py
+++ b/src/backend/marsha/bbb/permissions.py
@@ -8,6 +8,10 @@ from marsha.core import models
 
 def _is_organization_admin(user_id, classroom_id):
     """Check if user is an admin of the organization containing a classroom."""
+
+    if not user_id or not classroom_id:
+        return False
+
     return models.OrganizationAccess.objects.filter(
         role=models.ADMINISTRATOR,
         organization__playlists__classrooms__id=classroom_id,
@@ -17,6 +21,10 @@ def _is_organization_admin(user_id, classroom_id):
 
 def _is_playlist_admin(user_id, classroom_id):
     """Check if user is an admin of the playlist containing a classroom."""
+
+    if not user_id or not classroom_id:
+        return False
+
     return models.PlaylistAccess.objects.filter(
         role=models.ADMINISTRATOR,
         playlist__classrooms__id=classroom_id,

--- a/src/backend/marsha/bbb/tests/api/classroom/test_create.py
+++ b/src/backend/marsha/bbb/tests/api/classroom/test_create.py
@@ -207,6 +207,40 @@ class ClassroomCreateAPITest(TestCase):
             },
         )
 
+        response2 = self.client.post(
+            "/api/classrooms/",
+            {
+                "lti_id": "classroom_two",
+                "playlist": str(playlist.id),
+                "title": "classroom two",
+            },
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+        self.assertEqual(response2.status_code, 201)
+        self.assertEqual(Classroom.objects.count(), 2)
+        classroom2 = Classroom.objects.latest("created_on")
+        self.assertEqual(
+            response2.json(),
+            {
+                "description": "",
+                "ended": False,
+                "estimated_duration": None,
+                "id": str(classroom2.id),
+                "infos": {"returncode": "SUCCESS", "running": "true"},
+                "lti_id": "classroom_two",
+                "meeting_id": str(classroom2.meeting_id),
+                "playlist": {
+                    "id": str(playlist.id),
+                    "lti_id": playlist.lti_id,
+                    "title": playlist.title,
+                },
+                "started": False,
+                "starting_at": None,
+                "title": "classroom two",
+                "welcome_text": "Welcome!",
+            },
+        )
+
     @mock.patch.object(serializers, "get_meeting_infos")
     def test_api_classroom_create_user_access_token_playlist_admin(
         self, mock_get_meeting_infos
@@ -253,6 +287,40 @@ class ClassroomCreateAPITest(TestCase):
                 "started": False,
                 "starting_at": None,
                 "title": "Some classroom",
+                "welcome_text": "Welcome!",
+            },
+        )
+
+        response2 = self.client.post(
+            "/api/classrooms/",
+            {
+                "lti_id": "classroom_two",
+                "playlist": str(playlist_access.playlist.id),
+                "title": "classroom two",
+            },
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+        self.assertEqual(response2.status_code, 201)
+        self.assertEqual(Classroom.objects.count(), 2)
+        classroom2 = Classroom.objects.latest("created_on")
+        self.assertEqual(
+            response2.json(),
+            {
+                "description": "",
+                "ended": False,
+                "estimated_duration": None,
+                "id": str(classroom2.id),
+                "infos": {"returncode": "SUCCESS", "running": "true"},
+                "lti_id": "classroom_two",
+                "meeting_id": str(classroom2.meeting_id),
+                "playlist": {
+                    "id": str(playlist_access.playlist.id),
+                    "lti_id": playlist_access.playlist.lti_id,
+                    "title": playlist_access.playlist.title,
+                },
+                "started": False,
+                "starting_at": None,
+                "title": "classroom two",
                 "welcome_text": "Welcome!",
             },
         )

--- a/src/backend/marsha/deposit/api.py
+++ b/src/backend/marsha/deposit/api.py
@@ -79,7 +79,13 @@ class FileDepositoryViewSet(
                         | core_permissions.IsTokenAdmin
                     )
                 )
-                | IsFileDepositoryPlaylistOrOrganizationAdmin
+                | (
+                    core_permissions.UserIsAuthenticated  # asserts request.resource is None
+                    & (
+                        core_permissions.IsParamsPlaylistAdmin
+                        | core_permissions.IsParamsPlaylistAdminThroughOrganization
+                    )
+                )
             ]
         elif self.action in ["retrieve"]:
             permission_classes = [

--- a/src/backend/marsha/deposit/permissions.py
+++ b/src/backend/marsha/deposit/permissions.py
@@ -8,6 +8,10 @@ from marsha.core import models
 
 def _is_organization_admin(user_id, file_depository_id):
     """Check if user is an admin of the organization containing a file depository."""
+
+    if not user_id or not file_depository_id:
+        return False
+
     return models.OrganizationAccess.objects.filter(
         role=models.ADMINISTRATOR,
         organization__playlists__filedepositories__id=file_depository_id,
@@ -17,6 +21,10 @@ def _is_organization_admin(user_id, file_depository_id):
 
 def _is_playlist_admin(user_id, file_depository_id):
     """Check if user is an admin of the playlist containing a file depository."""
+
+    if not user_id or not file_depository_id:
+        return False
+
     return models.PlaylistAccess.objects.filter(
         role=models.ADMINISTRATOR,
         playlist__filedepositories__id=file_depository_id,

--- a/src/backend/marsha/deposit/tests/api/filedepositories/test_create.py
+++ b/src/backend/marsha/deposit/tests/api/filedepositories/test_create.py
@@ -158,6 +158,34 @@ class FileDepositoryCreateAPITest(TestCase):
             },
         )
 
+        response2 = self.client.post(
+            "/api/filedepositories/",
+            {
+                "lti_id": "file_depository_two",
+                "playlist": str(playlist.id),
+                "title": "file_depository two",
+            },
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+
+        self.assertEqual(FileDepository.objects.count(), 2)
+        self.assertEqual(response2.status_code, 201)
+        file_depository2 = FileDepository.objects.latest("created_on")
+        self.assertEqual(
+            response2.json(),
+            {
+                "description": "",
+                "id": str(file_depository2.id),
+                "lti_id": "file_depository_two",
+                "playlist": {
+                    "id": str(playlist.id),
+                    "lti_id": playlist.lti_id,
+                    "title": playlist.title,
+                },
+                "title": "file_depository two",
+            },
+        )
+
     def test_api_file_depository_create_user_access_token_playlist_admin(self):
         """A playlist administrator should be able to create a file depository."""
         playlist_access = PlaylistAccessFactory(role=ADMINISTRATOR)
@@ -190,5 +218,33 @@ class FileDepositoryCreateAPITest(TestCase):
                     "title": playlist_access.playlist.title,
                 },
                 "title": "Some file_depository",
+            },
+        )
+
+        response2 = self.client.post(
+            "/api/filedepositories/",
+            {
+                "lti_id": "file_depository_two",
+                "playlist": str(playlist_access.playlist.id),
+                "title": "file_depository two",
+            },
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+
+        self.assertEqual(FileDepository.objects.count(), 2)
+        self.assertEqual(response2.status_code, 201)
+        file_depository2 = FileDepository.objects.latest("created_on")
+        self.assertEqual(
+            response2.json(),
+            {
+                "description": "",
+                "id": str(file_depository2.id),
+                "lti_id": "file_depository_two",
+                "playlist": {
+                    "id": str(playlist_access.playlist.id),
+                    "lti_id": playlist_access.playlist.lti_id,
+                    "title": playlist_access.playlist.title,
+                },
+                "title": "file_depository two",
             },
         )

--- a/src/backend/marsha/markdown/api.py
+++ b/src/backend/marsha/markdown/api.py
@@ -69,7 +69,13 @@ class MarkdownDocumentViewSet(
                         | core_permissions.IsTokenAdmin
                     )
                 )
-                | markdown_permissions.IsMarkdownDocumentPlaylistOrOrganizationAdmin
+                | (
+                    core_permissions.UserIsAuthenticated  # asserts request.resource is None
+                    & (
+                        core_permissions.IsParamsPlaylistAdmin
+                        | core_permissions.IsParamsPlaylistAdminThroughOrganization
+                    )
+                )
             ]
         elif self.action in ["list"]:
             permission_classes = [core_permissions.UserIsAuthenticated]

--- a/src/backend/marsha/markdown/permissions.py
+++ b/src/backend/marsha/markdown/permissions.py
@@ -8,6 +8,10 @@ from marsha.core import models
 
 def _is_organization_admin(user_id, markdown_document_id):
     """Check if user is an admin of the organization containing a markdown document."""
+
+    if not user_id or not markdown_document_id:
+        return False
+
     return models.OrganizationAccess.objects.filter(
         role=models.ADMINISTRATOR,
         organization__playlists__markdowndocuments__id=markdown_document_id,
@@ -17,6 +21,10 @@ def _is_organization_admin(user_id, markdown_document_id):
 
 def _is_playlist_admin(user_id, markdown_document_id):
     """Check if user is an admin of the playlist containing a markdown document."""
+
+    if not user_id or not markdown_document_id:
+        return False
+
     return models.PlaylistAccess.objects.filter(
         role=models.ADMINISTRATOR,
         playlist__markdowndocuments__id=markdown_document_id,

--- a/src/backend/marsha/markdown/tests/api/markdown_documents/test_create.py
+++ b/src/backend/marsha/markdown/tests/api/markdown_documents/test_create.py
@@ -171,6 +171,43 @@ class MarkdownCreateAPITest(TestCase):
             },
         )
 
+        response2 = self.client.post(
+            "/api/markdown-documents/",
+            {
+                "lti_id": "document_two",
+                "playlist": str(playlist.id),
+                "title": "Document two",
+            },
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+
+        self.assertEqual(MarkdownDocument.objects.count(), 2)
+        self.assertEqual(response2.status_code, 201)
+        document2 = MarkdownDocument.objects.latest("created_on")
+        self.assertEqual(
+            response2.json(),
+            {
+                "id": str(document2.id),
+                "images": [],
+                "is_draft": True,
+                "playlist": {
+                    "id": str(playlist.id),
+                    "lti_id": playlist.lti_id,
+                    "title": playlist.title,
+                },
+                "position": 0,
+                "rendering_options": {},
+                "translations": [
+                    {
+                        "content": "",
+                        "language_code": "en",
+                        "rendered_content": "",
+                        "title": "Document two",
+                    }
+                ],
+            },
+        )
+
     def test_api_document_create_user_access_token_playlist_admin(self):
         """A playlist administrator should be able to create a Markdown document."""
         playlist_access = PlaylistAccessFactory(role=ADMINISTRATOR)
@@ -210,6 +247,43 @@ class MarkdownCreateAPITest(TestCase):
                         "language_code": "en",
                         "rendered_content": "",
                         "title": "Some document",
+                    }
+                ],
+            },
+        )
+
+        response2 = self.client.post(
+            "/api/markdown-documents/",
+            {
+                "lti_id": "document_two",
+                "playlist": str(playlist_access.playlist.id),
+                "title": "Document two",
+            },
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+
+        self.assertEqual(MarkdownDocument.objects.count(), 2)
+        self.assertEqual(response2.status_code, 201)
+        document2 = MarkdownDocument.objects.latest("created_on")
+        self.assertEqual(
+            response2.json(),
+            {
+                "id": str(document2.id),
+                "images": [],
+                "is_draft": True,
+                "playlist": {
+                    "id": str(playlist_access.playlist.id),
+                    "lti_id": playlist_access.playlist.lti_id,
+                    "title": playlist_access.playlist.title,
+                },
+                "position": 0,
+                "rendering_options": {},
+                "translations": [
+                    {
+                        "content": "",
+                        "language_code": "en",
+                        "rendered_content": "",
+                        "title": "Document two",
                     }
                 ],
             },


### PR DESCRIPTION
## Purpose

When creating one of these resources, we don't yet the resource primary key. But the permission class checking if the user can create a new resource id based on the resource id. For the first resource created in the targeted playlist, the permission returns `True` and `False` for all other resource creation. 
The core permission `IsParamsPlaylistAdmin` and `IsParamsPlaylistAdminThroughOrganization` must be used like we do for the video creation.

## Proposal

- [x] fix permission for classroom creation
- [x] fix permission for filedepository creation
- [x] fix permission for markdown document creation

