### PR TITLE
🔖(beta) bump release to 4.0.0-beta.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.0.0-beta.11] - 2022-11-08
+
 ### Added
 
 - Migrate app classroom from LTI to lib-classroom package
@@ -1311,7 +1313,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Minor fixes and improvements on features and tests
 
-[unreleased]: https://github.com/openfun/marsha/compare/v4.0.0-beta.10...master
+[unreleased]: https://github.com/openfun/marsha/compare/v4.0.0-beta.11...master
+[4.0.0-beta.11]: https://github.com/openfun/marsha/compare/v4.0.0-beta.10...v4.0.0-beta.11
 [4.0.0-beta.10]: https://github.com/openfun/marsha/compare/v4.0.0-beta.9...v4.0.0-beta.10
 [4.0.0-beta.9]: https://github.com/openfun/marsha/compare/v4.0.0-beta.8...v4.0.0-beta.9
 [4.0.0-beta.8]: https://github.com/openfun/marsha/compare/v4.0.0-beta.7...v4.0.0-beta.8

--- a/src/aws/lambda-complete/package.json
+++ b/src/aws/lambda-complete/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-complete",
-  "version": "4.0.0-beta.10",
+  "version": "4.0.0-beta.11",
   "engines": {
     "node": "16"
   },

--- a/src/aws/lambda-configure/package.json
+++ b/src/aws/lambda-configure/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-configure",
-  "version": "4.0.0-beta.10",
+  "version": "4.0.0-beta.11",
   "engines": {
     "node": "16"
   },

--- a/src/aws/lambda-convert/package.json
+++ b/src/aws/lambda-convert/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-convert",
-  "version": "4.0.0-beta.10",
+  "version": "4.0.0-beta.11",
   "engines": {
     "node": "16"
   },

--- a/src/aws/lambda-elemental-routing/package.json
+++ b/src/aws/lambda-elemental-routing/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-elemental-routing",
-  "version": "4.0.0-beta.10",
+  "version": "4.0.0-beta.11",
   "engines": {
     "node": "16"
   },

--- a/src/aws/lambda-medialive/package.json
+++ b/src/aws/lambda-medialive/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-medialive",
-  "version": "4.0.0-beta.10",
+  "version": "4.0.0-beta.11",
   "engines": {
     "node": "16"
   },

--- a/src/aws/lambda-mediapackage/package.json
+++ b/src/aws/lambda-mediapackage/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-mediapackage",
-  "version": "4.0.0-beta.10",
+  "version": "4.0.0-beta.11",
   "engines": {
     "node": "16"
   },

--- a/src/aws/lambda-migrate/package.json
+++ b/src/aws/lambda-migrate/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-migrate",
-  "version": "4.0.0-beta.10",
+  "version": "4.0.0-beta.11",
   "engines": {
     "node": "16"
   },

--- a/src/aws/utils/update-state/package.json
+++ b/src/aws/utils/update-state/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-update-state",
-  "version": "4.0.0-beta.10",
+  "version": "4.0.0-beta.11",
   "engines": {
     "node": "16"
   },

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = marsha
 description = A FUN video provider for Open edX
-version = 4.0.0-beta.10
+version = 4.0.0-beta.11
 author = Open FUN (France Universite Numerique)
 author_email = fun.dev@fun-mooc.fr
 license = MIT

--- a/src/frontend/apps/lti_site/package.json
+++ b/src/frontend/apps/lti_site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marsha",
-  "version": "4.0.0-beta.10",
+  "version": "4.0.0-beta.11",
   "description": "🐠 a FUN LTI video provider",
   "main": "front/index.tsx",
   "scripts": {

--- a/src/frontend/apps/standalone_site/package.json
+++ b/src/frontend/apps/standalone_site/package.json
@@ -1,6 +1,7 @@
 {
   "name": "standalone_site",
-  "version": "0.1.0",
+  "version": "4.0.0-beta.11",
+  "license": "MIT",
   "private": true,
   "devDependencies": {
     "@types/fetch-mock": "7.3.5",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,7 @@
 {
   "name": "common",
-  "version": "0.1.0",
+  "version": "4.0.0-beta.11",
+  "license": "MIT",
   "private": true,
   "workspaces": {
     "nohoist": [

--- a/src/frontend/packages/lib_classroom/package.json
+++ b/src/frontend/packages/lib_classroom/package.json
@@ -1,8 +1,7 @@
 {
   "name": "lib-classroom",
-  "version": "1.0.0",
-  "description": "",
-  "license": "ISC",
+  "version": "4.0.0-beta.11",
+  "license": "MIT",
   "main": "lib/index.js",
   "module": "lib/index.es.js",
   "types": "lib/index.d.ts",

--- a/src/frontend/packages/lib_common/package.json
+++ b/src/frontend/packages/lib_common/package.json
@@ -1,8 +1,7 @@
 {
   "name": "lib-common",
-  "version": "1.0.0",
-  "description": "",
-  "license": "ISC",
+  "version": "4.0.0-beta.11",
+  "license": "MIT",
   "main": "lib/index.js",
   "module": "lib/index.es.js",
   "jsnext:main": "lib/index.es.js",

--- a/src/frontend/packages/lib_components/package.json
+++ b/src/frontend/packages/lib_components/package.json
@@ -1,8 +1,7 @@
 {
   "name": "lib-components",
-  "version": "1.0.0",
-  "description": "",
-  "license": "ISC",
+  "version": "4.0.0-beta.11",
+  "license": "MIT",
   "main": "lib/index.js",
   "module": "lib/index.es.js",
   "types": "lib/index.d.ts",

--- a/src/frontend/packages/lib_tests/package.json
+++ b/src/frontend/packages/lib_tests/package.json
@@ -1,8 +1,7 @@
 {
   "name": "lib-tests",
-  "version": "1.0.0",
-  "description": "",
-  "license": "ISC",
+  "version": "4.0.0-beta.11",
+  "license": "MIT",
   "main": "lib/index.js",
   "module": "lib/index.es.js",
   "jsnext:main": "lib/index.es.js",


### PR DESCRIPTION
### Added

- Migrate app classroom from LTI to lib-classroom package
- Create lib-classroom package
- Add SharedLiveMedia widget to public and teacher VOD Dashboard
- Add new elements to the public VOD Dashboard :
  - Transcript reader
  - Video download
- standalone website:
  - playlists page
- install and configure drf-spectacular to serve a swagger ui
- Management command clean_aws_elemental_stack

### Changed

- Allow site users to manage classroom documents, deposited files, and markdown images through API.
- Site url serve the build generated by CRA
- Enrich playlist serializer with organization and consumer site infos
- Refactor check_live_state management command to use the live started_at timestamp to filter logs instead of using video creation date.

### Fixed

- fix permission for classroom creation
- fix permission for filedepository creation
- fix permission for markdown document creation


