### PR TITLE
🐛(back) force to save the starting live state on the start action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Change permission on retrieve endpoints
 - Deal with webinar without thumbnail
+- Force to save the starting live state on the start action
 
 ## [4.0.0-beta.11] - 2022-11-08
 


### PR DESCRIPTION
## Purpose

The start live endpoint can be very long. It has to create a complete AWS medialive and mediapackage stack. Once created, the medialive channel is started. Between the creation and the effective start we have to wait few seconds that the medialive channel is ready to be started. In the dashboard, we can't wait this time if there are several instructors on the page. We have to inform them as soon as possible that the live is starting. In a first implementation, we changed the live_state to starting, this clone object was dispatched in the webasocket and then all the AWS work was made. If something fails or in the same time, the video object is modified and then dispatch in the websocket, the starting live_state is lost and the start button is display again in the interface. To avoid this issue, the live_state is saved in database using an atmoic transaction and tollback to its initial value if something went wrong during the creation or start action on the AWS stack.
## Proposal

Description...

- [x] force to save the starting live state on the start action

@qbey an idea of improvement can be to remove the usage of `self.get_object()` in this endpoint and use `select_for_update` instead to set a lock on the row. 
