### PR TITLE
🐛(front) guess ISO15897 locale code in standalone site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - standalone website:
   - mutualize modals and styles
   - fine tune UI
+  - guess ISO15897 locale code
 - Filtered classroom list
 - Filtered deposit list
 - Filtered markdown document list

--- a/src/frontend/apps/standalone_site/src/App.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/App.spec.tsx
@@ -33,7 +33,7 @@ describe('<App />', () => {
 
   test('renders with another language', async () => {
     jest.mock(
-      'translations/fr.json',
+      'translations/fr_FR.json',
       () => ({
         'features.HomePage.HomePage': 'Mon Accueil',
         'routes.routes.menuHomePageLabel': 'Mon Tableau de bord',

--- a/src/frontend/apps/standalone_site/src/conf/global.ts
+++ b/src/frontend/apps/standalone_site/src/conf/global.ts
@@ -1,3 +1,4 @@
-export const DEFAULT_LANGUAGE = 'en';
+export const DEFAULT_LANGUAGE = 'en_US';
 export const ITEM_PER_PAGE = 20;
+export const REACT_LOCALES = ['en_US', 'es_ES', 'fr_FR', 'fr_CA'];
 export const TIME_USER_SESSION = 360; // In minute - Time a user is considered as connected

--- a/src/frontend/apps/standalone_site/src/utils/lang.spec.ts
+++ b/src/frontend/apps/standalone_site/src/utils/lang.spec.ts
@@ -1,0 +1,54 @@
+import { getLanguage, getLocaleCode, toLocale } from './lang';
+
+describe('toLocale', () => {
+  it('Turns a language name (en-us) into a locale name (en_US)', () => {
+    const language = ['en-us', 'en_US', 'en'];
+    const expectation = ['en_US', 'en_US', 'en'];
+
+    language.forEach((lang, index) => {
+      expect(toLocale(lang)).toEqual(expectation[index]);
+    });
+  });
+});
+
+describe('getLanguage', () => {
+  it('transforms the navigator language (fr) and returns the locale name (fr_FR)', () => {
+    Object.defineProperty(navigator, 'language', {
+      value: 'fr',
+      writable: false,
+      configurable: true,
+    });
+
+    expect(getLanguage()).toEqual('fr_FR');
+  });
+
+  it('fallbacks to default language when navigator.language is undefined', () => {
+    Object.defineProperty(navigator, 'language', {
+      value: undefined,
+      writable: false,
+      configurable: true,
+    });
+
+    expect(getLanguage()).toEqual('en_US');
+  });
+
+  it('fallbacks to default language when navigator.language is defined but unknown', () => {
+    Object.defineProperty(navigator, 'language', {
+      value: 'it',
+      writable: false,
+      configurable: true,
+    });
+
+    expect(getLanguage()).toEqual('en_US');
+  });
+});
+
+describe('getLocaleCode', () => {
+  it('extracts the locale code from a valid locale name', () => {
+    expect(getLocaleCode('fr_FR')).toEqual('fr');
+  });
+
+  it('returns the languages passed when it does not match a valid locale name', () => {
+    expect(getLocaleCode('fr-FR')).toEqual('fr-FR');
+  });
+});

--- a/src/frontend/apps/standalone_site/src/utils/lang.ts
+++ b/src/frontend/apps/standalone_site/src/utils/lang.ts
@@ -1,7 +1,38 @@
-import { DEFAULT_LANGUAGE } from 'conf/global';
+import { DEFAULT_LANGUAGE, REACT_LOCALES } from 'conf/global';
 
-export const getLanguage = () =>
-  !navigator || !navigator.language ? DEFAULT_LANGUAGE : navigator.language;
+// Turn a language name (en-us) into a locale name (en_US).
+export const toLocale = (language: string) => {
+  if (language.match(/^.*-.*$/)) {
+    const split_language = language.split('-');
+    return `${split_language[0]}_${split_language[1].toUpperCase()}`;
+  }
+
+  return language;
+};
+
+export const getLanguage = () => {
+  const value_locale = toLocale(navigator?.language || DEFAULT_LANGUAGE);
+
+  if (REACT_LOCALES.includes(value_locale)) {
+    return value_locale;
+  }
+
+  for (const locale of REACT_LOCALES) {
+    if (locale.startsWith(value_locale)) {
+      return locale;
+    }
+  }
+
+  return DEFAULT_LANGUAGE;
+};
+
+export const getLocaleCode = (language: string) => {
+  if (language.match(/^.*_.*$/)) {
+    return language.split('_')[0];
+  }
+
+  return language;
+};
 
 export const getCurrentTranslation = async (language: string) => {
   let translation: Record<string, string> | undefined;


### PR DESCRIPTION
## Purpose

In the standalone site, the language code is search in the navigator.language property. With this language code we try to load the translation file dynamically. But the files have a specific name base on a ISO15897 locale code and the value return navigator.language can be not compatible with this format. To fix this issue, we have to maintain a list of available react locales and thentry to guess this format from the navigatore language.
## Proposal

- [x] guess ISO15897 locale code in standalone site

