### PR TITLE
🐛(back) change permission on retrieve endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - the full name replaces the first and last names in the
   user's profile API
 
+### Fixed
+
+- change permission on retrieve endpoints
+
 ## [4.0.0-beta.11] - 2022-11-08
 
 ### Added

--- a/src/backend/marsha/.cookiecutter/{{cookiecutter.app_name}}/api.py
+++ b/src/backend/marsha/.cookiecutter/{{cookiecutter.app_name}}/api.py
@@ -44,7 +44,7 @@ class {{cookiecutter.model}}ViewSet(
                 & (core_permissions.IsTokenInstructor | core_permissions.IsTokenAdmin)
             ]
         elif self.action in ["retrieve"]:
-            permission_classes = [core_permissions.ResourceIsAuthenticated]
+            permission_classes = [core_permissions.IsTokenResourceRouteObject]
         else:
             permission_classes = self.permission_classes
         return [permission() for permission in permission_classes]

--- a/src/backend/marsha/.cookiecutter/{{cookiecutter.app_name}}/tests/test_api.py
+++ b/src/backend/marsha/.cookiecutter/{{cookiecutter.app_name}}/tests/test_api.py
@@ -89,6 +89,20 @@ class {{cookiecutter.model}}APITest(TestCase):
             content,
         )
 
+    def test_api_{{cookiecutter.model_lower}}_fetch_from_other_{{cookiecutter.model_lower}}(self):
+        """A student should be allowed to fetch a {{cookiecutter.model_lower}}."""
+        {{cookiecutter.model_lower}} = {{cookiecutter.model}}Factory()
+        other_{{cookiecutter.model_lower}} = {{cookiecutter.model}}Factory()
+
+
+        jwt_token = StudentLtiTokenFactory(resource=other_{{cookiecutter.model_lower}})
+
+        response = self.client.get(
+            f"/api/{{cookiecutter.model_url_part}}/{ {{cookiecutter.model_lower}}.id!s}/",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+        self.assertEqual(response.status_code, 403)
+
     def test_api_{{cookiecutter.model_lower}}_fetch_instructor(self):
         """An instructor should be able to fetch a {{cookiecutter.model_lower}}."""
         {{cookiecutter.model_lower}} = {{cookiecutter.model}}Factory()

--- a/src/backend/marsha/bbb/api.py
+++ b/src/backend/marsha/bbb/api.py
@@ -14,7 +14,6 @@ from marsha.core.api import APIViewMixin, ObjectPkMixin, ObjectRelatedMixin
 
 from . import permissions, serializers
 from ..core.models import ADMINISTRATOR
-from ..core.permissions import ResourceIsAuthenticated
 from ..core.utils.s3_utils import create_presigned_post
 from ..core.utils.time_utils import to_timestamp
 from .defaults import LTI_ROUTE
@@ -89,9 +88,10 @@ class ClassroomViewSet(
                     )
                 )
             ]
-        elif self.action in ["retrieve"]:
+        elif self.action in ["retrieve", "service_join"]:
             permission_classes = [
-                ResourceIsAuthenticated | IsClassroomPlaylistOrOrganizationAdmin
+                core_permissions.IsTokenResourceRouteObject
+                | IsClassroomPlaylistOrOrganizationAdmin
             ]
         elif self.action in ["list"]:
             permission_classes = [core_permissions.UserIsAuthenticated]
@@ -259,9 +259,6 @@ class ClassroomViewSet(
         methods=["patch"],
         detail=True,
         url_path="join",
-        permission_classes=[
-            ResourceIsAuthenticated | IsClassroomPlaylistOrOrganizationAdmin
-        ],
     )
     def service_join(self, request, *args, **kwargs):
         """Join a Big Blue Button classroom.

--- a/src/backend/marsha/bbb/tests/api/classroom/test_retrieve.py
+++ b/src/backend/marsha/bbb/tests/api/classroom/test_retrieve.py
@@ -80,6 +80,21 @@ class ClassroomRetrieveAPITest(TestCase):
             content,
         )
 
+    def test_api_classroom_fetch_from_other_classroom(self):
+        """
+        Fetching a classroom with a token resource for an other classroom should not be allowed.
+        """
+        classroom = ClassroomFactory()
+        other_classroom = ClassroomFactory()
+
+        jwt_token = StudentLtiTokenFactory(resource=other_classroom)
+
+        response = self.client.get(
+            f"/api/classrooms/{classroom.id!s}/",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+        self.assertEqual(response.status_code, 403)
+
     @mock.patch.object(serializers, "get_meeting_infos")
     def test_api_classroom_fetch_student_scheduled(self, mock_get_meeting_infos):
         """A student should be allowed to fetch a scheduled classroom."""

--- a/src/backend/marsha/bbb/tests/api/classroom/test_service_join.py
+++ b/src/backend/marsha/bbb/tests/api/classroom/test_service_join.py
@@ -99,6 +99,32 @@ class ClassroomServiceJoinAPITest(TestCase):
             response.data.get("url"),
         )
 
+    def test_api_bbb_join_from_other_classroom(self):
+        """
+        Joining a classroom using a resource token for an other resource should not be allowed.
+        """
+        classroom = ClassroomFactory(
+            meeting_id="21e6634f-ab6f-4c77-a665-4229c61b479a",
+            title="Classroom 1",
+            attendee_password="9#R1kuUl3R",
+            moderator_password="0$C7Aaz0o",
+        )
+        other_classroom = ClassroomFactory()
+
+        jwt_token = StudentLtiTokenFactory(
+            resource=other_classroom,
+            consumer_site="consumer_site",
+            user__id="user_id",
+        )
+
+        response = self.client.patch(
+            f"/api/classrooms/{classroom.id}/join/",
+            data=json.dumps({"fullname": "John Doe"}),
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+        self.assertEqual(response.status_code, 403)
+
     def test_api_bbb_join_instructor(self):
         """Joining a classroom as instructor should return a moderator classroom url."""
         classroom = ClassroomFactory(

--- a/src/backend/marsha/deposit/api.py
+++ b/src/backend/marsha/deposit/api.py
@@ -96,9 +96,12 @@ class FileDepositoryViewSet(
             ]
         elif self.action in ["retrieve"]:
             permission_classes = [
-                core_permissions.IsTokenInstructor
-                | core_permissions.IsTokenAdmin
-                | core_permissions.IsTokenStudent
+                core_permissions.IsTokenResourceRouteObject
+                & (
+                    core_permissions.IsTokenInstructor
+                    | core_permissions.IsTokenAdmin
+                    | core_permissions.IsTokenStudent
+                )
                 | IsFileDepositoryPlaylistOrOrganizationAdmin
             ]
         elif self.action in ["update", "partial_update"]:

--- a/src/backend/marsha/deposit/tests/api/filedepositories/test_retrieve.py
+++ b/src/backend/marsha/deposit/tests/api/filedepositories/test_retrieve.py
@@ -61,6 +61,21 @@ class FileDepositoryRetrieveAPITest(TestCase):
             content,
         )
 
+    def test_api_file_depository_fetch_from_other_file_depository(self):
+        """
+        Fetching a file depository using a resource token from an other resource should
+        not be allowed.
+        """
+        file_depository = FileDepositoryFactory()
+        other_file_depository = FileDepositoryFactory()
+        jwt_token = StudentLtiTokenFactory(resource=other_file_depository)
+
+        response = self.client.get(
+            f"/api/filedepositories/{file_depository.id!s}/",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+        self.assertEqual(response.status_code, 403)
+
     def test_api_file_depository_fetch_instructor(self):
         """An instructor should be able to fetch a file_depository."""
         file_depository = FileDepositoryFactory()

--- a/src/backend/marsha/markdown/tests/api/markdown_documents/test_retrieve.py
+++ b/src/backend/marsha/markdown/tests/api/markdown_documents/test_retrieve.py
@@ -101,6 +101,30 @@ class MarkdownRetrieveAPITest(TestCase):
             },
         )
 
+    def test_api_document_fetch_from_other_document(self):
+        """
+        An instructor should not be able to fetch a Markdown document with a resource
+        token from an other markdown document.
+        """
+        markdown_document = MarkdownDocumentFactory(
+            pk="4c51f469-f91e-4998-b438-e31ee3bd3ea6",
+            playlist__pk="6a716ff3-1bfb-4870-906e-fda50293f0ac",
+            playlist__title="foo",
+            playlist__lti_id="course-v1:ufr+mathematics+00001",
+            translations__title="Amazing title",
+            translations__content="# Heading1\nSome content",
+            translations__rendered_content="<h1>Heading1</h1>\n<p>Some content</p>",
+        )
+        other_markdown_document = MarkdownDocumentFactory()
+
+        jwt_token = InstructorOrAdminLtiTokenFactory(resource=other_markdown_document)
+
+        response = self.client.get(
+            f"/api/markdown-documents/{markdown_document.pk}/",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+        self.assertEqual(response.status_code, 403)
+
     def test_api_document_fetch_instructor_read_only(self):
         """An instructor should not be able to fetch a Markdown document in read_only."""
         markdown_document = MarkdownDocumentFactory()


### PR DESCRIPTION
## Purpose

Retrieve endpoints for classroom and deposit were too permissive. Having a token resource was just enought to access all classroom or deposit resources. The id in the route was not checked.


## Proposal

- [x] change permission on retrieve endpoints

