### PR TITLE
Refactor list filtering for classroom, deposit and markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - filtered classroom list
 - filtered deposit list
+- filtered markdown document list
 
 ## [4.0.0-beta.11] - 2022-11-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - filtered classroom list
+- filtered deposit list
 
 ## [4.0.0-beta.11] - 2022-11-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- filtered classroom list
+
 ## [4.0.0-beta.11] - 2022-11-08
 
 ### Added


### PR DESCRIPTION
## Purpose

List endpoint for classroom, deposit and markdown was harcoded and redefining the list method from DRF. We choose to reafctor them in order to use DRF mechanism like ordering and filtering. A dedicated queryset is made for list action. Also, this new queryset includes all resources in playlist **or** organization the user is administrator

## Proposal

- [x] Refactor classroom list endpoint
- [x] Refactor deposit list endpoint
- [x] Refactor markdown list endpoint

