### PR TITLE
🐛(front) move jwt store initialization in LTI to AppInitializer

### DIFF
--- a/src/frontend/apps/lti_site/components/App/AppInitializer/index.spec.tsx
+++ b/src/frontend/apps/lti_site/components/App/AppInitializer/index.spec.tsx
@@ -1,5 +1,6 @@
 import { screen } from '@testing-library/react';
 import {
+  useJwt,
   useMaintenance,
   useSentry,
   useVideo,
@@ -40,9 +41,6 @@ jest.mock('lib-components', () => ({
   decodeJwt: () => ({
     maintenance: true,
   }),
-  useJwt: () => ({
-    jwt: 'some jwt',
-  }),
 }));
 
 describe('<AppInitializer />', () => {
@@ -55,9 +53,11 @@ describe('<AppInitializer />', () => {
     expect(useDocument.getState().documents).toEqual({});
     expect(useAttendance.getState().delay).toEqual(10000);
     expect(useMaintenance.getState().isActive).toEqual(false);
+    expect(useJwt.getState().jwt).toBeUndefined();
+    expect(useJwt.getState().refreshJwt).toBeUndefined();
 
     render(
-      <AppInitializer>
+      <AppInitializer jwt="jwt" refresh_token="refresh_token">
         <span>some cool content</span>
       </AppInitializer>,
     );
@@ -82,5 +82,7 @@ describe('<AppInitializer />', () => {
     });
     expect(useAttendance.getState().delay).toEqual(6);
     expect(useMaintenance.getState().isActive).toEqual(true);
+    expect(useJwt.getState().jwt).toEqual('jwt');
+    expect(useJwt.getState().refreshJwt).toEqual('refresh_token');
   });
 });

--- a/src/frontend/apps/lti_site/components/App/index.tsx
+++ b/src/frontend/apps/lti_site/components/App/index.tsx
@@ -1,7 +1,6 @@
 import React, { lazy, Suspense } from 'react';
-import { createJSONStorage } from 'zustand/middleware';
 
-import { Loader, useJwt, AppConfigProvider } from 'lib-components';
+import { Loader, AppConfigProvider } from 'lib-components';
 import { parseDataElements } from 'utils/parseDataElements/parseDataElements';
 
 import { AppInitializer } from './AppInitializer';
@@ -15,17 +14,10 @@ if (!domElementToParse) {
 const { jwt, refresh_token, ...appConfig } =
   parseDataElements(domElementToParse);
 
-useJwt.persist.setOptions({
-  name: `jwt-store-${appConfig.modelName}-${appConfig.resource_id || ''}`,
-  storage: createJSONStorage(() => sessionStorage),
-});
-
-useJwt.setState({ jwt, refreshJwt: refresh_token });
-
 export const App = () => {
   return (
     <AppConfigProvider value={appConfig}>
-      <AppInitializer>
+      <AppInitializer jwt={jwt} refresh_token={refresh_token}>
         <Suspense fallback={<Loader />}>
           <AppContentLoader />
         </Suspense>


### PR DESCRIPTION
## Purpose

The jwt store was initialized outside react lifecycle leading to error if the persistent store is already existing. The store initialization has been moved to the AppInitializer waiting the jwt store is fully initialized before using it.

## Proposal

- [x] move jwt store initialization in LTI to AppInitializer

