### PR TITLE
Feature/apichard/upload video max size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - lti:
   - service worker 401 reconnect
+- Add a check on video file size when uploading content 
 
 ### Changed
 

--- a/src/backend/marsha/bbb/serializers.py
+++ b/src/backend/marsha/bbb/serializers.py
@@ -19,7 +19,7 @@ from marsha.bbb.utils.bbb_utils import (
 )
 from marsha.bbb.utils.tokens import create_classroom_stable_invite_jwt
 from marsha.core.serializers import (
-    InitiateUploadSerializer,
+    BaseInitiateUploadSerializer,
     UploadableFileWithExtensionSerializerMixin,
 )
 from marsha.core.serializers.base import ReadOnlyModelSerializer
@@ -302,8 +302,18 @@ class ClassroomDocumentSerializer(
         return None
 
 
-class ClassroomDocumentInitiateUploadSerializer(InitiateUploadSerializer):
+class ClassroomDocumentInitiateUploadSerializer(BaseInitiateUploadSerializer):
     """An initiate-upload serializer dedicated to classroom document."""
+
+    @property
+    def max_upload_file_size(self):
+        """return the class room document max file size define in the settings.
+
+        The @property decorator is used to ease the use of @override_settings
+        in tests. Otherwise the setting is not changed and we can't easily test
+        an upload with a size higher than the one defined in the settings
+        """
+        return settings.CLASSROOM_DOCUMENT_SOURCE_MAX_SIZE
 
     def validate(self, attrs):
         """Validate if the mimetype is allowed or not."""

--- a/src/backend/marsha/bbb/tests/api/classroomdocument/test_initiate_upload.py
+++ b/src/backend/marsha/bbb/tests/api/classroomdocument/test_initiate_upload.py
@@ -58,7 +58,7 @@ class ClassroomDocumentInitiateUploadAPITest(TestCase):
             mock_dt.utcnow = mock.Mock(return_value=now)
             response = self.client.post(
                 f"/api/classroomdocuments/{classroom_document.id}/initiate-upload/",
-                {"filename": "foo.pdf", "mimetype": "application/pdf"},
+                {"filename": "foo.pdf", "mimetype": "application/pdf", "size": 10},
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
                 content_type="application/json",
             )
@@ -116,7 +116,7 @@ class ClassroomDocumentInitiateUploadAPITest(TestCase):
             mock_dt.utcnow = mock.Mock(return_value=now)
             response = self.client.post(
                 f"/api/classroomdocuments/{classroom_document.id}/initiate-upload/",
-                {"filename": "foo", "mimetype": "application/pdf"},
+                {"filename": "foo", "mimetype": "application/pdf", "size": 10},
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
                 content_type="application/json",
             )
@@ -174,7 +174,7 @@ class ClassroomDocumentInitiateUploadAPITest(TestCase):
             mock_dt.utcnow = mock.Mock(return_value=now)
             response = self.client.post(
                 f"/api/classroomdocuments/{classroom_document.id}/initiate-upload/",
-                {"filename": "foo", "mimetype": ""},
+                {"filename": "foo", "mimetype": "", "size": 10},
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
                 content_type="application/json",
             )
@@ -204,7 +204,7 @@ class ClassroomDocumentInitiateUploadAPITest(TestCase):
             mock_dt.utcnow = mock.Mock(return_value=now)
             response = self.client.post(
                 f"/api/classroomdocuments/{classroom_document.id}/initiate-upload/",
-                {"filename": "foo", "mimetype": "application/wrong-type"},
+                {"filename": "foo", "mimetype": "application/wrong-type", "size": 10},
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
                 content_type="application/json",
             )
@@ -236,7 +236,7 @@ class ClassroomDocumentInitiateUploadAPITest(TestCase):
             mock_dt.utcnow = mock.Mock(return_value=now)
             response = self.client.post(
                 f"/api/classroomdocuments/{classroom_document.id}/initiate-upload/",
-                {"filename": "foo.pdf", "mimetype": "application/pdf"},
+                {"filename": "foo.pdf", "mimetype": "application/pdf", "size": 10},
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
                 content_type="application/json",
             )
@@ -265,7 +265,7 @@ class ClassroomDocumentInitiateUploadAPITest(TestCase):
             mock_dt.utcnow = mock.Mock(return_value=now)
             response = self.client.post(
                 f"/api/classroomdocuments/{classroom_document.id}/initiate-upload/",
-                {"filename": "foo.pdf", "mimetype": "application/pdf"},
+                {"filename": "foo.pdf", "mimetype": "application/pdf", "size": 10},
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
                 content_type="application/json",
             )
@@ -326,7 +326,7 @@ class ClassroomDocumentInitiateUploadAPITest(TestCase):
             mock_dt.utcnow = mock.Mock(return_value=now)
             response = self.client.post(
                 f"/api/classroomdocuments/{classroom_document.id}/initiate-upload/",
-                {"filename": "foo.pdf", "mimetype": "application/pdf"},
+                {"filename": "foo.pdf", "mimetype": "application/pdf", "size": 10},
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
                 content_type="application/json",
             )

--- a/src/backend/marsha/core/api/file.py
+++ b/src/backend/marsha/core/api/file.py
@@ -77,10 +77,9 @@ class DocumentViewSet(
             HttpResponse carrying the AWS S3 upload policy as a JSON object.
 
         """
-        serializer = serializers.InitiateUploadSerializer(data=request.data)
+        serializer = serializers.DocumentUploadSerializer(data=request.data)
 
-        if serializer.is_valid() is not True:
-            return Response(serializer.errors, status=400)
+        serializer.is_valid(raise_exception=True)
 
         extension = splitext(serializer.validated_data["filename"])[
             1

--- a/src/backend/marsha/core/api/video.py
+++ b/src/backend/marsha/core/api/video.py
@@ -230,6 +230,9 @@ class VideoViewSet(APIViewMixin, ObjectPkMixin, viewsets.ModelViewSet):
             HttpResponse carrying the upload policy as a JSON object.
 
         """
+        serializer = serializers.VideoUploadSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
         response = storage.get_initiate_backend().initiate_video_upload(request, pk)
 
         # Reset the upload state of the video

--- a/src/backend/marsha/core/metadata.py
+++ b/src/backend/marsha/core/metadata.py
@@ -1,4 +1,4 @@
-"""This module holds custome metadata class dedicated to Marsha."""
+"""This module holds custom metadata class dedicated to Marsha."""
 from django.conf import settings
 
 from rest_framework.metadata import SimpleMetadata
@@ -13,5 +13,6 @@ class VideoMetadata(SimpleMetadata):
         metadata["live"] = {
             "segment_duration_seconds": settings.LIVE_SEGMENT_DURATION_SECONDS
         }
+        metadata["vod"] = {"upload_max_size_bytes": settings.VIDEO_SOURCE_MAX_SIZE}
 
         return metadata

--- a/src/backend/marsha/core/tests/test_api_document.py
+++ b/src/backend/marsha/core/tests/test_api_document.py
@@ -400,7 +400,7 @@ class DocumentAPITest(TestCase):
             mock_dt.utcnow = mock.Mock(return_value=now)
             response = self.client.post(
                 f"/api/documents/{document.id}/initiate-upload/",
-                {"filename": "foo.pdf", "mimetype": "application/pdf"},
+                {"filename": "foo.pdf", "mimetype": "application/pdf", "size": 10},
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
                 content_type="application/json",
             )
@@ -452,7 +452,7 @@ class DocumentAPITest(TestCase):
             mock_dt.utcnow = mock.Mock(return_value=now)
             response = self.client.post(
                 f"/api/documents/{document.id}/initiate-upload/",
-                {"filename": "foo", "mimetype": "application/pdf"},
+                {"filename": "foo", "mimetype": "application/pdf", "size": 10},
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
                 content_type="application/json",
             )
@@ -504,7 +504,7 @@ class DocumentAPITest(TestCase):
             mock_dt.utcnow = mock.Mock(return_value=now)
             response = self.client.post(
                 f"/api/documents/{document.id}/initiate-upload/",
-                {"filename": "foo", "mimetype": ""},
+                {"filename": "foo", "mimetype": "", "size": 10},
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
                 content_type="application/json",
             )

--- a/src/backend/marsha/core/tests/test_api_shared_live_media.py
+++ b/src/backend/marsha/core/tests/test_api_shared_live_media.py
@@ -1998,7 +1998,11 @@ class SharedLiveMediaAPITest(TestCase):
 
         response = self.client.post(
             f"/api/sharedlivemedias/{shared_live_media.id}/initiate-upload/",
-            {"filename": "python extensions.pdf", "mimetype": "application/pdf"},
+            {
+                "filename": "python extensions.pdf",
+                "mimetype": "application/pdf",
+                "size": 10,
+            },
             content_type="application/json",
         )
 
@@ -2013,7 +2017,11 @@ class SharedLiveMediaAPITest(TestCase):
 
         response = self.client.post(
             f"/api/sharedlivemedias/{shared_live_media.id}/initiate-upload/",
-            {"filename": "python extensions.pdf", "mimetype": "application/pdf"},
+            {
+                "filename": "python extensions.pdf",
+                "mimetype": "application/pdf",
+                "size": 10,
+            },
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
@@ -2037,7 +2045,11 @@ class SharedLiveMediaAPITest(TestCase):
             mock_dt.utcnow = mock.Mock(return_value=now)
             response = self.client.post(
                 f"/api/sharedlivemedias/{shared_live_media.id}/initiate-upload/",
-                {"filename": "python extensions.pdf", "mimetype": "application/pdf"},
+                {
+                    "filename": "python extensions.pdf",
+                    "mimetype": "application/pdf",
+                    "size": 10,
+                },
                 content_type="application/json",
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
@@ -2095,7 +2107,11 @@ class SharedLiveMediaAPITest(TestCase):
             mock_dt.utcnow = mock.Mock(return_value=now)
             response = self.client.post(
                 f"/api/sharedlivemedias/{shared_live_media.id}/initiate-upload/",
-                {"filename": "python extensions", "mimetype": "application/pdf"},
+                {
+                    "filename": "python extensions",
+                    "mimetype": "application/pdf",
+                    "size": 10,
+                },
                 content_type="application/json",
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
@@ -2153,7 +2169,7 @@ class SharedLiveMediaAPITest(TestCase):
             mock_dt.utcnow = mock.Mock(return_value=now)
             response = self.client.post(
                 f"/api/sharedlivemedias/{shared_live_media.id}/initiate-upload/",
-                {"filename": "python extensions", "mimetype": ""},
+                {"filename": "python extensions", "mimetype": "", "size": 10},
                 content_type="application/json",
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
@@ -2182,7 +2198,11 @@ class SharedLiveMediaAPITest(TestCase):
             mock_dt.utcnow = mock.Mock(return_value=now)
             response = self.client.post(
                 f"/api/sharedlivemedias/{shared_live_media.id}/initiate-upload/",
-                {"filename": "python extensions", "mimetype": "application/wrong-type"},
+                {
+                    "filename": "python extensions",
+                    "mimetype": "application/wrong-type",
+                    "size": 10,
+                },
                 content_type="application/json",
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
@@ -2204,7 +2224,11 @@ class SharedLiveMediaAPITest(TestCase):
             self.client.login(username=user.username, password="test")
             response = self.client.post(
                 f"/api/sharedlivemedias/{shared_live_media.id}/initiate-upload/",
-                {"filename": "python extensions.pdf", "mimetype": "application/pdf"},
+                {
+                    "filename": "python extensions.pdf",
+                    "mimetype": "application/pdf",
+                    "size": 10,
+                },
                 content_type="application/json",
             )
             self.assertEqual(response.status_code, 401)
@@ -2222,7 +2246,11 @@ class SharedLiveMediaAPITest(TestCase):
 
         response = self.client.post(
             f"/api/sharedlivemedias/{shared_live_media.id}/initiate-upload/",
-            {"filename": "python extensions.pdf", "mimetype": "application/pdf"},
+            {
+                "filename": "python extensions.pdf",
+                "mimetype": "application/pdf",
+                "size": 10,
+            },
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             content_type="application/json",
         )
@@ -2247,7 +2275,11 @@ class SharedLiveMediaAPITest(TestCase):
 
         response = self.client.post(
             f"/api/sharedlivemedias/{shared_live_media.id}/initiate-upload/",
-            {"filename": "python extensions.pdf", "mimetype": "application/pdf"},
+            {
+                "filename": "python extensions.pdf",
+                "mimetype": "application/pdf",
+                "size": 10,
+            },
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             content_type="application/json",
         )
@@ -2286,7 +2318,11 @@ class SharedLiveMediaAPITest(TestCase):
             mock_dt.utcnow = mock.Mock(return_value=now)
             response = self.client.post(
                 f"/api/sharedlivemedias/{shared_live_media.id}/initiate-upload/",
-                {"filename": "python extensions.pdf", "mimetype": "application/pdf"},
+                {
+                    "filename": "python extensions.pdf",
+                    "mimetype": "application/pdf",
+                    "size": 10,
+                },
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
                 content_type="application/json",
             )
@@ -2349,7 +2385,11 @@ class SharedLiveMediaAPITest(TestCase):
 
         response = self.client.post(
             f"/api/sharedlivemedias/{shared_live_media.id}/initiate-upload/",
-            {"filename": "python extensions.pdf", "mimetype": "application/pdf"},
+            {
+                "filename": "python extensions.pdf",
+                "mimetype": "application/pdf",
+                "size": 10,
+            },
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             content_type="application/json",
         )
@@ -2392,7 +2432,11 @@ class SharedLiveMediaAPITest(TestCase):
             mock_dt.utcnow = mock.Mock(return_value=now)
             response = self.client.post(
                 f"/api/sharedlivemedias/{shared_live_media.id}/initiate-upload/",
-                {"filename": "python extensions.pdf", "mimetype": "application/pdf"},
+                {
+                    "filename": "python extensions.pdf",
+                    "mimetype": "application/pdf",
+                    "size": 10,
+                },
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
                 content_type="application/json",
             )

--- a/src/backend/marsha/deposit/serializers.py
+++ b/src/backend/marsha/deposit/serializers.py
@@ -9,7 +9,7 @@ from django.urls import reverse
 from rest_framework import serializers
 
 from marsha.core.serializers import (
-    InitiateUploadSerializer,
+    BaseInitiateUploadSerializer,
     UploadableFileWithExtensionSerializerMixin,
     get_resource_cloudfront_url_params,
 )
@@ -152,8 +152,18 @@ class DepositedFileSerializer(
         return url
 
 
-class DepositedFileInitiateUploadSerializer(InitiateUploadSerializer):
+class DepositedFileInitiateUploadSerializer(BaseInitiateUploadSerializer):
     """An initiate-upload serializer dedicated to deposited file."""
+
+    @property
+    def max_upload_file_size(self):
+        """return the deposited max file size define in the settings.
+
+        The @property decorator is used to ease the use of @override_settings
+        in tests. Otherwise the setting is not changed and we can't easily test
+        an upload with a size higher than the one defined in the settings
+        """
+        return settings.DEPOSITED_FILE_SOURCE_MAX_SIZE
 
     def validate(self, attrs):
         """Validate if the mimetype is allowed or not."""

--- a/src/backend/marsha/deposit/tests/api/depositedfiles/test_initiate_upload.py
+++ b/src/backend/marsha/deposit/tests/api/depositedfiles/test_initiate_upload.py
@@ -57,7 +57,7 @@ class DepositedFileInitiateUploadAPITest(TestCase):
             mock_dt.utcnow = mock.Mock(return_value=now)
             response = self.client.post(
                 f"/api/depositedfiles/{deposited_file.id}/initiate-upload/",
-                {"filename": "foo.pdf", "mimetype": "application/pdf"},
+                {"filename": "foo.pdf", "mimetype": "application/pdf", "size": 10},
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
                 content_type="application/json",
             )
@@ -120,7 +120,7 @@ class DepositedFileInitiateUploadAPITest(TestCase):
             mock_dt.utcnow = mock.Mock(return_value=now)
             response = self.client.post(
                 f"/api/depositedfiles/{deposited_file.id}/initiate-upload/",
-                {"filename": "foo.pdf", "mimetype": "application/pdf"},
+                {"filename": "foo.pdf", "mimetype": "application/pdf", "size": 10},
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
                 content_type="application/json",
             )
@@ -185,7 +185,7 @@ class DepositedFileInitiateUploadAPITest(TestCase):
             mock_dt.utcnow = mock.Mock(return_value=now)
             response = self.client.post(
                 f"/api/depositedfiles/{deposited_file.id}/initiate-upload/",
-                {"filename": "foo.pdf", "mimetype": "application/pdf"},
+                {"filename": "foo.pdf", "mimetype": "application/pdf", "size": 10},
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
                 content_type="application/json",
             )
@@ -247,7 +247,7 @@ class DepositedFileInitiateUploadAPITest(TestCase):
             mock_dt.utcnow = mock.Mock(return_value=now)
             response = self.client.post(
                 f"/api/depositedfiles/{deposited_file.id}/initiate-upload/",
-                {"filename": "foo.pdf", "mimetype": "application/pdf"},
+                {"filename": "foo.pdf", "mimetype": "application/pdf", "size": 10},
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
                 content_type="application/json",
             )

--- a/src/backend/marsha/markdown/serializers.py
+++ b/src/backend/marsha/markdown/serializers.py
@@ -8,7 +8,7 @@ from django.urls import reverse
 from rest_framework import serializers
 
 from marsha.core.serializers import (
-    InitiateUploadSerializer,
+    BaseInitiateUploadSerializer,
     ReadOnlyModelSerializer,
     TimestampField,
     UploadableFileWithExtensionSerializerMixin,
@@ -115,8 +115,18 @@ class MarkdownImageSerializer(
         return cloudfront_utils.build_signed_url(url, params)
 
 
-class MarkdownImageUploadSerializer(InitiateUploadSerializer):
+class MarkdownImageUploadSerializer(BaseInitiateUploadSerializer):
     """An initiate-upload serializer dedicated to Markdown image."""
+
+    @property
+    def max_upload_file_size(self):
+        """return the markdown image max file size define in the settings.
+
+        The @property decorator is used to ease the use of @override_settings
+        in tests. Otherwise the setting is not changed and we can't easily test
+        an upload with a size higher than the one defined in the settings
+        """
+        return settings.MARKDOWN_IMAGE_SOURCE_MAX_SIZE
 
     def validate(self, attrs):
         """Validate if the mimetype is allowed or not."""

--- a/src/backend/marsha/markdown/tests/api/markdown_images/test_initiate_upload.py
+++ b/src/backend/marsha/markdown/tests/api/markdown_images/test_initiate_upload.py
@@ -66,7 +66,7 @@ class MarkdownImageInitiateUploadApiTest(TestCase):
             mock_dt.utcnow = mock.Mock(return_value=now)
             response = self.client.post(
                 f"/api/markdown-images/{markdown_image.id}/initiate-upload/",
-                data={"filename": "not_used.png", "mimetype": "image/png"},
+                data={"filename": "not_used.png", "mimetype": "image/png", "size": 10},
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
         self.assertEqual(response.status_code, 200)
@@ -117,7 +117,7 @@ class MarkdownImageInitiateUploadApiTest(TestCase):
 
         response = self.client.post(
             f"/api/markdown-images/{markdown_image.id}/initiate-upload/",
-            data={"filename": "not_used.gif", "mimetype": "image/gif"},
+            data={"filename": "not_used.gif", "mimetype": "image/gif", "size": 10},
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
@@ -161,7 +161,7 @@ class MarkdownImageInitiateUploadApiTest(TestCase):
             mock_dt.utcnow = mock.Mock(return_value=now)
             response = self.client.post(
                 f"/api/markdown-images/{markdown_image.id}/initiate-upload/",
-                data={"filename": "not_used.png", "mimetype": "image/png"},
+                data={"filename": "not_used.png", "mimetype": "image/png", "size": 10},
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
         self.assertEqual(response.status_code, 200)
@@ -222,7 +222,7 @@ class MarkdownImageInitiateUploadApiTest(TestCase):
             mock_dt.utcnow = mock.Mock(return_value=now)
             response = self.client.post(
                 f"/api/markdown-images/{markdown_image.id}/initiate-upload/",
-                data={"filename": "not_used.png", "mimetype": "image/png"},
+                data={"filename": "not_used.png", "mimetype": "image/png", "size": 10},
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
         self.assertEqual(response.status_code, 200)

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -414,14 +414,18 @@ class Base(Configuration):
     SENTRY_DSN = values.Value(None)
 
     # Resource max file size
-    DOCUMENT_SOURCE_MAX_SIZE = values.Value(2**30)  # 1GB
-    VIDEO_SOURCE_MAX_SIZE = values.Value(2**30)  # 1GB
-    SUBTITLE_SOURCE_MAX_SIZE = values.Value(2**20)  # 1MB
-    THUMBNAIL_SOURCE_MAX_SIZE = values.Value(10 * (2**20))  # 10MB
-    SHARED_LIVE_MEDIA_SOURCE_MAX_SIZE = values.Value(300 * (2**20))  # 300MB
-    MARKDOWN_IMAGE_SOURCE_MAX_SIZE = values.Value(10 * (2**20))  # 10MB
-    DEPOSITED_FILE_SOURCE_MAX_SIZE = values.Value(2**30)  # 1GB
-    CLASSROOM_DOCUMENT_SOURCE_MAX_SIZE = values.Value(300 * (2**20))  # 300MB
+    DOCUMENT_SOURCE_MAX_SIZE = values.PositiveIntegerValue(2**30)  # 1GB
+    VIDEO_SOURCE_MAX_SIZE = values.PositiveIntegerValue(2**30)  # 1GB
+    SUBTITLE_SOURCE_MAX_SIZE = values.PositiveIntegerValue(2**20)  # 1MB
+    THUMBNAIL_SOURCE_MAX_SIZE = values.PositiveIntegerValue(10 * (2**20))  # 10MB
+    SHARED_LIVE_MEDIA_SOURCE_MAX_SIZE = values.PositiveIntegerValue(
+        300 * (2**20)
+    )  # 300MB
+    MARKDOWN_IMAGE_SOURCE_MAX_SIZE = values.PositiveIntegerValue(10 * (2**20))  # 10MB
+    DEPOSITED_FILE_SOURCE_MAX_SIZE = values.PositiveIntegerValue(2**30)  # 1GB
+    CLASSROOM_DOCUMENT_SOURCE_MAX_SIZE = values.PositiveIntegerValue(
+        300 * (2**20)
+    )  # 300MB
 
     EXTERNAL_JAVASCRIPT_SCRIPTS = values.ListValue([])
 

--- a/src/frontend/apps/lti_site/components/UploadableObjectStatusBadge/index.tsx
+++ b/src/frontend/apps/lti_site/components/UploadableObjectStatusBadge/index.tsx
@@ -112,6 +112,13 @@ export const UploadableObjectStatusBadge = ({
             </Badge>
           );
 
+        case UploadManagerStatus.ERR_SIZE:
+          return (
+            <Badge role="status" background="status-error">
+              <FormattedMessage {...messages[uploadState.ERROR]} />
+            </Badge>
+          );
+
         case UploadManagerStatus.SUCCESS:
           return (
             <Badge role="status" background="brand">

--- a/src/frontend/packages/lib_components/src/common/ErrorComponents/index.tsx
+++ b/src/frontend/packages/lib_components/src/common/ErrorComponents/index.tsx
@@ -20,7 +20,8 @@ export interface ErrorComponentsProps {
     | 'liveInit'
     | 'liveToVod'
     | 'liveStopped'
-    | 'videoDeleted';
+    | 'videoDeleted'
+    | 'fileTooLarge';
 }
 
 const FullScreenErrorStyled = styled(LayoutMainArea)`
@@ -173,6 +174,18 @@ const messages = {
       description:
         'Title for a user accessing a deleted video (or a live ended without any record).',
       id: 'components.ErrorComponents.videoDeleted.title',
+    },
+  },
+  fileTooLarge: {
+    text: {
+      defaultMessage: 'This file is too large to be uploaded.',
+      description: 'Text explaining that the file provided is too large.',
+      id: 'components.ErrorComponents.fileTooLarge.text',
+    },
+    title: {
+      defaultMessage: 'This file is too large',
+      description: 'Title for a user trying to upload a too large file.',
+      id: 'components.ErrorComponents.fileTooLarge.title',
     },
   },
 };

--- a/src/frontend/packages/lib_components/src/common/UploadForm/index.tsx
+++ b/src/frontend/packages/lib_components/src/common/UploadForm/index.tsx
@@ -159,6 +159,9 @@ export const UploadForm = ({ objectId, objectType }: UploadFormProps) => {
     case UploadManagerStatus.ERR_POLICY:
       return <Redirect push to={FULL_SCREEN_ERROR_ROUTE('policy')} />;
 
+    case UploadManagerStatus.ERR_SIZE:
+      return <Redirect push to={FULL_SCREEN_ERROR_ROUTE('fileTooLarge')} />;
+
     case UploadManagerStatus.ERR_UPLOAD:
       return <Redirect push to={FULL_SCREEN_ERROR_ROUTE('upload')} />;
 

--- a/src/frontend/packages/lib_components/src/utils/formatSizeErrorScale.spec.ts
+++ b/src/frontend/packages/lib_components/src/utils/formatSizeErrorScale.spec.ts
@@ -1,0 +1,12 @@
+import { formatSizeErrorScale } from './formatSizeErrorScale';
+
+describe('lib_components/src/utils/formatSizeErrorScale.ts', () => {
+  it('converts Bytes to the right human-readable scale', () => {
+    expect(formatSizeErrorScale(10)).toEqual('10 B');
+    expect(formatSizeErrorScale(Math.pow(10, 3))).toEqual('1 kB');
+    expect(formatSizeErrorScale(Math.pow(10, 5))).toEqual('100 kB');
+    expect(formatSizeErrorScale(Math.pow(10, 7))).toEqual('10 MB');
+    expect(formatSizeErrorScale(Math.pow(10, 9))).toEqual('1 GB');
+    expect(formatSizeErrorScale(Math.pow(10, 10))).toEqual('10 GB');
+  });
+});

--- a/src/frontend/packages/lib_components/src/utils/formatSizeErrorScale.ts
+++ b/src/frontend/packages/lib_components/src/utils/formatSizeErrorScale.ts
@@ -1,0 +1,9 @@
+export const formatSizeErrorScale = (maxSize: number): string => {
+  const index =
+    maxSize === 0 ? 0 : Math.floor(Math.log(maxSize) / Math.log(1000));
+  return (
+    ((maxSize / Math.pow(1000, index)) * 1).toFixed(0) +
+    ' ' +
+    ['B', 'kB', 'MB', 'GB', 'TB'][index]
+  );
+};

--- a/src/frontend/packages/lib_components/src/utils/index.ts
+++ b/src/frontend/packages/lib_components/src/utils/index.ts
@@ -11,3 +11,4 @@ export * from './useResizeBox';
 export * from './useResizer';
 export * from './XAPI';
 export * from './XAPI/DocumentXapiStatement';
+export * from './formatSizeErrorScale';

--- a/src/frontend/packages/lib_video/src/api/useVideoMetadata/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/api/useVideoMetadata/index.spec.tsx
@@ -57,6 +57,9 @@ describe('useVideoMetadata', () => {
       live: {
         segment_duration_seconds: 4,
       },
+      vod: {
+        upload_max_size_bytes: 100,
+      },
     };
     fetchMock.mock(`/api/videos/`, videoMetadata);
 

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/LocalizedTimedTextTrackUpload/index.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/LocalizedTimedTextTrackUpload/index.tsx
@@ -38,32 +38,15 @@ export const LocalizedTimedTextTrackUpload = ({
   timedTextModeWidget,
 }: UploadWidgetGenericProps) => {
   const intl = useIntl();
-
   const { addUpload, resetUpload, uploadManagerState } = useUploadManager();
   const timedTextTracks = useTimedTextTrack((state) =>
     state.getTimedTextTracks(),
   );
-
   const filteredTimedTextTracks = timedTextTracks.filter(
     (track) => track.mode === timedTextModeWidget,
   );
-
-  // When an upload is over and successful, it is deleted from the uploadManagerState, in order
-  // to be able to perform a consecutive upload
-  useEffect(() => {
-    filteredTimedTextTracks.forEach((timedText) => {
-      if (
-        timedText.upload_state === uploadState.READY &&
-        uploadManagerState[timedText.id]
-      ) {
-        resetUpload(timedText.id);
-      }
-    });
-  }, [filteredTimedTextTracks, resetUpload, uploadManagerState]);
-
   const hiddenFileInput = useRef<Nullable<HTMLInputElement>>(null);
   const retryUploadIdRef = useRef<Nullable<string>>(null);
-
   const [selectedLanguage, setSelectedLanguage] =
     useState<Nullable<LanguageChoice>>(null);
 
@@ -99,6 +82,24 @@ export const LocalizedTimedTextTrackUpload = ({
       hiddenFileInput.current.click();
     }
   };
+
+  // When an upload is over and successful, it is deleted from the uploadManagerState, in order
+  // to be able to perform a consecutive upload
+  useEffect(() => {
+    filteredTimedTextTracks.forEach((timedText) => {
+      if (
+        timedText.upload_state === uploadState.READY &&
+        uploadManagerState[timedText.id]
+      ) {
+        resetUpload(timedText.id);
+      }
+    });
+  }, [
+    resetUpload,
+    timedTextModeWidget,
+    filteredTimedTextTracks,
+    uploadManagerState,
+  ]);
 
   return (
     <Box direction="column" gap="small" margin={{ top: 'small' }}>

--- a/src/frontend/packages/lib_video/src/components/common/VideoWizard/CreateVOD/UploadVideoForm/UploadVideoRetry/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWizard/CreateVOD/UploadVideoForm/UploadVideoRetry/index.spec.tsx
@@ -8,11 +8,30 @@ import { UploadVideoRetry } from '.';
 const mockedOnClick = jest.fn();
 
 describe('<UploadVideoRetry />', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
   it('renders UploadVideoRetry and clicks on it', () => {
     render(<UploadVideoRetry onClickRetry={mockedOnClick} />);
     screen.getByText(
       'An error occured when uploading your video. Please retry.',
     );
+    const retryButton = screen.getByRole('button');
+
+    userEvent.click(retryButton);
+
+    expect(mockedOnClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders UploadVideoRetry with sizeError and clicks on it', () => {
+    render(
+      <UploadVideoRetry
+        onClickRetry={mockedOnClick}
+        maxSize={Math.pow(10, 9)}
+      />,
+    );
+    screen.getByText('Error : File too large. Max size authorized is 1 GB.');
     const retryButton = screen.getByRole('button');
 
     userEvent.click(retryButton);

--- a/src/frontend/packages/lib_video/src/components/common/VideoWizard/CreateVOD/UploadVideoForm/UploadVideoRetry/index.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWizard/CreateVOD/UploadVideoForm/UploadVideoRetry/index.tsx
@@ -1,5 +1,5 @@
 import { Text } from 'grommet';
-import { RetryUploadButton } from 'lib-components';
+import { formatSizeErrorScale, RetryUploadButton } from 'lib-components';
 import React from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 
@@ -12,19 +12,38 @@ const messages = defineMessages({
       "Button's label offering the user to go validate is form and create a new video.",
     id: 'components.UploadVideoRetry.errorOccuredVideoUpload',
   },
+  errorFileTooLarge: {
+    defaultMessage: 'Error : File too large. Max size authorized is {maxSize}.',
+    description:
+      "Button's label explaining the 400 error that happens on large files upload.",
+    id: 'components.UploadVideoRetry.errorFileTooLarge',
+  },
 });
 
 interface UploadVideoRetryProps {
   onClickRetry: () => void;
+  maxSize?: number;
 }
 
-export const UploadVideoRetry = ({ onClickRetry }: UploadVideoRetryProps) => {
+export const UploadVideoRetry = ({
+  onClickRetry,
+  maxSize,
+}: UploadVideoRetryProps) => {
   const intl = useIntl();
+  let outputMessage: string;
+
+  if (maxSize) {
+    outputMessage = intl.formatMessage(messages.errorFileTooLarge, {
+      maxSize: formatSizeErrorScale(maxSize),
+    });
+  } else {
+    outputMessage = intl.formatMessage(messages.errorOccuredVideoUpload);
+  }
 
   return (
     <BigDashedBox direction="row">
       <Text color="red-active" size="1rem">
-        {intl.formatMessage(messages.errorOccuredVideoUpload)}
+        {outputMessage}
       </Text>
       <RetryUploadButton
         color="red-active"

--- a/src/frontend/packages/lib_video/src/components/common/VideoWizard/CreateVOD/UploadVideoForm/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWizard/CreateVOD/UploadVideoForm/index.spec.tsx
@@ -2,6 +2,7 @@
 /* eslint-disable testing-library/no-container */
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import fetchMock from 'fetch-mock';
 import {
   videoMockFactory,
   UploadManagerStatus,
@@ -36,6 +37,9 @@ URL.createObjectURL = () => '/blob/path/to/video';
 describe('<UploadVideoForm />', () => {
   beforeEach(() => {
     jest.resetAllMocks();
+  });
+  afterEach(() => {
+    fetchMock.restore();
   });
 
   it('renders UploadVideoForm when there is no file selected', () => {
@@ -182,6 +186,61 @@ describe('<UploadVideoForm />', () => {
 
     await screen.findByText(
       'An error occured when uploading your video. Please retry.',
+    );
+
+    const retryButton = screen.getByRole('button');
+
+    userEvent.click(retryButton);
+
+    expect(mockedSetVideoFile).toHaveBeenNthCalledWith(2, null);
+    expect(mockedResetUpload).toHaveBeenNthCalledWith(1, mockedVideo.id);
+    expect(mockedOnRetry).toHaveBeenCalledTimes(1);
+
+    screen.getByText('Add a video or drag & drop it');
+  });
+
+  it('renders UploadVideoForm with a file too large and clicks on the retry button', async () => {
+    const mockedVideo = videoMockFactory({ upload_state: uploadState.ERROR });
+    fetchMock.mock('/api/videos/', {
+      vod: {
+        upload_max_size_bytes: Math.pow(10, 9),
+      },
+    });
+
+    const mockedResetUpload = jest.fn();
+    mockUseUploadManager.mockReturnValue({
+      addUpload: jest.fn(),
+      resetUpload: mockedResetUpload,
+      uploadManagerState: {
+        [mockedVideo.id]: {
+          file: new File(['(⌐□_□)'], 'video.mp4', {
+            type: 'video/mp4',
+          }),
+          objectType: modelName.VIDEOS,
+          objectId: mockedVideo.id,
+          progress: 0,
+          status: UploadManagerStatus.ERR_SIZE,
+          message: 'file too large, max size allowed is 1 GB',
+        },
+      },
+    });
+
+    render(
+      wrapInVideo(
+        <UploadVideoForm
+          onRetry={mockedOnRetry}
+          setVideoFile={mockedSetVideoFile}
+        />,
+        mockedVideo,
+      ),
+    );
+    const file = new File(['(⌐□_□)'], 'course.mp4', { type: 'video/mp4' });
+    const hiddenInput = screen.getByTestId('input-video-test-id');
+
+    userEvent.upload(hiddenInput, file);
+
+    await screen.findByText(
+      'Error : File too large. Max size authorized is 1 GB.',
     );
 
     const retryButton = screen.getByRole('button');

--- a/src/frontend/packages/lib_video/src/components/common/VideoWizard/CreateVOD/UploadVideoForm/index.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWizard/CreateVOD/UploadVideoForm/index.tsx
@@ -1,3 +1,4 @@
+import { useVideoMetadata } from 'api';
 import { Nullable } from 'lib-common';
 import {
   UploadManagerStatus,
@@ -5,6 +6,7 @@ import {
   uploadState,
 } from 'lib-components';
 import React, { useState } from 'react';
+import { useIntl } from 'react-intl';
 
 import { useCurrentVideo } from 'hooks/useCurrentVideo';
 
@@ -22,7 +24,9 @@ export const UploadVideoForm = ({
   onRetry,
   setVideoFile,
 }: UploadVideoFormProps) => {
+  const intl = useIntl();
   const video = useCurrentVideo();
+  const metadata = useVideoMetadata(intl.locale);
   const { resetUpload, uploadManagerState } = useUploadManager();
   const [src, setSrc] = useState<Nullable<string>>(null);
 
@@ -41,6 +45,19 @@ export const UploadVideoForm = ({
     uploadManagerState[video.id] &&
     uploadManagerState[video.id].status !== UploadManagerStatus.SUCCESS
   ) {
+    if (uploadManagerState[video.id].status === UploadManagerStatus.ERR_SIZE) {
+      return (
+        <UploadVideoRetry
+          onClickRetry={() => {
+            setVideoFile(null);
+            setSrc(null);
+            resetUpload(video.id);
+            onRetry();
+          }}
+          maxSize={metadata.data?.vod.upload_max_size_bytes}
+        />
+      );
+    }
     if (
       uploadManagerState[video.id].status === UploadManagerStatus.ERR_UPLOAD ||
       video.upload_state === uploadState.ERROR

--- a/src/frontend/packages/lib_video/src/types/metadata.ts
+++ b/src/frontend/packages/lib_video/src/types/metadata.ts
@@ -14,6 +14,9 @@ export interface VideoMetadata extends ResourceMetadata<Video> {
   live: {
     segment_duration_seconds: number;
   };
+  vod: {
+    upload_max_size_bytes: number;
+  };
 }
 
 export type TimedTextMetadata = ResourceMetadata<TimedText>;


### PR DESCRIPTION
## Purpose

For each uploaded file on S3 we set a max file size limit. But we don't control before the upload starts if the file size is higher than the limit we set. This PR focuses on video upload.

## Proposal

In the response when we fetch a policy upload, this max file size should be added and then in the component managing the upload we should check if it is possible to determine this size. Then we check the size and if it's the file size is higher thant the max file size, the upload is aborted with an error message.

- [x] Add a serialization check in the backend
- [x] Display an adapted error message in the front when triggering the serialization error
