### PR TITLE
🚨(front) fix DashboardClassroomForm test

### DIFF
--- a/src/frontend/packages/lib_classroom/src/components/DashboardClassroomForm/index.spec.tsx
+++ b/src/frontend/packages/lib_classroom/src/components/DashboardClassroomForm/index.spec.tsx
@@ -246,8 +246,11 @@ describe('<DashboardClassroomForm />', () => {
       />,
     );
 
+    // using userEvent.type with following input doesn't work
     const inputStartingAtDate = screen.getByLabelText(/starting date/i);
-    userEvent.type(inputStartingAtDate, startingAt.toFormat('yyyy/MM/dd'));
+    fireEvent.change(inputStartingAtDate, {
+      target: { value: startingAt.toFormat('yyyy/MM/dd') },
+    });
     fireEvent.blur(inputStartingAtDate);
     deferredPatch.resolve({ message: 'Classroom scheduled.' });
 


### PR DESCRIPTION
## Purpose

In the `schedules a classroom` scenario, the userEvent library is not able anymore to fill the Date input. Instead of having a valid date, there is `0` as value. Changing to the fireEvent lib fix the issue.

## Proposal

- [x] fix DashboardClassroomForm test

