### PR TITLE
🐛(front) create unique storage name for useJwt hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- create unique storage name for useJwt hook
+
 ## [4.0.0-beta.12] - 2022-12-28
 
 ### Added

--- a/src/frontend/packages/lib_components/src/hooks/stores/useJwt/index.ts
+++ b/src/frontend/packages/lib_components/src/hooks/stores/useJwt/index.ts
@@ -1,8 +1,21 @@
 import create from 'zustand';
 import { persist } from 'zustand/middleware';
 
+import { AppData } from '../../../types/AppData';
 import { DecodedJwt } from '../../../types/jwt';
 import { decodeJwt } from '../../../utils/decodeJwt';
+
+const domElementToParse = document.getElementById('marsha-frontend-data');
+let storageName = 'jwt-storage';
+if (domElementToParse) {
+  const dataContext = domElementToParse.getAttribute('data-context');
+  if (dataContext) {
+    const context = JSON.parse(dataContext) as AppData;
+    storageName = `jwt-store-${context.modelName}-${
+      context.resource?.id || ''
+    }`;
+  }
+}
 
 interface JwtStoreInterface {
   jwt?: string;
@@ -41,7 +54,7 @@ export const useJwt = create<JwtStoreInterface>()(
       },
     }),
     {
-      name: 'jwt-storage',
+      name: storageName,
     },
   ),
 );


### PR DESCRIPTION
## Purpose

The zustand hook useJwt is using a persistent middleware. A unique name must be set and this name is the key used as local storage key. In  LTI context, we can have several iframe launched in the same page and the JWT token will be overwritten between LTI app present in the page. To fix this, we choose to create unique storage name by checking of in the DOM we have the data-context set by the LTI view. If present we know we are in a LTI context and we can pick in the LTI context the resource modl and it's unique id.


## Proposal

- [x] create unique storage name for useJwt hook
