### PR TITLE
🐛(front) display valid webinar url when creating one with LTI select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Set unique storage name for useJwt hook for LTI
-- Live parameters sync between users
+- lti_site:
+  - Live parameters sync between users
+  - Display valid webinar url when creating one with LTI select content
 
 ## [4.0.0-beta.12] - 2022-12-28
 

--- a/src/frontend/apps/lti_site/components/LTIRoutes/index.tsx
+++ b/src/frontend/apps/lti_site/components/LTIRoutes/index.tsx
@@ -115,6 +115,7 @@ const Routes = () => {
                 webinars={appData.webinars}
                 new_document_url={appData.new_document_url}
                 new_video_url={appData.new_video_url}
+                new_webinar_url={appData.new_webinar_url}
                 lti_select_form_action_url={appData.lti_select_form_action_url!}
                 lti_select_form_data={appData.lti_select_form_data!}
                 targeted_resource={appData.targeted_resource}

--- a/src/frontend/apps/lti_site/components/SelectContent/SelectContentTargetedResource/index.tsx
+++ b/src/frontend/apps/lti_site/components/SelectContent/SelectContentTargetedResource/index.tsx
@@ -150,6 +150,7 @@ interface SelectContentTargetedResourceProps {
   webinars?: Live[];
   new_document_url?: string;
   new_video_url?: string;
+  new_webinar_url?: string;
   lti_select_form_data: {
     [key: string]: string;
   };
@@ -164,6 +165,7 @@ export const SelectContentTargetedResource = ({
   webinars,
   new_document_url,
   new_video_url,
+  new_webinar_url,
   lti_select_form_data,
   setContentItemsValue,
   targeted_resource,
@@ -201,7 +203,7 @@ export const SelectContentTargetedResource = ({
       content = (
         <SelectContentVideo
           videos={webinars!}
-          new_video_url={new_video_url!}
+          new_video_url={new_webinar_url!}
           playlist={playlist!}
           lti_select_form_data={lti_select_form_data}
           setContentItemsValue={setContentItemsValue}

--- a/src/frontend/apps/lti_site/components/SelectContent/index.tsx
+++ b/src/frontend/apps/lti_site/components/SelectContent/index.tsx
@@ -35,6 +35,7 @@ interface SelectContentProps {
   webinars?: Live[];
   new_document_url?: string;
   new_video_url?: string;
+  new_webinar_url?: string;
   lti_select_form_action_url: string;
   lti_select_form_data: {
     [key: string]: string;
@@ -49,6 +50,7 @@ export const SelectContent = ({
   webinars,
   new_document_url,
   new_video_url,
+  new_webinar_url,
   lti_select_form_action_url,
   lti_select_form_data,
   targeted_resource,
@@ -107,6 +109,7 @@ export const SelectContent = ({
           webinars={webinars}
           new_document_url={new_document_url}
           new_video_url={new_video_url}
+          new_webinar_url={new_webinar_url}
           lti_select_form_data={lti_select_form_data}
           setContentItemsValue={setContentItemsValue}
           targeted_resource={targeted_resource}

--- a/src/frontend/packages/lib_components/src/types/AppData.ts
+++ b/src/frontend/packages/lib_components/src/types/AppData.ts
@@ -57,6 +57,7 @@ export interface AppConfig {
   appName?: appNames;
   new_document_url?: string;
   new_video_url?: string;
+  new_webinar_url?: string;
   lti_select_form_action_url?: string;
   lti_select_form_data?: {
     [key: string]: string;


### PR DESCRIPTION
## Purpose

Every resource managed with LTI select content have their own new url parameter. Video and Webinar share the same value but they their paramter name is different. We have to reflect this in the front SelectContent component and retrieve both in the AppData.

## Proposal

- [x]  display valid webinar url when creating one with LTI select

Fixes #1922 
