### PR TITLE
File upload size check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   - service worker 401 reconnect
   - Password reset views & API
   - Renater IdP's logo display on login page
+- Add a check on file size when uploading content 
 
 ### Changed
 

--- a/src/backend/marsha/bbb/api.py
+++ b/src/backend/marsha/bbb/api.py
@@ -18,6 +18,7 @@ from ..core.utils.s3_utils import create_presigned_post
 from ..core.utils.time_utils import to_timestamp
 from .defaults import LTI_ROUTE
 from .forms import ClassroomForm
+from .metadata import ClassroomDocumentMetadata
 from .models import Classroom, ClassroomDocument
 from .permissions import (
     IsClassroomPlaylistOrOrganizationAdmin,
@@ -375,6 +376,7 @@ class ClassroomDocumentViewSet(
 
     queryset = ClassroomDocument.objects.all()
     serializer_class = serializers.ClassroomDocumentSerializer
+    metadata_class = ClassroomDocumentMetadata
 
     permission_classes = [
         permissions.IsTokenResourceRouteObjectRelatedClassroom

--- a/src/backend/marsha/bbb/api.py
+++ b/src/backend/marsha/bbb/api.py
@@ -440,9 +440,7 @@ class ClassroomDocumentViewSet(
         serializer = serializers.ClassroomDocumentInitiateUploadSerializer(
             data=request.data
         )
-
-        if serializer.is_valid() is not True:
-            return Response(serializer.errors, status=400)
+        serializer.is_valid(raise_exception=True)
 
         now = timezone.now()
         stamp = to_timestamp(now)

--- a/src/backend/marsha/bbb/metadata.py
+++ b/src/backend/marsha/bbb/metadata.py
@@ -1,0 +1,15 @@
+"""This module holds custom metadata class dedicated to Marsha."""
+from django.conf import settings
+
+from rest_framework.metadata import SimpleMetadata
+
+
+class ClassroomDocumentMetadata(SimpleMetadata):
+    """Metadata class dedicated to video model."""
+
+    def determine_metadata(self, request, view):
+        """Adds live info in video metadata."""
+        metadata = super().determine_metadata(request, view)
+        metadata["upload_max_size_bytes"] = settings.CLASSROOM_DOCUMENT_SOURCE_MAX_SIZE
+
+        return metadata

--- a/src/backend/marsha/bbb/serializers.py
+++ b/src/backend/marsha/bbb/serializers.py
@@ -264,8 +264,16 @@ class ClassroomDocumentSerializer(
 class ClassroomDocumentInitiateUploadSerializer(InitiateUploadSerializer):
     """An initiate-upload serializer dedicated to classroom document."""
 
-    def validate(self, attrs):
-        """Validate if the mimetype is allowed or not."""
+    def validate_size(self, value):
+        if value > settings.CLASSROOM_DOCUMENT_SOURCE_MAX_SIZE:
+            raise serializers.ValidationError(
+                f"file too large, max size allowed is {settings.CLASSROOM_DOCUMENT_SOURCE_MAX_SIZE} Bytes"
+            )
+
+        return value
+
+    def validate_mimetype(self, attrs):
+        """Validate if the mimetype is allowed or not, and if the size is coherent with django settings."""
         # mimetype is provided, we directly check it
         if attrs["mimetype"] != "":
             if attrs["mimetype"] not in settings.ALLOWED_CLASSROOM_DOCUMENT_MIME_TYPES:

--- a/src/backend/marsha/bbb/tests/api/classroomdocument/test_initiate_upload.py
+++ b/src/backend/marsha/bbb/tests/api/classroomdocument/test_initiate_upload.py
@@ -58,7 +58,7 @@ class ClassroomDocumentInitiateUploadAPITest(TestCase):
             mock_dt.utcnow = mock.Mock(return_value=now)
             response = self.client.post(
                 f"/api/classroomdocuments/{classroom_document.id}/initiate-upload/",
-                {"filename": "foo.pdf", "mimetype": "application/pdf"},
+                {"filename": "foo.pdf", "mimetype": "application/pdf", "size": 100},
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
                 content_type="application/json",
             )
@@ -116,7 +116,7 @@ class ClassroomDocumentInitiateUploadAPITest(TestCase):
             mock_dt.utcnow = mock.Mock(return_value=now)
             response = self.client.post(
                 f"/api/classroomdocuments/{classroom_document.id}/initiate-upload/",
-                {"filename": "foo", "mimetype": "application/pdf"},
+                {"filename": "foo", "mimetype": "application/pdf", "size": 100},
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
                 content_type="application/json",
             )
@@ -156,6 +156,65 @@ class ClassroomDocumentInitiateUploadAPITest(TestCase):
         self.assertEqual(classroom_document.filename, "foo")
         self.assertEqual(classroom_document.upload_state, "pending")
 
+    def test_api_classroom_document_initiate_upload_file_without_size(self):
+        "With no size field provided, the request should fail"
+        classroom_document = ClassroomDocumentFactory(
+            id="27a23f52-3379-46a2-94fa-697b59cfe3c7",
+            upload_state=random.choice(["ready", "error"]),
+            classroom__id="ed08da34-7447-4141-96ff-5740315d7b99",
+        )
+        jwt_token = InstructorOrAdminLtiTokenFactory(
+            resource=classroom_document.classroom
+        )
+
+        now = datetime(2018, 8, 8, tzinfo=timezone.utc)
+        with mock.patch.object(timezone, "now", return_value=now), mock.patch(
+            "datetime.datetime"
+        ) as mock_dt:
+            mock_dt.utcnow = mock.Mock(return_value=now)
+            response = self.client.post(
+                f"/api/classroomdocuments/{classroom_document.id}/initiate-upload/",
+                {"filename": "foo.pdf", "mimetype": "application/pdf"},
+                HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+                content_type="application/json",
+            )
+        self.assertEqual(response.status_code, 400)
+        content = json.loads(response.content)
+        self.assertEqual(
+            content,
+            {"size": ["This field is required."]},
+        )
+
+    @override_settings(CLASSROOM_DOCUMENT_SOURCE_MAX_SIZE=10)
+    def test_api_classroom_document_initiate_upload_file_too_large(self):
+        """With a file size too large the request should fail"""
+        classroom_document = ClassroomDocumentFactory(
+            id="27a23f52-3379-46a2-94fa-697b59cfe3c7",
+            upload_state=random.choice(["ready", "error"]),
+            classroom__id="ed08da34-7447-4141-96ff-5740315d7b99",
+        )
+        jwt_token = InstructorOrAdminLtiTokenFactory(
+            resource=classroom_document.classroom
+        )
+
+        now = datetime(2018, 8, 8, tzinfo=timezone.utc)
+        with mock.patch.object(timezone, "now", return_value=now), mock.patch(
+            "datetime.datetime"
+        ) as mock_dt:
+            mock_dt.utcnow = mock.Mock(return_value=now)
+            response = self.client.post(
+                f"/api/classroomdocuments/{classroom_document.id}/initiate-upload/",
+                {"filename": "foo.pdf", "mimetype": "application/pdf", "size": 100},
+                HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+                content_type="application/json",
+            )
+        self.assertEqual(response.status_code, 400)
+        content = json.loads(response.content)
+        self.assertEqual(
+            content,
+            {"size": ["file too large, max size allowed is 10 Bytes"]},
+        )
+
     def test_api_classroom_document_initiate_upload_instructor_without_mimetype(self):
         """With no mimetype the request should fail."""
         classroom_document = ClassroomDocumentFactory(
@@ -174,7 +233,7 @@ class ClassroomDocumentInitiateUploadAPITest(TestCase):
             mock_dt.utcnow = mock.Mock(return_value=now)
             response = self.client.post(
                 f"/api/classroomdocuments/{classroom_document.id}/initiate-upload/",
-                {"filename": "foo", "mimetype": ""},
+                {"filename": "foo", "mimetype": "", "size": 100},
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
                 content_type="application/json",
             )
@@ -204,7 +263,7 @@ class ClassroomDocumentInitiateUploadAPITest(TestCase):
             mock_dt.utcnow = mock.Mock(return_value=now)
             response = self.client.post(
                 f"/api/classroomdocuments/{classroom_document.id}/initiate-upload/",
-                {"filename": "foo", "mimetype": "application/wrong-type"},
+                {"filename": "foo", "mimetype": "application/wrong-type", "size": 100},
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
                 content_type="application/json",
             )
@@ -236,7 +295,7 @@ class ClassroomDocumentInitiateUploadAPITest(TestCase):
             mock_dt.utcnow = mock.Mock(return_value=now)
             response = self.client.post(
                 f"/api/classroomdocuments/{classroom_document.id}/initiate-upload/",
-                {"filename": "foo.pdf", "mimetype": "application/pdf"},
+                {"filename": "foo.pdf", "mimetype": "application/pdf", "size": 100},
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
                 content_type="application/json",
             )
@@ -265,7 +324,7 @@ class ClassroomDocumentInitiateUploadAPITest(TestCase):
             mock_dt.utcnow = mock.Mock(return_value=now)
             response = self.client.post(
                 f"/api/classroomdocuments/{classroom_document.id}/initiate-upload/",
-                {"filename": "foo.pdf", "mimetype": "application/pdf"},
+                {"filename": "foo.pdf", "mimetype": "application/pdf", "size": 100},
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
                 content_type="application/json",
             )
@@ -326,7 +385,7 @@ class ClassroomDocumentInitiateUploadAPITest(TestCase):
             mock_dt.utcnow = mock.Mock(return_value=now)
             response = self.client.post(
                 f"/api/classroomdocuments/{classroom_document.id}/initiate-upload/",
-                {"filename": "foo.pdf", "mimetype": "application/pdf"},
+                {"filename": "foo.pdf", "mimetype": "application/pdf", "size": 100},
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
                 content_type="application/json",
             )

--- a/src/backend/marsha/core/api/shared_live_media.py
+++ b/src/backend/marsha/core/api/shared_live_media.py
@@ -10,6 +10,7 @@ from rest_framework.response import Response
 from marsha.websocket.utils import channel_layers_utils
 
 from .. import defaults, permissions, serializers
+from ..metadata import SharedLiveMediaMetadata
 from ..models import SharedLiveMedia
 from ..utils.s3_utils import create_presigned_post
 from ..utils.time_utils import to_timestamp
@@ -24,6 +25,7 @@ class SharedLiveMediaViewSet(
     permission_classes = [permissions.NotAllowed]
     queryset = SharedLiveMedia.objects.all()
     serializer_class = serializers.SharedLiveMediaSerializer
+    metadata_class = SharedLiveMediaMetadata
 
     def get_serializer_context(self):
         """Extra context provided to the serializer class."""

--- a/src/backend/marsha/core/api/shared_live_media.py
+++ b/src/backend/marsha/core/api/shared_live_media.py
@@ -133,9 +133,7 @@ class SharedLiveMediaViewSet(
             HttpResponse carrying the AWS S3 upload policy as a JSON object.
 
         """
-        serializer = serializers.SharedLiveMediaInitiateUploadSerializer(
-            data=request.data
-        )
+        serializer = serializers.SharedLiveMediaUploadSerializer(data=request.data)
 
         if serializer.is_valid() is not True:
             return Response(serializer.errors, status=400)

--- a/src/backend/marsha/core/api/thumbnail.py
+++ b/src/backend/marsha/core/api/thumbnail.py
@@ -69,6 +69,9 @@ class ThumbnailViewSet(
             HttpResponse carrying the AWS S3 upload policy as a JSON object.
 
         """
+        serializer = serializers.ThumbailUploadSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
         now = timezone.now()
         stamp = to_timestamp(now)
 

--- a/src/backend/marsha/core/api/thumbnail.py
+++ b/src/backend/marsha/core/api/thumbnail.py
@@ -7,6 +7,7 @@ from rest_framework.decorators import action
 from rest_framework.response import Response
 
 from .. import defaults, permissions, serializers
+from ..metadata import ThumbnailMetadata
 from ..models import Thumbnail
 from ..utils.s3_utils import create_presigned_post
 from ..utils.time_utils import to_timestamp
@@ -26,6 +27,7 @@ class ThumbnailViewSet(
 
     permission_classes = [permissions.NotAllowed]
     serializer_class = serializers.ThumbnailSerializer
+    metadata_class = ThumbnailMetadata
 
     def get_permissions(self):
         """Instantiate and return the list of permissions that this view requires."""

--- a/src/backend/marsha/core/api/timed_text_track.py
+++ b/src/backend/marsha/core/api/timed_text_track.py
@@ -86,6 +86,9 @@ class TimedTextTrackViewSet(
             HttpResponse carrying the AWS S3 upload policy as a JSON object.
 
         """
+        serializer = serializers.TimedTextTrackUploadSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
         now = timezone.now()
         stamp = to_timestamp(now)
 

--- a/src/backend/marsha/core/api/timed_text_track.py
+++ b/src/backend/marsha/core/api/timed_text_track.py
@@ -7,6 +7,7 @@ from rest_framework.decorators import action
 from rest_framework.response import Response
 
 from .. import defaults, permissions, serializers
+from ..metadata import SubtitleMetadata
 from ..models import TimedTextTrack
 from ..utils.s3_utils import create_presigned_post
 from ..utils.time_utils import to_timestamp
@@ -21,6 +22,7 @@ class TimedTextTrackViewSet(
     permission_classes = [permissions.NotAllowed]
     queryset = TimedTextTrack.objects.all()
     serializer_class = serializers.TimedTextTrackSerializer
+    metadata_class = SubtitleMetadata
 
     def get_permissions(self):
         """Instantiate and return the list of permissions that this view requires."""

--- a/src/backend/marsha/core/api/video.py
+++ b/src/backend/marsha/core/api/video.py
@@ -230,6 +230,9 @@ class VideoViewSet(APIViewMixin, ObjectPkMixin, viewsets.ModelViewSet):
             HttpResponse carrying the upload policy as a JSON object.
 
         """
+        serializer = serializers.VideoUploadSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
         response = storage.get_initiate_backend().initiate_video_upload(request, pk)
 
         # Reset the upload state of the video

--- a/src/backend/marsha/core/metadata.py
+++ b/src/backend/marsha/core/metadata.py
@@ -1,4 +1,4 @@
-"""This module holds custome metadata class dedicated to Marsha."""
+"""This module holds custom metadata class dedicated to Marsha."""
 from django.conf import settings
 
 from rest_framework.metadata import SimpleMetadata
@@ -13,5 +13,39 @@ class VideoMetadata(SimpleMetadata):
         metadata["live"] = {
             "segment_duration_seconds": settings.LIVE_SEGMENT_DURATION_SECONDS
         }
+        metadata["vod"] = {"upload_max_size_bytes": settings.VIDEO_SOURCE_MAX_SIZE}
+
+        return metadata
+
+
+class SubtitleMetadata(SimpleMetadata):
+    """Metadata class dedicated to subtitle model."""
+
+    def determine_metadata(self, request, view):
+        """Adds live info in video metadata."""
+        metadata = super().determine_metadata(request, view)
+        metadata["upload_max_size_bytes"] = settings.SUBTITLE_SOURCE_MAX_SIZE
+
+        return metadata
+
+
+class ThumbnailMetadata(SimpleMetadata):
+    """Metadata class dedicated to thumbnail model."""
+
+    def determine_metadata(self, request, view):
+        """Adds live info in video metadata."""
+        metadata = super().determine_metadata(request, view)
+        metadata["upload_max_size_bytes"] = settings.THUMBNAIL_SOURCE_MAX_SIZE
+
+        return metadata
+
+
+class SharedLiveMediaMetadata(SimpleMetadata):
+    """Metadata class dedicated to sharedLiveMedia model."""
+
+    def determine_metadata(self, request, view):
+        """Adds live info in video metadata."""
+        metadata = super().determine_metadata(request, view)
+        metadata["upload_max_size_bytes"] = settings.SHARED_LIVE_MEDIA_SOURCE_MAX_SIZE
 
         return metadata

--- a/src/backend/marsha/core/serializers/file.py
+++ b/src/backend/marsha/core/serializers/file.py
@@ -175,13 +175,35 @@ class InitiateUploadSerializer(serializers.Serializer):
 
     filename = serializers.CharField()
     mimetype = serializers.CharField(allow_blank=True)
+    size = serializers.IntegerField()
+
+    def validate_size(self, value):
+        """Validate if the size is coherent with django settings."""
+        if value > settings.DOCUMENT_SOURCE_MAX_SIZE:
+            raise serializers.ValidationError(
+                {
+                    "size": f"file too large, max size allowed is {settings.DOCUMENT_SOURCE_MAX_SIZE} Bytes"
+                }
+            )
+
+        return value
 
 
-class SharedLiveMediaInitiateUploadSerializer(InitiateUploadSerializer):
+class SharedLiveMediaUploadSerializer(InitiateUploadSerializer):
     """An initiate-upload serializer dedicated to shared live media."""
 
+    def validate_size(self, value):
+        if value > settings.SHARED_LIVE_MEDIA_SOURCE_MAX_SIZE:
+            raise serializers.ValidationError(
+                {
+                    "size": f"file too large, max size allowed is {settings.SHARED_LIVE_MEDIA_SOURCE_MAX_SIZE} Bytes"
+                }
+            )
+
+        return value
+
     def validate(self, attrs):
-        """Validate if the mimetype is allowed or not."""
+        """Validate if the mimetype is allowed or not, and if the size is coherent with django settings."""
         # mimetype is provided, we directly check it
         if attrs["mimetype"] != "":
             if attrs["mimetype"] not in settings.ALLOWED_SHARED_LIVE_MEDIA_MIME_TYPES:
@@ -204,3 +226,42 @@ class SharedLiveMediaInitiateUploadSerializer(InitiateUploadSerializer):
             attrs["mimetype"] = mimetype
 
         return attrs
+
+
+class ThumbailUploadSerializer(InitiateUploadSerializer):
+    def validate_size(self, value):
+        """Validate if the size is coherent with django settings."""
+        if value > settings.THUMBNAIL_SOURCE_MAX_SIZE:
+            raise serializers.ValidationError(
+                {
+                    "size": f"file too large, max size allowed is {settings.THUMBNAIL_SOURCE_MAX_SIZE} Bytes"
+                }
+            )
+
+        return value
+
+
+class TimedTextTrackUploadSerializer(InitiateUploadSerializer):
+    def validate_size(self, value):
+        """Validate if the size is coherent with django settings."""
+        if value > settings.SUBTITLE_SOURCE_MAX_SIZE:
+            raise serializers.ValidationError(
+                {
+                    "size": f"file too large, max size allowed is {settings.SUBTITLE_SOURCE_MAX_SIZE} Bytes"
+                }
+            )
+
+        return value
+
+
+class VideoUploadSerializer(InitiateUploadSerializer):
+    def validate_size(self, value):
+        """Validate if the size is coherent with django settings."""
+        if value > settings.VIDEO_SOURCE_MAX_SIZE:
+            raise serializers.ValidationError(
+                {
+                    "size": f"file too large, max size allowed is {settings.VIDEO_SOURCE_MAX_SIZE} Bytes"
+                }
+            )
+
+        return value

--- a/src/backend/marsha/core/serializers/file.py
+++ b/src/backend/marsha/core/serializers/file.py
@@ -181,9 +181,7 @@ class InitiateUploadSerializer(serializers.Serializer):
         """Validate if the size is coherent with django settings."""
         if value > settings.DOCUMENT_SOURCE_MAX_SIZE:
             raise serializers.ValidationError(
-                {
-                    "size": f"file too large, max size allowed is {settings.DOCUMENT_SOURCE_MAX_SIZE} Bytes"
-                }
+                f"file too large, max size allowed is {settings.DOCUMENT_SOURCE_MAX_SIZE} Bytes"
             )
 
         return value
@@ -195,9 +193,7 @@ class SharedLiveMediaUploadSerializer(InitiateUploadSerializer):
     def validate_size(self, value):
         if value > settings.SHARED_LIVE_MEDIA_SOURCE_MAX_SIZE:
             raise serializers.ValidationError(
-                {
-                    "size": f"file too large, max size allowed is {settings.SHARED_LIVE_MEDIA_SOURCE_MAX_SIZE} Bytes"
-                }
+                f"file too large, max size allowed is {settings.SHARED_LIVE_MEDIA_SOURCE_MAX_SIZE} Bytes"
             )
 
         return value
@@ -233,9 +229,7 @@ class ThumbailUploadSerializer(InitiateUploadSerializer):
         """Validate if the size is coherent with django settings."""
         if value > settings.THUMBNAIL_SOURCE_MAX_SIZE:
             raise serializers.ValidationError(
-                {
-                    "size": f"file too large, max size allowed is {settings.THUMBNAIL_SOURCE_MAX_SIZE} Bytes"
-                }
+                f"file too large, max size allowed is {settings.THUMBNAIL_SOURCE_MAX_SIZE} Bytes"
             )
 
         return value
@@ -246,9 +240,7 @@ class TimedTextTrackUploadSerializer(InitiateUploadSerializer):
         """Validate if the size is coherent with django settings."""
         if value > settings.SUBTITLE_SOURCE_MAX_SIZE:
             raise serializers.ValidationError(
-                {
-                    "size": f"file too large, max size allowed is {settings.SUBTITLE_SOURCE_MAX_SIZE} Bytes"
-                }
+                f"file too large, max size allowed is {settings.SUBTITLE_SOURCE_MAX_SIZE} Bytes"
             )
 
         return value
@@ -259,9 +251,7 @@ class VideoUploadSerializer(InitiateUploadSerializer):
         """Validate if the size is coherent with django settings."""
         if value > settings.VIDEO_SOURCE_MAX_SIZE:
             raise serializers.ValidationError(
-                {
-                    "size": f"file too large, max size allowed is {settings.VIDEO_SOURCE_MAX_SIZE} Bytes"
-                }
+                f"file too large, max size allowed is {settings.VIDEO_SOURCE_MAX_SIZE} Bytes"
             )
 
         return value

--- a/src/backend/marsha/deposit/api.py
+++ b/src/backend/marsha/deposit/api.py
@@ -17,6 +17,7 @@ from . import permissions, serializers
 from ..core.models import ADMINISTRATOR, LTI_ROLES, STUDENT
 from .defaults import LTI_ROUTE
 from .forms import FileDepositoryForm
+from .metadata import DepositedFileMetadata
 from .models import DepositedFile, FileDepository
 from .permissions import (
     IsFileDepositoryPlaylistOrOrganizationAdmin,
@@ -258,6 +259,7 @@ class DepositedFileViewSet(
 
     queryset = DepositedFile.objects.all()
     serializer_class = serializers.DepositedFileSerializer
+    metadata_class = DepositedFileMetadata
 
     permission_classes = [
         permissions.IsTokenResourceRouteObjectRelatedFileDepository

--- a/src/backend/marsha/deposit/metadata.py
+++ b/src/backend/marsha/deposit/metadata.py
@@ -1,0 +1,15 @@
+"""This module holds custom metadata class dedicated to Marsha."""
+from django.conf import settings
+
+from rest_framework.metadata import SimpleMetadata
+
+
+class DepositedFileMetadata(SimpleMetadata):
+    """Metadata class dedicated to video model."""
+
+    def determine_metadata(self, request, view):
+        """Adds live info in video metadata."""
+        metadata = super().determine_metadata(request, view)
+        metadata["upload_max_size_bytes"] = settings.DEPOSITED_FILE_SOURCE_MAX_SIZE
+
+        return metadata

--- a/src/backend/marsha/deposit/serializers.py
+++ b/src/backend/marsha/deposit/serializers.py
@@ -155,8 +155,16 @@ class DepositedFileSerializer(
 class DepositedFileInitiateUploadSerializer(InitiateUploadSerializer):
     """An initiate-upload serializer dedicated to deposited file."""
 
+    def validate_size(self, value):
+        if value > settings.DEPOSITED_FILE_SOURCE_MAX_SIZE:
+            raise serializers.ValidationError(
+                f"file too large, max size allowed is {settings.DEPOSITED_FILE_SOURCE_MAX_SIZE} Bytes"
+            )
+
+        return value
+
     def validate(self, attrs):
-        """Validate if the mimetype is allowed or not."""
+        """Validate if the mimetype is allowed or not, and if the size is coherent with django settings."""
         # mimetype is provided, we directly check it
         if attrs["mimetype"] != "":
             attrs["extension"] = mimetypes.guess_extension(attrs["mimetype"])

--- a/src/backend/marsha/deposit/tests/api/depositedfiles/test_initiate_upload.py
+++ b/src/backend/marsha/deposit/tests/api/depositedfiles/test_initiate_upload.py
@@ -1,5 +1,6 @@
 """Tests for the deposited files initiate-upload API."""
 from datetime import datetime
+import json
 import random
 from unittest import mock
 
@@ -57,7 +58,7 @@ class DepositedFileInitiateUploadAPITest(TestCase):
             mock_dt.utcnow = mock.Mock(return_value=now)
             response = self.client.post(
                 f"/api/depositedfiles/{deposited_file.id}/initiate-upload/",
-                {"filename": "foo.pdf", "mimetype": "application/pdf"},
+                {"filename": "foo.pdf", "mimetype": "application/pdf", "size": 100},
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
                 content_type="application/json",
             )
@@ -97,6 +98,61 @@ class DepositedFileInitiateUploadAPITest(TestCase):
         self.assertEqual(deposited_file.filename, "foo.pdf")
         self.assertEqual(deposited_file.upload_state, "pending")
 
+    def test_api_deposited_file_initiate_upload_file_without_size(self):
+        "With no size field provided, the request should fail"
+        deposited_file = DepositedFileFactory(
+            id="27a23f52-3379-46a2-94fa-697b59cfe3c7",
+            upload_state=random.choice(["ready", "error"]),
+            file_depository__id="ed08da34-7447-4141-96ff-5740315d7b99",
+        )
+        jwt_token = StudentLtiTokenFactory(resource=deposited_file.file_depository)
+
+        now = datetime(2018, 8, 8, tzinfo=timezone.utc)
+        with mock.patch.object(timezone, "now", return_value=now), mock.patch(
+            "datetime.datetime"
+        ) as mock_dt:
+            mock_dt.utcnow = mock.Mock(return_value=now)
+            response = self.client.post(
+                f"/api/depositedfiles/{deposited_file.id}/initiate-upload/",
+                {"filename": "foo.pdf", "mimetype": "application/pdf"},
+                HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+                content_type="application/json",
+            )
+        self.assertEqual(response.status_code, 400)
+        content = json.loads(response.content)
+        self.assertEqual(
+            content,
+            {"size": ["This field is required."]},
+        )
+
+    @override_settings(DEPOSITED_FILE_SOURCE_MAX_SIZE=10)
+    def test_api_deposited_file_initiate_upload_file_too_large(self):
+        """With a file size too large the request should fail"""
+        deposited_file = DepositedFileFactory(
+            id="27a23f52-3379-46a2-94fa-697b59cfe3c7",
+            upload_state=random.choice(["ready", "error"]),
+            file_depository__id="ed08da34-7447-4141-96ff-5740315d7b99",
+        )
+        jwt_token = StudentLtiTokenFactory(resource=deposited_file.file_depository)
+
+        now = datetime(2018, 8, 8, tzinfo=timezone.utc)
+        with mock.patch.object(timezone, "now", return_value=now), mock.patch(
+            "datetime.datetime"
+        ) as mock_dt:
+            mock_dt.utcnow = mock.Mock(return_value=now)
+            response = self.client.post(
+                f"/api/depositedfiles/{deposited_file.id}/initiate-upload/",
+                {"filename": "foo.pdf", "mimetype": "application/pdf", "size": 100},
+                HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+                content_type="application/json",
+            )
+        self.assertEqual(response.status_code, 400)
+        content = json.loads(response.content)
+        self.assertEqual(
+            content,
+            {"size": ["file too large, max size allowed is 10 Bytes"]},
+        )
+
     def test_api_deposited_file_initiate_upload_user_access_token(self):
         """
         A user with UserAccessToken should be able to initiate an upload for a deposited file.
@@ -120,7 +176,7 @@ class DepositedFileInitiateUploadAPITest(TestCase):
             mock_dt.utcnow = mock.Mock(return_value=now)
             response = self.client.post(
                 f"/api/depositedfiles/{deposited_file.id}/initiate-upload/",
-                {"filename": "foo.pdf", "mimetype": "application/pdf"},
+                {"filename": "foo.pdf", "mimetype": "application/pdf", "size": 100},
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
                 content_type="application/json",
             )
@@ -185,7 +241,7 @@ class DepositedFileInitiateUploadAPITest(TestCase):
             mock_dt.utcnow = mock.Mock(return_value=now)
             response = self.client.post(
                 f"/api/depositedfiles/{deposited_file.id}/initiate-upload/",
-                {"filename": "foo.pdf", "mimetype": "application/pdf"},
+                {"filename": "foo.pdf", "mimetype": "application/pdf", "size": 100},
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
                 content_type="application/json",
             )
@@ -247,7 +303,7 @@ class DepositedFileInitiateUploadAPITest(TestCase):
             mock_dt.utcnow = mock.Mock(return_value=now)
             response = self.client.post(
                 f"/api/depositedfiles/{deposited_file.id}/initiate-upload/",
-                {"filename": "foo.pdf", "mimetype": "application/pdf"},
+                {"filename": "foo.pdf", "mimetype": "application/pdf", "size": 100},
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
                 content_type="application/json",
             )

--- a/src/backend/marsha/markdown/api.py
+++ b/src/backend/marsha/markdown/api.py
@@ -18,6 +18,7 @@ from ..core.models import ADMINISTRATOR
 from ..core.utils.s3_utils import create_presigned_post
 from .defaults import LTI_ROUTE
 from .forms import MarkdownDocumentForm
+from .metadata import MarkdownImageMetadata
 from .models import MarkdownDocument, MarkdownImage
 from .permissions import IsRelatedMarkdownDocumentPlaylistOrOrganizationAdmin
 from .utils.converter import LatexConversionException, render_latex_to_image
@@ -272,6 +273,7 @@ class MarkdownImageViewSet(
 
     permission_classes = [core_permissions.NotAllowed]
     serializer_class = serializers.MarkdownImageSerializer
+    metadata_class = MarkdownImageMetadata
 
     def get_permissions(self):
         """Instantiate and return the list of permissions that this view requires."""

--- a/src/backend/marsha/markdown/metadata.py
+++ b/src/backend/marsha/markdown/metadata.py
@@ -1,0 +1,15 @@
+"""This module holds custom metadata class dedicated to Marsha."""
+from django.conf import settings
+
+from rest_framework.metadata import SimpleMetadata
+
+
+class MarkdownImageMetadata(SimpleMetadata):
+    """Metadata class dedicated to video model."""
+
+    def determine_metadata(self, request, view):
+        """Adds live info in video metadata."""
+        metadata = super().determine_metadata(request, view)
+        metadata["upload_max_size_bytes"] = settings.MARKDOWN_IMAGE_SOURCE_MAX_SIZE
+
+        return metadata

--- a/src/backend/marsha/markdown/serializers.py
+++ b/src/backend/marsha/markdown/serializers.py
@@ -119,7 +119,7 @@ class MarkdownImageUploadSerializer(InitiateUploadSerializer):
     """An initiate-upload serializer dedicated to Markdown image."""
 
     def validate(self, attrs):
-        """Validate if the mimetype is allowed or not."""
+        """Validate if the mimetype is allowed or not, and if the size is coherent with django settings."""
         # mimetype is provided, we directly check it
         if attrs["mimetype"] != "":
             attrs["extension"] = mimetypes.guess_extension(attrs["mimetype"])
@@ -139,6 +139,14 @@ class MarkdownImageUploadSerializer(InitiateUploadSerializer):
             )
 
         return attrs
+
+    def validate_size(self, value):
+        if value > settings.MARKDOWN_IMAGE_SOURCE_MAX_SIZE:
+            raise serializers.ValidationError(
+                f"file too large, max size allowed is {settings.MARKDOWN_IMAGE_SOURCE_MAX_SIZE} Bytes"
+            )
+
+        return value
 
 
 class MarkdownPreviewSerializer(serializers.Serializer):

--- a/src/frontend/apps/lti_site/components/UploadableObjectStatusBadge/index.tsx
+++ b/src/frontend/apps/lti_site/components/UploadableObjectStatusBadge/index.tsx
@@ -112,6 +112,13 @@ export const UploadableObjectStatusBadge = ({
             </Badge>
           );
 
+        case UploadManagerStatus.ERR_SIZE:
+          return (
+            <Badge role="status" background="status-error">
+              <FormattedMessage {...messages[uploadState.ERROR]} />
+            </Badge>
+          );
+
         case UploadManagerStatus.SUCCESS:
           return (
             <Badge role="status" background="brand">

--- a/src/frontend/packages/lib_components/src/common/ErrorComponents/index.tsx
+++ b/src/frontend/packages/lib_components/src/common/ErrorComponents/index.tsx
@@ -20,7 +20,8 @@ export interface ErrorComponentsProps {
     | 'liveInit'
     | 'liveToVod'
     | 'liveStopped'
-    | 'videoDeleted';
+    | 'videoDeleted'
+    | 'fileTooLarge';
 }
 
 const FullScreenErrorStyled = styled(LayoutMainArea)`
@@ -173,6 +174,18 @@ const messages = {
       description:
         'Title for a user accessing a deleted video (or a live ended without any record).',
       id: 'components.ErrorComponents.videoDeleted.title',
+    },
+  },
+  fileTooLarge: {
+    text: {
+      defaultMessage: 'This file is too large to be uploaded.',
+      description: 'Text explaining that the file provided is too large.',
+      id: 'components.ErrorComponents.fileTooLarge.text',
+    },
+    title: {
+      defaultMessage: 'This file is too large',
+      description: 'Title for a user trying to upload a too large file.',
+      id: 'components.ErrorComponents.fileTooLarge.title',
     },
   },
 };

--- a/src/frontend/packages/lib_components/src/common/UploadForm/index.tsx
+++ b/src/frontend/packages/lib_components/src/common/UploadForm/index.tsx
@@ -159,6 +159,9 @@ export const UploadForm = ({ objectId, objectType }: UploadFormProps) => {
     case UploadManagerStatus.ERR_POLICY:
       return <Redirect push to={FULL_SCREEN_ERROR_ROUTE('policy')} />;
 
+    case UploadManagerStatus.ERR_SIZE:
+      return <Redirect push to={FULL_SCREEN_ERROR_ROUTE('fileTooLarge')} />;
+
     case UploadManagerStatus.ERR_UPLOAD:
       return <Redirect push to={FULL_SCREEN_ERROR_ROUTE('upload')} />;
 

--- a/src/frontend/packages/lib_components/src/utils/formatSizeErrorScale.spec.ts
+++ b/src/frontend/packages/lib_components/src/utils/formatSizeErrorScale.spec.ts
@@ -1,0 +1,12 @@
+import { formatSizeErrorScale } from './formatSizeErrorScale';
+
+describe('lib_components/src/utils/formatSizeErrorScale.ts', () => {
+  it('converts Bytes to the right human-readable scale', () => {
+    expect(formatSizeErrorScale(10)).toEqual('10 B');
+    expect(formatSizeErrorScale(Math.pow(10, 3))).toEqual('1 kB');
+    expect(formatSizeErrorScale(Math.pow(10, 5))).toEqual('100 kB');
+    expect(formatSizeErrorScale(Math.pow(10, 7))).toEqual('10 MB');
+    expect(formatSizeErrorScale(Math.pow(10, 9))).toEqual('1 GB');
+    expect(formatSizeErrorScale(Math.pow(10, 10))).toEqual('10 GB');
+  });
+});

--- a/src/frontend/packages/lib_components/src/utils/formatSizeErrorScale.ts
+++ b/src/frontend/packages/lib_components/src/utils/formatSizeErrorScale.ts
@@ -1,0 +1,9 @@
+export const formatSizeErrorScale = (maxSize: number): string => {
+  const index =
+    maxSize === 0 ? 0 : Math.floor(Math.log(maxSize) / Math.log(1000));
+  return (
+    ((maxSize / Math.pow(1000, index)) * 1).toFixed(0) +
+    ' ' +
+    ['B', 'kB', 'MB', 'GB', 'TB'][index]
+  );
+};

--- a/src/frontend/packages/lib_components/src/utils/index.ts
+++ b/src/frontend/packages/lib_components/src/utils/index.ts
@@ -10,3 +10,4 @@ export * from './XAPI/DocumentXapiStatement';
 export * from './useFetchButton';
 export * from './useResizeBox';
 export * from './useResizer';
+export * from './formatSizeErrorScale';

--- a/src/frontend/packages/lib_video/src/api/useSharedLiveMediaMetadata.tsx/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/api/useSharedLiveMediaMetadata.tsx/index.spec.tsx
@@ -4,7 +4,7 @@ import { useJwt } from 'lib-components';
 import React from 'react';
 import { QueryClient, QueryClientProvider, setLogger } from 'react-query';
 
-import { useVideoMetadata } from '.';
+import { useSharedLiveMediaMetadata } from '.';
 
 setLogger({
   log: console.log,
@@ -20,7 +20,7 @@ jest.mock('lib-components', () => ({
 
 let Wrapper: WrapperComponent<Element>;
 
-describe('useVideoMetadata', () => {
+describe('useSharedLiveMediaMetadata', () => {
   beforeEach(() => {
     useJwt.setState({
       jwt: 'some token',
@@ -44,31 +44,29 @@ describe('useVideoMetadata', () => {
     jest.resetAllMocks();
   });
 
-  it('requests the video metadata', async () => {
-    const videoMetadata = {
-      name: 'Video List',
-      description: 'Viewset for the API of the video object.',
+  it('requests the shared live media metadata', async () => {
+    const sharedLiveMediaMetadata = {
+      name: 'document',
+      description: 'Viewset for the API of the document object.',
       renders: ['application/json', 'text/html'],
       parses: [
         'application/json',
         'application/x-www-form-urlencoded',
         'multipart/form-data',
       ],
-      live: {
-        segment_duration_seconds: 4,
-      },
-      vod: {
-        upload_max_size_bytes: 100,
-      },
+      upload_max_size_bytes: 100,
     };
-    fetchMock.mock(`/api/videos/`, videoMetadata);
+    fetchMock.mock(`/api/sharedlivemedias/`, sharedLiveMediaMetadata);
 
-    const { result, waitFor } = renderHook(() => useVideoMetadata('fr'), {
-      wrapper: Wrapper,
-    });
+    const { result, waitFor } = renderHook(
+      () => useSharedLiveMediaMetadata('fr'),
+      {
+        wrapper: Wrapper,
+      },
+    );
     await waitFor(() => result.current.isSuccess);
 
-    expect(fetchMock.lastCall()![0]).toEqual(`/api/videos/`);
+    expect(fetchMock.lastCall()![0]).toEqual(`/api/sharedlivemedias/`);
     expect(fetchMock.lastCall()![1]).toEqual({
       headers: {
         Authorization: 'Bearer some token',
@@ -77,20 +75,23 @@ describe('useVideoMetadata', () => {
       },
       method: 'OPTIONS',
     });
-    expect(result.current.data).toEqual(videoMetadata);
+    expect(result.current.data).toEqual(sharedLiveMediaMetadata);
     expect(result.current.status).toEqual('success');
   });
 
-  it('fails to get the video metadata', async () => {
-    fetchMock.mock(`/api/videos/`, 404);
+  it('fails to get the shared live media metadata', async () => {
+    fetchMock.mock(`/api/sharedlivemedias/`, 404);
 
-    const { result, waitFor } = renderHook(() => useVideoMetadata('en'), {
-      wrapper: Wrapper,
-    });
+    const { result, waitFor } = renderHook(
+      () => useSharedLiveMediaMetadata('en'),
+      {
+        wrapper: Wrapper,
+      },
+    );
 
     await waitFor(() => result.current.isError);
 
-    expect(fetchMock.lastCall()![0]).toEqual(`/api/videos/`);
+    expect(fetchMock.lastCall()![0]).toEqual(`/api/sharedlivemedias/`);
     expect(fetchMock.lastCall()![1]).toEqual({
       headers: {
         Authorization: 'Bearer some token',

--- a/src/frontend/packages/lib_video/src/api/useSharedLiveMediaMetadata.tsx/index.ts
+++ b/src/frontend/packages/lib_video/src/api/useSharedLiveMediaMetadata.tsx/index.ts
@@ -1,0 +1,45 @@
+import { fetchOne, metadata, SharedLiveMedia } from 'lib-components';
+import { useQuery, UseQueryOptions } from 'react-query';
+
+import { SharedLiveMediaMetadata } from 'types/metadata';
+
+export const useSharedLiveMedia = (
+  sharedLiveMediaId: string,
+  queryConfig?: UseQueryOptions<
+    SharedLiveMedia,
+    'sharedlivemedias',
+    SharedLiveMedia
+  >,
+) => {
+  const key = ['sharedlivemedias', sharedLiveMediaId];
+  return useQuery<SharedLiveMedia, 'sharedlivemedias'>(
+    key,
+    fetchOne,
+    queryConfig,
+  );
+};
+
+export const useSharedLiveMediaMetadata = (
+  locale: string,
+  queryConfig?: UseQueryOptions<
+    SharedLiveMediaMetadata,
+    'sharedlivemedias',
+    SharedLiveMediaMetadata,
+    string[]
+  >,
+) => {
+  const key = ['sharedlivemedias', locale];
+  return useQuery<
+    SharedLiveMediaMetadata,
+    'sharedlivemedias',
+    SharedLiveMediaMetadata,
+    string[]
+  >(key, metadata, {
+    refetchInterval: false,
+    refetchIntervalInBackground: false,
+    refetchOnWindowFocus: false,
+    cacheTime: Infinity,
+    staleTime: Infinity,
+    ...queryConfig,
+  });
+};

--- a/src/frontend/packages/lib_video/src/api/useThumbnailMetadata/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/api/useThumbnailMetadata/index.spec.tsx
@@ -4,7 +4,7 @@ import { useJwt } from 'lib-components';
 import React from 'react';
 import { QueryClient, QueryClientProvider, setLogger } from 'react-query';
 
-import { useVideoMetadata } from '.';
+import { useThumbnailMetadata } from '.';
 
 setLogger({
   log: console.log,
@@ -20,7 +20,7 @@ jest.mock('lib-components', () => ({
 
 let Wrapper: WrapperComponent<Element>;
 
-describe('useVideoMetadata', () => {
+describe('useThumbnailMetadata', () => {
   beforeEach(() => {
     useJwt.setState({
       jwt: 'some token',
@@ -44,31 +44,26 @@ describe('useVideoMetadata', () => {
     jest.resetAllMocks();
   });
 
-  it('requests the video metadata', async () => {
-    const videoMetadata = {
-      name: 'Video List',
-      description: 'Viewset for the API of the video object.',
+  it('requests the thumbnail metadata', async () => {
+    const thumbnailMetadata = {
+      name: 'picture',
+      description: 'Viewset for the API of the thumbnail object.',
       renders: ['application/json', 'text/html'],
       parses: [
         'application/json',
         'application/x-www-form-urlencoded',
         'multipart/form-data',
       ],
-      live: {
-        segment_duration_seconds: 4,
-      },
-      vod: {
-        upload_max_size_bytes: 100,
-      },
+      upload_max_size_bytes: 100,
     };
-    fetchMock.mock(`/api/videos/`, videoMetadata);
+    fetchMock.mock(`/api/thumbnails/`, thumbnailMetadata);
 
-    const { result, waitFor } = renderHook(() => useVideoMetadata('fr'), {
+    const { result, waitFor } = renderHook(() => useThumbnailMetadata('fr'), {
       wrapper: Wrapper,
     });
     await waitFor(() => result.current.isSuccess);
 
-    expect(fetchMock.lastCall()![0]).toEqual(`/api/videos/`);
+    expect(fetchMock.lastCall()![0]).toEqual(`/api/thumbnails/`);
     expect(fetchMock.lastCall()![1]).toEqual({
       headers: {
         Authorization: 'Bearer some token',
@@ -77,20 +72,20 @@ describe('useVideoMetadata', () => {
       },
       method: 'OPTIONS',
     });
-    expect(result.current.data).toEqual(videoMetadata);
+    expect(result.current.data).toEqual(thumbnailMetadata);
     expect(result.current.status).toEqual('success');
   });
 
-  it('fails to get the video metadata', async () => {
-    fetchMock.mock(`/api/videos/`, 404);
+  it('fails to get the thumbnail metadata', async () => {
+    fetchMock.mock(`/api/thumbnails/`, 404);
 
-    const { result, waitFor } = renderHook(() => useVideoMetadata('en'), {
+    const { result, waitFor } = renderHook(() => useThumbnailMetadata('en'), {
       wrapper: Wrapper,
     });
 
     await waitFor(() => result.current.isError);
 
-    expect(fetchMock.lastCall()![0]).toEqual(`/api/videos/`);
+    expect(fetchMock.lastCall()![0]).toEqual(`/api/thumbnails/`);
     expect(fetchMock.lastCall()![1]).toEqual({
       headers: {
         Authorization: 'Bearer some token',

--- a/src/frontend/packages/lib_video/src/api/useThumbnailMetadata/index.ts
+++ b/src/frontend/packages/lib_video/src/api/useThumbnailMetadata/index.ts
@@ -1,0 +1,36 @@
+import { fetchOne, metadata, Thumbnail } from 'lib-components';
+import { useQuery, UseQueryOptions } from 'react-query';
+
+import { ThumbnailMetadata } from 'types/metadata';
+
+export const useThumbnail = (
+  thumbnailId: string,
+  queryConfig?: UseQueryOptions<Thumbnail, 'thumbnails', Thumbnail>,
+) => {
+  const key = ['thumbnails', thumbnailId];
+  return useQuery<Thumbnail, 'thumbnails'>(key, fetchOne, queryConfig);
+};
+
+export const useThumbnailMetadata = (
+  locale: string,
+  queryConfig?: UseQueryOptions<
+    ThumbnailMetadata,
+    'thumbnails',
+    ThumbnailMetadata,
+    string[]
+  >,
+) => {
+  const key = ['thumbnails', locale];
+  return useQuery<ThumbnailMetadata, 'thumbnails', ThumbnailMetadata, string[]>(
+    key,
+    metadata,
+    {
+      refetchInterval: false,
+      refetchIntervalInBackground: false,
+      refetchOnWindowFocus: false,
+      cacheTime: Infinity,
+      staleTime: Infinity,
+      ...queryConfig,
+    },
+  );
+};

--- a/src/frontend/packages/lib_video/src/api/useTimedTextMetadata/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/api/useTimedTextMetadata/index.spec.tsx
@@ -4,7 +4,7 @@ import { useJwt } from 'lib-components';
 import React from 'react';
 import { QueryClient, QueryClientProvider, setLogger } from 'react-query';
 
-import { useVideoMetadata } from '.';
+import { useTimedTextMetadata } from '.';
 
 setLogger({
   log: console.log,
@@ -20,7 +20,7 @@ jest.mock('lib-components', () => ({
 
 let Wrapper: WrapperComponent<Element>;
 
-describe('useVideoMetadata', () => {
+describe('useTimedTextMetadata', () => {
   beforeEach(() => {
     useJwt.setState({
       jwt: 'some token',
@@ -44,31 +44,26 @@ describe('useVideoMetadata', () => {
     jest.resetAllMocks();
   });
 
-  it('requests the video metadata', async () => {
-    const videoMetadata = {
-      name: 'Video List',
-      description: 'Viewset for the API of the video object.',
+  it('requests the timed text metadata', async () => {
+    const timedTextMetadata = {
+      name: 'subtitles',
+      description: 'Viewset for the API of the timed text object.',
       renders: ['application/json', 'text/html'],
       parses: [
         'application/json',
         'application/x-www-form-urlencoded',
         'multipart/form-data',
       ],
-      live: {
-        segment_duration_seconds: 4,
-      },
-      vod: {
-        upload_max_size_bytes: 100,
-      },
+      upload_max_size_bytes: 100,
     };
-    fetchMock.mock(`/api/videos/`, videoMetadata);
+    fetchMock.mock(`/api/timed_text_tracks/`, timedTextMetadata);
 
-    const { result, waitFor } = renderHook(() => useVideoMetadata('fr'), {
+    const { result, waitFor } = renderHook(() => useTimedTextMetadata('fr'), {
       wrapper: Wrapper,
     });
     await waitFor(() => result.current.isSuccess);
 
-    expect(fetchMock.lastCall()![0]).toEqual(`/api/videos/`);
+    expect(fetchMock.lastCall()![0]).toEqual(`/api/timed_text_tracks/`);
     expect(fetchMock.lastCall()![1]).toEqual({
       headers: {
         Authorization: 'Bearer some token',
@@ -77,20 +72,20 @@ describe('useVideoMetadata', () => {
       },
       method: 'OPTIONS',
     });
-    expect(result.current.data).toEqual(videoMetadata);
+    expect(result.current.data).toEqual(timedTextMetadata);
     expect(result.current.status).toEqual('success');
   });
 
-  it('fails to get the video metadata', async () => {
-    fetchMock.mock(`/api/videos/`, 404);
+  it('fails to get the timed text metadata', async () => {
+    fetchMock.mock(`/api/timed_text_tracks/`, 404);
 
-    const { result, waitFor } = renderHook(() => useVideoMetadata('en'), {
+    const { result, waitFor } = renderHook(() => useTimedTextMetadata('en'), {
       wrapper: Wrapper,
     });
 
     await waitFor(() => result.current.isError);
 
-    expect(fetchMock.lastCall()![0]).toEqual(`/api/videos/`);
+    expect(fetchMock.lastCall()![0]).toEqual(`/api/timed_text_tracks/`);
     expect(fetchMock.lastCall()![1]).toEqual({
       headers: {
         Authorization: 'Bearer some token',

--- a/src/frontend/packages/lib_video/src/api/useTimedTextMetadata/index.ts
+++ b/src/frontend/packages/lib_video/src/api/useTimedTextMetadata/index.ts
@@ -1,0 +1,37 @@
+import { fetchOne, metadata, TimedText } from 'lib-components';
+import { useQuery, UseQueryOptions } from 'react-query';
+
+import { TimedTextMetadata } from 'types/metadata';
+
+export const useTimedText = (
+  trackId: string,
+  queryConfig?: UseQueryOptions<TimedText, 'timed_text_tracks', TimedText>,
+) => {
+  const key = ['timed_text_tracks', trackId];
+  return useQuery<TimedText, 'timed_text_tracks'>(key, fetchOne, queryConfig);
+};
+
+export const useTimedTextMetadata = (
+  locale: string,
+  queryConfig?: UseQueryOptions<
+    TimedTextMetadata,
+    'timed_text_tracks',
+    TimedTextMetadata,
+    string[]
+  >,
+) => {
+  const key = ['timed_text_tracks', locale];
+  return useQuery<
+    TimedTextMetadata,
+    'timed_text_tracks',
+    TimedTextMetadata,
+    string[]
+  >(key, metadata, {
+    refetchInterval: false,
+    refetchIntervalInBackground: false,
+    refetchOnWindowFocus: false,
+    cacheTime: Infinity,
+    staleTime: Infinity,
+    ...queryConfig,
+  });
+};

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/LocalizedTimedTextTrackUpload/index.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/LocalizedTimedTextTrackUpload/index.tsx
@@ -38,32 +38,15 @@ export const LocalizedTimedTextTrackUpload = ({
   timedTextModeWidget,
 }: UploadWidgetGenericProps) => {
   const intl = useIntl();
-
   const { addUpload, resetUpload, uploadManagerState } = useUploadManager();
   const timedTextTracks = useTimedTextTrack((state) =>
     state.getTimedTextTracks(),
   );
-
   const filteredTimedTextTracks = timedTextTracks.filter(
     (track) => track.mode === timedTextModeWidget,
   );
-
-  // When an upload is over and successful, it is deleted from the uploadManagerState, in order
-  // to be able to perform a consecutive upload
-  useEffect(() => {
-    filteredTimedTextTracks.forEach((timedText) => {
-      if (
-        timedText.upload_state === uploadState.READY &&
-        uploadManagerState[timedText.id]
-      ) {
-        resetUpload(timedText.id);
-      }
-    });
-  }, [filteredTimedTextTracks, resetUpload, uploadManagerState]);
-
   const hiddenFileInput = useRef<Nullable<HTMLInputElement>>(null);
   const retryUploadIdRef = useRef<Nullable<string>>(null);
-
   const [selectedLanguage, setSelectedLanguage] =
     useState<Nullable<LanguageChoice>>(null);
 
@@ -99,6 +82,24 @@ export const LocalizedTimedTextTrackUpload = ({
       hiddenFileInput.current.click();
     }
   };
+
+  // When an upload is over and successful, it is deleted from the uploadManagerState, in order
+  // to be able to perform a consecutive upload
+  useEffect(() => {
+    filteredTimedTextTracks.forEach((timedText) => {
+      if (
+        timedText.upload_state === uploadState.READY &&
+        uploadManagerState[timedText.id]
+      ) {
+        resetUpload(timedText.id);
+      }
+    });
+  }, [
+    resetUpload,
+    timedTextModeWidget,
+    filteredTimedTextTracks,
+    uploadManagerState,
+  ]);
 
   return (
     <Box direction="column" gap="small" margin={{ top: 'small' }}>

--- a/src/frontend/packages/lib_video/src/components/common/VideoWizard/CreateVOD/UploadVideoForm/UploadVideoRetry/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWizard/CreateVOD/UploadVideoForm/UploadVideoRetry/index.spec.tsx
@@ -8,11 +8,30 @@ import { UploadVideoRetry } from '.';
 const mockedOnClick = jest.fn();
 
 describe('<UploadVideoRetry />', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
   it('renders UploadVideoRetry and clicks on it', () => {
     render(<UploadVideoRetry onClickRetry={mockedOnClick} />);
     screen.getByText(
       'An error occured when uploading your video. Please retry.',
     );
+    const retryButton = screen.getByRole('button');
+
+    userEvent.click(retryButton);
+
+    expect(mockedOnClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders UploadVideoRetry with sizeError and clicks on it', () => {
+    render(
+      <UploadVideoRetry
+        onClickRetry={mockedOnClick}
+        maxSize={Math.pow(10, 9)}
+      />,
+    );
+    screen.getByText('Error : File too large. Max size authorized is 1 GB.');
     const retryButton = screen.getByRole('button');
 
     userEvent.click(retryButton);

--- a/src/frontend/packages/lib_video/src/components/common/VideoWizard/CreateVOD/UploadVideoForm/UploadVideoRetry/index.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWizard/CreateVOD/UploadVideoForm/UploadVideoRetry/index.tsx
@@ -1,5 +1,5 @@
 import { Text } from 'grommet';
-import { RetryUploadButton } from 'lib-components';
+import { formatSizeErrorScale, RetryUploadButton } from 'lib-components';
 import React from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 
@@ -12,19 +12,40 @@ const messages = defineMessages({
       "Button's label offering the user to go validate is form and create a new video.",
     id: 'components.UploadVideoRetry.errorOccuredVideoUpload',
   },
+  errorFileTooLarge: {
+    defaultMessage: 'Error : File too large. Max size authorized is {maxSize}.',
+    description:
+      "Button's label explaining the 400 error that happens on large files upload.",
+    id: 'components.UploadVideoRetry.errorFileTooLarge',
+  },
 });
 
 interface UploadVideoRetryProps {
   onClickRetry: () => void;
+  maxSize?: number;
 }
 
-export const UploadVideoRetry = ({ onClickRetry }: UploadVideoRetryProps) => {
+export const UploadVideoRetry = ({
+  onClickRetry,
+  maxSize,
+}: UploadVideoRetryProps) => {
   const intl = useIntl();
+  let outputMessage: string;
+
+  if (maxSize) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+    const formattedMaxSize = formatSizeErrorScale(maxSize) as string;
+    outputMessage = intl.formatMessage(messages.errorFileTooLarge, {
+      maxSize: formattedMaxSize,
+    });
+  } else {
+    outputMessage = intl.formatMessage(messages.errorOccuredVideoUpload);
+  }
 
   return (
     <BigDashedBox direction="row">
       <Text color="red-active" size="1rem">
-        {intl.formatMessage(messages.errorOccuredVideoUpload)}
+        {outputMessage}
       </Text>
       <RetryUploadButton
         color="red-active"

--- a/src/frontend/packages/lib_video/src/components/common/VideoWizard/CreateVOD/UploadVideoForm/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWizard/CreateVOD/UploadVideoForm/index.spec.tsx
@@ -2,6 +2,7 @@
 /* eslint-disable testing-library/no-container */
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import fetchMock from 'fetch-mock';
 import {
   videoMockFactory,
   UploadManagerStatus,
@@ -36,6 +37,9 @@ URL.createObjectURL = () => '/blob/path/to/video';
 describe('<UploadVideoForm />', () => {
   beforeEach(() => {
     jest.resetAllMocks();
+  });
+  afterEach(() => {
+    fetchMock.restore();
   });
 
   it('renders UploadVideoForm when there is no file selected', () => {
@@ -182,6 +186,61 @@ describe('<UploadVideoForm />', () => {
 
     await screen.findByText(
       'An error occured when uploading your video. Please retry.',
+    );
+
+    const retryButton = screen.getByRole('button');
+
+    userEvent.click(retryButton);
+
+    expect(mockedSetVideoFile).toHaveBeenNthCalledWith(2, null);
+    expect(mockedResetUpload).toHaveBeenNthCalledWith(1, mockedVideo.id);
+    expect(mockedOnRetry).toHaveBeenCalledTimes(1);
+
+    screen.getByText('Add a video or drag & drop it');
+  });
+
+  it('renders UploadVideoForm with a file too large and clicks on the retry button', async () => {
+    const mockedVideo = videoMockFactory({ upload_state: uploadState.ERROR });
+    fetchMock.mock('/api/videos/', {
+      vod: {
+        upload_max_size_bytes: Math.pow(10, 9),
+      },
+    });
+
+    const mockedResetUpload = jest.fn();
+    mockUseUploadManager.mockReturnValue({
+      addUpload: jest.fn(),
+      resetUpload: mockedResetUpload,
+      uploadManagerState: {
+        [mockedVideo.id]: {
+          file: new File(['(⌐□_□)'], 'video.mp4', {
+            type: 'video/mp4',
+          }),
+          objectType: modelName.VIDEOS,
+          objectId: mockedVideo.id,
+          progress: 0,
+          status: UploadManagerStatus.ERR_SIZE,
+          message: 'file too large, max size allowed is 1 GB',
+        },
+      },
+    });
+
+    render(
+      wrapInVideo(
+        <UploadVideoForm
+          onRetry={mockedOnRetry}
+          setVideoFile={mockedSetVideoFile}
+        />,
+        mockedVideo,
+      ),
+    );
+    const file = new File(['(⌐□_□)'], 'course.mp4', { type: 'video/mp4' });
+    const hiddenInput = screen.getByTestId('input-video-test-id');
+
+    userEvent.upload(hiddenInput, file);
+
+    await screen.findByText(
+      'Error : File too large. Max size authorized is 1 GB.',
     );
 
     const retryButton = screen.getByRole('button');

--- a/src/frontend/packages/lib_video/src/components/common/VideoWizard/CreateVOD/UploadVideoForm/index.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWizard/CreateVOD/UploadVideoForm/index.tsx
@@ -1,3 +1,4 @@
+import { useVideoMetadata } from 'api';
 import { Nullable } from 'lib-common';
 import {
   UploadManagerStatus,
@@ -5,6 +6,7 @@ import {
   uploadState,
 } from 'lib-components';
 import React, { useState } from 'react';
+import { useIntl } from 'react-intl';
 
 import { useCurrentVideo } from 'hooks/useCurrentVideo';
 
@@ -22,7 +24,9 @@ export const UploadVideoForm = ({
   onRetry,
   setVideoFile,
 }: UploadVideoFormProps) => {
+  const intl = useIntl();
   const video = useCurrentVideo();
+  const metadata = useVideoMetadata(intl.locale);
   const { resetUpload, uploadManagerState } = useUploadManager();
   const [src, setSrc] = useState<Nullable<string>>(null);
 
@@ -41,6 +45,19 @@ export const UploadVideoForm = ({
     uploadManagerState[video.id] &&
     uploadManagerState[video.id].status !== UploadManagerStatus.SUCCESS
   ) {
+    if (uploadManagerState[video.id].status === UploadManagerStatus.ERR_SIZE) {
+      return (
+        <UploadVideoRetry
+          onClickRetry={() => {
+            setVideoFile(null);
+            setSrc(null);
+            resetUpload(video.id);
+            onRetry();
+          }}
+          maxSize={metadata.data?.vod.upload_max_size_bytes}
+        />
+      );
+    }
     if (
       uploadManagerState[video.id].status === UploadManagerStatus.ERR_UPLOAD ||
       video.upload_state === uploadState.ERROR

--- a/src/frontend/packages/lib_video/src/types/metadata.ts
+++ b/src/frontend/packages/lib_video/src/types/metadata.ts
@@ -1,4 +1,10 @@
-import { Resource, TimedText, Video } from 'lib-components';
+import {
+  Resource,
+  SharedLiveMedia,
+  Thumbnail,
+  TimedText,
+  Video,
+} from 'lib-components';
 
 import { RouteOptions } from './RouteOptions';
 
@@ -14,6 +20,20 @@ export interface VideoMetadata extends ResourceMetadata<Video> {
   live: {
     segment_duration_seconds: number;
   };
+  vod: {
+    upload_max_size_bytes: number;
+  };
 }
 
-export type TimedTextMetadata = ResourceMetadata<TimedText>;
+export interface TimedTextMetadata extends ResourceMetadata<TimedText> {
+  upload_max_size_bytes: number;
+}
+
+export interface ThumbnailMetadata extends ResourceMetadata<Thumbnail> {
+  upload_max_size_bytes: number;
+}
+
+export interface SharedLiveMediaMetadata
+  extends ResourceMetadata<SharedLiveMedia> {
+  upload_max_size_bytes: number;
+}


### PR DESCRIPTION
## Purpose

For each uploaded file on S3 we set a max file size limit. But we don't control before the upload starts if the file size is higher than the limit we set.

## Proposal

In the response when we fetch a policy upload, this max file size should be added and then in the component managing the upload we should check if it is possible to determine this size. Then we check the size and if it's the file size is higher thant the max file size, the upload is aborted with an error message.

- [ ] For each resource, add a serialization check in the backend
- [ ] Display an adapted error message in the front when triggering the serialization error

