### PR TITLE
✨(feature) give organization instructor right to create playlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   - service worker 401 reconnect
   - Password reset views & API
   - Renater IdP's logo display on login page
+  - Allow organization instructors to create playlists
 
 ### Changed
 

--- a/src/backend/marsha/core/api/account.py
+++ b/src/backend/marsha/core/api/account.py
@@ -8,7 +8,7 @@ from rest_framework.response import Response
 from rest_framework_simplejwt.exceptions import InvalidToken, TokenError
 
 from .. import permissions, serializers
-from ..models import ADMINISTRATOR, Organization
+from ..models import ADMINISTRATOR, INSTRUCTOR, Organization
 from ..serializers import ChallengeTokenSerializer
 from .base import APIViewMixin, ObjectPkMixin
 
@@ -109,7 +109,7 @@ class OrganizationViewSet(APIViewMixin, ObjectPkMixin, viewsets.ModelViewSet):
                 .get_queryset()
                 .filter(
                     user_accesses__user_id=self.request.user.id,
-                    user_accesses__role=ADMINISTRATOR,
+                    user_accesses__role__in=[ADMINISTRATOR, INSTRUCTOR],
                 )
             )
 

--- a/src/backend/marsha/core/api/playlist.py
+++ b/src/backend/marsha/core/api/playlist.py
@@ -5,7 +5,7 @@ import django_filters
 from rest_framework import filters, viewsets
 
 from .. import permissions, serializers
-from ..models import ADMINISTRATOR, Playlist
+from ..models import ADMINISTRATOR, INSTRUCTOR, Playlist
 from .base import APIViewMixin, ObjectPkMixin
 
 
@@ -44,8 +44,8 @@ class PlaylistViewSet(APIViewMixin, ObjectPkMixin, viewsets.ModelViewSet):
             permission_classes = [permissions.UserIsAuthenticated]
         elif self.action in ["retrieve"]:
             permission_classes = [
-                # users who are playlist administrators
-                permissions.IsPlaylistAdmin
+                # users who are playlist administrators or instructor
+                permissions.IsPlaylistAdminOrInstructor
                 # or users who are administrators of the playlist organization
                 | permissions.IsPlaylistOrganizationAdmin
                 # or
@@ -86,7 +86,7 @@ class PlaylistViewSet(APIViewMixin, ObjectPkMixin, viewsets.ModelViewSet):
                 )
                 | Q(
                     user_accesses__user_id=self.request.user.id,
-                    user_accesses__role=ADMINISTRATOR,
+                    user_accesses__role__in=[ADMINISTRATOR, INSTRUCTOR],
                 )
             )
             .distinct()

--- a/src/backend/marsha/core/api/playlist.py
+++ b/src/backend/marsha/core/api/playlist.py
@@ -74,10 +74,17 @@ class PlaylistViewSet(APIViewMixin, ObjectPkMixin, viewsets.ModelViewSet):
             permission_classes = [permissions.IsParamsOrganizationInstructorOrAdmin]
         elif self.action in ["partial_update", "update"]:
             permission_classes = [
-                # requests made with a JWT token granting instructor or administrator
-                (permissions.IsTokenInstructor | permissions.IsTokenAdmin)
-                # and to an object related to the playlist
-                & permissions.IsTokenResourceRouteObjectRelatedPlaylist
+                # users who are playlist administrators or instructor
+                permissions.IsPlaylistAdminOrInstructor
+                # or users who are administrators of the playlist organization
+                | permissions.IsPlaylistOrganizationAdmin
+                # or
+                | (
+                    # requests made with a JWT token granting instructor or administrator
+                    (permissions.IsTokenInstructor | permissions.IsTokenAdmin)
+                    # and to an object related to the playlist
+                    & permissions.IsTokenResourceRouteObjectRelatedPlaylist
+                )
             ]
         else:
             try:

--- a/src/backend/marsha/core/api/playlist.py
+++ b/src/backend/marsha/core/api/playlist.py
@@ -57,7 +57,7 @@ class PlaylistViewSet(APIViewMixin, ObjectPkMixin, viewsets.ModelViewSet):
                 )
             ]
         elif self.action in ["create"]:
-            permission_classes = [permissions.IsParamsOrganizationAdmin]
+            permission_classes = [permissions.IsParamsOrganizationInstructorOrAdmin]
         elif self.action in ["partial_update", "update"]:
             permission_classes = [
                 # requests made with a JWT token granting instructor or administrator

--- a/src/backend/marsha/core/serializers/playlist.py
+++ b/src/backend/marsha/core/serializers/playlist.py
@@ -32,6 +32,8 @@ class PlaylistSerializer(serializers.ModelSerializer):
             "portable_to",
             "title",
             "users",
+            # Non-model fields
+            "can_edit",
         ]
 
     portable_to = serializers.SerializerMethodField(read_only=False)
@@ -47,6 +49,10 @@ class PlaylistSerializer(serializers.ModelSerializer):
         required=False,
         allow_null=True,
     )
+
+    # Field consuming the `can_edit` property filled by
+    # the `PlaylistManager` `annotate_can_edit`
+    can_edit = serializers.BooleanField(read_only=True)
 
     def get_portable_to(self, obj):
         """Getter for portable_to attribute instead of PlaylistSerializer to prevent recursion."""

--- a/src/backend/marsha/core/tests/api/playlists/test_list.py
+++ b/src/backend/marsha/core/tests/api/playlists/test_list.py
@@ -99,6 +99,7 @@ class PlaylistListAPITest(TestCase):
                     "portable_to": [],
                     "title": "Second playlist",
                     "users": [],
+                    "can_edit": True,
                 },
                 {
                     "consumer_site": {
@@ -120,6 +121,7 @@ class PlaylistListAPITest(TestCase):
                     "portable_to": [],
                     "title": "First playlist",
                     "users": [],
+                    "can_edit": True,
                 },
             ],
         )
@@ -193,6 +195,7 @@ class PlaylistListAPITest(TestCase):
                     "portable_to": [],
                     "title": "First playlist",
                     "users": [],
+                    "can_edit": True,
                 },
             ],
         )
@@ -291,6 +294,7 @@ class PlaylistListAPITest(TestCase):
                     "portable_to": [],
                     "title": "Fourth playlist",
                     "users": [str(user.id)],
+                    "can_edit": True,
                 },
                 {
                     "consumer_site": {
@@ -312,6 +316,7 @@ class PlaylistListAPITest(TestCase):
                     "portable_to": [],
                     "title": "Third playlist",
                     "users": [str(user.id)],
+                    "can_edit": True,
                 },
                 {
                     "consumer_site": {
@@ -333,6 +338,7 @@ class PlaylistListAPITest(TestCase):
                     "portable_to": [],
                     "title": "First playlist",
                     "users": [str(user.id)],
+                    "can_edit": True,
                 },
             ],
         )
@@ -448,6 +454,7 @@ class PlaylistListAPITest(TestCase):
                     "portable_to": [],
                     "title": "First playlist",
                     "users": [str(user.id)],
+                    "can_edit": True,
                 },
                 {
                     "consumer_site": {
@@ -469,6 +476,7 @@ class PlaylistListAPITest(TestCase):
                     "portable_to": [],
                     "title": "Third playlist",
                     "users": [str(user.id)],
+                    "can_edit": True,
                 },
                 {
                     "consumer_site": {
@@ -487,6 +495,7 @@ class PlaylistListAPITest(TestCase):
                     "portable_to": [],
                     "title": "Fourth playlist",
                     "users": [str(user.id)],
+                    "can_edit": True,
                 },
             ],
         )

--- a/src/backend/marsha/core/tests/api/playlists/test_retrieve.py
+++ b/src/backend/marsha/core/tests/api/playlists/test_retrieve.py
@@ -48,7 +48,7 @@ class PlaylistRetrieveAPITest(TestCase):
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 200)
 
     def test_retrieve_playlist_through_video_token_instructor(self):
         """Playlist instructors can retrieve playlists through video token."""

--- a/src/backend/marsha/core/tests/test_api_playlist_portability.py
+++ b/src/backend/marsha/core/tests/test_api_playlist_portability.py
@@ -35,7 +35,7 @@ class PlaylistPortabilityAPITest(TestCase):
         """
         video = factories.VideoFactory()
 
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(8):
             response = self._patch_video(video, {})
 
         self.assertEqual(response.status_code, 200)
@@ -50,7 +50,7 @@ class PlaylistPortabilityAPITest(TestCase):
         """
         video = factories.VideoFactory()
 
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(9):
             response = self._patch_video(video, {"portable_to": []})
 
         self.assertEqual(response.status_code, 200)
@@ -66,7 +66,7 @@ class PlaylistPortabilityAPITest(TestCase):
         video = factories.VideoFactory()
         new_playlist = factories.PlaylistFactory()
 
-        with self.assertNumQueries(10):
+        with self.assertNumQueries(12):
             response = self._patch_video(video, {"portable_to": [str(new_playlist.id)]})
 
         self.assertEqual(response.status_code, 200)
@@ -253,7 +253,7 @@ class PlaylistPortabilityAPITest(TestCase):
         ported_to_playlist = factories.PlaylistFactory()
         video.playlist.portable_to.add(ported_to_playlist)
 
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(8):
             response = self._patch_video(video, {})
 
         self.assertEqual(response.status_code, 200)
@@ -270,7 +270,7 @@ class PlaylistPortabilityAPITest(TestCase):
         ported_to_playlist = factories.PlaylistFactory()
         video.playlist.portable_to.add(ported_to_playlist)
 
-        with self.assertNumQueries(9):
+        with self.assertNumQueries(11):
             response = self._patch_video(video, {"portable_to": []})
 
         self.assertEqual(response.status_code, 200)
@@ -287,7 +287,7 @@ class PlaylistPortabilityAPITest(TestCase):
         ported_to_playlist = factories.PlaylistFactory()
         video.playlist.portable_to.add(ported_to_playlist)
 
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(10):
             response = self._patch_video(
                 video, {"portable_to": [str(ported_to_playlist.id)]}
             )

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Create/ClassRoomCreateForm.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Create/ClassRoomCreateForm.spec.tsx
@@ -20,7 +20,7 @@ describe('<ClassRoomCreateForm />', () => {
 
   beforeEach(() => {
     fetchMock.get(
-      '/api/playlists/?limit=20&offset=0&ordering=-created_on',
+      '/api/playlists/?limit=20&offset=0&ordering=-created_on&can_edit=true',
       deferred.promise,
     );
   });

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Create/ClassRoomCreateForm.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Create/ClassRoomCreateForm.tsx
@@ -68,6 +68,7 @@ const ClassroomCreateForm = ({ onSubmit }: ClassroomCreateFormProps) => {
       offset: `${currentPlaylistPage * ITEM_PER_PAGE}`,
       limit: `${ITEM_PER_PAGE}`,
       ordering: PlaylistOrderType.BY_CREATED_ON_REVERSED,
+      can_edit: 'true',
     },
     { keepPreviousData: true, staleTime: 20000 },
   );

--- a/src/frontend/apps/standalone_site/src/features/Playlist/api/usePlaylists/index.ts
+++ b/src/frontend/apps/standalone_site/src/features/Playlist/api/usePlaylists/index.ts
@@ -18,6 +18,7 @@ type UsePlaylistsParams = {
   limit: string;
   offset: string;
   ordering?: PlaylistOrderType;
+  can_edit?: 'true' | 'false'; // boolean as string
 };
 
 export const usePlaylists = (


### PR DESCRIPTION
## Purpose

Using the standalone site, instructors should be able to create their own playlist and classroom in it. Before this PR, only organization instructors can do that.

## Proposal

In this PR we introduce the following changes:

- [x] Organization instructor can now create a new playlist
- [x] Organization instructor can list organization they belong to (ie they have a role `instructor` on the organization)
- [ ]  💩 Organization instructor can see all playlists in the `My Playlists` page
- [x] When creating a classroom, only the playlist you have administrator or instructor role on are displayed.
- [ ] 💩 Organization instructor should be able to see (`read only`) all organization classrooms, but they cannot add documents
- [x] Playlist administrator or instructor can update the playlist
