### PR TITLE
🐛(backend) Renater SSO user role is a list

### DIFF
--- a/src/backend/marsha/account/social_pipeline/organization.py
+++ b/src/backend/marsha/account/social_pipeline/organization.py
@@ -2,6 +2,8 @@
 from django.db import IntegrityError
 from django.db.transaction import atomic
 
+from social_edu_federation.defaults import EduPersonAffiliationEnum
+
 from marsha.account.models import IdpOrganizationAssociation
 from marsha.core.models import INSTRUCTOR, STUDENT, Organization, OrganizationAccess
 
@@ -119,7 +121,12 @@ def create_organization_from_saml(
         OrganizationAccess.objects.create(
             user=user,
             organization=association.organization,
-            role=INSTRUCTOR if details["role"] == "teacher" else STUDENT,
+            role=INSTRUCTOR
+            if (
+                details.get("roles", None)
+                and EduPersonAffiliationEnum.TEACHER.value in details["roles"]
+            )
+            else STUDENT,
         )
     except IntegrityError:
         pass

--- a/src/backend/marsha/account/tests/test_social_pipeline_organization.py
+++ b/src/backend/marsha/account/tests/test_social_pipeline_organization.py
@@ -104,7 +104,7 @@ class OrganizationPipelineTestCase(TestCase):
         Main test method used everywhere in following tests.
 
         This asserts the values for Organization and linking objects are properly defined.
-        This expect only one organization for all tests.
+        This expects only one organization for all tests.
 
         Parameters
         ----------
@@ -144,7 +144,7 @@ class OrganizationPipelineTestCase(TestCase):
     def test_create_organization_from_saml_teacher_new(self):
         """Assert new teacher from new organization initializes properly."""
         # Prepare data
-        saml_details = {"role": "teacher", **self.default_saml_details}
+        saml_details = {"roles": ["teacher"], **self.default_saml_details}
 
         # Call pipeline step "create_organization_from_saml"
         with self.assertNumQueries(
@@ -195,7 +195,7 @@ class OrganizationPipelineTestCase(TestCase):
     def test_create_organization_from_saml_student_or_unknown_new(self):
         """Assert new student from new organization initializes properly."""
         # Prepare data
-        saml_details = {"role": "", **self.default_saml_details}
+        saml_details = {"roles": [], **self.default_saml_details}
 
         # Call pipeline step "create_organization_from_saml"
         with self.assertNumQueries(
@@ -252,7 +252,7 @@ class OrganizationPipelineTestCase(TestCase):
         OrganizationFactory(name="Marsha organization")
 
         # Prepare data
-        saml_details = {"role": "teacher", **self.default_saml_details}
+        saml_details = {"roles": ["teacher"], **self.default_saml_details}
 
         # Call pipeline step "create_organization_from_saml"
         with self.assertNumQueries(
@@ -298,7 +298,7 @@ class OrganizationPipelineTestCase(TestCase):
         OrganizationFactory(name="Marsha organization")
 
         # Prepare data
-        saml_details = {"role": "not_teacher", **self.default_saml_details}
+        saml_details = {"roles": ["not_teacher"], **self.default_saml_details}
 
         # Call pipeline step "create_organization_from_saml"
         with self.assertNumQueries(
@@ -340,7 +340,7 @@ class OrganizationPipelineTestCase(TestCase):
         Assert new student from existing organization linked to an IdP
         initializes properly.
         """
-        saml_details = {"role": "not_teacher", **self.default_saml_details}
+        saml_details = {"roles": ["not_teacher"], **self.default_saml_details}
 
         # Init organization with already one user
         create_organization_from_saml(
@@ -388,7 +388,7 @@ class OrganizationPipelineTestCase(TestCase):
         while other already exist.
         """
         # Init organization with already one user
-        saml_details = {"role": "not_teacher", **self.default_saml_details}
+        saml_details = {"roles": ["not_teacher"], **self.default_saml_details}
 
         create_organization_from_saml(
             None,  # strategy is unused
@@ -465,7 +465,7 @@ class OrganizationPipelineTestCase(TestCase):
         """
         Assert the pipeline step fails if `new_association` has not been already defined.
         """
-        saml_details = {"role": "not_teacher", **self.default_saml_details}
+        saml_details = {"roles": ["not_teacher"], **self.default_saml_details}
 
         with self.assertRaises(RuntimeError):
             create_organization_from_saml(

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -59,7 +59,7 @@ install_requires =
     requests==2.28.1
     social-auth-app-django==5.0.0
     social-auth-core[saml]==4.3.0
-    social-edu-federation==1.0.1
+    social-edu-federation==2.0.0
     urllib3==1.26.13
     uvicorn[standard]==0.20.0
     whitenoise==6.2.0


### PR DESCRIPTION
## Purpose

The roles provided by the Renater SSO is a list, using the new version of `social-edu-federation` provides a list of roles where we can look for a `teacher` role.

## Proposal

- [x] Bump `social-edu-federation` to the latest version
- [x] Update the "teacher" role presence test in SAML response details.


