### PR TITLE
⚡️ use a lite serializer for classroom resource on list endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - filtered classroom list
 - filtered deposit list
 - filtered markdown document list
+- use a lite serializer for classroom resource on list endpoint
 
 ## [4.0.0-beta.11] - 2022-11-08
 

--- a/src/backend/marsha/bbb/api.py
+++ b/src/backend/marsha/bbb/api.py
@@ -99,6 +99,15 @@ class ClassroomViewSet(
             permission_classes = self.permission_classes
         return [permission() for permission in permission_classes]
 
+    def get_serializer_class(self):
+        """
+        Manage the serializer class to use based on the action
+        """
+        if self.action in ["list"]:
+            return serializers.ClassroomLiteSerializer
+
+        return super().get_serializer_class()
+
     def _get_list_queryset(self):
         """Build the queryset used on the list action."""
         queryset = (

--- a/src/backend/marsha/bbb/serializers.py
+++ b/src/backend/marsha/bbb/serializers.py
@@ -21,6 +21,7 @@ from marsha.core.serializers import (
     InitiateUploadSerializer,
     UploadableFileWithExtensionSerializerMixin,
 )
+from marsha.core.serializers.base import ReadOnlyModelSerializer
 from marsha.core.serializers.playlist import PlaylistLiteSerializer
 
 
@@ -85,6 +86,25 @@ class ClassroomSerializer(serializers.ModelSerializer):
                 )
 
         return value
+
+
+class ClassroomLiteSerializer(ReadOnlyModelSerializer):
+    """Classroom lite serializer without playlist and infos fetch from the BBB api."""
+
+    class Meta:  # noqa
+        model = Classroom
+        fields = (
+            "id",
+            "lti_id",
+            "title",
+            "description",
+            "meeting_id",
+            "welcome_text",
+            "started",
+            "ended",
+            "starting_at",
+            "estimated_duration",
+        )
 
 
 class ClassroomSelectLTISerializer(ClassroomSerializer):

--- a/src/backend/marsha/bbb/tests/api/classroom/test_list.py
+++ b/src/backend/marsha/bbb/tests/api/classroom/test_list.py
@@ -1,9 +1,6 @@
 """Tests for the classroom API."""
-from unittest import mock
-
 from django.test import TestCase, override_settings
 
-from marsha.bbb import serializers
 from marsha.bbb.factories import ClassroomFactory
 from marsha.core.factories import (
     OrganizationAccessFactory,
@@ -69,10 +66,7 @@ class ClassroomListAPITest(TestCase):
         )
         self.assertEqual(response.status_code, 403)
 
-    @mock.patch.object(serializers, "get_meeting_infos")
-    def test_api_fetch_list_user_access_token_playlist_admin(
-        self, mock_get_meeting_infos
-    ):
+    def test_api_fetch_list_user_access_token_playlist_admin(self):
         """
         A user with UserAccessToken should be able to fetch a classroom list from playlist
         he is admin
@@ -81,11 +75,6 @@ class ClassroomListAPITest(TestCase):
         playlist_access = PlaylistAccessFactory(user=user, role=ADMINISTRATOR)
         classrooms = ClassroomFactory.create_batch(3, playlist=playlist_access.playlist)
         ClassroomFactory()
-
-        mock_get_meeting_infos.return_value = {
-            "returncode": "SUCCESS",
-            "running": "true",
-        }
 
         jwt_token = UserAccessTokenFactory(user=user)
         response = self.client.get(
@@ -105,14 +94,8 @@ class ClassroomListAPITest(TestCase):
                         "ended": False,
                         "estimated_duration": None,
                         "id": str(classrooms[2].id),
-                        "infos": {"returncode": "SUCCESS", "running": "true"},
                         "lti_id": str(classrooms[2].lti_id),
                         "meeting_id": str(classrooms[2].meeting_id),
-                        "playlist": {
-                            "id": str(playlist_access.playlist.id),
-                            "lti_id": playlist_access.playlist.lti_id,
-                            "title": playlist_access.playlist.title,
-                        },
                         "started": False,
                         "starting_at": None,
                         "title": classrooms[2].title,
@@ -123,14 +106,8 @@ class ClassroomListAPITest(TestCase):
                         "ended": False,
                         "estimated_duration": None,
                         "id": str(classrooms[1].id),
-                        "infos": {"returncode": "SUCCESS", "running": "true"},
                         "lti_id": str(classrooms[1].lti_id),
                         "meeting_id": str(classrooms[1].meeting_id),
-                        "playlist": {
-                            "id": str(playlist_access.playlist.id),
-                            "lti_id": playlist_access.playlist.lti_id,
-                            "title": playlist_access.playlist.title,
-                        },
                         "started": False,
                         "starting_at": None,
                         "title": classrooms[1].title,
@@ -141,14 +118,8 @@ class ClassroomListAPITest(TestCase):
                         "ended": False,
                         "estimated_duration": None,
                         "id": str(classrooms[0].id),
-                        "infos": {"returncode": "SUCCESS", "running": "true"},
                         "lti_id": str(classrooms[0].lti_id),
                         "meeting_id": str(classrooms[0].meeting_id),
-                        "playlist": {
-                            "id": str(playlist_access.playlist.id),
-                            "lti_id": playlist_access.playlist.lti_id,
-                            "title": playlist_access.playlist.title,
-                        },
                         "started": False,
                         "starting_at": None,
                         "title": classrooms[0].title,
@@ -158,10 +129,7 @@ class ClassroomListAPITest(TestCase):
             },
         )
 
-    @mock.patch.object(serializers, "get_meeting_infos")
-    def test_api_fetch_list_user_access_token_organization_admin(
-        self, mock_get_meeting_infos
-    ):
+    def test_api_fetch_list_user_access_token_organization_admin(self):
         """A user with UserAccessToken should be able to fetch a classroom list."""
         organization_access_admin = OrganizationAccessFactory(role=ADMINISTRATOR)
         organization_access = OrganizationAccessFactory(
@@ -180,11 +148,6 @@ class ClassroomListAPITest(TestCase):
         ClassroomFactory.create_batch(3, playlist=playlist_2_a)
         ClassroomFactory.create_batch(3, playlist=playlist_2_b)
         ClassroomFactory()
-
-        mock_get_meeting_infos.return_value = {
-            "returncode": "SUCCESS",
-            "running": "true",
-        }
 
         jwt_token = UserAccessTokenFactory(user=organization_access_admin.user)
 
@@ -205,14 +168,8 @@ class ClassroomListAPITest(TestCase):
                         "ended": False,
                         "estimated_duration": None,
                         "id": str(classrooms_1_b[2].id),
-                        "infos": {"returncode": "SUCCESS", "running": "true"},
                         "lti_id": str(classrooms_1_b[2].lti_id),
                         "meeting_id": str(classrooms_1_b[2].meeting_id),
-                        "playlist": {
-                            "id": str(playlist_1_b.id),
-                            "lti_id": playlist_1_b.lti_id,
-                            "title": playlist_1_b.title,
-                        },
                         "started": False,
                         "starting_at": None,
                         "title": classrooms_1_b[2].title,
@@ -223,14 +180,8 @@ class ClassroomListAPITest(TestCase):
                         "ended": False,
                         "estimated_duration": None,
                         "id": str(classrooms_1_b[1].id),
-                        "infos": {"returncode": "SUCCESS", "running": "true"},
                         "lti_id": str(classrooms_1_b[1].lti_id),
                         "meeting_id": str(classrooms_1_b[1].meeting_id),
-                        "playlist": {
-                            "id": str(playlist_1_b.id),
-                            "lti_id": playlist_1_b.lti_id,
-                            "title": playlist_1_b.title,
-                        },
                         "started": False,
                         "starting_at": None,
                         "title": classrooms_1_b[1].title,
@@ -240,10 +191,7 @@ class ClassroomListAPITest(TestCase):
             },
         )
 
-    @mock.patch.object(serializers, "get_meeting_infos")
-    def test_api_fetch_list_user_access_token_not_duplicated(
-        self, mock_get_meeting_infos
-    ):
+    def test_api_fetch_list_user_access_token_not_duplicated(self):
         """
         When several users have administrator role on a playlist,
         the classroom must be returned only once.
@@ -269,11 +217,6 @@ class ClassroomListAPITest(TestCase):
         classroom = ClassroomFactory(playlist=playlist)
         ClassroomFactory.create_batch(3)
 
-        mock_get_meeting_infos.return_value = {
-            "returncode": "SUCCESS",
-            "running": "true",
-        }
-
         jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
@@ -293,14 +236,8 @@ class ClassroomListAPITest(TestCase):
                         "ended": False,
                         "estimated_duration": None,
                         "id": str(classroom.id),
-                        "infos": {"returncode": "SUCCESS", "running": "true"},
                         "lti_id": str(classroom.lti_id),
                         "meeting_id": str(classroom.meeting_id),
-                        "playlist": {
-                            "id": str(playlist.id),
-                            "lti_id": playlist.lti_id,
-                            "title": playlist.title,
-                        },
                         "started": False,
                         "starting_at": None,
                         "title": classroom.title,
@@ -310,10 +247,7 @@ class ClassroomListAPITest(TestCase):
             },
         )
 
-    @mock.patch.object(serializers, "get_meeting_infos")
-    def test_api_fetch_list_user_access_token_filter_organization(
-        self, mock_get_meeting_infos
-    ):
+    def test_api_fetch_list_user_access_token_filter_organization(self):
         """A user with UserAccessToken should be able to filter classroom list by organization."""
         organization_access_admin_1 = OrganizationAccessFactory(role=ADMINISTRATOR)
         organization_access_admin_2 = OrganizationAccessFactory(
@@ -337,11 +271,6 @@ class ClassroomListAPITest(TestCase):
         classrooms_2_b = ClassroomFactory.create_batch(3, playlist=playlist_2_b)
         ClassroomFactory()
 
-        mock_get_meeting_infos.return_value = {
-            "returncode": "SUCCESS",
-            "running": "true",
-        }
-
         jwt_token = UserAccessTokenFactory(user=organization_access_admin_1.user)
 
         response = self.client.get(
@@ -364,14 +293,8 @@ class ClassroomListAPITest(TestCase):
                         "ended": False,
                         "estimated_duration": None,
                         "id": str(classrooms_2_b[2].id),
-                        "infos": {"returncode": "SUCCESS", "running": "true"},
                         "lti_id": str(classrooms_2_b[2].lti_id),
                         "meeting_id": str(classrooms_2_b[2].meeting_id),
-                        "playlist": {
-                            "id": str(playlist_2_b.id),
-                            "lti_id": playlist_2_b.lti_id,
-                            "title": playlist_2_b.title,
-                        },
                         "started": False,
                         "starting_at": None,
                         "title": classrooms_2_b[2].title,
@@ -382,14 +305,8 @@ class ClassroomListAPITest(TestCase):
                         "ended": False,
                         "estimated_duration": None,
                         "id": str(classrooms_2_b[1].id),
-                        "infos": {"returncode": "SUCCESS", "running": "true"},
                         "lti_id": str(classrooms_2_b[1].lti_id),
                         "meeting_id": str(classrooms_2_b[1].meeting_id),
-                        "playlist": {
-                            "id": str(playlist_2_b.id),
-                            "lti_id": playlist_2_b.lti_id,
-                            "title": playlist_2_b.title,
-                        },
                         "started": False,
                         "starting_at": None,
                         "title": classrooms_2_b[1].title,
@@ -399,10 +316,7 @@ class ClassroomListAPITest(TestCase):
             },
         )
 
-    @mock.patch.object(serializers, "get_meeting_infos")
-    def test_api_fetch_list_user_access_token_filter_playlist(
-        self, mock_get_meeting_infos
-    ):
+    def test_api_fetch_list_user_access_token_filter_playlist(self):
         """A user with UserAccessToken should be able to filter classroom list by playlist."""
         organization_access_admin = OrganizationAccessFactory(role=ADMINISTRATOR)
         organization_access = OrganizationAccessFactory(
@@ -421,11 +335,6 @@ class ClassroomListAPITest(TestCase):
         ClassroomFactory.create_batch(3, playlist=playlist_2_a)
         ClassroomFactory.create_batch(3, playlist=playlist_2_b)
         ClassroomFactory()
-
-        mock_get_meeting_infos.return_value = {
-            "returncode": "SUCCESS",
-            "running": "true",
-        }
 
         jwt_token = UserAccessTokenFactory(user=organization_access_admin.user)
 
@@ -449,14 +358,8 @@ class ClassroomListAPITest(TestCase):
                         "ended": False,
                         "estimated_duration": None,
                         "id": str(classrooms_1_b[2].id),
-                        "infos": {"returncode": "SUCCESS", "running": "true"},
                         "lti_id": str(classrooms_1_b[2].lti_id),
                         "meeting_id": str(classrooms_1_b[2].meeting_id),
-                        "playlist": {
-                            "id": str(playlist_1_b.id),
-                            "lti_id": playlist_1_b.lti_id,
-                            "title": playlist_1_b.title,
-                        },
                         "started": False,
                         "starting_at": None,
                         "title": classrooms_1_b[2].title,
@@ -467,14 +370,8 @@ class ClassroomListAPITest(TestCase):
                         "ended": False,
                         "estimated_duration": None,
                         "id": str(classrooms_1_b[1].id),
-                        "infos": {"returncode": "SUCCESS", "running": "true"},
                         "lti_id": str(classrooms_1_b[1].lti_id),
                         "meeting_id": str(classrooms_1_b[1].meeting_id),
-                        "playlist": {
-                            "id": str(playlist_1_b.id),
-                            "lti_id": playlist_1_b.lti_id,
-                            "title": playlist_1_b.title,
-                        },
                         "started": False,
                         "starting_at": None,
                         "title": classrooms_1_b[1].title,

--- a/src/backend/marsha/bbb/utils/bbb_utils.py
+++ b/src/backend/marsha/bbb/utils/bbb_utils.py
@@ -134,7 +134,7 @@ def create(classroom: Classroom):
     classroom.started = True
     classroom.moderator_password = api_response["moderatorPW"]
     classroom.attendee_password = api_response["attendeePW"]
-    classroom.save()
+    classroom.save(update_fields=["started", "moderator_password", "attendee_password"])
     return api_response
 
 
@@ -159,7 +159,7 @@ def end(classroom: Classroom, moderator=False):
     api_response = request_api("end", parameters)
     classroom.started = False
     classroom.ended = True
-    classroom.save()
+    classroom.save(update_fields=["started", "ended"])
     return api_response
 
 
@@ -182,9 +182,9 @@ def get_meeting_infos(classroom: Classroom):
             else:
                 api_response["attendees"] = [attendees]
 
-        classroom.save()
+        classroom.save(update_fields=["started"])
         return api_response
     except ApiMeetingException as exception:
         classroom.started = False
-        classroom.save()
+        classroom.save(update_fields=["started"])
         raise exception

--- a/src/frontend/apps/standalone_site/src/features/ClassRooms/components/ClassRoom.tsx
+++ b/src/frontend/apps/standalone_site/src/features/ClassRooms/components/ClassRoom.tsx
@@ -1,6 +1,6 @@
 import { Text, Box } from 'grommet';
 import { FormSchedule, InProgress } from 'grommet-icons';
-import { Classroom } from 'lib-components';
+import { ClassroomLite } from 'lib-components';
 import React, { Fragment } from 'react';
 import { useIntl } from 'react-intl';
 import styled from 'styled-components';
@@ -16,7 +16,7 @@ const TextTruncated = styled(Text)`
   overflow: hidden;
 `;
 
-function ClassRoom({ classroom }: { classroom: Classroom }) {
+function ClassRoom({ classroom }: { classroom: ClassroomLite }) {
   const intl = useIntl();
 
   return (

--- a/src/frontend/packages/lib_classroom/src/data/queries/index.tsx
+++ b/src/frontend/packages/lib_classroom/src/data/queries/index.tsx
@@ -18,6 +18,7 @@ import {
   JoinClassroomActionRequest,
   JoinClassroomActionResponse,
   Classroom,
+  ClassroomLite,
   CreateClassroomActionRequest,
   CreateClassroomActionResponse,
   ClassroomDocument,
@@ -31,7 +32,7 @@ import {
   UseQueryOptions,
 } from 'react-query';
 
-type ClassroomsResponse = APIList<Classroom>;
+type ClassroomsResponse = APIList<ClassroomLite>;
 type UseClassroomsParams = {
   organization?: Maybe<string>;
   limit?: Maybe<string>;

--- a/src/frontend/packages/lib_components/src/types/apps/classroom/models.ts
+++ b/src/frontend/packages/lib_components/src/types/apps/classroom/models.ts
@@ -16,6 +16,8 @@ export interface Classroom extends Resource {
   estimated_duration: Nullable<string>;
 }
 
+export type ClassroomLite = Omit<Classroom, 'infos' | 'playlist'>;
+
 export interface ClassroomInfos {
   returncode: string;
   classroomName: string;


### PR DESCRIPTION
## Purpose

The classroom serializer is fetching the bbb api to find fresh
information. We don't need this information on the list endpoint.
Removing them increase the performace of this endpoint.

## Proposal

- [x] use a lite serializer for classroom resource on list endpoint
- [x] select updated fields saved in bbb_utils module
- [x] create ClassroomLite type  

