### PR TITLE
♻️(back) make bbb record optional on meeting creation

### DIFF
--- a/src/backend/marsha/bbb/utils/bbb_utils.py
+++ b/src/backend/marsha/bbb/utils/bbb_utils.py
@@ -111,7 +111,7 @@ def create(classroom: Classroom):
         "attendeePW": classroom.attendee_password,
         "moderatorPW": classroom.moderator_password,
         "welcome": classroom.welcome_text,
-        "record": True,
+        "record": settings.BBB_ENABLE_RECORD,
     }
 
     documents = classroom.classroom_documents.filter(upload_state="ready")

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -343,6 +343,7 @@ class Base(Configuration):
     BBB_API_ENDPOINT = values.Value()
     BBB_API_SECRET = values.Value(None)
     BBB_API_TIMEOUT = values.PositiveIntegerValue(10)
+    BBB_ENABLE_RECORD = values.BooleanValue(False)
     ALLOWED_CLASSROOM_DOCUMENT_MIME_TYPES = values.ListValue(["application/pdf"])
 
     # deposit application


### PR DESCRIPTION
## Purpose

The record parameter was set to True when a meeting in bbb is created. We want to set this parameter optional and by default set to False to choose when to enable it and on which environment to enable it.

## Proposal

- [x] make bbb record optional on meeting creation
