### PR TITLE
🐛(backend) add missing SAML setting to use cache

### DIFF
--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -534,6 +534,9 @@ class Base(Configuration):
     SOCIAL_AUTH_URL_NAMESPACE = "account:social"
     SOCIAL_AUTH_SAML_FER_IDP_FAKER = False
     SOCIAL_AUTH_SAML_FER_IDP_FAKER_DOCKER_PORT = 8060
+    SOCIAL_AUTH_SAML_FER_FEDERATION_SAML_METADATA_STORE = (
+        "social_edu_federation.django.metadata_store.CachedMetadataStore"
+    )
 
     SOCIAL_AUTH_SAML_FER_SECURITY_CONFIG = {
         "authnRequestsSigned": values.BooleanValue(


### PR DESCRIPTION
## Purpose

Store Renater's federation IDP list in cache for faster list rendering.

## Proposal

This setting allows to use a cache to store the SAML Federation metadata in marsha's cache (redis in production).

Without the view to list all Renater's available IDP will be fetch on every display (slower).

- [x] add `SOCIAL_AUTH_SAML_FER_FEDERATION_SAML_METADATA_STORE` setting 

