### PR TITLE
♻️(back) teacher from shibboleth are now administrator in their orga

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Remove deprecated params from BBB API calls
 - Keep resource property in AppData
 - Create a lib to handle all components for video (VOD and live)
+- User created from shibboleth with TEACHER affiliation are now Administrator
+  in their organization
 
 ### Fixed
 

--- a/src/backend/marsha/account/social_pipeline/organization.py
+++ b/src/backend/marsha/account/social_pipeline/organization.py
@@ -5,7 +5,7 @@ from django.db.transaction import atomic
 from social_edu_federation.defaults import EduPersonAffiliationEnum
 
 from marsha.account.models import IdpOrganizationAssociation
-from marsha.core.models import INSTRUCTOR, STUDENT, Organization, OrganizationAccess
+from marsha.core.models import ADMINISTRATOR, STUDENT, Organization, OrganizationAccess
 
 
 @atomic()
@@ -121,7 +121,7 @@ def create_organization_from_saml(
         OrganizationAccess.objects.create(
             user=user,
             organization=association.organization,
-            role=INSTRUCTOR
+            role=ADMINISTRATOR
             if (
                 details.get("roles", None)
                 and EduPersonAffiliationEnum.TEACHER.value in details["roles"]

--- a/src/backend/marsha/account/tests/test_social_pipeline_organization.py
+++ b/src/backend/marsha/account/tests/test_social_pipeline_organization.py
@@ -11,7 +11,7 @@ from marsha.account.social_pipeline.organization import create_organization_from
 from marsha.account.tests.utils import override_saml_fer_settings
 from marsha.core.factories import OrganizationFactory, UserFactory
 from marsha.core.models import (
-    INSTRUCTOR,
+    ADMINISTRATOR,
     NONE,
     STUDENT,
     Organization,
@@ -165,7 +165,7 @@ class OrganizationPipelineTestCase(TestCase):
             )
 
         # Test results
-        self.assertLatestOrganizationAccessIsConsistent(role=INSTRUCTOR)
+        self.assertLatestOrganizationAccessIsConsistent(role=ADMINISTRATOR)
 
         # Call pipeline step again
         with self.assertNumQueries(2):  # @atomic(): 2 savepoints
@@ -179,7 +179,7 @@ class OrganizationPipelineTestCase(TestCase):
             )
 
         # Test results are still unique
-        self.assertLatestOrganizationAccessIsConsistent(role=INSTRUCTOR)
+        self.assertLatestOrganizationAccessIsConsistent(role=ADMINISTRATOR)
 
         # Edge case: assert we don't fail if `new_association` with already existing data
         create_organization_from_saml(
@@ -190,7 +190,7 @@ class OrganizationPipelineTestCase(TestCase):
             response=self.saml_response,
             new_association=True,
         )
-        self.assertLatestOrganizationAccessIsConsistent(role=INSTRUCTOR)
+        self.assertLatestOrganizationAccessIsConsistent(role=ADMINISTRATOR)
 
     def test_create_organization_from_saml_student_or_unknown_new(self):
         """Assert new student from new organization initializes properly."""
@@ -273,7 +273,7 @@ class OrganizationPipelineTestCase(TestCase):
             )
 
         # Test results
-        self.assertLatestOrganizationAccessIsConsistent(role=INSTRUCTOR)
+        self.assertLatestOrganizationAccessIsConsistent(role=ADMINISTRATOR)
 
         # Call pipeline step again
         with self.assertNumQueries(2):  # @atomic(): 2 savepoints
@@ -287,7 +287,7 @@ class OrganizationPipelineTestCase(TestCase):
             )
 
         # Test results are still unique
-        self.assertLatestOrganizationAccessIsConsistent(role=INSTRUCTOR)
+        self.assertLatestOrganizationAccessIsConsistent(role=ADMINISTRATOR)
 
     def test_create_organization_from_saml_student_existing_organization(self):
         """


### PR DESCRIPTION
## Purpose

To correctly use the standalone site, when a user coming from shibboleth is created, it should be administrator in its organization. Doing this change, they are able to create new playlist and manage them.

## Proposal

- [x] ser created from shibboleth with TEACHER affiliation are now Administrator in their organization

