### PR TITLE
🔖(beta) bump release to 4.0.0-beta.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.0.0-beta.12] - 2022-12-28
+
 ### Added
 
 - standalone website:
@@ -1368,7 +1370,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Minor fixes and improvements on features and tests
 
-[unreleased]: https://github.com/openfun/marsha/compare/v4.0.0-beta.11...master
+[unreleased]: https://github.com/openfun/marsha/compare/v4.0.0-beta.12...master
+[4.0.0-beta.12]: https://github.com/openfun/marsha/compare/v4.0.0-beta.11...v4.0.0-beta.12
 [4.0.0-beta.11]: https://github.com/openfun/marsha/compare/v4.0.0-beta.10...v4.0.0-beta.11
 [4.0.0-beta.10]: https://github.com/openfun/marsha/compare/v4.0.0-beta.9...v4.0.0-beta.10
 [4.0.0-beta.9]: https://github.com/openfun/marsha/compare/v4.0.0-beta.8...v4.0.0-beta.9

--- a/src/aws/lambda-complete/package.json
+++ b/src/aws/lambda-complete/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-complete",
-  "version": "4.0.0-beta.11",
+  "version": "4.0.0-beta.12",
   "engines": {
     "node": "16"
   },

--- a/src/aws/lambda-configure/package.json
+++ b/src/aws/lambda-configure/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-configure",
-  "version": "4.0.0-beta.11",
+  "version": "4.0.0-beta.12",
   "engines": {
     "node": "16"
   },

--- a/src/aws/lambda-convert/package.json
+++ b/src/aws/lambda-convert/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-convert",
-  "version": "4.0.0-beta.11",
+  "version": "4.0.0-beta.12",
   "engines": {
     "node": "16"
   },

--- a/src/aws/lambda-elemental-routing/package.json
+++ b/src/aws/lambda-elemental-routing/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-elemental-routing",
-  "version": "4.0.0-beta.11",
+  "version": "4.0.0-beta.12",
   "engines": {
     "node": "16"
   },

--- a/src/aws/lambda-medialive/package.json
+++ b/src/aws/lambda-medialive/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-medialive",
-  "version": "4.0.0-beta.11",
+  "version": "4.0.0-beta.12",
   "engines": {
     "node": "16"
   },

--- a/src/aws/lambda-mediapackage/package.json
+++ b/src/aws/lambda-mediapackage/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-mediapackage",
-  "version": "4.0.0-beta.11",
+  "version": "4.0.0-beta.12",
   "engines": {
     "node": "16"
   },

--- a/src/aws/lambda-migrate/package.json
+++ b/src/aws/lambda-migrate/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-migrate",
-  "version": "4.0.0-beta.11",
+  "version": "4.0.0-beta.12",
   "engines": {
     "node": "16"
   },

--- a/src/aws/utils/update-state/package.json
+++ b/src/aws/utils/update-state/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-update-state",
-  "version": "4.0.0-beta.11",
+  "version": "4.0.0-beta.12",
   "engines": {
     "node": "16"
   },

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = marsha
 description = A FUN video provider for Open edX
-version = 4.0.0-beta.11
+version = 4.0.0-beta.12
 author = Open FUN (France Universite Numerique)
 author_email = fun.dev@fun-mooc.fr
 license = MIT

--- a/src/frontend/apps/lti_site/package.json
+++ b/src/frontend/apps/lti_site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marsha",
-  "version": "4.0.0-beta.11",
+  "version": "4.0.0-beta.12",
   "description": "🐠 a FUN LTI video provider",
   "main": "front/index.tsx",
   "scripts": {

--- a/src/frontend/apps/standalone_site/package.json
+++ b/src/frontend/apps/standalone_site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "standalone_site",
-  "version": "4.0.0-beta.11",
+  "version": "4.0.0-beta.12",
   "license": "MIT",
   "private": true,
   "devDependencies": {

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "common",
-  "version": "4.0.0-beta.11",
+  "version": "4.0.0-beta.12",
   "license": "MIT",
   "private": true,
   "workspaces": {

--- a/src/frontend/packages/lib_classroom/package.json
+++ b/src/frontend/packages/lib_classroom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lib-classroom",
-  "version": "4.0.0-beta.11",
+  "version": "4.0.0-beta.12",
   "license": "MIT",
   "main": "lib/index.js",
   "module": "lib/index.es.js",

--- a/src/frontend/packages/lib_common/package.json
+++ b/src/frontend/packages/lib_common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lib-common",
-  "version": "4.0.0-beta.11",
+  "version": "4.0.0-beta.12",
   "license": "MIT",
   "main": "lib/index.js",
   "module": "lib/index.es.js",

--- a/src/frontend/packages/lib_components/package.json
+++ b/src/frontend/packages/lib_components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lib-components",
-  "version": "4.0.0-beta.11",
+  "version": "4.0.0-beta.12",
   "license": "MIT",
   "main": "lib/index.js",
   "module": "lib/index.es.js",

--- a/src/frontend/packages/lib_tests/package.json
+++ b/src/frontend/packages/lib_tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lib-tests",
-  "version": "4.0.0-beta.11",
+  "version": "4.0.0-beta.12",
   "license": "MIT",
   "main": "lib/index.js",
   "module": "lib/index.es.js",


### PR DESCRIPTION
### Added

- standalone website:
  - classroom (list/create/update)
  - Add a new "invite" JWT in classroom API to allow students to join a classroom through a link
  - Manage portability requests (list/accept/reject)
  - dynamic content in homepage
  - page my-contents
  - access site visitor mode
  - login page
- Add new elements to the teacher VOD Dashboard :
  - Attendances from live session
- Allow to store link between an LTI user and a "site" user
- Allow LTI users to request for a playlist portability
- Enable recording when creating a BBB room instance
- Mutualize Eslint configuration
- Shareable classroom link
- Endpoint fetching jitsi info for a specific video (/api/videos/{video_id}/jitsi/)
- Reopen chatrooms in readonly mode when converting a live to a vod

### Changed

- Number of viewer doesn't include the instructor accounts
- Move title edition on the title itself
- Move record toggle
- standalone website:
  - mutualize modals and styles
  - fine tune UI
  - guess ISO15897 locale code
- Filtered classroom list
- Filtered deposit list
- Filtered markdown document list
- Use a lite serializer for classroom resource on list endpoint
- Rework of the TimedTextTrackLanguageChoices hook
- Adapt lib-components with eslint rules
- Adapt lib-classroom with eslint rules
- The full name replaces the first and last names in the user's profile API
- Always show the "use subtitle as transcript" toggle in the UploadSubtitles widget

### Fixed

- Remove hangup button
- Fix overlap display of the modal to end live on mobile view
- Fix recording button bugs
- Fix recording button bug on small display
- Change permission on retrieve endpoints
- Deal with webinar without thumbnail
- Force to save the starting live state on the start action
- Update gitlint_emoji.py
