### PR TITLE
Always show the "use subtitle as transcript" toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Adapt lib-classroom with eslint rules
 - The full name replaces the first and last names in the
   user's profile API
+- Always show the "use subtitle as transcript" toggle in the 
+  UploadSubtitles widget
 
 ### Fixed
 

--- a/src/frontend/apps/lti_site/components/VideoWidgetProvider/widgets/UploadSubtitles/index.spec.tsx
+++ b/src/frontend/apps/lti_site/components/VideoWidgetProvider/widgets/UploadSubtitles/index.spec.tsx
@@ -60,7 +60,7 @@ describe('<UploadSubtitles />', () => {
     expect(mockSetInfoWidgetModalProvider).toHaveBeenCalledTimes(1);
     expect(mockSetInfoWidgetModalProvider).toHaveBeenLastCalledWith({
       title: 'Subtitles',
-      text: 'This widget allows you upload subtitles for the video.',
+      text: 'This widget allows you upload subtitles for the video. Toggle to use as transcripts can be disabled because there is no subtitle or at least one transcript exists.',
     });
   });
 });

--- a/src/frontend/apps/lti_site/components/VideoWidgetProvider/widgets/UploadSubtitles/index.tsx
+++ b/src/frontend/apps/lti_site/components/VideoWidgetProvider/widgets/UploadSubtitles/index.tsx
@@ -8,7 +8,9 @@ import { ToggleSubtitlesAsTranscript } from './ToggleSubtitlesAsTranscript';
 
 const messages = defineMessages({
   info: {
-    defaultMessage: 'This widget allows you upload subtitles for the video.',
+    defaultMessage: `This widget allows you upload subtitles for the video.
+    Toggle to use as transcripts can be disabled because there
+    is no subtitle or at least one transcript exists.`,
     description: 'Info of the widget used for uploading subtitles.',
     id: 'components.UploadSubtitles.info',
   },


### PR DESCRIPTION
Linked with https://github.com/openfun/marsha/issues/1716

## Purpose

It is possible to use a subtitle as a transcript. To do that, at least one subtitle should be valid and no transcript uploaded. In that case, a toggle appears allowing to use subtitles as transcript. But it disappears once there is no subtitles or at least one transcript exists.
We would like to keep always visible the toggle. Instead of hidding it, we want to disable it and add a tooltip explaining why it is disabled.


## Proposal

Add a useEffect hook to update the component when needed

