### PR TITLE
🐛(backend) fix missing URL for statics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Authentication renater select crashing the site on scroll
 - Fix firefox chunk CDN invite mode
+- Return 404 for missing static files
 
 ## [4.0.0-beta.13] - 2023-01-23
 

--- a/src/backend/marsha/core/tests/test_urls.py
+++ b/src/backend/marsha/core/tests/test_urls.py
@@ -1,0 +1,33 @@
+"""Test some marsha URLs integration."""
+from django.core.cache import cache
+from django.test import TestCase, override_settings
+
+from waffle.testutils import override_switch
+
+from marsha.core.tests.utils import reload_urlconf
+
+
+@override_settings(DEBUG=False)
+class MarshBaseURLTestCase(TestCase):
+    """
+    Test case for some of marsha's URLs which requires precaution.
+
+    For example, the static URLs.
+    """
+
+    def setUp(self):
+        """Pre-flight resets"""
+        super().setUp()
+
+        # Reset the cache to always reach the site route.
+        cache.clear()
+
+        # Force URLs reload to take DEBUG into account
+        reload_urlconf()
+
+    @override_switch("site", active=True)
+    def test_missing_statics_returns_404(self):
+        """Test that missing static files return a 404."""
+        response = self.client.get("/static/oups_im_not_here.png")
+
+        self.assertEqual(response.status_code, 404)

--- a/src/backend/marsha/urls.py
+++ b/src/backend/marsha/urls.py
@@ -1,4 +1,5 @@
 """Marsha URLs configuration."""
+import re
 
 from django.conf import settings
 from django.contrib import admin
@@ -159,9 +160,15 @@ if "dummy" in settings.STORAGE_BACKEND:
         ),
     ]
 
+static_path = re.escape(settings.STATIC_URL.lstrip("/"))
+media_path = re.escape(settings.MEDIA_URL.lstrip("/"))
+SITE_IGNORE_PREFIX = "|".join([static_path, media_path])
+
 urlpatterns += [
     re_path(
-        ".*",
+        # Catch all URLs that are not handled before
+        # and which do not regard static files or media files
+        rf"^(?!{SITE_IGNORE_PREFIX}).*",
         cache_page(86400, key_prefix=settings.RELEASE)(SiteView.as_view()),
         name="site",
     ),


### PR DESCRIPTION
## Purpose

Do not catch the static or media URLs to redirect to the site.

See https://github.com/openfun/marsha/issues/1981

## Proposal

Ignore the "static" and "media" URL prefix in the catch all URL which provides
the standalone site.
