### PR TITLE
👷(circle) build only once front libs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -410,14 +410,14 @@ jobs:
           name: Compile translations
           command: yarn compile-translations
       - run:
-          name: Build lib_tests
-          command: yarn build-tests
+          name: Build all libs
+          command: yarn build-libs
       - run:
           name: Build front-end lti application
-          command: yarn build-lti
+          command: yarn workspace marsha run build
       - run:
           name: Build front-end standalone application
-          command: yarn build-site
+          command: yarn workspace standalone_site run build
       - run:
           name: Extract all translations
           command: yarn extract-translations

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -34,7 +34,7 @@
     "build-tests": "yarn workspace lib-common run build && yarn workspace lib-tests run build",
     "build-libs": "yarn build-tests && yarn workspace lib-components run build && yarn workspace lib-classroom run build",
     "build-lti": "yarn build-libs && yarn workspace marsha run build",
-    "build-site": "yarn build-libs && yarn build-tests && yarn workspace standalone_site run build",
+    "build-site": "yarn build-libs && yarn workspace standalone_site run build",
     "start-site": "yarn build-libs && yarn workspace standalone_site run start",
     "prettier": "yarn workspaces run prettier"
   },

--- a/src/frontend/packages/lib_components/src/common/UploadForm/index.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/UploadForm/index.spec.tsx
@@ -103,7 +103,7 @@ describe('UploadForm', () => {
     },
   });
 
-  beforeEach(jest.resetAllMocks);
+  beforeEach(() => jest.resetAllMocks());
 
   afterEach(() => fetchMock.restore());
 
@@ -133,21 +133,19 @@ describe('UploadForm', () => {
     mockGetResource.mockResolvedValue(object);
     mockUploadFile.mockResolvedValue(true);
 
-    render(
-      <UploadManager>
-        <UploadForm objectId={object.id} objectType={modelName.VIDEOS} />
-      </UploadManager>,
-      {
-        routerOptions: {
-          routes: [
-            {
-              path: DASHBOARD_ROUTE(),
-              render: () => <span>dashboard</span>,
-            },
-          ],
-        },
+    render(<UploadForm objectId={object.id} objectType={modelName.VIDEOS} />, {
+      routerOptions: {
+        routes: [
+          {
+            path: DASHBOARD_ROUTE(),
+            render: () => <span>dashboard</span>,
+          },
+        ],
+        wrapper: (routing: JSX.Element) => (
+          <UploadManager>{routing}</UploadManager>
+        ),
       },
-    );
+    });
 
     // First the form goes through a loading state as we get the object
     screen.getByRole('status', { name: 'Preparing for upload...' });
@@ -174,21 +172,20 @@ describe('UploadForm', () => {
     );
     mockGetResource.mockResolvedValue(object);
 
-    render(
-      <UploadManager>
-        <UploadForm objectId={object.id} objectType={modelName.VIDEOS} />
-      </UploadManager>,
-      {
-        routerOptions: {
-          routes: [
-            {
-              path: FULL_SCREEN_ERROR_ROUTE('policy'),
-              render: () => <span>error policy</span>,
-            },
-          ],
-        },
+    render(<UploadForm objectId={object.id} objectType={modelName.VIDEOS} />, {
+      routerOptions: {
+        routes: [
+          {
+            path: FULL_SCREEN_ERROR_ROUTE('policy'),
+            render: () => <span>error policy</span>,
+          },
+        ],
+        wrapper: (routing: JSX.Element) => (
+          <UploadManager>{routing}</UploadManager>
+        ),
       },
-    );
+    });
+
     await screen.findByText('Create a new video');
 
     fireEvent.change(screen.getByLabelText('File Upload'), {
@@ -218,21 +215,20 @@ describe('UploadForm', () => {
     mockGetResource.mockResolvedValue(object);
     mockUploadFile.mockRejectedValue(new Error('failed to upload file'));
 
-    render(
-      <UploadManager>
-        <UploadForm objectId={object.id} objectType={modelName.VIDEOS} />
-      </UploadManager>,
-      {
-        routerOptions: {
-          routes: [
-            {
-              path: FULL_SCREEN_ERROR_ROUTE('upload'),
-              render: () => <span>error upload</span>,
-            },
-          ],
-        },
+    render(<UploadForm objectId={object.id} objectType={modelName.VIDEOS} />, {
+      routerOptions: {
+        routes: [
+          {
+            path: FULL_SCREEN_ERROR_ROUTE('upload'),
+            render: () => <span>error upload</span>,
+          },
+        ],
+        wrapper: (routing: JSX.Element) => (
+          <UploadManager>{routing}</UploadManager>
+        ),
       },
-    );
+    });
+
     await screen.findByText('Create a new video');
 
     fireEvent.change(screen.getByLabelText('File Upload'), {

--- a/src/frontend/packages/lib_tests/src/render.tsx
+++ b/src/frontend/packages/lib_tests/src/render.tsx
@@ -25,6 +25,7 @@ interface RouterOptions {
   componentPath?: string;
   header?: React.ReactElement;
   history?: string[];
+  wrapper?: (routing: JSX.Element) => JSX.Element;
 }
 interface QueryOptions {
   client: QueryClient;
@@ -107,6 +108,7 @@ const appendUtilsElement = (
               options?.routerOptions?.componentPath || '/',
               options?.routerOptions?.history,
               options?.routerOptions?.header,
+              options?.routerOptions?.wrapper,
             )}
           </QueryClientProvider>
         </BreadCrumbsProvider>

--- a/src/frontend/packages/lib_tests/src/router.tsx
+++ b/src/frontend/packages/lib_tests/src/router.tsx
@@ -2,29 +2,39 @@ import { Maybe } from 'lib-common';
 import React from 'react';
 import { MemoryRouter, Route, RouteProps, Switch } from 'react-router-dom';
 
+const defaultWrapper = (routing: JSX.Element) => routing;
+
 export const wrapInRouter = (
   Component: JSX.Element,
   routes?: RouteProps[],
   componentPath = '/',
   history: Maybe<string[]> = undefined,
   header: React.ReactNode = undefined,
-) => (
-  <MemoryRouter initialEntries={history || [componentPath]} initialIndex={0}>
-    {header}
-    <Switch>
-      {routes &&
-        routes.map((routeProps) => (
-          <Route
-            exact
-            key={
-              Array.isArray(routeProps.path)
-                ? String(routeProps.path[0])
-                : String(routeProps.path || '')
-            }
-            {...routeProps}
-          />
-        ))}
-      <Route path={componentPath}>{Component}</Route>
-    </Switch>
-  </MemoryRouter>
-);
+  wrapper: (routing: JSX.Element) => JSX.Element = defaultWrapper,
+) => {
+  const switchElement = (
+    <React.Fragment>
+      {header}
+      <Switch>
+        {routes &&
+          routes.map((routeProps) => (
+            <Route
+              exact
+              key={
+                Array.isArray(routeProps.path)
+                  ? String(routeProps.path[0])
+                  : String(routeProps.path || '')
+              }
+              {...routeProps}
+            />
+          ))}
+        <Route path={componentPath}>{Component}</Route>
+      </Switch>
+    </React.Fragment>
+  );
+  return (
+    <MemoryRouter initialEntries={history || [componentPath]} initialIndex={0}>
+      {wrapper(switchElement)}
+    </MemoryRouter>
+  );
+};


### PR DESCRIPTION
## Purpose

Front libs where built every time an app is built. This is not optimal. We choose to build them all once at the beginning of build-front job and then only build the app without rebuilding all the libs.

Also in this PR the wrapInRouter function is modified to accept, as new parameter, a function to decorate all routes with a manager like the UploadManager for example.

## Proposal

- [x] build only once front libs
- [x] allow to wrap routing elements
- [x] use UploadManager as wrapper in UploadForm tests 
