### PR TITLE
Fix localstorage disable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## Added
+
+- Add a configuration for jwt state preservation with localstorage
+
 ## Fixed
 
 - standalone website:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Fixed
 
-- Authentication renater select crashing the site on scroll
-- Fix firefox chunk CDN invite mode
+- standalone website:
+  - Authentication renater select crashing the site on scroll
+  - Consider local storage is optional depending on browser settings
+  - Fix firefox chunk CDN invite mode
 - Return 404 for missing static files
 
 ## [4.0.0-beta.13] - 2023-01-23

--- a/src/frontend/apps/lti_site/components/App/AppInitializer/index.tsx
+++ b/src/frontend/apps/lti_site/components/App/AppInitializer/index.tsx
@@ -21,7 +21,6 @@ import React, {
   useMemo,
   useState,
 } from 'react';
-import { createJSONStorage } from 'zustand/middleware';
 
 import { useIsFeatureEnabled } from 'data/hooks/useIsFeatureEnabled';
 import { Maybe } from 'lib-common';
@@ -66,20 +65,9 @@ export const AppInitializer = (
       return;
     }
 
-    useJwt.persist.setOptions({
-      name: `jwt-store-${appConfig.modelName}-${appConfig.resource_id || ''}`,
-      storage: createJSONStorage(() => sessionStorage),
-    });
-
     useJwt.setState({ jwt: props.jwt, refreshJwt: props.refresh_token });
     setIsJwtInitialized(true);
-  }, [
-    isJwtInitialized,
-    appConfig.modelName,
-    appConfig.resource_id,
-    props.jwt,
-    props.refresh_token,
-  ]);
+  }, [isJwtInitialized, props.jwt, props.refresh_token]);
 
   useEffect(() => {
     if (isFeatureEnabled(flags.SENTRY) && appConfig.sentry_dsn) {

--- a/src/frontend/apps/standalone_site/src/features/Authentication/components/Authenticator.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Authentication/components/Authenticator.tsx
@@ -1,5 +1,6 @@
 import {
   AnonymousUser,
+  isLocalStorageEnabled,
   Loader,
   useCurrentUser,
   useJwt,
@@ -15,6 +16,13 @@ import { validateChallenge } from '../api/validateChallenge';
 
 const TARGET_URL_STORAGE_KEY = 'redirect_uri';
 const QUERY_PARAMS_CHALLENGE_TOKEN_NAME = 'token';
+
+function getLocalStorage() {
+  if (isLocalStorageEnabled()) {
+    return localStorage;
+  }
+  return undefined;
+}
 
 export const Authenticator = ({ children }: PropsWithChildren<unknown>) => {
   const { pathname, search } = useLocation();
@@ -41,7 +49,7 @@ export const Authenticator = ({ children }: PropsWithChildren<unknown>) => {
     if (code) {
       fetchJwt(code);
     } else {
-      localStorage.setItem(TARGET_URL_STORAGE_KEY, pathname + search);
+      getLocalStorage()?.setItem(TARGET_URL_STORAGE_KEY, pathname + search);
       history.push(routes.LOGIN.path);
     }
   }, [code, history, jwt, pathname, search, setJwt]);
@@ -61,8 +69,8 @@ export const Authenticator = ({ children }: PropsWithChildren<unknown>) => {
 
       setCurrentUser(_currentUser);
 
-      const targetUri = localStorage.getItem(TARGET_URL_STORAGE_KEY);
-      localStorage.removeItem(TARGET_URL_STORAGE_KEY);
+      const targetUri = getLocalStorage()?.getItem(TARGET_URL_STORAGE_KEY);
+      getLocalStorage()?.removeItem(TARGET_URL_STORAGE_KEY);
       // redirect to the originally targeted URL (ie before the authentication loop)
       // or the root page if no target was set
       history.replace(targetUri || pathname);

--- a/src/frontend/apps/standalone_site/src/index.tsx
+++ b/src/frontend/apps/standalone_site/src/index.tsx
@@ -1,3 +1,4 @@
+import 'init';
 import 'public-path';
 import { serviceWorkerRegistration } from 'lib-components';
 import React from 'react';

--- a/src/frontend/apps/standalone_site/src/init.ts
+++ b/src/frontend/apps/standalone_site/src/init.ts
@@ -1,0 +1,3 @@
+window.use_jwt_persistence = true;
+
+export {};

--- a/src/frontend/packages/lib_components/src/types/index.ts
+++ b/src/frontend/packages/lib_components/src/types/index.ts
@@ -11,5 +11,6 @@ export * from './ResourceContext';
 export * from './serviceWorker';
 export * from './tracks';
 export * from './User';
+export * from './window';
 export * from './XMPP';
 export * from './XAPI';

--- a/src/frontend/packages/lib_components/src/types/window.ts
+++ b/src/frontend/packages/lib_components/src/types/window.ts
@@ -1,0 +1,7 @@
+declare global {
+  interface Window {
+    use_jwt_persistence?: boolean;
+  }
+}
+
+export {};

--- a/src/frontend/packages/lib_components/src/utils/index.ts
+++ b/src/frontend/packages/lib_components/src/utils/index.ts
@@ -5,6 +5,7 @@ export * from './errors/report';
 export * from './errors/exception';
 export * from './serviceWorker';
 export * from './tests/factories';
+export * from './localstorage';
 export * from './truncateFilename';
 export * from './useFetchButton';
 export * from './useResizeBox';

--- a/src/frontend/packages/lib_components/src/utils/localstorage.spec.ts
+++ b/src/frontend/packages/lib_components/src/utils/localstorage.spec.ts
@@ -1,0 +1,59 @@
+import { isLocalStorageEnabled } from '.';
+
+let storage: {
+  [key in string]?: string;
+} = {};
+
+describe('isLocalStorageEnabled()', () => {
+  beforeAll(() => {
+    global.window = Object.create(window);
+  });
+
+  beforeEach(() => {
+    storage = {};
+    jest.clearAllMocks();
+  });
+
+  it('returns true if localstorage is available', () => {
+    Object.defineProperty(window, 'localStorage', {
+      value: {
+        getItem: (item: string) => storage[item] || null,
+        removeItem: (item: string) => delete storage[item],
+        setItem: (item: string, value: string) => (storage[item] = value),
+      },
+      writable: true,
+    });
+
+    expect(isLocalStorageEnabled()).toEqual(true);
+  });
+
+  it('returns false if we fail to write in the localstorage', () => {
+    Object.defineProperty(window, 'localStorage', {
+      value: {
+        getItem: (item: string) => storage[item] || null,
+        removeItem: (item: string) => delete storage[item],
+        setItem: (_item: string, _value: string) => {
+          throw new Error('failed');
+        },
+      },
+      writable: true,
+    });
+
+    expect(isLocalStorageEnabled()).toEqual(false);
+  });
+
+  it('returns false if we fail to read in the localstorage', () => {
+    Object.defineProperty(window, 'localStorage', {
+      value: {
+        getItem: (item: string) => storage[item] || null,
+        removeItem: (_item: string) => {
+          throw new Error('failed');
+        },
+        setItem: (item: string, value: string) => (storage[item] = value),
+      },
+      writable: true,
+    });
+
+    expect(isLocalStorageEnabled()).toEqual(false);
+  });
+});

--- a/src/frontend/packages/lib_components/src/utils/localstorage.ts
+++ b/src/frontend/packages/lib_components/src/utils/localstorage.ts
@@ -1,0 +1,9 @@
+export const isLocalStorageEnabled = (): boolean => {
+  try {
+    localStorage.setItem('enabled', '1');
+    localStorage.removeItem('enabled');
+    return true;
+  } catch (e) {
+    return false;
+  }
+};

--- a/src/frontend/packages/lib_video/src/utils/localstorage.ts
+++ b/src/frontend/packages/lib_video/src/utils/localstorage.ts
@@ -1,22 +1,10 @@
-import { report } from 'lib-components';
+import { report, isLocalStorageEnabled } from 'lib-components';
 import { v4 as uuidv4 } from 'uuid';
 
 export const ANONYMOUS_ID_KEY = 'marsha_anonymous_id';
 
-const localStorageEnabled = (): boolean => {
-  try {
-    localStorage.setItem('enabled', '1');
-    localStorage.removeItem('enabled');
-    return true;
-  } catch (e) {
-    return false;
-  }
-};
-
-const isLocaleStorageEnabled = localStorageEnabled();
-
 export const getAnonymousId = (): string => {
-  if (!isLocaleStorageEnabled) {
+  if (!isLocalStorageEnabled()) {
     return uuidv4();
   }
 
@@ -36,7 +24,7 @@ export const getAnonymousId = (): string => {
 };
 
 export const setAnonymousId = (anonymousId: string): void => {
-  if (isLocaleStorageEnabled) {
+  if (isLocalStorageEnabled()) {
     localStorage.setItem(ANONYMOUS_ID_KEY, anonymousId);
   }
 };


### PR DESCRIPTION
## Purpose

With the new authent process, we uses extensively localstorage that might be disable.

## Proposal

Make localstorage optional during authent or simply no longer store data in it for lti since this is not needed at all.

