### PR TITLE
⏪️(front) keep resource in AppData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Remove deprecated params from BBB API calls
+- Keep resource property in AppData
 
 ### Fixed
 

--- a/src/frontend/apps/lti_site/apps/.cookiecutter/{{cookiecutter.app_name}}/utils/parseDataElements/parseDataElements.ts
+++ b/src/frontend/apps/lti_site/apps/.cookiecutter/{{cookiecutter.app_name}}/utils/parseDataElements/parseDataElements.ts
@@ -4,6 +4,7 @@ import { {{cookiecutter.model}}ModelName as modelName } from 'lib-components';
 export const parseDataElements = (element: Element): {{cookiecutter.app_name_capitalized}}AppData => {
   const context = JSON.parse(element.getAttribute('data-context')!);
 
+  context.resource_id = context.resource?.id;
   if (context.modelName === modelName.{{cookiecutter.model_plural_capitalized}}) {
     context.{{cookiecutter.model_lower}} = context.resource;
     delete context.resource;

--- a/src/frontend/apps/lti_site/apps/classroom/utils/parseDataElements/parseDataElements.ts
+++ b/src/frontend/apps/lti_site/apps/classroom/utils/parseDataElements/parseDataElements.ts
@@ -4,6 +4,7 @@ import { ClassroomModelName } from 'lib-components';
 export const parseDataElements = (element: Element): ClassroomAppData => {
   const context = JSON.parse(element.getAttribute('data-context')!);
 
+  context.resource_id = context.resource?.id;
   if (context.modelName === ClassroomModelName.CLASSROOMS) {
     context.classroom = context.resource;
     delete context.resource;

--- a/src/frontend/apps/lti_site/apps/deposit/utils/parseDataElements/parseDataElements.ts
+++ b/src/frontend/apps/lti_site/apps/deposit/utils/parseDataElements/parseDataElements.ts
@@ -4,6 +4,7 @@ import { FileDepositoryModelName as modelName } from 'lib-components';
 export const parseDataElements = (element: Element): DepositAppData => {
   const context = JSON.parse(element.getAttribute('data-context')!);
 
+  context.resource_id = context.resource?.id;
   if (context.modelName === modelName.FileDepositories) {
     context.fileDepository = context.resource;
     delete context.resource;

--- a/src/frontend/apps/lti_site/apps/markdown/utils/parseDataElements/parseDataElements.ts
+++ b/src/frontend/apps/lti_site/apps/markdown/utils/parseDataElements/parseDataElements.ts
@@ -4,6 +4,7 @@ import { MarkdownDocumentModelName as modelName } from 'lib-components';
 export const parseDataElements = (element: Element): MarkdownAppData => {
   const context = JSON.parse(element.getAttribute('data-context')!);
 
+  context.resource_id = context.resource?.id;
   if (context.modelName === modelName.MARKDOWN_DOCUMENTS) {
     context.markdownDocument = context.resource;
     delete context.resource;

--- a/src/frontend/apps/lti_site/components/App/index.tsx
+++ b/src/frontend/apps/lti_site/components/App/index.tsx
@@ -14,7 +14,7 @@ if (!domElementToParse) {
 const { jwt, ...appConfig } = parseDataElements(domElementToParse);
 
 useJwt.persist.setOptions({
-  name: `jwt-store-${appConfig.modelName}-${appConfig.resource?.id || ''}`,
+  name: `jwt-store-${appConfig.modelName}-${appConfig.resource_id || ''}`,
 });
 
 useJwt.setState({ jwt });

--- a/src/frontend/apps/lti_site/utils/parseDataElements/parseDataElements.spec.ts
+++ b/src/frontend/apps/lti_site/utils/parseDataElements/parseDataElements.spec.ts
@@ -13,6 +13,7 @@ describe.only('utils/parseDataElements', () => {
 
       const data = parseDataElements(dataElement);
       expect(data.video).toEqual(context.resource);
+      expect(data.resource_id).toEqual(data.video!.id);
       expect(data.resource).toEqual(undefined);
     });
 
@@ -26,10 +27,11 @@ describe.only('utils/parseDataElements', () => {
 
       const data = parseDataElements(dataElement);
       expect(data.document).toEqual(context.resource);
+      expect(data.resource_id).toEqual(data.document!.id);
       expect(data.resource).toEqual(undefined);
     });
 
-    it('leaves the context unmodified when the model is unknown', () => {
+    it('adds the resource_id parameter when the model is unknown', () => {
       const dataElement = document.createElement('div');
       const context = {
         modelName: modelName.THUMBNAILS,
@@ -38,7 +40,10 @@ describe.only('utils/parseDataElements', () => {
       dataElement.setAttribute('data-context', JSON.stringify(context));
 
       const data = parseDataElements(dataElement);
-      expect(data).toEqual(context);
+      expect(data).toEqual({
+        resource_id: 'thumbnail',
+        ...context,
+      });
     });
   });
 });

--- a/src/frontend/apps/lti_site/utils/parseDataElements/parseDataElements.ts
+++ b/src/frontend/apps/lti_site/utils/parseDataElements/parseDataElements.ts
@@ -2,7 +2,7 @@ import { AppData, modelName } from 'lib-components';
 
 export const parseDataElements = (element: Element): AppData => {
   const context = JSON.parse(element.getAttribute('data-context')!);
-
+  context.resource_id = context.resource?.id;
   if (context.modelName) {
     switch (context.modelName) {
       case modelName.VIDEOS:

--- a/src/frontend/packages/lib_components/src/types/AppData.ts
+++ b/src/frontend/packages/lib_components/src/types/AppData.ts
@@ -3,7 +3,13 @@ import { Nullable } from 'lib-common';
 
 import { Document } from 'types/file';
 import { modelName } from 'types/models';
-import { AppDataRessource, Live, Playlist, Video } from 'types/tracks';
+import {
+  AppDataRessource,
+  Live,
+  Playlist,
+  Resource,
+  Video,
+} from 'types/tracks';
 
 export enum appState {
   ERROR = 'error',
@@ -53,6 +59,7 @@ export interface AppConfig {
   document?: Nullable<Document>;
   documents?: Document[];
   resource?: AppDataRessource;
+  resource_id?: Resource['id'];
   modelName: modelName.VIDEOS | modelName.DOCUMENTS;
   appName?: appNames;
   new_document_url?: string;


### PR DESCRIPTION
## Purpose

In the AppData, the resource property was removed once a copy made in the model property. We need to know the resource id outside any react context in order to configure the useJwt zustand storage name. This storage name needs to be unique and we want to use the resource id to make it unique.

## Proposal

- [x] keep resource in AppData

