### PR TITLE
♻️(front) display current user full name instead of John Doe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- standalone website:
+  - Display current user full name instead of John Doe
+
 ### Changed
 
 - Remove deprecated params from BBB API calls

--- a/src/frontend/apps/standalone_site/src/App.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/App.spec.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import fetchMock from 'fetch-mock';
+import { useCurrentUser, userMockFactory } from 'lib-components';
 
 import fetchMockAuth from '__mock__/fetchMockAuth.mock';
 
@@ -14,6 +15,12 @@ const consoleWarn = jest
 window.scrollTo = jest.fn();
 
 describe('<App />', () => {
+  beforeEach(() => {
+    useCurrentUser.setState({
+      currentUser: undefined,
+    });
+  });
+
   afterEach(() => {
     fetchMock.restore();
     consoleWarn.mockClear();
@@ -21,6 +28,11 @@ describe('<App />', () => {
   });
 
   test('renders <App />', async () => {
+    useCurrentUser.setState({
+      currentUser: userMockFactory({
+        full_name: 'John Doe',
+      }),
+    });
     render(<App />);
 
     expect(await screen.findByText(/John Doe/i)).toBeInTheDocument();
@@ -31,6 +43,11 @@ describe('<App />', () => {
   });
 
   test('renders with another language', async () => {
+    useCurrentUser.setState({
+      currentUser: userMockFactory({
+        full_name: 'John Doe',
+      }),
+    });
     jest.mock(
       'translations/fr_FR.json',
       () => ({
@@ -44,8 +61,9 @@ describe('<App />', () => {
 
     render(<App />);
 
+    expect(await screen.findByText(/John Doe/i)).toBeInTheDocument();
     expect(
-      await screen.findByRole(/menuitem/i, { name: /Mon Tableau de bord/i }),
+      screen.getByRole(/menuitem/i, { name: /Mon Tableau de bord/i }),
     ).toBeInTheDocument();
   });
 });

--- a/src/frontend/apps/standalone_site/src/features/Header/Header.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Header/Header.spec.tsx
@@ -1,10 +1,21 @@
 import { render, screen, fireEvent } from '@testing-library/react';
-import React from 'react';
+import { useCurrentUser, userMockFactory } from 'lib-components';
 
 import Header from './Header';
 
 describe('<Header />', () => {
+  beforeEach(() => {
+    useCurrentUser.setState({
+      currentUser: undefined,
+    });
+  });
+
   test('renders Header', () => {
+    useCurrentUser.setState({
+      currentUser: userMockFactory({
+        full_name: 'John Doe',
+      }),
+    });
     render(<Header />);
     expect(screen.getByRole(/menubar/i)).toBeInTheDocument();
     expect(screen.getByText(/John Doe/i)).toBeInTheDocument();

--- a/src/frontend/apps/standalone_site/src/features/Header/Header.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Header/Header.tsx
@@ -1,6 +1,7 @@
 import { Box, Text } from 'grommet';
 import { normalizeColor } from 'grommet/utils';
 import { Nullable, theme } from 'lib-common';
+import { AnonymousUser, useCurrentUser } from 'lib-components';
 import { forwardRef, useEffect, useState } from 'react';
 import styled from 'styled-components';
 
@@ -33,6 +34,18 @@ const HeaderBox = styled(Box)<PropsExtended>`
 const Header = forwardRef<Nullable<HTMLDivElement>>((_props, ref) => {
   const [isScrollTop, setIsScrollTop] = useState(true);
   const { isDesktop } = useResponsive();
+  const { currentUser } = useCurrentUser((state) => ({
+    currentUser: state.currentUser,
+  }));
+  const [fullName, setFullName] = useState<Nullable<string>>();
+
+  useEffect(() => {
+    if (currentUser === AnonymousUser.ANONYMOUS) {
+      return;
+    }
+
+    setFullName(currentUser?.full_name);
+  }, [currentUser, setFullName]);
 
   useEffect(() => {
     const onScroll = () => {
@@ -64,7 +77,7 @@ const Header = forwardRef<Nullable<HTMLDivElement>>((_props, ref) => {
         <LogoIcon width={117} height={80} />
       </Box>
       <Box direction="row" align="center" gap="small" justify="end">
-        <Text>John Doe</Text>
+        <Text>{fullName}</Text>
         <AvatarIcon width={42} height={42} />
       </Box>
     </HeaderBox>

--- a/src/frontend/packages/lib_components/src/utils/tests/factories.ts
+++ b/src/frontend/packages/lib_components/src/utils/tests/factories.ts
@@ -397,6 +397,7 @@ export const userMockFactory = (user: Partial<User> = {}): User => {
     is_staff: false,
     is_superuser: false,
     organization_accesses: [],
+    full_name: `${faker.name.firstName()} ${faker.name.lastName()}`,
     ...user,
   };
 };


### PR DESCRIPTION
## Purpose

In the Header, the user full name John Doe was hardcoded. We replace it by the current user full name when available.

## Proposal

- display current user full name instead of John Doe

Closes #1918 
