### PR TITLE
✨(front/back) use refresh token along with access token for standalone site

### DIFF
--- a/src/backend/marsha/account/api.py
+++ b/src/backend/marsha/account/api.py
@@ -5,23 +5,9 @@ from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.status import HTTP_200_OK
 from rest_framework.views import APIView
-from rest_framework_simplejwt.views import TokenObtainPairView
 from social_django.utils import load_backend, load_strategy
 from social_edu_federation.django.metadata_store import CachedMetadataStore
 from social_edu_federation.django.views import SocialBackendViewMixin
-
-from marsha.account.serializers import ChallengeTokenObtainSerializer
-
-
-class LoginView(TokenObtainPairView):
-    """
-    Login API view which expects payload with `username` and `password`
-    and returns a `challenge_token`.
-    """
-
-    serializer_class = ChallengeTokenObtainSerializer
-    permission_classes = (AllowAny,)
-    http_method_names = ["post"]
 
 
 class SamlFerIdpListAPIView(SocialBackendViewMixin, APIView):

--- a/src/backend/marsha/account/serializers.py
+++ b/src/backend/marsha/account/serializers.py
@@ -1,23 +1,10 @@
 """Account API serializers."""
-from django.contrib.auth.models import update_last_login
+from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
 
-from rest_framework_simplejwt.serializers import TokenObtainSerializer
-
-from marsha.core.simple_jwt.tokens import ChallengeToken
+from marsha.core.simple_jwt.tokens import UserRefreshToken
 
 
-class ChallengeTokenObtainSerializer(TokenObtainSerializer):
-    """
-    Custom serializer for the login API endpoint:
+class UserTokenObtainPairSerializer(TokenObtainPairSerializer):
+    """Serializer for the user token obtain pair API using our own refresh token."""
 
-    Receives a username and password and return a challenge token.
-    """
-
-    token_class = ChallengeToken
-
-    def validate(self, attrs):
-        data = super().validate(attrs)
-        challenge_token = self.get_token(self.user)
-        data["challenge_token"] = str(challenge_token)
-        update_last_login(None, self.user)
-        return data
+    token_class = UserRefreshToken

--- a/src/backend/marsha/account/serializers.py
+++ b/src/backend/marsha/account/serializers.py
@@ -1,10 +1,19 @@
 """Account API serializers."""
-from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
+from rest_framework_simplejwt.serializers import (
+    TokenObtainPairSerializer,
+    TokenRefreshSerializer,
+)
 
 from marsha.core.simple_jwt.tokens import UserRefreshToken
 
 
 class UserTokenObtainPairSerializer(TokenObtainPairSerializer):
     """Serializer for the user token obtain pair API using our own refresh token."""
+
+    token_class = UserRefreshToken
+
+
+class UserTokenRefreshSerializer(TokenRefreshSerializer):
+    """Serializer for the user token refresh API using our own refresh token."""
 
     token_class = UserRefreshToken

--- a/src/backend/marsha/account/tests/api/test_token_refresh.py
+++ b/src/backend/marsha/account/tests/api/test_token_refresh.py
@@ -1,0 +1,82 @@
+"""Tests for the obtain token pair (access/refresh) API."""
+import json
+
+from django.test import TestCase
+
+from rest_framework_simplejwt.exceptions import TokenError
+
+from marsha.core.factories import UserFactory
+from marsha.core.simple_jwt.tokens import UserAccessToken, UserRefreshToken
+
+
+class TokenObtainPairViewTest(TestCase):
+    """Testcase for the obtain token pair (access/refresh) API."""
+
+    maxDiff = None
+
+    @classmethod
+    def setUpClass(cls):
+        """Set up the test suite."""
+        super().setUpClass()
+        cls.user = UserFactory(username="marsha")
+
+    def test_no_data(self):
+        """An empty request should return a 400 error."""
+
+        response = self.client.post(
+            "/account/api/token/refresh/",
+            content_type="application/json",
+            data=json.dumps({}),
+        )
+
+        self.assertEqual(response.status_code, 400)  # Bad request
+
+    def test_invalid_refresh_token(self):
+        """A request with an invalid refresh token should return a 401 error."""
+
+        response = self.client.post(
+            "/account/api/token/refresh/",
+            content_type="application/json",
+            data=json.dumps(
+                {
+                    "access": "could_be_anything",
+                    "refresh": "wrong_refresh_token",
+                }
+            ),
+        )
+
+        self.assertEqual(response.status_code, 401)  # Unauthorized
+
+    def test_success(self):
+        """
+        A request with a correct refresh token should return a 200 response with new token pair.
+        """
+        refresh_token = UserRefreshToken.for_user(self.user)
+        # note: OutstandingToken is created by UserRefreshToken.for_user
+        access_token = refresh_token.access_token
+
+        response = self.client.post(
+            "/account/api/token/refresh/",
+            content_type="application/json",
+            data=json.dumps(
+                {
+                    "access": str(access_token),
+                    "refresh": str(refresh_token),
+                }
+            ),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        response_data = response.json()
+        self.assertIn("access", response_data)
+        self.assertIn("refresh", response_data)
+
+        # Verify tokens
+        UserAccessToken(response_data["access"])
+        new_refresh_token = UserRefreshToken(response_data["refresh"])
+
+        # Assert old refresh token is blacklisted ...
+        with self.assertRaises(TokenError):
+            refresh_token.verify()
+        # ... and new refresh token is not
+        new_refresh_token.verify()

--- a/src/backend/marsha/account/urls.py
+++ b/src/backend/marsha/account/urls.py
@@ -2,7 +2,7 @@
 from django.conf import settings
 from django.urls import include, path
 
-from rest_framework_simplejwt.views import TokenObtainPairView
+from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 from social_edu_federation.django.views import EduFedMetadataView
 
 from .api import SamlFerIdpListAPIView
@@ -60,6 +60,7 @@ urlpatterns = [
     ),
     # API
     path("api/token/", TokenObtainPairView.as_view(), name="token_obtain_pair"),
+    path("api/token/refresh/", TokenRefreshView.as_view(), name="token_refresh"),
     path(
         "api/saml/renater_fer_idp_list/",
         SamlFerIdpListAPIView.as_view(),

--- a/src/backend/marsha/account/urls.py
+++ b/src/backend/marsha/account/urls.py
@@ -2,9 +2,10 @@
 from django.conf import settings
 from django.urls import include, path
 
+from rest_framework_simplejwt.views import TokenObtainPairView
 from social_edu_federation.django.views import EduFedMetadataView
 
-from .api import LoginView as ApiLoginView, SamlFerIdpListAPIView
+from .api import SamlFerIdpListAPIView
 from .views import (
     LoginView,
     LogoutView,
@@ -58,7 +59,7 @@ urlpatterns = [
         name="saml_fer_idp_choice",
     ),
     # API
-    path("api/login/", ApiLoginView.as_view(), name="api_login"),
+    path("api/token/", TokenObtainPairView.as_view(), name="token_obtain_pair"),
     path(
         "api/saml/renater_fer_idp_list/",
         SamlFerIdpListAPIView.as_view(),

--- a/src/backend/marsha/core/simple_jwt/tokens.py
+++ b/src/backend/marsha/core/simple_jwt/tokens.py
@@ -6,7 +6,7 @@ from django.utils.translation import gettext_lazy as _
 
 from rest_framework_simplejwt.exceptions import TokenError
 from rest_framework_simplejwt.settings import api_settings
-from rest_framework_simplejwt.tokens import AccessToken, Token
+from rest_framework_simplejwt.tokens import AccessToken, RefreshToken, Token
 
 from marsha.core.models import NONE, STUDENT
 from marsha.core.simple_jwt.utils import define_locales
@@ -462,3 +462,9 @@ class UserAccessToken(AccessToken):
 
         if not self.payload.get("user_id", None):
             raise TokenError(_("Malformed user token"))
+
+
+class UserRefreshToken(RefreshToken):
+    """Refresh token for user authentication, which relies on our own `UserAccessToken`."""
+
+    access_token_class = UserAccessToken

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -122,6 +122,7 @@ class Base(Configuration):
         "corsheaders",
         "channels",
         "parler",  # django-parler, for translated models
+        "rest_framework_simplejwt.token_blacklist",
         "social_django.apps.PythonSocialAuthConfig",  # python-social-auth for Django
         "social_edu_federation.django.apps.PythonSocialEduFedAuthConfig",
         # Marsha
@@ -682,6 +683,9 @@ class Base(Configuration):
             # Settings for authentication API
             "UPDATE_LAST_LOGIN": True,
             "TOKEN_OBTAIN_SERIALIZER": "marsha.account.serializers.UserTokenObtainPairSerializer",
+            "ROTATE_REFRESH_TOKENS": True,
+            "BLACKLIST_AFTER_ROTATION": True,
+            "TOKEN_REFRESH_SERIALIZER": "marsha.account.serializers.UserTokenRefreshSerializer",
         }
 
     # pylint: disable=invalid-name

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -679,6 +679,9 @@ class Base(Configuration):
                 "marsha.core.simple_jwt.tokens.ResourceAccessToken",
                 "marsha.core.simple_jwt.tokens.UserAccessToken",
             ),
+            # Settings for authentication API
+            "UPDATE_LAST_LOGIN": True,
+            "TOKEN_OBTAIN_SERIALIZER": "marsha.account.serializers.UserTokenObtainPairSerializer",
         }
 
     # pylint: disable=invalid-name

--- a/src/frontend/apps/standalone_site/src/features/Authentication/api/basicLogin/index.ts
+++ b/src/frontend/apps/standalone_site/src/features/Authentication/api/basicLogin/index.ts
@@ -1,8 +1,6 @@
 import { useJwt } from 'lib-components';
 import { useMutation, UseMutationOptions } from 'react-query';
 
-import { validateChallenge } from '../validateChallenge';
-
 type UseBasicLoginData = {
   username: string;
   password: string;
@@ -10,7 +8,8 @@ type UseBasicLoginData = {
 export type UseBasicLoginError = { code: 'exception'; detail?: string };
 
 type UseBasicLoginResponseData = {
-  challenge_token: string;
+  access: string;
+  refresh: string;
 };
 
 type UseBasicLoginOptions = UseMutationOptions<
@@ -24,7 +23,7 @@ const actionLogin = async ({
 }: {
   object: UseBasicLoginData;
 }): Promise<UseBasicLoginResponseData> => {
-  const response = await fetch('/account/api/login/', {
+  const response = await fetch('/account/api/token/', {
     headers: {
       'Content-Type': 'application/json',
     },
@@ -58,8 +57,8 @@ export const useBasicLogin = (options?: UseBasicLoginOptions) => {
       }),
     {
       ...options,
-      onSuccess: async (data, variables, context) => {
-        setJwt(await validateChallenge(data.challenge_token));
+      onSuccess: (data, variables, context) => {
+        setJwt(data.access);
         if (options?.onSuccess) {
           options.onSuccess(data, variables, context);
         }

--- a/src/frontend/apps/standalone_site/src/features/Authentication/components/LoginForm.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Authentication/components/LoginForm.spec.tsx
@@ -54,7 +54,7 @@ describe('<LoginFrom />', () => {
   });
 
   it('attempts to login: with fail', async () => {
-    fetchMock.post('/account/api/login/', {
+    fetchMock.post('/account/api/token/', {
       status: 401,
       body: {
         detail: 'No active account found with the given credentials',
@@ -83,7 +83,7 @@ describe('<LoginFrom />', () => {
 
     expect(consoleError).toHaveBeenCalled();
 
-    expect(fetchMock.lastCall()![0]).toEqual('/account/api/login/');
+    expect(fetchMock.lastCall()![0]).toEqual('/account/api/token/');
     expect(fetchMock.lastCall()![1]).toEqual({
       headers: {
         'Content-Type': 'application/json',
@@ -97,7 +97,7 @@ describe('<LoginFrom />', () => {
   });
 
   it('attempts to login: with success', async () => {
-    fetchMock.post('/account/api/login/', {
+    fetchMock.post('/account/api/token/', {
       status: 200,
       ok: true,
     });
@@ -111,7 +111,5 @@ describe('<LoginFrom />', () => {
     userEvent.click(screen.getByRole('button', { name: /OK/i }));
 
     await waitFor(() => expect(mockHistoryPush).toHaveBeenCalledWith('/'));
-
-    expect(fetchMock.lastCall()![0]).toEqual('/api/auth/challenge/');
   });
 });


### PR DESCRIPTION
## Purpose

Update the authentication process for standalone frontend to use access/refresh token pair.

## Proposal

- [x] Replace the "login" endpoint to use an "obtain token pair" endpoint
- [x] Introduce a new endpoint to fetch a new access token and use the "rotate refresh token" mechanism.

