### PR TITLE
🐛(frontend) create unique storage name for useJwt hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- set unique storage name for useJwt hook for LTI
+
 ## [4.0.0-beta.12] - 2022-12-28
 
 ### Added

--- a/src/frontend/apps/lti_site/components/App/index.tsx
+++ b/src/frontend/apps/lti_site/components/App/index.tsx
@@ -12,6 +12,11 @@ if (!domElementToParse) {
   throw new Error('Appdata are missing from DOM.');
 }
 const { jwt, ...appConfig } = parseDataElements(domElementToParse);
+
+useJwt.persist.setOptions({
+  name: `jwt-store-${appConfig.modelName}-${appConfig.resource?.id || ''}`,
+});
+
 useJwt.setState({ jwt });
 
 export const App = () => {


### PR DESCRIPTION
## Purpose

The zustand hook useJwt is using a persistent middleware. A unique name must be set and this name is the key used as local storage key. In  LTI context, we can have several iframe launched in the same page and the JWT token will be overwritten between LTI app present in the page. To fix this, we choose to create unique storage name by checking of in the DOM we have the data-context set by the LTI view. If present we know we are in a LTI context and we can pick in the LTI context the resource modl and it's unique id.

