### PR TITLE
✨(backend) add a new "invite token" to allow student to join a classroom from standalone site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - standalone website:
   - classroom (list/create/update)
+  - Add a new "invite" JWT in classroom API to allow
+    students to join a classroom through a link
 - Add new elements to the teacher VOD Dashboard :
   - Attendances from live session
 - Allow to store link between an LTI user and a "site" user

--- a/src/backend/marsha/bbb/tests/api/classroom/test_create.py
+++ b/src/backend/marsha/bbb/tests/api/classroom/test_create.py
@@ -136,6 +136,7 @@ class ClassroomCreateAPITest(TestCase):
                 "starting_at": None,
                 "title": "Some classroom",
                 "welcome_text": "Welcome!",
+                "invite_token": None,
             },
         )
 
@@ -204,6 +205,7 @@ class ClassroomCreateAPITest(TestCase):
                 "starting_at": None,
                 "title": "Some classroom",
                 "welcome_text": "Welcome!",
+                "invite_token": None,
             },
         )
 
@@ -238,6 +240,7 @@ class ClassroomCreateAPITest(TestCase):
                 "starting_at": None,
                 "title": "classroom two",
                 "welcome_text": "Welcome!",
+                "invite_token": None,
             },
         )
 
@@ -288,6 +291,7 @@ class ClassroomCreateAPITest(TestCase):
                 "starting_at": None,
                 "title": "Some classroom",
                 "welcome_text": "Welcome!",
+                "invite_token": None,
             },
         )
 
@@ -322,5 +326,6 @@ class ClassroomCreateAPITest(TestCase):
                 "starting_at": None,
                 "title": "classroom two",
                 "welcome_text": "Welcome!",
+                "invite_token": None,
             },
         )

--- a/src/backend/marsha/bbb/tests/test_utils_tokens.py
+++ b/src/backend/marsha/bbb/tests/test_utils_tokens.py
@@ -1,0 +1,194 @@
+"""Tests for the specific classroom related simple JWT helpers."""
+from datetime import datetime, timedelta
+import json
+from unittest import mock
+from urllib.parse import quote_plus
+
+from django.test import TestCase, override_settings
+from django.utils import timezone
+
+from marsha.bbb.factories import ClassroomFactory
+from marsha.bbb.utils.tokens import create_classroom_stable_invite_jwt
+from marsha.core.tests.utils import reload_urlconf
+
+
+class CreateStableInviteJwtTestCase(TestCase):
+    """Test the create_classroom_stable_invite_jwt function."""
+
+    maxDiff = None
+
+    def test_jwt_content_starting_at_and_duration(self):
+        """Assert the payload contains the expected data."""
+        now_fixed = datetime(2020, 8, 8, tzinfo=timezone.utc)
+        with mock.patch.object(timezone, "now", return_value=now_fixed):
+            classroom = ClassroomFactory(
+                pk="ad0395fd-3023-45da-8801-93d1ce64acd5",
+                created_on=timezone.now(),
+                starting_at=datetime(2020, 8, 20, 14, tzinfo=timezone.utc),
+                estimated_duration=timedelta(hours=2),
+            )
+            jwt = create_classroom_stable_invite_jwt(classroom)
+
+        self.assertDictEqual(
+            jwt.payload,
+            {
+                "exp": 1598104800,  # Saturday 22 August 2020 14:00:00 UTC
+                "iat": 1596844800,  # Saturday 8 August 2020 00:00:00 UTC
+                "jti": "classroom-invite-ad0395fd-3023-45da-8801-93d1ce64acd5-2020-08-08",
+                "locale": "en_US",
+                "maintenance": False,
+                "permissions": {"can_access_dashboard": False, "can_update": False},
+                "resource_id": "ad0395fd-3023-45da-8801-93d1ce64acd5",
+                "roles": ["none"],
+                "session_id": "ad0395fd-3023-45da-8801-93d1ce64acd5-invite",
+                "token_type": "resource_access",
+            },
+        )
+
+    def test_jwt_content_starting_at_in_past(self):
+        """Assert the payload contains the expected data."""
+        now_fixed = datetime(2020, 8, 8, tzinfo=timezone.utc)
+        with mock.patch.object(timezone, "now", return_value=now_fixed):
+            classroom = ClassroomFactory(
+                pk="ad0395fd-3023-45da-8801-93d1ce64acd5",
+                created_on=datetime(2020, 8, 4, 11, tzinfo=timezone.utc),
+                starting_at=datetime(2020, 8, 4, 14, tzinfo=timezone.utc),
+                estimated_duration=timedelta(hours=2),
+            )
+            jwt = create_classroom_stable_invite_jwt(classroom)
+
+        self.assertDictEqual(
+            jwt.payload,
+            {
+                "exp": 1596722400,  # Thursday 6 August 2020 14:00:00 UTC
+                "iat": 1596538800,  # Tuesday 4 August 2020 11:00:00 UTC
+                "jti": "classroom-invite-ad0395fd-3023-45da-8801-93d1ce64acd5-2020-08-04",
+                "locale": "en_US",
+                "maintenance": False,
+                "permissions": {"can_access_dashboard": False, "can_update": False},
+                "resource_id": "ad0395fd-3023-45da-8801-93d1ce64acd5",
+                "roles": ["none"],
+                "session_id": "ad0395fd-3023-45da-8801-93d1ce64acd5-invite",
+                "token_type": "resource_access",
+            },
+        )
+
+    def test_jwt_content_starting_at_and_no_duration(self):
+        """Assert the payload contains the expected data."""
+        now_fixed = datetime(2020, 8, 8, tzinfo=timezone.utc)
+        with mock.patch.object(timezone, "now", return_value=now_fixed):
+            classroom = ClassroomFactory(
+                pk="ad0395fd-3023-45da-8801-93d1ce64acd5",
+                created_on=timezone.now(),
+                starting_at=datetime(2020, 8, 20, 14, tzinfo=timezone.utc),
+            )
+            jwt = create_classroom_stable_invite_jwt(classroom)
+
+        self.assertDictEqual(
+            jwt.payload,
+            {
+                "exp": 1598104800,  # Saturday 22 August 2020 14:00:00 UTC
+                "iat": 1596844800,  # Saturday 8 August 2020 00:00:00 UTC
+                "jti": "classroom-invite-ad0395fd-3023-45da-8801-93d1ce64acd5-2020-08-08",
+                "locale": "en_US",
+                "maintenance": False,
+                "permissions": {"can_access_dashboard": False, "can_update": False},
+                "resource_id": "ad0395fd-3023-45da-8801-93d1ce64acd5",
+                "roles": ["none"],
+                "session_id": "ad0395fd-3023-45da-8801-93d1ce64acd5-invite",
+                "token_type": "resource_access",
+            },
+        )
+
+    def test_jwt_content_without_starting_at_and_no_duration(self):
+        """
+        Assert the payload contains the expected data,
+        when classroom has no starting time and no duration.
+
+        JWT will be valid for at least 24 hours.
+        """
+        now_fixed = datetime(2020, 8, 8, 14, tzinfo=timezone.utc)
+        with mock.patch.object(timezone, "now", return_value=now_fixed):
+            classroom = ClassroomFactory(
+                pk="ad0395fd-3023-45da-8801-93d1ce64acd5",
+                created_on=timezone.now(),
+            )
+            jwt = create_classroom_stable_invite_jwt(classroom)
+
+        self.assertDictEqual(
+            jwt.payload,
+            {
+                "exp": 1599436800,  # Monday 7 September 2020 00:00:00 UTC
+                "iat": 1596895200,  # Saturday 8 August 2020 14:00:00 UTC
+                "jti": "classroom-invite-ad0395fd-3023-45da-8801-93d1ce64acd5-2020-08-08",
+                "locale": "en_US",
+                "maintenance": False,
+                "permissions": {"can_access_dashboard": False, "can_update": False},
+                "resource_id": "ad0395fd-3023-45da-8801-93d1ce64acd5",
+                "roles": ["none"],
+                "session_id": "ad0395fd-3023-45da-8801-93d1ce64acd5-invite",
+                "token_type": "resource_access",
+            },
+        )
+
+    def test_jwt_content_without_starting_at_and_duration(self):
+        """Assert the payload contains the expected data."""
+        now_fixed = datetime(2020, 8, 8, tzinfo=timezone.utc)
+        with mock.patch.object(timezone, "now", return_value=now_fixed):
+            classroom = ClassroomFactory(
+                pk="ad0395fd-3023-45da-8801-93d1ce64acd5",
+                created_on=timezone.now(),
+                estimated_duration=timedelta(hours=2),
+            )
+            jwt = create_classroom_stable_invite_jwt(classroom)
+
+        self.assertDictEqual(
+            jwt.payload,
+            {
+                "exp": 1599436800,  # Monday 7 September 2020 00:00:00 UTC
+                "iat": 1596844800,  # Saturday 8 August 2020 00:00:00 UTC
+                "jti": "classroom-invite-ad0395fd-3023-45da-8801-93d1ce64acd5-2020-08-08",
+                "locale": "en_US",
+                "maintenance": False,
+                "permissions": {"can_access_dashboard": False, "can_update": False},
+                "resource_id": "ad0395fd-3023-45da-8801-93d1ce64acd5",
+                "roles": ["none"],
+                "session_id": "ad0395fd-3023-45da-8801-93d1ce64acd5-invite",
+                "token_type": "resource_access",
+            },
+        )
+
+    def test_jwt_content_when_called_twice(self):
+        """Assert the payload contains the same data for several calls for same classroom."""
+        classroom = ClassroomFactory()
+        jwt = create_classroom_stable_invite_jwt(classroom)
+        jwt2 = create_classroom_stable_invite_jwt(classroom)
+
+        self.assertDictEqual(jwt.payload, jwt2.payload)
+        self.assertEqual(str(jwt), str(jwt2))
+
+    @override_settings(BBB_API_ENDPOINT="https://10.7.7.1/bigbluebutton/api")
+    @override_settings(BBB_API_SECRET="SuperSecret")
+    @override_settings(BBB_ENABLED=True)
+    def test_classroom_stable_invite_jwt_allows_access_to_classroom(self):
+        """Assert the JWT allows to join to the classroom."""
+        # Force URLs reload to use BBB_ENABLED
+        reload_urlconf()
+
+        classroom = ClassroomFactory()
+        jwt = create_classroom_stable_invite_jwt(classroom)
+
+        response = self.client.patch(
+            f"/api/classrooms/{classroom.id}/join/",
+            data=json.dumps({"fullname": "John Doe"}),
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {jwt}",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(
+            "https://10.7.7.1/bigbluebutton/api/join?"
+            f"fullName=John+Doe&meetingID={classroom.meeting_id}&"
+            f"password={quote_plus(classroom.attendee_password)}&"
+            "userID=None_None&redirect=true",
+            response.data.get("url"),
+        )

--- a/src/backend/marsha/bbb/tests/test_views_lti.py
+++ b/src/backend/marsha/bbb/tests/test_views_lti.py
@@ -20,7 +20,7 @@ from marsha.core.factories import (
     UserFactory,
 )
 from marsha.core.lti import LTI
-from marsha.core.models import ADMINISTRATOR
+from marsha.core.models import ADMINISTRATOR, NONE
 from marsha.core.simple_jwt.tokens import ResourceAccessToken
 from marsha.core.tests.test_views_lti_base import BaseLTIViewForPortabilityTestCase
 from marsha.core.tests.utils import reload_urlconf
@@ -274,7 +274,9 @@ class ClassroomLTIViewTestCase(TestCase):
             {"can_access_dashboard": True, "can_update": True},
         )
         self.assertEqual(context.get("state"), "success")
-        self.assertIsNotNone(context.get("resource"))
+
+        resource_data = context.get("resource")
+        invite_token = resource_data.pop("invite_token")
         self.assertEqual(
             {
                 "id": str(classroom.id),
@@ -293,9 +295,18 @@ class ClassroomLTIViewTestCase(TestCase):
                 "welcome_text": classroom.welcome_text,
                 "starting_at": None,
                 "estimated_duration": None,
+                # "invite_token" is tested separately
             },
-            context.get("resource"),
+            resource_data,
         )
+        decoded_invite_token = ResourceAccessToken(invite_token)
+        self.assertEqual(decoded_invite_token.payload["resource_id"], str(classroom.id))
+        self.assertEqual(decoded_invite_token.payload["roles"], [NONE])
+        self.assertEqual(
+            decoded_invite_token.payload["permissions"],
+            {"can_update": False, "can_access_dashboard": False},
+        )
+
         self.assertEqual(context.get("modelName"), "classrooms")
         self.assertEqual(context.get("appName"), "classroom")
         self.assertEqual(
@@ -609,7 +620,9 @@ class MeetingLTIViewTestCase(TestCase):
             {"can_access_dashboard": True, "can_update": True},
         )
         self.assertEqual(context.get("state"), "success")
-        self.assertIsNotNone(context.get("resource"))
+
+        resource_data = context.get("resource")
+        invite_token = resource_data.pop("invite_token")
         self.assertEqual(
             {
                 "id": str(classroom.id),
@@ -628,9 +641,18 @@ class MeetingLTIViewTestCase(TestCase):
                 "welcome_text": classroom.welcome_text,
                 "starting_at": None,
                 "estimated_duration": None,
+                # "invite_token" is tested separately
             },
-            context.get("resource"),
+            resource_data,
         )
+        decoded_invite_token = ResourceAccessToken(invite_token)
+        self.assertEqual(decoded_invite_token.payload["resource_id"], str(classroom.id))
+        self.assertEqual(decoded_invite_token.payload["roles"], [NONE])
+        self.assertEqual(
+            decoded_invite_token.payload["permissions"],
+            {"can_update": False, "can_access_dashboard": False},
+        )
+
         self.assertEqual(context.get("modelName"), "classrooms")
         self.assertEqual(context.get("appName"), "classroom")
         self.assertEqual(

--- a/src/backend/marsha/bbb/utils/tokens.py
+++ b/src/backend/marsha/bbb/utils/tokens.py
@@ -1,0 +1,54 @@
+"""Specific classroom related simple JWT helpers."""
+from datetime import timedelta
+
+from django.conf import settings
+from django.utils import timezone
+
+from marsha.core.simple_jwt.tokens import ResourceAccessToken
+
+
+def create_classroom_stable_invite_jwt(classroom):
+    """Create a resource JWT to be used in classroom invite links.
+
+    Parameters
+    ----------
+    classroom : Type[models.Classroom]
+        The classroom for which we want to create a JWT.
+
+    Returns
+    -------
+    ResourceAccessToken
+        The JWT.
+
+    """
+    resource_jwt = ResourceAccessToken.for_resource_id(
+        resource_id=str(classroom.id),
+        session_id=f"{classroom.id}-invite",
+    )
+
+    # Set a fixed JWT ID
+    resource_jwt.set_jti(
+        f"classroom-invite-{classroom.id}-{classroom.created_on.strftime('%Y-%m-%d')}"
+    )
+
+    # Set a fixed validity beginning: the classroom creation date
+    resource_jwt.set_iat(at_time=classroom.created_on)
+
+    # Determine the validity end:
+    # - if the classroom has a starting date, the JWT is valid
+    #   until the starting date plus two days
+    # - if the classroom has no starting date, the JWT is valid
+    #   for a month **starting now** (not on classroom creation)
+    if classroom.starting_at:
+        validity_end = classroom.starting_at + timedelta(days=2)
+    else:
+        validity_end = timezone.now().replace(
+            hour=0, minute=0, second=0, microsecond=0
+        ) + timedelta(days=settings.BBB_INVITE_JWT_DEFAULT_DAYS_DURATION)
+
+    resource_jwt.set_exp(
+        from_time=classroom.created_on,
+        lifetime=validity_end - classroom.created_on,
+    )
+
+    return resource_jwt

--- a/src/backend/marsha/core/simple_jwt/tokens.py
+++ b/src/backend/marsha/core/simple_jwt/tokens.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 
 from rest_framework_simplejwt.exceptions import TokenError
+from rest_framework_simplejwt.settings import api_settings
 from rest_framework_simplejwt.tokens import AccessToken, Token
 
 from marsha.core.models import NONE, STUDENT
@@ -75,6 +76,20 @@ class ResourceAccessToken(AccessToken):
     """
 
     token_type = "resource_access"  # nosec
+
+    def set_jti(self, jti=None):
+        """
+        Populates the configured jti claim of a token with a string where there
+        is a negligible probability that the same string will be chosen at a
+        later time.
+
+        See here:
+        https://tools.ietf.org/html/rfc7519#section-4.1.7
+        """
+        if not jti:
+            super().set_jti()
+        else:
+            self.payload[api_settings.JTI_CLAIM] = jti
 
     def verify(self):
         """Performs additional validation steps to test payload content."""

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -346,6 +346,7 @@ class Base(Configuration):
     BBB_API_TIMEOUT = values.PositiveIntegerValue(10)
     BBB_ENABLE_RECORD = values.BooleanValue(False)
     ALLOWED_CLASSROOM_DOCUMENT_MIME_TYPES = values.ListValue(["application/pdf"])
+    BBB_INVITE_JWT_DEFAULT_DAYS_DURATION = values.PositiveIntegerValue(30)
 
     # deposit application
     DEPOSIT_ENABLED = values.BooleanValue(False)

--- a/src/frontend/packages/lib_classroom/src/utils/tests/factories.ts
+++ b/src/frontend/packages/lib_classroom/src/utils/tests/factories.ts
@@ -25,6 +25,7 @@ export const classroomMockFactory = (
     infos: classroomInfosMockFactory(),
     starting_at: null,
     estimated_duration: null,
+    invite_token: null,
     ...classroom,
   };
 };

--- a/src/frontend/packages/lib_components/src/types/apps/classroom/models.ts
+++ b/src/frontend/packages/lib_components/src/types/apps/classroom/models.ts
@@ -14,6 +14,7 @@ export interface Classroom extends Resource {
   infos?: ClassroomInfos;
   starting_at: Nullable<string>;
   estimated_duration: Nullable<string>;
+  invite_token: Nullable<string>;
 }
 
 export type ClassroomLite = Omit<Classroom, 'infos' | 'playlist'>;


### PR DESCRIPTION
## Purpose

Provide a resource JWT which will be used  by the frontend to authenticate students joining a classroom.

- The standalone site will forge and URL the instructor will share to their student and append this `invite_token` to it
- The standalone will provide a dedicated page for student to access the classroom and the `invite_token` will be used to authenticate requests to the backend.

## Proposal

- [x] Add a `invite_token` to the full Classroom serializer (used by the `retrieve` endpoint)
- [x] The `invite_token` is only provided to teachers or administrators (according to LTI or standalone site context)

## Note

The way to determine whether the user is a teacher or administrator using DRF permissions gives way to improvement. Still for a first version is help readability and understanding...
