### PR TITLE
🔖(beta) bump release to 4.0.0-beta.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.0.0-beta.13] - 2023-01-23
+
 ### Added
 
 - standalone website:
@@ -1405,7 +1407,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Minor fixes and improvements on features and tests
 
-[unreleased]: https://github.com/openfun/marsha/compare/v4.0.0-beta.12...master
+[unreleased]: https://github.com/openfun/marsha/compare/v4.0.0-beta.13...master
+[4.0.0-beta.13]: https://github.com/openfun/marsha/compare/v4.0.0-beta.12...v4.0.0-beta.13
 [4.0.0-beta.12]: https://github.com/openfun/marsha/compare/v4.0.0-beta.11...v4.0.0-beta.12
 [4.0.0-beta.11]: https://github.com/openfun/marsha/compare/v4.0.0-beta.10...v4.0.0-beta.11
 [4.0.0-beta.10]: https://github.com/openfun/marsha/compare/v4.0.0-beta.9...v4.0.0-beta.10

--- a/src/aws/lambda-complete/package.json
+++ b/src/aws/lambda-complete/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-complete",
-  "version": "4.0.0-beta.12",
+  "version": "4.0.0-beta.13",
   "engines": {
     "node": "16"
   },

--- a/src/aws/lambda-configure/package.json
+++ b/src/aws/lambda-configure/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-configure",
-  "version": "4.0.0-beta.12",
+  "version": "4.0.0-beta.13",
   "engines": {
     "node": "16"
   },

--- a/src/aws/lambda-convert/package.json
+++ b/src/aws/lambda-convert/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-convert",
-  "version": "4.0.0-beta.12",
+  "version": "4.0.0-beta.13",
   "engines": {
     "node": "16"
   },

--- a/src/aws/lambda-elemental-routing/package.json
+++ b/src/aws/lambda-elemental-routing/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-elemental-routing",
-  "version": "4.0.0-beta.12",
+  "version": "4.0.0-beta.13",
   "engines": {
     "node": "16"
   },

--- a/src/aws/lambda-medialive/package.json
+++ b/src/aws/lambda-medialive/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-medialive",
-  "version": "4.0.0-beta.12",
+  "version": "4.0.0-beta.13",
   "engines": {
     "node": "16"
   },

--- a/src/aws/lambda-mediapackage/package.json
+++ b/src/aws/lambda-mediapackage/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-mediapackage",
-  "version": "4.0.0-beta.12",
+  "version": "4.0.0-beta.13",
   "engines": {
     "node": "16"
   },

--- a/src/aws/lambda-migrate/package.json
+++ b/src/aws/lambda-migrate/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-migrate",
-  "version": "4.0.0-beta.12",
+  "version": "4.0.0-beta.13",
   "engines": {
     "node": "16"
   },

--- a/src/aws/utils/update-state/package.json
+++ b/src/aws/utils/update-state/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-update-state",
-  "version": "4.0.0-beta.12",
+  "version": "4.0.0-beta.13",
   "engines": {
     "node": "16"
   },

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = marsha
 description = A FUN video provider for Open edX
-version = 4.0.0-beta.12
+version = 4.0.0-beta.13
 author = Open FUN (France Universite Numerique)
 author_email = fun.dev@fun-mooc.fr
 license = MIT

--- a/src/frontend/apps/lti_site/package.json
+++ b/src/frontend/apps/lti_site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marsha",
-  "version": "4.0.0-beta.12",
+  "version": "4.0.0-beta.13",
   "description": "🐠 a FUN LTI video provider",
   "main": "front/index.tsx",
   "scripts": {

--- a/src/frontend/apps/standalone_site/package.json
+++ b/src/frontend/apps/standalone_site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "standalone_site",
-  "version": "4.0.0-beta.12",
+  "version": "4.0.0-beta.13",
   "license": "MIT",
   "private": true,
   "devDependencies": {

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "common",
-  "version": "4.0.0-beta.12",
+  "version": "4.0.0-beta.13",
   "license": "MIT",
   "private": true,
   "workspaces": {

--- a/src/frontend/packages/lib_classroom/package.json
+++ b/src/frontend/packages/lib_classroom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lib-classroom",
-  "version": "4.0.0-beta.12",
+  "version": "4.0.0-beta.13",
   "license": "MIT",
   "main": "lib/index.js",
   "module": "lib/index.es.js",

--- a/src/frontend/packages/lib_common/package.json
+++ b/src/frontend/packages/lib_common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lib-common",
-  "version": "4.0.0-beta.12",
+  "version": "4.0.0-beta.13",
   "license": "MIT",
   "main": "lib/index.js",
   "module": "lib/index.es.js",

--- a/src/frontend/packages/lib_components/package.json
+++ b/src/frontend/packages/lib_components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lib-components",
-  "version": "4.0.0-beta.12",
+  "version": "4.0.0-beta.13",
   "license": "MIT",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",

--- a/src/frontend/packages/lib_tests/package.json
+++ b/src/frontend/packages/lib_tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lib-tests",
-  "version": "4.0.0-beta.12",
+  "version": "4.0.0-beta.13",
   "license": "MIT",
   "main": "lib/index.js",
   "module": "lib/index.es.js",

--- a/src/frontend/packages/lib_video/package.json
+++ b/src/frontend/packages/lib_video/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lib-video",
-  "version": "1.0.0",
+  "version": "4.0.0-beta.13",
   "description": "",
   "license": "ISC",
   "main": "lib/index.js",


### PR DESCRIPTION
### Added

- standalone website:
  - Display current user full name instead of John Doe
  - service worker 401 reconnect
  - Password reset views & API
  - Renater IdP's logo display on login page
  - Allow organization instructors to create playlists
  - profile page and update password form in settings
  - Select an organization by default in create playlist form
- Allow instructors to download recorded BBB classroom sessions

- lti:
  - service worker 401 reconnect
- Add a check on video file size when uploading content

### Changed

- Remove deprecated params from BBB API calls
- Keep resource property in AppData
- Create a lib to handle all components for video (VOD and live)
- Optimize LTI images

### Fixed

- Set unique storage name for useJwt hook for LTI
- lti_site:
  - Live parameters sync between users
  - Display valid webinar url when creating one with LTI select content
  - Bundle size polyfill
  - White band under video player on student side
- standalone website:
  - fix renater select box on smaller screens
- Stabilize flaky e2e tests