### PR TITLE
🐛(backend) remove duplicated data on resources API list

### DIFF
--- a/src/backend/marsha/bbb/api.py
+++ b/src/backend/marsha/bbb/api.py
@@ -115,6 +115,7 @@ class ClassroomViewSet(
                     playlist__user_accesses__role=ADMINISTRATOR,
                 )
             )
+            .distinct()
         )
 
         return queryset

--- a/src/backend/marsha/core/api/playlist.py
+++ b/src/backend/marsha/core/api/playlist.py
@@ -89,6 +89,7 @@ class PlaylistViewSet(APIViewMixin, ObjectPkMixin, viewsets.ModelViewSet):
                     user_accesses__role=ADMINISTRATOR,
                 )
             )
+            .distinct()
         )
 
         return queryset

--- a/src/backend/marsha/core/factories.py
+++ b/src/backend/marsha/core/factories.py
@@ -77,7 +77,10 @@ class OrganizationFactory(DjangoModelFactory):
 
 
 class ConsumerSiteOrganizationFactory(DjangoModelFactory):
-    """Factory for the SiteOrganization model."""
+    """Factory for the ConsumerSiteOrganization model."""
+
+    consumer_site = factory.SubFactory(ConsumerSiteFactory)
+    organization = factory.SubFactory(OrganizationFactory)
 
     class Meta:  # noqa
         model = models.ConsumerSiteOrganization

--- a/src/backend/marsha/core/tests/api/organizations/test_list.py
+++ b/src/backend/marsha/core/tests/api/organizations/test_list.py
@@ -9,6 +9,8 @@ from marsha.core.simple_jwt.factories import UserAccessTokenFactory
 class OrganizationListAPITest(TestCase):
     """Test the list API for organization objects."""
 
+    maxDiff = None
+
     def test_list_organizations_by_anonymous_user(self):
         """Anonymous users cannot list organizations."""
         factories.OrganizationFactory()
@@ -68,4 +70,72 @@ class OrganizationListAPITest(TestCase):
                     "users": [str(user.pk)],
                 }
             ],
+        )
+
+    def test_list_organizations_not_duplicated(self):
+        """
+        Test the list of organizations to not be duplicated.
+        This cannot be possible for now, as the base queryset uses
+        only one OUTER JOIN, but we expect to prevent this in the future.
+        """
+        user = factories.UserFactory()
+        created_on = timezone.now()
+        organization = factories.OrganizationFactory(created_on=created_on)
+        factories.OrganizationAccessFactory(
+            user=user, organization=organization, role=models.ADMINISTRATOR
+        )
+
+        # Other organization access not linked to the current user
+        other_accesses = factories.OrganizationAccessFactory.create_batch(
+            10, organization=organization
+        )
+
+        # Other organization not linked to the current user
+        factories.OrganizationAccessFactory.create_batch(3)
+
+        # Other organization linked to the current user but not as admin
+        factories.OrganizationAccessFactory(
+            user=user,
+            role=models.INSTRUCTOR,
+        )
+
+        # In case we also add a consumer site admin to access organization
+        consumer_site_organization = factories.ConsumerSiteOrganizationFactory(
+            organization=organization,
+        )
+        factories.ConsumerSiteAccessFactory(
+            user=user,
+            consumer_site=consumer_site_organization.consumer_site,
+            role=models.ADMINISTRATOR,
+        )
+
+        # other consumer site administrator
+        factories.ConsumerSiteAccessFactory(
+            consumer_site=consumer_site_organization.consumer_site,
+            role=models.ADMINISTRATOR,
+        )
+
+        factories.ConsumerSiteAccessFactory.create_batch(
+            10, consumer_site=consumer_site_organization.consumer_site
+        )
+
+        jwt_token = UserAccessTokenFactory(user=user)
+
+        response = self.client.get(
+            "/api/organizations/",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["count"], 1)
+
+        self.assertEqual(response.json()["results"][0]["id"], str(organization.pk))
+        self.assertEqual(response.json()["results"][0]["name"], organization.name)
+        self.assertListEqual(
+            response.json()["results"][0]["consumer_sites"],
+            [str(consumer_site_organization.consumer_site.pk)],
+        )
+        self.assertListEqual(
+            sorted(response.json()["results"][0]["users"]),
+            sorted([str(user.pk)] + [str(access.user_id) for access in other_accesses]),
         )

--- a/src/backend/marsha/deposit/api.py
+++ b/src/backend/marsha/deposit/api.py
@@ -134,6 +134,7 @@ class FileDepositoryViewSet(
                     playlist__user_accesses__role=ADMINISTRATOR,
                 )
             )
+            .distinct()
         )
 
         return queryset

--- a/src/backend/marsha/markdown/api.py
+++ b/src/backend/marsha/markdown/api.py
@@ -111,6 +111,7 @@ class MarkdownDocumentViewSet(
                     playlist__user_accesses__role=ADMINISTRATOR,
                 )
             )
+            .distinct()
         )
 
         return queryset


### PR DESCRIPTION
## Purpose

The filter on playlist permissions may return the same resource several times.

This can be explained with the fact we use an `OR` filter on two many-to-many relations, resulting in two `OUTER JOIN` and a filter on each on or another.

For instance:
| playlist.id                          | organization_access.id               | organization_access.user_id          | organization_access.role | playlist_access.id                   | playlist_access.user_id                            | playlist_access.role |
|--------------------------------------|--------------------------------------|--------------------------------------|--------------------------|--------------------------------------|----------------------------------------------------|----------------------|
| 6fd18380-fb81-43ce-87e9-276247631621 | 2f9b3103-a163-417a-a5dd-bee158bdba59 | 64412577-755a-4701-994b-9fd4810b9e49 | administrator            | 1bf1ee8f-8f9d-4eb0-991c-0681fb96797b | 4dad755e-29b4-440d-b596-38aa889d23b0 | administrator        |
| 6fd18380-fb81-43ce-87e9-276247631621 | 2d9ca180-78fe-47e9-aba5-e24dac6e850c | 60f8cb37-97dc-49f7-a144-94b4d6c3f20b | instructor               | 1bf1ee8f-8f9d-4eb0-991c-0681fb96797b | 4dad755e-29b4-440d-b596-38aa889d23b0 | administrator        |
| 6fd18380-fb81-43ce-87e9-276247631621 | eec8375e-a598-4d01-9dcd-00035eae33ea | ec2513fc-4538-4ab2-823a-a253f49ed6e8 | student                  | 1bf1ee8f-8f9d-4eb0-991c-0681fb96797b | 4dad755e-29b4-440d-b596-38aa889d23b0 | administrator        |

- for one user having the `administrator` role on the playlist
- we have one line per organization access, 
- resulting in three time the same playlist

## Proposal

User a `SELECT DISTINCT` to fetch only once the playlist.

Warning: As this will only retain one line, this is what we want since we expect to fetch the data (the playlist or the resource), be we must not rely on the "outer joined" data. See further information in Django documentation ^^ https://docs.djangoproject.com/fr/4.1/ref/models/querysets/#distinct

Apply this on:

- [x] ClassroomViewSet
- [x] PlaylistViewSet
- [x] FileDepositoryViewSet
- [x] MarkdownViewSet


