### PR TITLE
🐛(front) deal with webinar without thumbnail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Change permission on retrieve endpoints
+- Deal with webinar without thumbnail
 
 ## [4.0.0-beta.11] - 2022-11-08
 

--- a/src/frontend/apps/lti_site/components/VideoPlayer/index.spec.tsx
+++ b/src/frontend/apps/lti_site/components/VideoPlayer/index.spec.tsx
@@ -5,6 +5,8 @@ import {
   videoMockFactory,
   timedTextMode,
   uploadState,
+  liveState,
+  LiveModeType,
 } from 'lib-components';
 import React from 'react';
 
@@ -168,5 +170,37 @@ describe('VideoPlayer', () => {
       'https://example.com/thumbnail/1080p.jpg',
     );
     expect(screen.queryByText('Webinar is paused')).not.toBeInTheDocument();
+  });
+
+  it('renders a live video without mp4 or thumbnails', async () => {
+    const video = videoMockFactory({
+      live_state: liveState.RUNNING,
+      live_type: LiveModeType.JITSI,
+      urls: {
+        manifests: {
+          hls: 'https://example.com/hls.m3u8',
+        },
+        mp4: {},
+        thumbnails: {},
+      },
+    });
+
+    const { container } = render(
+      <VideoPlayer video={video} playerType={'videojs'} timedTextTracks={[]} />,
+    );
+    await waitFor(() =>
+      expect(mockCreatePlayer).toHaveBeenCalledWith(
+        'videojs',
+        expect.any(Element),
+        expect.anything(),
+        video,
+        'en',
+        expect.any(Function),
+      ),
+    );
+
+    const videoElement = container.querySelector('video');
+    expect(videoElement).toBeInTheDocument();
+    expect(videoElement?.poster).toEqual('');
   });
 });

--- a/src/frontend/apps/lti_site/components/VideoPlayer/index.tsx
+++ b/src/frontend/apps/lti_site/components/VideoPlayer/index.tsx
@@ -137,6 +137,19 @@ const VideoPlayer = ({
     oldTimedTextTracks.current = timedTextTracks;
   }, [timedTextTracks]);
 
+  const resolutions = useMemo(() => {
+    if (video?.urls?.mp4) {
+      const tmpResolutions = Object.keys(video.urls.mp4).map(
+        (size) => Number(size) as videoSize,
+      );
+      tmpResolutions.sort((a, b) => b - a);
+
+      return tmpResolutions;
+    }
+
+    return [];
+  }, [video?.urls?.mp4]);
+
   // The video is somehow missing and jwt must be set
   if (!video) {
     return <Redirect push to={FULL_SCREEN_ERROR_ROUTE('notFound')} />;
@@ -144,20 +157,14 @@ const VideoPlayer = ({
 
   const thumbnailUrls =
     (thumbnail && thumbnail.is_ready_to_show && thumbnail.urls) ||
-    video.urls!.thumbnails;
-  const resolutions = Object.keys(video.urls!.mp4).map(
-    (size) => Number(size) as videoSize,
-  );
-
-  // order resolutions from the higher to the lower
-  resolutions.sort((a, b) => b - a);
+    video.urls?.thumbnails;
 
   return (
     <Box>
       <video
         ref={videoNodeRef}
         crossOrigin="anonymous"
-        poster={thumbnailUrls[resolutions[0]]}
+        poster={thumbnailUrls && thumbnailUrls[resolutions[0]]}
         /* tabIndex is set to -1 to not take focus on this element when a user is navigating using
        their keyboard. */
         tabIndex={-1}


### PR DESCRIPTION
## Purpose

In the VideoPlayer component, we are looking for thumbnail to use tham as poster in the video element. For a webinar, there is no thumbnail nor resolution available and sometimes the rendering of this component fails on this part of the code. We are managing this case to avoid future error.

## Proposal

- [x] deal with webinar without thumbnail

Fixes #1835 