### PR TITLE
🏗️(tray) bootstrap arnold tray

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1219,6 +1219,105 @@ jobs:
               ./bin/lambda publish latest
             fi
 
+# ---- Tray jobs (k8s) ----
+  tray:
+    machine:
+      image: ubuntu-2004:2022.07.1
+    working_directory: ~/marsha
+    resource_class: large
+    environment:
+      DJANGO_CONFIGURATION: Test
+    steps:
+      - checkout
+      # Generate a version.json file describing app release
+      - <<: *generate-version-file
+      - *docker_login
+      - run:
+         name: Build production image
+         command: |
+           export DOCKER_BUILDKIT=1
+           docker build \
+             -t marsha:${CIRCLE_SHA1} \
+             .
+      - run:
+          name: Check built image availability
+          command: docker images "marsha:${CIRCLE_SHA1}*"
+      - run:
+          name: Install the kubectl client and k3d
+          command: |
+            export KUBECTL_RELEASE="v1.25.2"
+            curl -Lo "${HOME}/bin/kubectl" "https://dl.k8s.io/release/${KUBECTL_RELEASE}/bin/linux/amd64/kubectl"
+            curl -Lo /tmp/kubectl.sha256 "https://dl.k8s.io/${KUBECTL_RELEASE}/bin/linux/amd64/kubectl.sha256"
+            echo "$(</tmp/kubectl.sha256) ${HOME}/bin/kubectl" | sha256sum --check
+            chmod 755 "${HOME}/bin/kubectl"
+            export K3D_RELEASE="v5.4.6"
+            curl -Lo "${HOME}/bin/k3d" "https://github.com/k3d-io/k3d/releases/download/${K3D_RELEASE}/k3d-linux-amd64"
+            # FIXME
+            # Removed checksum checking: https://github.com/k3d-io/k3d/discussions/1037
+            #curl -sL https://github.com/k3d-io/k3d/releases/download/${K3D_RELEASE}/sha256sum.txt | \
+            #  grep _dist/k3d-linux-amd64 | \
+            #  sed "s|_dist/k3d-linux-amd64|${HOME}/bin/k3d|" | \
+            #  sha256sum --check
+            chmod 755 "${HOME}/bin/k3d"
+      - run:
+          name: Run local k3d cluster & configure environment
+          command: |
+            curl -Lo "${HOME}/bin/init-cluster" "https://raw.githubusercontent.com/openfun/arnold/master/bin/init-cluster"
+            chmod +x "${HOME}/bin/init-cluster"
+            # Bootstrap the k3d cluster with the following specific settings :
+            # - use standard HTTP and HTTPS ports
+            # - pre-provision 15 volumes instead of 100
+            MINIMUM_AVAILABLE_RWX_VOLUME=15 \
+            K3D_BIND_HOST_PORT_HTTP=80 \
+            K3D_BIND_HOST_PORT_HTTPS=443 \
+            K3D_REGISTRY_HOST=registry.127.0.0.1.nip.io \
+            K3D_ENABLE_REGISTRY=1 \
+              init-cluster arnold
+            # Set environment variables for the CI
+            echo "export K8S_DOMAIN=$(hostname -I | awk '{print $1}')" >> $BASH_ENV
+            echo 'export ARNOLD_DEFAULT_VAULT_PASSWORD="arnold"' >> $BASH_ENV
+            echo 'export ANSIBLE_VAULT_PASSWORD="${ARNOLD_DEFAULT_VAULT_PASSWORD}"' >> $BASH_ENV
+            echo "export ARNOLD_IMAGE_TAG=master" >> $BASH_ENV
+            echo "export K3D_REGISTRY_NAME=k3d-registry.127.0.0.1.nip.io" >> $BASH_ENV
+            echo "export K3D_REGISTRY_PORT=5000" >> $BASH_ENV
+            source $BASH_ENV
+      - run:
+          name: Install arnold CLI
+          command: |
+            curl -Lo"${HOME}/bin/arnold" "https://raw.githubusercontent.com/openfun/arnold/master/bin/arnold"
+            chmod +x "${HOME}/bin/arnold"
+      - run:
+          name: Setup a new Arnold project
+          command: |
+            env | grep "ARNOLD_"
+            arnold -c marsha -e ci setup
+            arnold -d -c marsha -e ci -a marsha create_db_vault
+            arnold -d -c marsha -e ci -a marsha create_app_vaults
+            arnold -d -c marsha -e ci -- vault -a marsha decrypt
+            sed -i 's/^# DJANGO_/DJANGO_/g' group_vars/customer/marsha/ci/secrets/marsha.vault.yml
+            sed -i '/DJANGO_SENTRY_DSN/d' group_vars/customer/marsha/ci/secrets/marsha.vault.yml
+            arnold -d -c marsha -e ci -- vault -a marsha encrypt
+            VARS_FILE="group_vars/customer/marsha/ci/main.yml"
+            echo "skip_verification: True" > ${VARS_FILE}
+            echo "apps:" >> ${VARS_FILE}
+            echo "  - name: marsha" >> ${VARS_FILE}
+            echo "marsha_image_name: ${K3D_REGISTRY_NAME}:${K3D_REGISTRY_PORT}/ci-marsha/marsha" >> ${VARS_FILE}
+            echo "marsha_image_tag: ${CIRCLE_SHA1}" >> ${VARS_FILE}
+            echo "marsha_app_replicas: 1" >> ${VARS_FILE}
+            echo "marsha_django_configuration: ${DJANGO_CONFIGURATION}" >> ${VARS_FILE}
+            echo "marsha_postgresql_pgdata: /tmp/pgdata" >> ${VARS_FILE}
+      - run:
+          name: Push marsha image to the k8s cluster docker registry
+          command: |
+            docker tag marsha:${CIRCLE_SHA1} "${K3D_REGISTRY_NAME}:${K3D_REGISTRY_PORT}/ci-marsha/marsha:${CIRCLE_SHA1}"
+            docker push "${K3D_REGISTRY_NAME}:${K3D_REGISTRY_PORT}/ci-marsha/marsha:${CIRCLE_SHA1}"
+      - run:
+          name: Bootstrap marsha application
+          command: |
+            arnold -d -c marsha -e ci -a marsha init
+            arnold -d -c marsha -e ci -a marsha deploy
+            kubectl -n ci-marsha get pods -l app=marsha | grep Running
+
 workflows:
   version: 2
 
@@ -1464,3 +1563,11 @@ workflows:
               only: master
             tags:
               only: /^v.*/
+
+      # Tray
+      #
+      # Deploy marsha in a k8s cluster using arnold
+      - tray:
+          filters:
+            tags:
+              only: /.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - LTI link for classroom available in every context
 - standalone website:
   - banner homepage with dynamic text
+- Arnold tray to manage definition directly in marsha repository
+
 
 ### Changed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,6 @@ RUN yarn compile-translations && \
     yarn workspace marsha run sass scss/_main.scss /app/marsha/static/css/main.css --style=compressed --load-path=../../node_modules  && \
     mkdir -p /app/marsha/static/css/fonts && cp node_modules/katex/dist/fonts/* /app/marsha/static/css/fonts && \
     yarn build-libs && \
-    yarn build-tests && \
     BUILD_PATH=/app/marsha/static/js/build/site/ DJANGO_STATIC_DIR=/app/marsha/static yarn workspace standalone_site run build && \
     yarn workspace marsha run build --mode=production --output-path /app/marsha/static/js/build/lti_site/
 

--- a/arnold.yml
+++ b/arnold.yml
@@ -1,0 +1,6 @@
+# arnold.yml
+metadata:
+  name: marsha
+  version: 4.0.0-beta.13
+source:
+  path: src/tray

--- a/src/tray/templates/services/app/_deploy_base.yml.j2
+++ b/src/tray/templates/services/app/_deploy_base.yml.j2
@@ -1,0 +1,127 @@
+{%- set dc_name = "marsha-%s" | format(service_variant) -%}
+
+apiVersion: v1
+kind: Deployment
+metadata:
+  labels:
+    app: marsha
+    service: "{{ service_variant }}"
+    version: "{{ marsha_image_tag }}"
+    deployment_stamp: "{{ deployment_stamp }}"
+  name: "{{ dc_name }}-{{ deployment_stamp }}"
+  namespace: "{{ namespace_name }}"
+spec:
+  replicas: {{ marsha_replicas }}
+  selector:
+    matchLabels:
+      app: marsha
+      service: "{{ service_variant }}"
+      version: "{{ marsha_image_tag }}"
+      deployment: "{{ dc_name }}-{{ deployment_stamp }}"
+      deployment_stamp: "{{ deployment_stamp }}"
+  template:
+    metadata:
+      labels:
+        app: marsha
+        service: "{{ service_variant }}"
+        version: "{{ marsha_image_tag }}"
+        deployment: "{{ dc_name }}-{{ deployment_stamp }}"
+        deployment_stamp: "{{ deployment_stamp }}"
+    spec:
+      # Prefer running pods on different nodes for redundancy
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: deployment
+                      operator: In
+                      values:
+                        - "{{ dc_name }}-{{ deployment_stamp }}"
+                topologyKey: kubernetes.io/hostname
+{% set image_pull_secret_name = marsha_image_pull_secret_name | default(none) or default_image_pull_secret_name %}
+{% if image_pull_secret_name is not none %}
+      imagePullSecrets:
+        - name: "{{ image_pull_secret_name }}"
+{% endif %}
+      containers:
+        - name: marsha
+          image: "{{ marsha_image_name }}:{{ marsha_image_tag }}"
+          imagePullPolicy: Always
+          livenessProbe:
+            httpGet:
+              path: /__heartbeat__
+              port: {{ marsha_django_port }}
+              httpHeaders:
+                - name: Host
+                  value: "{{ marsha_host }}"
+            initialDelaySeconds: 60
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /__lbheartbeat__
+              port: {{ marsha_django_port }}
+              httpHeaders:
+                - name: Host
+                  value: "{{ marsha_host }}"
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          env:
+            - name: DJANGO_SETTINGS_MODULE
+              value: marsha.configs.settings
+            - name: DJANGO_CONFIGURATION
+              value: "{{ marsha_django_configuration }}"
+            - name: POSTGRES_DB
+              value: "{{ marsha_postgresql_database }}"
+            - name: POSTGRES_HOST
+              value: "marsha-{{ marsha_postgresql_host }}-{{ deployment_stamp }}"
+            - name: POSTGRES_PORT
+              value: "{{ marsha_postgresql_port }}"
+            - name: DJANGO_ALLOWED_HOSTS
+              value: "{{ marsha_host | blue_green_hosts }}"
+            - name: DJANGO_CSRF_TRUSTED_ORIGINS
+              value: "{{ marsha_host | blue_green_hosts | split(',') | map('regex_replace', '^(.*)$', 'https://\\1') | join(',') }}"
+            - name: DJANGO_CLOUDFRONT_PRIVATE_KEY_PATH
+              value: "{{ marsha_cloudfront_private_key_path }}"
+          envFrom:
+            - secretRef:
+                name: "{{ marsha_secret_name }}"
+            - configMapRef:
+                name: "marsha-app-dotenv-{{ deployment_stamp }}"
+          resources: {{ marsha_app_resources }}
+          volumeMounts:
+            - name: marsha-configmap
+              mountPath: /app/src/backend/marsha/configs
+{% if env_type in trashable_env_types %}
+            - name: marsha-v-media
+              mountPath: /data/media
+            - name: marsha-v-static
+              mountPath: /data/static
+{% endif %}
+{% if marsha_should_sign_requests %}
+            - mountPath: "{{ marsha_cloudfront_private_key_path | dirname }}"
+              name: marsha-cloudfront-private-key-secret
+{% endif %}
+      securityContext:
+        runAsUser: {{ container_uid }}
+        runAsGroup: {{ container_gid }}
+      volumes:
+        - name: marsha-configmap
+          configMap:
+            defaultMode: 420
+            name: marsha-app-{{ deployment_stamp }}
+{% if env_type in trashable_env_types %}
+        - name: marsha-v-media
+          persistentVolumeClaim:
+            claimName: marsha-pvc-media
+        - name: marsha-v-static
+          persistentVolumeClaim:
+            claimName: marsha-pvc-static
+{% endif %}
+{% if marsha_should_sign_requests %}
+        - name: marsha-cloudfront-private-key-secret
+          secret:
+            secretName: "{{ marsha_cloudfront_private_key_secret_name }}"
+{% endif %}

--- a/src/tray/templates/services/app/_env.yml.j2
+++ b/src/tray/templates/services/app/_env.yml.j2
@@ -1,0 +1,1 @@
+DJANGO_SILENCED_SYSTEM_CHECKS: security.W008,security.W004

--- a/src/tray/templates/services/app/configs/__init__.py.j2
+++ b/src/tray/templates/services/app/configs/__init__.py.j2
@@ -1,0 +1,1 @@
+"""custom settings."""

--- a/src/tray/templates/services/app/configs/settings.py.j2
+++ b/src/tray/templates/services/app/configs/settings.py.j2
@@ -1,0 +1,1 @@
+from ..settings import *

--- a/src/tray/templates/services/app/cronjob_check_harvested.yml.j2
+++ b/src/tray/templates/services/app/cronjob_check_harvested.yml.j2
@@ -1,0 +1,69 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  labels:
+    app: marsha
+    service: app
+    version: "{{ marsha_image_tag }}"
+    deployment_stamp: "{{ deployment_stamp }}"
+  name: "check-harvested-{{ deployment_stamp }}"
+  namespace: "{{ namespace_name }}"
+spec:
+  schedule: "{{ marsha_check_harvested_cronjob_schedule }}"
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 1
+  concurrencyPolicy: Forbid
+  suspend: {{ suspend_cronjob | default(false) }}
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          name: "check-harvested-{{ deployment_stamp }}"
+          labels:
+            app: marsha
+            service: app
+            version: "{{ marsha_image_tag }}"
+            deployment_stamp: "{{ deployment_stamp }}"
+        spec:
+{% set image_pull_secret_name = marsha_image_pull_secret_name | default(none) or default_image_pull_secret_name %}
+{% if image_pull_secret_name is not none %}
+          imagePullSecrets:
+            - name: "{{ image_pull_secret_name }}"
+{% endif %}
+          containers:
+            - name: marsha
+              image: "{{ marsha_image_name }}:{{ marsha_image_tag }}"
+              imagePullPolicy: Always
+              command:
+                - "/bin/bash"
+                - "-c"
+                - python manage.py check_harvested
+              env:
+                - name: DJANGO_SETTINGS_MODULE
+                  value: marsha.configs.settings
+                - name: DJANGO_CONFIGURATION
+                  value: "{{ marsha_django_configuration }}"
+                - name: POSTGRES_DB
+                  value: "{{ marsha_postgresql_database }}"
+                - name: POSTGRES_HOST
+                  value: "marsha-{{ marsha_postgresql_host }}-{{ deployment_stamp }}"
+                - name: POSTGRES_PORT
+                  value: "{{ marsha_postgresql_port }}"
+              envFrom:
+                - secretRef:
+                    name: "{{ marsha_secret_name }}"
+                - configMapRef:
+                    name: "marsha-app-dotenv-{{ deployment_stamp }}"
+              resources: {{ marsha_app_cronjob_check_harvested_resources }}
+              volumeMounts:
+                - name: marsha-configmap
+                  mountPath: /app/src/backend/marsha/configs
+          securityContext:
+            runAsUser: {{ container_uid }}
+            runAsGroup: {{ container_gid }}
+          volumes:
+            - name: marsha-configmap
+              configMap:
+                defaultMode: 420
+                name: marsha-app-{{ deployment_stamp }}
+          restartPolicy: Never

--- a/src/tray/templates/services/app/cronjob_check_live_state.yml.j2
+++ b/src/tray/templates/services/app/cronjob_check_live_state.yml.j2
@@ -1,0 +1,69 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  labels:
+    app: marsha
+    service: app
+    version: "{{ marsha_image_tag }}"
+    deployment_stamp: "{{ deployment_stamp }}"
+  name: "check-live-state-{{ deployment_stamp }}"
+  namespace: "{{ namespace_name }}"
+spec:
+  schedule: "{{ marsha_check_live_state_cronjob_schedule }}"
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 1
+  concurrencyPolicy: Forbid
+  suspend: {{ suspend_cronjob | default(false) }}
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          name: "check-live-state-{{ deployment_stamp }}"
+          labels:
+            app: marsha
+            service: app
+            version: "{{ marsha_image_tag }}"
+            deployment_stamp: "{{ deployment_stamp }}"
+        spec:
+{% set image_pull_secret_name = marsha_image_pull_secret_name | default(none) or default_image_pull_secret_name %}
+{% if image_pull_secret_name is not none %}
+          imagePullSecrets:
+            - name: "{{ image_pull_secret_name }}"
+{% endif %}
+          containers:
+            - name: marsha
+              image: "{{ marsha_image_name }}:{{ marsha_image_tag }}"
+              imagePullPolicy: Always
+              command:
+                - "/bin/bash"
+                - "-c"
+                - python manage.py check_live_state
+              env:
+                - name: DJANGO_SETTINGS_MODULE
+                  value: marsha.configs.settings
+                - name: DJANGO_CONFIGURATION
+                  value: "{{ marsha_django_configuration }}"
+                - name: POSTGRES_DB
+                  value: "{{ marsha_postgresql_database }}"
+                - name: POSTGRES_HOST
+                  value: "marsha-{{ marsha_postgresql_host }}-{{ deployment_stamp }}"
+                - name: POSTGRES_PORT
+                  value: "{{ marsha_postgresql_port }}"
+              envFrom:
+                - secretRef:
+                    name: "{{ marsha_secret_name }}"
+                - configMapRef:
+                    name: "marsha-app-dotenv-{{ deployment_stamp }}"
+              resources: {{ marsha_app_cronjob_check_live_state_resources }}
+              volumeMounts:
+                - name: marsha-configmap
+                  mountPath: /app/src/backend/marsha/configs
+          securityContext:
+            runAsUser: {{ container_uid }}
+            runAsGroup: {{ container_gid }}
+          volumes:
+            - name: marsha-configmap
+              configMap:
+                defaultMode: 420
+                name: marsha-app-{{ deployment_stamp }}
+          restartPolicy: Never

--- a/src/tray/templates/services/app/cronjob_clean_aws_elemental_stack.yml.j2
+++ b/src/tray/templates/services/app/cronjob_clean_aws_elemental_stack.yml.j2
@@ -1,0 +1,69 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  labels:
+    app: marsha
+    service: app
+    version: "{{ marsha_image_tag }}"
+    deployment_stamp: "{{ deployment_stamp }}"
+  name: "clean-aws-elemental-stack-{{ deployment_stamp }}"
+  namespace: "{{ namespace_name }}"
+spec:
+  schedule: "{{ marsha_clean_aws_elemental_stack_cronjob_schedule }}"
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 1
+  concurrencyPolicy: Forbid
+  suspend: {{ suspend_cronjob | default(false) }}
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          name: "clean-aws-elemental-stack-{{ deployment_stamp }}"
+          labels:
+            app: marsha
+            service: app
+            version: "{{ marsha_image_tag }}"
+            deployment_stamp: "{{ deployment_stamp }}"
+        spec:
+{% set image_pull_secret_name = marsha_image_pull_secret_name | default(none) or default_image_pull_secret_name %}
+{% if image_pull_secret_name is not none %}
+          imagePullSecrets:
+            - name: "{{ image_pull_secret_name }}"
+{% endif %}
+          containers:
+            - name: marsha
+              image: "{{ marsha_image_name }}:{{ marsha_image_tag }}"
+              imagePullPolicy: Always
+              command:
+                - "/bin/bash"
+                - "-c"
+                - python manage.py clean_aws_elemental_stack
+              env:
+                - name: DJANGO_SETTINGS_MODULE
+                  value: marsha.configs.settings
+                - name: DJANGO_CONFIGURATION
+                  value: "{{ marsha_django_configuration }}"
+                - name: POSTGRES_DB
+                  value: "{{ marsha_postgresql_database }}"
+                - name: POSTGRES_HOST
+                  value: "marsha-{{ marsha_postgresql_host }}-{{ deployment_stamp }}"
+                - name: POSTGRES_PORT
+                  value: "{{ marsha_postgresql_port }}"
+              envFrom:
+                - secretRef:
+                    name: "{{ marsha_secret_name }}"
+                - configMapRef:
+                    name: "marsha-app-dotenv-{{ deployment_stamp }}"
+              resources: {{ marsha_app_cronjob_clean_aws_elemental_stack_resources }}
+              volumeMounts:
+                - name: marsha-configmap
+                  mountPath: /app/src/backend/marsha/configs
+          securityContext:
+            runAsUser: {{ container_uid }}
+            runAsGroup: {{ container_gid }}
+          volumes:
+            - name: marsha-configmap
+              configMap:
+                defaultMode: 420
+                name: marsha-app-{{ deployment_stamp }}
+          restartPolicy: Never

--- a/src/tray/templates/services/app/cronjob_clean_medialive_dev_stack.yml.j2
+++ b/src/tray/templates/services/app/cronjob_clean_medialive_dev_stack.yml.j2
@@ -1,0 +1,71 @@
+{% if marsha_deploy_clean_medialive_dev_stack_cronjob %}
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  labels:
+    app: marsha
+    service: app
+    version: "{{ marsha_image_tag }}"
+    deployment_stamp: "{{ deployment_stamp }}"
+  name: "clean-medialive-dev-stack-{{ deployment_stamp }}"
+  namespace: "{{ namespace_name }}"
+spec:
+  schedule: "{{ marsha_clean_medialive_dev_stack_cronjob_schedule }}"
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 1
+  concurrencyPolicy: Forbid
+  suspend: {{ suspend_cronjob | default(false) }}
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          name: "clean-medialive-dev-stack-{{ deployment_stamp }}"
+          labels:
+            app: marsha
+            service: app
+            version: "{{ marsha_image_tag }}"
+            deployment_stamp: "{{ deployment_stamp }}"
+        spec:
+{% set image_pull_secret_name = marsha_image_pull_secret_name | default(none) or default_image_pull_secret_name %}
+{% if image_pull_secret_name is not none %}
+          imagePullSecrets:
+            - name: "{{ image_pull_secret_name }}"
+{% endif %}
+          containers:
+            - name: marsha
+              image: "{{ marsha_image_name }}:{{ marsha_image_tag }}"
+              imagePullPolicy: Always
+              command:
+                - "/bin/bash"
+                - "-c"
+                - python manage.py clean_medialive_dev_stack
+              env:
+                - name: DJANGO_SETTINGS_MODULE
+                  value: marsha.configs.settings
+                - name: DJANGO_CONFIGURATION
+                  value: "{{ marsha_django_configuration }}"
+                - name: POSTGRES_DB
+                  value: "{{ marsha_postgresql_database }}"
+                - name: POSTGRES_HOST
+                  value: "marsha-{{ marsha_postgresql_host }}-{{ deployment_stamp }}"
+                - name: POSTGRES_PORT
+                  value: "{{ marsha_postgresql_port }}"
+              envFrom:
+                - secretRef:
+                    name: "{{ marsha_secret_name }}"
+                - configMapRef:
+                    name: "marsha-app-dotenv-{{ deployment_stamp }}"
+              resources: {{ marsha_app_cronjob_clean_mediapackages_resources }}
+              volumeMounts:
+                - name: marsha-configmap
+                  mountPath: /app/src/backend/marsha/configs
+          securityContext:
+            runAsUser: {{ container_uid }}
+            runAsGroup: {{ container_gid }}
+          volumes:
+            - name: marsha-configmap
+              configMap:
+                defaultMode: 420
+                name: marsha-app-{{ deployment_stamp }}
+          restartPolicy: Never
+{% endif %}

--- a/src/tray/templates/services/app/cronjob_clean_mediapackages.yml.j2
+++ b/src/tray/templates/services/app/cronjob_clean_mediapackages.yml.j2
@@ -1,0 +1,69 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  labels:
+    app: marsha
+    service: app
+    version: "{{ marsha_image_tag }}"
+    deployment_stamp: "{{ deployment_stamp }}"
+  name: "clean-mediapackages-{{ deployment_stamp }}"
+  namespace: "{{ namespace_name }}"
+spec:
+  schedule: "{{ marsha_clean_mediapackages_cronjob_schedule }}"
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 1
+  concurrencyPolicy: Forbid
+  suspend: {{ suspend_cronjob | default(false) }}
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          name: "clean-mediapackages-{{ deployment_stamp }}"
+          labels:
+            app: marsha
+            service: app
+            version: "{{ marsha_image_tag }}"
+            deployment_stamp: "{{ deployment_stamp }}"
+        spec:
+{% set image_pull_secret_name = marsha_image_pull_secret_name | default(none) or default_image_pull_secret_name %}
+{% if image_pull_secret_name is not none %}
+          imagePullSecrets:
+            - name: "{{ image_pull_secret_name }}"
+{% endif %}
+          containers:
+            - name: marsha
+              image: "{{ marsha_image_name }}:{{ marsha_image_tag }}"
+              imagePullPolicy: Always
+              command:
+                - "/bin/bash"
+                - "-c"
+                - python manage.py clean_mediapackages
+              env:
+                - name: DJANGO_SETTINGS_MODULE
+                  value: marsha.configs.settings
+                - name: DJANGO_CONFIGURATION
+                  value: "{{ marsha_django_configuration }}"
+                - name: POSTGRES_DB
+                  value: "{{ marsha_postgresql_database }}"
+                - name: POSTGRES_HOST
+                  value: "marsha-{{ marsha_postgresql_host }}-{{ deployment_stamp }}"
+                - name: POSTGRES_PORT
+                  value: "{{ marsha_postgresql_port }}"
+              envFrom:
+                - secretRef:
+                    name: "{{ marsha_secret_name }}"
+                - configMapRef:
+                    name: "marsha-app-dotenv-{{ deployment_stamp }}"
+              resources: {{ marsha_app_cronjob_clean_mediapackages_resources }}
+              volumeMounts:
+                - name: marsha-configmap
+                  mountPath: /app/src/backend/marsha/configs
+          securityContext:
+            runAsUser: {{ container_uid }}
+            runAsGroup: {{ container_gid }}
+          volumes:
+            - name: marsha-configmap
+              configMap:
+                defaultMode: 420
+                name: marsha-app-{{ deployment_stamp }}
+          restartPolicy: Never

--- a/src/tray/templates/services/app/cronjob_prefetch_saml_fer_metadata.yml.j2
+++ b/src/tray/templates/services/app/cronjob_prefetch_saml_fer_metadata.yml.j2
@@ -1,0 +1,69 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  labels:
+    app: marsha
+    service: app
+    version: "{{ marsha_image_tag }}"
+    deployment_stamp: "{{ deployment_stamp }}"
+  name: "prefetch-saml-fer-metadata-{{ deployment_stamp }}"
+  namespace: "{{ namespace_name }}"
+spec:
+  schedule: "{{ marsha_prefetch_saml_fer_metadata_cronjob_schedule }}"
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 1
+  concurrencyPolicy: Forbid
+  suspend: {{ suspend_cronjob | default(false) }}
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          name: "prefetch-saml-fer-metadata-{{ deployment_stamp }}"
+          labels:
+            app: marsha
+            service: app
+            version: "{{ marsha_image_tag }}"
+            deployment_stamp: "{{ deployment_stamp }}"
+        spec:
+{% set image_pull_secret_name = marsha_image_pull_secret_name | default(none) or default_image_pull_secret_name %}
+{% if image_pull_secret_name is not none %}
+          imagePullSecrets:
+            - name: "{{ image_pull_secret_name }}"
+{% endif %}
+          containers:
+            - name: marsha
+              image: "{{ marsha_image_name }}:{{ marsha_image_tag }}"
+              imagePullPolicy: Always
+              command:
+                - "/bin/bash"
+                - "-c"
+                - python manage.py prefetch_saml_fer_metadata saml_fer
+              env:
+                - name: DJANGO_SETTINGS_MODULE
+                  value: marsha.configs.settings
+                - name: DJANGO_CONFIGURATION
+                  value: "{{ marsha_django_configuration }}"
+                - name: POSTGRES_DB
+                  value: "{{ marsha_postgresql_database }}"
+                - name: POSTGRES_HOST
+                  value: "marsha-{{ marsha_postgresql_host }}-{{ deployment_stamp }}"
+                - name: POSTGRES_PORT
+                  value: "{{ marsha_postgresql_port }}"
+              envFrom:
+                - secretRef:
+                    name: "{{ marsha_secret_name }}"
+                - configMapRef:
+                    name: "marsha-app-dotenv-{{ deployment_stamp }}"
+              resources: {{ marsha_app_cronjob_prefetch_saml_fer_metadata_resources }}
+              volumeMounts:
+                - name: marsha-configmap
+                  mountPath: /app/src/backend/marsha/configs
+          securityContext:
+            runAsUser: {{ container_uid }}
+            runAsGroup: {{ container_gid }}
+          volumes:
+            - name: marsha-configmap
+              configMap:
+                defaultMode: 420
+                name: marsha-app-{{ deployment_stamp }}
+          restartPolicy: Never

--- a/src/tray/templates/services/app/deploy_app.yml.j2
+++ b/src/tray/templates/services/app/deploy_app.yml.j2
@@ -1,0 +1,4 @@
+{% set service_variant = "app" %}
+{% set marsha_replicas = marsha_app_replicas %}
+
+{% include "./_deploy_base.yml.j2" with context %}

--- a/src/tray/templates/services/app/deploy_xapi.yml.j2
+++ b/src/tray/templates/services/app/deploy_xapi.yml.j2
@@ -1,0 +1,4 @@
+{% set service_variant = "xapi" %}
+{% set marsha_replicas = marsha_xapi_replicas %}
+
+{% include "./_deploy_base.yml.j2" with context %}

--- a/src/tray/templates/services/app/job_db_migrate.yml.j2
+++ b/src/tray/templates/services/app/job_db_migrate.yml.j2
@@ -1,0 +1,53 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "marsha-app-dbmigrate-{{ job_stamp }}"
+  namespace: "{{ namespace_name }}"
+  labels:
+    app: marsha
+    service: marsha
+    version: "{{ marsha_image_tag }}"
+    deployment_stamp: "{{ deployment_stamp }}"
+    job_stamp: "{{ job_stamp }}"
+spec:
+  template:
+    metadata:
+      name: "marsha-app-dbmigrate-{{ job_stamp }}"
+      labels:
+        app: marsha
+        service: marsha
+        version: "{{ marsha_image_tag }}"
+        deployment_stamp: "{{ deployment_stamp }}"
+        job_stamp: "{{ job_stamp }}"
+    spec:
+{% set image_pull_secret_name = marsha_image_pull_secret_name | default(none) or default_image_pull_secret_name %}
+{% if image_pull_secret_name is not none %}
+      imagePullSecrets:
+        - name: "{{ image_pull_secret_name }}"
+{% endif %}
+      containers:
+        - name: marsha-dbmigrate
+          image: "{{ marsha_image_name }}:{{ marsha_image_tag }}"
+          imagePullPolicy: Always
+          env:
+            - name: DJANGO_SETTINGS_MODULE
+              value: marsha.settings
+            - name: DJANGO_CONFIGURATION
+              value: "{{ marsha_django_configuration }}"
+            - name: POSTGRES_DB
+              value: "{{ marsha_postgresql_database }}"
+            - name: POSTGRES_HOST
+              value: "marsha-{{ marsha_postgresql_host }}-{{ deployment_stamp }}"
+            - name: POSTGRES_PORT
+              value: "{{ marsha_postgresql_port }}"
+            - name: DJANGO_ALLOWED_HOSTS
+              value: "{{ marsha_host }}"
+          envFrom:
+            - secretRef:
+                name: "{{ marsha_secret_name }}"
+          command: ["python", "manage.py", "migrate"]
+          resources: {{ marsha_app_job_db_migrate_resources }}
+      restartPolicy: Never
+      securityContext:
+        runAsUser: {{ container_uid }}
+        runAsGroup: {{ container_gid }}

--- a/src/tray/templates/services/app/secret.yml.j2
+++ b/src/tray/templates/services/app/secret.yml.j2
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: marsha
+    service: marsha
+  name: "{{ marsha_secret_name }}"
+  namespace: "{{ namespace_name }}"
+data:
+  POSTGRES_USER: "{{ MARSHA_VAULT.POSTGRESQL_USER | default('marsha_user') | b64encode }}"
+  POSTGRES_PASSWORD: "{{ MARSHA_VAULT.POSTGRESQL_PASSWORD | default('password') | b64encode }}"
+  DJANGO_AWS_ACCESS_KEY_ID: "{{ MARSHA_VAULT.DJANGO_AWS_ACCESS_KEY_ID | default('secret') | b64encode }}"
+  DJANGO_AWS_SECRET_ACCESS_KEY: "{{ MARSHA_VAULT.DJANGO_AWS_SECRET_ACCESS_KEY | default('secret') | b64encode }}"
+  DJANGO_UPDATE_STATE_SHARED_SECRETS: "{{ MARSHA_VAULT.DJANGO_UPDATE_STATE_SHARED_SECRETS | default('secret') | b64encode }}"
+  DJANGO_CLOUDFRONT_ACCESS_KEY_ID: "{{ MARSHA_VAULT.DJANGO_CLOUDFRONT_ACCESS_KEY_ID | default('secret') | b64encode }}"
+  DJANGO_CLOUDFRONT_DOMAIN: "{{ MARSHA_VAULT.DJANGO_CLOUDFRONT_DOMAIN | default('foo.com') | b64encode }}"
+  DJANGO_JWT_SIGNING_KEY: "{{ MARSHA_VAULT.DJANGO_JWT_SIGNING_KEY | default('secret') | b64encode }}"
+  DJANGO_SECRET_KEY: "{{ MARSHA_VAULT.DJANGO_SECRET_KEY | default('supersecret') | b64encode }}"
+  DJANGO_AWS_MEDIALIVE_ROLE_ARN: "{{ MARSHA_VAULT.DJANGO_AWS_MEDIALIVE_ROLE_ARN | default('secret') | b64encode }}"
+  DJANGO_AWS_MEDIAPACKAGE_HARVEST_JOB_ARN: "{{ MARSHA_VAULT.DJANGO_AWS_MEDIAPACKAGE_HARVEST_JOB_ARN | default('secret') | b64encode }}"
+{% if MARSHA_VAULT.DJANGO_SENTRY_DSN is defined and MARSHA_VAULT.DJANGO_SENTRY_DSN is not none %}
+  DJANGO_SENTRY_DSN: "{{ MARSHA_VAULT.DJANGO_SENTRY_DSN | b64encode }}"
+{% endif %}
+  DJANGO_AWS_S3_REGION_NAME: "{{ MARSHA_VAULT.DJANGO_AWS_S3_REGION_NAME | default('eu-west-1') | b64encode }}"
+{% if MARSHA_VAULT.DJANGO_LRS_AUTH_TOKEN is defined %}
+  DJANGO_LRS_AUTH_TOKEN: "{{ MARSHA_VAULT.DJANGO_LRS_AUTH_TOKEN | b64encode }}"
+{% endif %}
+{% if MARSHA_VAULT.DJANGO_LRS_URL is defined %}
+  DJANGO_LRS_URL: "{{ MARSHA_VAULT.DJANGO_LRS_URL | b64encode }}"
+{% endif %}
+{% if MARSHA_VAULT.SECRETS is defined %}
+{% for k, v in MARSHA_VAULT.SECRETS.items() %}
+  {{ k }}: {{ v | default('') | b64encode }}
+{% endfor %}
+{% endif %}

--- a/src/tray/templates/services/app/secret_cloudfront_private_key.yml.j2
+++ b/src/tray/templates/services/app/secret_cloudfront_private_key.yml.j2
@@ -1,0 +1,13 @@
+{% if marsha_should_sign_requests %}
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: marsha
+    service: "marsha"
+  name: "{{ marsha_cloudfront_private_key_secret_name }}"
+  namespace: "{{ namespace_name }}"
+data:
+  ssh-privatekey: "{{ MARSHA_VAULT.DJANGO_CLOUDFRONT_PRIVATE_KEY | default('') | b64encode }}"
+type: kubernetes.io/ssh-auth
+{% endif %}

--- a/src/tray/templates/services/app/svc_app.yml.j2
+++ b/src/tray/templates/services/app/svc_app.yml.j2
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: marsha
+    service: app
+    version: "{{ marsha_image_tag }}"
+    deployment_stamp: "{{ deployment_stamp }}"
+  name: marsha-app-{{ deployment_stamp }}  # name of the service should be host name in nginx
+  namespace: "{{ namespace_name }}"
+spec:
+  ports:
+  - name: {{ marsha_django_port }}-tcp
+    port: {{ marsha_django_port }}
+    protocol: TCP
+    targetPort: {{ marsha_django_port }}
+  selector:
+    app: marsha
+    deployment: "marsha-app-{{ deployment_stamp }}"
+  type: ClusterIP

--- a/src/tray/templates/services/app/svc_xapi.yml.j2
+++ b/src/tray/templates/services/app/svc_xapi.yml.j2
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: marsha
+    service: xapi
+    version: "{{ marsha_image_tag }}"
+    deployment_stamp: "{{ deployment_stamp }}"
+  name: marsha-xapi-{{ deployment_stamp }}  # name of the service should be host name in nginx
+  namespace: "{{ namespace_name }}"
+spec:
+  ports:
+  - name: {{ marsha_django_port }}-tcp
+    port: {{ marsha_django_port }}
+    protocol: TCP
+    targetPort: {{ marsha_django_port }}
+  selector:
+    app: marsha
+    deployment: "marsha-xapi-{{ deployment_stamp }}"
+  type: ClusterIP

--- a/src/tray/templates/services/nginx/configs/healthcheck.conf.j2
+++ b/src/tray/templates/services/nginx/configs/healthcheck.conf.j2
@@ -1,0 +1,14 @@
+server {
+  listen {{ marsha_nginx_healthcheck_port }};
+  server_name localhost;
+
+  location {{ marsha_nginx_healthcheck_endpoint }} {
+    add_header Content-Type text/plain;
+    return 200 "OK";
+  }
+
+  location {{ marsha_nginx_status_endpoint }} {
+     stub_status;
+  }
+
+}

--- a/src/tray/templates/services/nginx/configs/marsha.conf.j2
+++ b/src/tray/templates/services/nginx/configs/marsha.conf.j2
@@ -1,0 +1,118 @@
+{% set http_basic_auth_enabled = activate_http_basic_auth or marsha_activate_http_basic_auth %}
+{% set bypass_htaccess = marsha_nginx_bypass_htaccess_ip_whitelist | length > 0 %}
+upstream marsha-backend {
+  server marsha-app-{{ deployment_stamp }}:{{ marsha_django_port }} fail_timeout=0;
+}
+
+upstream marsha-xapi {
+  server marsha-xapi-{{ deployment_stamp }}:{{ marsha_django_port }} fail_timeout=0;
+}
+
+server {
+  listen {{ marsha_nginx_port }};
+  server_name localhost;
+
+{% if http_basic_auth_enabled %}
+{% if bypass_htaccess %}
+  location @basicauth {
+    auth_basic "{{ http_basic_auth_message }}";
+    auth_basic_user_file {{ http_basic_auth_user_file }};
+
+    try_files $uri @proxy_to_marsha_app;
+  }
+{% else %}
+  auth_basic "{{ http_basic_auth_message }}";
+  auth_basic_user_file {{ http_basic_auth_user_file }};
+{% endif %}
+{% endif %}
+
+  client_max_body_size 100M;
+
+  rewrite ^(.*)/favicon.ico$ /static/images/favicon.ico last;
+
+  # Disables server version feedback on pages and in headers
+  server_tokens off;
+  {% block server_extra %}{% endblock %}
+
+  location @proxy_to_marsha_app {
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+    proxy_redirect off;
+    proxy_pass http://marsha-backend;
+  }
+
+  location @proxy_to_marsha_xapi {
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+    proxy_redirect off;
+    proxy_pass http://marsha-xapi;
+  }
+
+  location / {
+{% if http_basic_auth_enabled and bypass_htaccess %}
+    if ($http_x_forwarded_for !~ ^({{ marsha_nginx_bypass_htaccess_ip_whitelist | join("|") }})) {
+      error_page 401 = @basicauth;
+      return 401;
+    }
+{% endif %} 
+
+    try_files $uri @proxy_to_marsha_app;
+  }
+
+  location /ws/ {
+    proxy_pass http://marsha-backend;
+
+    proxy_http_version 1.1;
+    proxy_set_header Connection "Upgrade";
+    proxy_set_header Upgrade $http_upgrade;
+
+    proxy_buffering off;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+
+  location /xapi {
+{% if http_basic_auth_enabled and bypass_htaccess %}
+    if ($http_x_forwarded_for !~ ^({{ marsha_nginx_bypass_htaccess_ip_whitelist | join("|") }})) {
+      error_page 401 = @basicauth;
+      return 401;
+    }
+{% endif %} 
+
+    try_files $uri @proxy_to_marsha_xapi;
+  }
+
+{% if marsha_nginx_admin_ip_whitelist | length > 0 %}
+  location /admin {
+    {#
+      We want to limit access to a list of whitelisted IP addresses.
+
+      $http_x_forwarded_for variable contains a list of IPs listed from the HTTP_X_FORWARED_FOR
+      header (e.g. w.x.y.z, 10.0.0.1). The first IP corresponds to the client's public address,
+      which is of interest (other ones have been added by subsequent proxies),
+      hence we restrict our comparison with the beginning of this list (this is why our regex starts with a ^).
+    #}
+    if ($http_x_forwarded_for !~ ^({{ marsha_nginx_admin_ip_whitelist | join("|") }})) {
+      return 403;
+    }
+
+    try_files $uri @proxy_to_marsha_app;
+  }
+{% endif %}
+
+  {% if env_type in trashable_env_types %}
+  location ~ ^/static/(?P<file>.*) {
+    access_log off;
+    gzip on;
+    gzip_comp_level 5;
+    gzip_types text/plain text/css text/xml text/javascript application/x-javascript application/xml image/svg+xml;
+    expires {{ marsha_nginx_static_cache_expires }};
+    add_header Cache-Control public;
+    root /data/static/marsha;
+    try_files /$file =404;
+  }
+  {% endif %}
+}

--- a/src/tray/templates/services/nginx/deploy.yml.j2
+++ b/src/tray/templates/services/nginx/deploy.yml.j2
@@ -1,0 +1,102 @@
+apiVersion: v1
+kind: Deployment
+metadata:
+  labels:
+    app: marsha
+    service: nginx
+    version: "{{ marsha_nginx_image_tag }}"
+    deployment_stamp: "{{ deployment_stamp }}"
+  name: "marsha-nginx-{{ deployment_stamp }}"
+  namespace: "{{ namespace_name }}"
+spec:
+  replicas: {{ marsha_nginx_replicas }}
+  selector:
+    matchLabels:
+      app: marsha
+      service: nginx
+      version: "{{ marsha_nginx_image_tag }}"
+      deployment: "marsha-nginx-{{ deployment_stamp }}"
+      deployment_stamp: "{{ deployment_stamp }}"
+  template:
+    metadata:
+      labels:
+        app: marsha
+        service: nginx
+        version: "{{ marsha_nginx_image_tag }}"
+        deployment: "marsha-nginx-{{ deployment_stamp }}"
+        deployment_stamp: "{{ deployment_stamp }}"
+    spec:
+      # Prefer running pods on different nodes for redundancy
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: deployment
+                  operator: In
+                  values:
+                  - "marsha-nginx-{{ deployment_stamp }}"
+              topologyKey: kubernetes.io/hostname
+{% set image_pull_secret_name = marsha_nginx_image_pull_secret_name | default(none) or default_image_pull_secret_name %}
+{% if image_pull_secret_name is not none %}
+      imagePullSecrets:
+        - name: "{{ image_pull_secret_name }}"
+{% endif %}
+      containers:
+        - image: "{{ marsha_nginx_image_name }}:{{ marsha_nginx_image_tag }}"
+          name: nginx
+          ports:
+            - containerPort: 80
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /etc/nginx/conf.d
+              name: marsha-v-nginx
+              readOnly: true
+{% if env_type in trashable_env_types %}
+            - mountPath: /data/media/marsha
+              name: marsha-v-media
+              readOnly: true
+            - mountPath: /data/static/marsha
+              name: marsha-v-static
+              readOnly: true
+{% endif %}
+{% if activate_http_basic_auth or marsha_activate_http_basic_auth %}
+            - mountPath: "{{ http_basic_auth_user_file | dirname }}"
+              name: marsha-htpasswd
+{% endif %}
+
+          livenessProbe:
+            httpGet:
+              path: "{{ marsha_nginx_healthcheck_endpoint }}"
+              port: {{ marsha_nginx_healthcheck_port }}
+            initialDelaySeconds: 60
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: "{{ marsha_nginx_healthcheck_endpoint }}"
+              port: {{ marsha_nginx_healthcheck_port }}
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          resources: {{ marsha_nginx_resources }}
+      securityContext:
+        runAsUser: {{ container_uid }}
+        runAsGroup: {{ container_gid }}
+      volumes:
+        - name: marsha-v-nginx
+          configMap:
+            name: marsha-nginx-{{ deployment_stamp }}
+{% if env_type in trashable_env_types %}
+        - name: marsha-v-media
+          persistentVolumeClaim:
+            claimName: marsha-pvc-media
+        - name: marsha-v-static
+          persistentVolumeClaim:
+            claimName: marsha-pvc-static
+{% endif %}
+{% if activate_http_basic_auth or marsha_activate_http_basic_auth %}
+        - name: marsha-htpasswd
+          secret:
+            secretName: "{{ marsha_nginx_htpasswd_secret_name }}"
+{% endif %}

--- a/src/tray/templates/services/nginx/ingress.yml.j2
+++ b/src/tray/templates/services/nginx/ingress.yml.j2
@@ -1,0 +1,33 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  namespace: "{{ namespace_name }}"
+  name: "marsha-nginx-{{ prefix }}"
+  labels:
+    env_type: "{{ env_type }}"
+    customer: "{{ customer }}"
+    app: "marsha"
+    service: "nginx"
+    route_prefix: "{{ prefix }}"
+    route_target_service: "app"
+  annotations:
+{% if prefix in acme_enabled_route_prefix %}
+    cert-manager.io/issuer: "{{ acme_issuer_name }}"
+{% endif %}
+spec:
+  ingressClassName: "{{ marsha_ingress_class_name }}"
+  rules:
+  - host: "{{ marsha_host | blue_green_host(prefix) }}"
+    http:
+      paths:
+      - backend:
+          service:
+            name: "marsha-nginx-{{ prefix }}"
+            port:
+              number: {{ marsha_nginx_port }}
+        path: /
+        pathType: Prefix
+  tls:
+  - hosts:
+    - "{{ marsha_host | blue_green_host(prefix) }}"
+    secretName: "marsha-app-tls-{{ prefix }}-{{ acme_env }}"

--- a/src/tray/templates/services/nginx/secret.yml.j2
+++ b/src/tray/templates/services/nginx/secret.yml.j2
@@ -1,0 +1,14 @@
+{% if activate_http_basic_auth or marsha_activate_http_basic_auth %}
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: marsha
+    service: "nginx"
+  name: "{{ marsha_nginx_htpasswd_secret_name }}"
+  namespace: "{{ namespace_name }}"
+data:
+  # nota bene: the {{ app.name }}_htpasswd variable is set in
+  # tasks/get_vault_for_app.yml tasks list only if the pointed file exists
+  "{{ http_basic_auth_user_file | basename }}": "{{ lookup('file', marsha_htpasswd) | b64encode }}"
+{% endif %}

--- a/src/tray/templates/services/nginx/static-svc.yml.j2
+++ b/src/tray/templates/services/nginx/static-svc.yml.j2
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: marsha
+    service: nginx
+    deployment_stamp: "{{ deployment_stamp }}"
+    service_prefix: "{{ prefix }}"
+    type: static-service
+    removable: "no"
+  name: "marsha-nginx-{{ prefix }}"
+  namespace: "{{ namespace_name }}"
+spec:
+  ports:
+    - name: {{ marsha_nginx_port }}-tcp
+      port: {{ marsha_nginx_port }}
+      protocol: TCP
+      targetPort: {{ marsha_nginx_port }}
+    - name: "{{ marsha_nginx_healthcheck_port }}-tcp"
+      port: {{ marsha_nginx_healthcheck_port }}
+      protocol: TCP
+      targetPort: {{ marsha_nginx_healthcheck_port }}
+  selector:
+    app: marsha
+    deployment: "marsha-nginx-{{ deployment_stamp | default('undefined', true) }}"
+  type: ClusterIP

--- a/src/tray/templates/services/nginx/svc.yml.j2
+++ b/src/tray/templates/services/nginx/svc.yml.j2
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: marsha
+    service: nginx
+    version: "{{ marsha_nginx_image_tag }}"
+    deployment_stamp: "{{ deployment_stamp }}"
+  name: "marsha-nginx-{{ deployment_stamp }}"
+  namespace: "{{ namespace_name }}"
+spec:
+  ports:
+    - name: {{ marsha_nginx_port }}-tcp
+      port: {{ marsha_nginx_port }}
+      protocol: TCP
+      targetPort: {{ marsha_nginx_port }}
+    - name: "{{ marsha_nginx_healthcheck_port }}-tcp"
+      port: {{ marsha_nginx_healthcheck_port }}
+      protocol: TCP
+      targetPort: {{ marsha_nginx_healthcheck_port }}
+  selector:
+    app: marsha
+    deployment: "marsha-nginx-{{ deployment_stamp }}"
+  type: ClusterIP

--- a/src/tray/templates/services/postgresql/deploy.yml.j2
+++ b/src/tray/templates/services/postgresql/deploy.yml.j2
@@ -1,0 +1,53 @@
+{% if env_type in trashable_env_types %}
+apiVersion: v1
+kind: Deployment
+metadata:
+  labels:
+    app: marsha
+    service: postgresql
+    version: "{{ marsha_postgresql_image_tag }}"
+    deployment_stamp: "{{ deployment_stamp }}"
+  name: "marsha-postgresql-{{ deployment_stamp }}"
+  namespace: "{{ namespace_name }}"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: marsha
+      service: postgresql
+      version: "{{ marsha_postgresql_image_tag }}"
+      deployment: "marsha-postgresql-{{ deployment_stamp }}"
+      deployment_stamp: "{{ deployment_stamp }}"
+  template:
+    metadata:
+      labels:
+        app: marsha
+        service: postgresql
+        version: "{{ marsha_postgresql_image_tag }}"
+        deployment: "marsha-postgresql-{{ deployment_stamp }}"
+        deployment_stamp: "{{ deployment_stamp }}"
+    spec:
+{% set image_pull_secret_name = marsha_postgresql_image_pull_secret_name | default(none) or default_image_pull_secret_name %}
+{% if image_pull_secret_name is not none %}
+      imagePullSecrets:
+        - name: "{{ image_pull_secret_name }}"
+{% endif %}
+      containers:
+        - image: {{ marsha_postgresql_image_name }}:{{ marsha_postgresql_image_tag }}
+          name: postgresql
+          ports:
+            - containerPort: {{ marsha_postgresql_port }}
+              protocol: TCP
+          env:
+            - name: POSTGRES_DB
+              value: "{{ marsha_postgresql_database }}"
+            - name: PGDATA
+              value: "{{ marsha_postgresql_pgdata }}"
+          envFrom:
+            - secretRef:
+                name: "{{ marsha_postgresql_secret_name }}"
+          resources: {{ marsha_postgresql_resources }}
+      securityContext:
+        runAsUser: {{ container_uid }}
+        runAsGroup: {{ container_gid }}
+{% endif %}

--- a/src/tray/templates/services/postgresql/ep.yml.j2
+++ b/src/tray/templates/services/postgresql/ep.yml.j2
@@ -1,0 +1,18 @@
+{% if endpoint_postgresql_ip | ipaddr != false %}
+apiVersion: v1
+kind: Endpoints
+metadata:
+  labels:
+    app: marsha
+    endpoint: postgresql
+    deployment_stamp: "{{ deployment_stamp }}"
+  # name of the endpoint should be the same as the corresponding service
+  name: "marsha-postgresql-{{ deployment_stamp }}"
+  namespace: "{{ namespace_name }}"
+subsets:
+  - addresses:
+    - ip: "{{ endpoint_postgresql_ip }}"
+    ports:
+    - port: 5432
+      name: 5432-tcp
+{% endif %}

--- a/src/tray/templates/services/postgresql/secret.yml.j2
+++ b/src/tray/templates/services/postgresql/secret.yml.j2
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: marsha
+    service: postgresql
+  name: "{{ marsha_postgresql_secret_name }}"
+  namespace: "{{ namespace_name }}"
+data:
+  POSTGRES_USER: "{{ MARSHA_VAULT.POSTGRESQL_USER | default('marsha_user') | b64encode }}"
+  POSTGRES_PASSWORD: "{{ MARSHA_VAULT.POSTGRESQL_PASSWORD | default('pass') | b64encode }}"

--- a/src/tray/templates/services/postgresql/svc.yml.j2
+++ b/src/tray/templates/services/postgresql/svc.yml.j2
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: marsha
+    service: postgresql
+    version: "{{ marsha_postgresql_image_tag }}"
+    deployment_stamp: "{{ deployment_stamp }}"
+  # name of the service should be database host name in settings
+  name: "marsha-postgresql-{{ deployment_stamp }}"
+  namespace: "{{ namespace_name }}"
+spec:
+  ports:
+    - name: "{{ marsha_postgresql_port }}-tcp"
+      port: {{ marsha_postgresql_port }}
+      protocol: TCP
+      targetPort: {{ marsha_postgresql_port }}
+# As commented in the ad hoc endpoint, the endpoint name points to this service
+# so that it does not rely on a deployment configuration when the "env_type" is
+# not trashable. In this case, we use a PostgreSQL cluster outside of k8s.
+{% if env_type in trashable_env_types %}
+  selector:
+    app: marsha
+    service: postgresql
+    deployment: "marsha-postgresql-{{ deployment_stamp }}"
+  type: ClusterIP
+{% endif%}

--- a/src/tray/templates/volumes/media.yml.j2
+++ b/src/tray/templates/volumes/media.yml.j2
@@ -1,0 +1,18 @@
+{% if env_type in trashable_env_types %}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: marsha-pvc-media
+  namespace: "{{ namespace_name }}"
+  labels:
+    app: marsha
+    version: "{{ marsha_image_tag }}"
+    deployment_stamp: "{{ deployment_stamp }}"
+spec:
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ marsha_media_volume_size }}
+  storageClassName: "{{ default_storage_class_rwx }}"
+{% endif %}

--- a/src/tray/templates/volumes/static.yml.j2
+++ b/src/tray/templates/volumes/static.yml.j2
@@ -1,0 +1,18 @@
+{% if env_type in trashable_env_types %}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: marsha-pvc-static
+  namespace: "{{ namespace_name }}"
+  labels:
+    app: marsha
+    version: "{{ marsha_image_tag }}"
+    deployment_stamp: "{{ deployment_stamp }}"
+spec:
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ marsha_static_volume_size }}
+  storageClassName: "{{ default_storage_class_rwx }}"
+{% endif %}

--- a/src/tray/tray.yml
+++ b/src/tray/tray.yml
@@ -1,0 +1,3 @@
+metadata:
+  name: marsha
+  version: 4.0.0-beta.13

--- a/src/tray/vars/all/main.yml
+++ b/src/tray/vars/all/main.yml
@@ -1,0 +1,82 @@
+# Application default configuration
+
+# -- ingress
+marsha_host: "marsha.{{ namespace_name }}.{{ domain_name }}"
+marsha_ingress_class_name: "{{ default_ingress_class_name }}"
+
+# -- nginx
+marsha_nginx_image_name: "nginxinc/nginx-unprivileged"
+marsha_nginx_image_tag: "1.20"
+marsha_nginx_port: 8061
+marsha_nginx_replicas: 1
+marsha_nginx_htpasswd_secret_name: "marsha-htpasswd"
+marsha_nginx_healthcheck_port: 5000
+marsha_nginx_healthcheck_endpoint: "/__healthcheck__"
+marsha_nginx_status_endpoint: "/__status__"
+marsha_nginx_admin_ip_whitelist: []
+marsha_nginx_bypass_htaccess_ip_whitelist: []
+marsha_nginx_static_cache_expires: "1M"
+
+# -- postgresql
+marsha_postgresql_version: "12"
+marsha_postgresql_image_name: "postgres"
+marsha_postgresql_image_tag: "12"
+marsha_postgresql_host: "postgresql"
+marsha_postgresql_port: 5432
+marsha_postgresql_database: "marsha"
+marsha_postgresql_pgdata: "/var/lib/postgresql/data"
+marsha_postgresql_secret_name: "marsha-postgresql-{{ marsha_vault_checksum | default('undefined_marsha_vault_checksum') }}"
+
+# -- marsha
+marsha_image_name: "fundocker/marsha"
+marsha_image_tag: "3.23.0"
+marsha_django_port: 8000
+marsha_app_replicas: 1
+marsha_xapi_replicas: 1
+marsha_django_configuration: "Development"
+marsha_secret_name: "marsha-{{ marsha_vault_checksum | default('undefined_marsha_vault_checksum') }}"
+marsha_cloudfront_private_key_secret_name: "marsha-sshkey-{{ marsha_vault_checksum | default('undefined_marsha_vault_checksum') }}"
+marsha_cloudfront_private_key_path: "/private/.ssh/aws/ssh-privatekey"
+# Set this to true if you have configured AWS CloudFront to require requests
+# signature with the aforementioned SSH key
+marsha_should_sign_requests: true
+marsha_activate_http_basic_auth: false
+marsha_deploy_clean_medialive_dev_stack_cronjob: false
+marsha_check_harvested_cronjob_schedule: "0 3 * * *"
+marsha_check_live_state_cronjob_schedule: "*/20 * * * *"
+marsha_check_idle_state_cronjob_schedule: "0 4 * * *"
+marsha_clean_mediapackages_cronjob_schedule: "0 5 * * *"
+marsha_clean_medialive_dev_stack_cronjob_schedule: "*/5 * * * *"
+marsha_clean_aws_elemental_stack_cronjob_schedule: "0 */2 * * *"
+marsha_prefetch_saml_fer_metadata_cronjob_schedule: "0 */6 * * *"
+
+# -- volumes
+marsha_media_volume_size: 2Gi
+marsha_static_volume_size: 2Gi
+
+# -- resources
+{% set app_resources = {
+  "requests": {
+    "cpu": "50m",
+    "memory": "500Mi"
+  }
+} %}
+
+marsha_app_resources: "{{ app_resources }}"
+marsha_app_job_db_migrate_resources: "{{ app_resources }}"
+marsha_app_cronjob_check_harvested_resources: "{{ app_resources }}"
+marsha_app_cronjob_check_live_idle_resources: "{{ app_resources }}"
+marsha_app_cronjob_check_live_state_resources: "{{ app_resources }}"
+marsha_app_cronjob_clean_mediapackages_resources: "{{ app_resources }}"
+marsha_app_cronjob_clean_aws_elemental_stack_resources: "{{ app_resources }}"
+marsha_app_cronjob_prefetch_saml_fer_metadata_resources: "{{ app_resources }}"
+
+marsha_nginx_resources:
+  requests:
+    cpu: 10m
+    memory: 5Mi
+
+marsha_postgresql_resources:
+  requests:
+    cpu: 10m
+    memory: 100Mi

--- a/src/tray/vars/settings.yml
+++ b/src/tray/vars/settings.yml
@@ -1,0 +1,3 @@
+databases:
+  - engine: "postgresql"
+    release: "12"

--- a/src/tray/vars/vault/main.yml.j2
+++ b/src/tray/vars/vault/main.yml.j2
@@ -1,0 +1,30 @@
+# customer: {{ customer }}
+# env_type: {{ env_type }}
+
+# postgresql
+{% set postgresql_credentials = databases.postgresql | json_query("[?release=='" ~ marsha_postgresql_version ~ "'].databases | [0][?application=='marsha'].{user: user, password: password} | [0]") %}
+POSTGRESQL_USER: {{ postgresql_credentials.user }}
+POSTGRESQL_PASSWORD: {{ postgresql_credentials.password }}
+
+# marsha environment
+DJANGO_SECRET_KEY: {{ lookup('password', '/dev/null length=50') }}
+# FIXME uncomment this variable and replace with your sentry's credentials
+# DJANGO_SENTRY_DSN: https://super:marsha@sentry.io/foo
+
+# FIXME uncomment this block and replace with your AWS credentials.
+# You can refer to Marsha's documentation to know what are these variables:
+# https://github.com/openfun/marsha/blob/master/docs/env.md#amazon-web-services-related-settings
+# AWS
+# DJANGO_AWS_ACCESS_KEY_ID: yourAwsAccessKeyId
+# DJANGO_AWS_SECRET_ACCESS_KEY: yourAwsSecretAccessKey
+
+# FIXME uncomment this block and replace with your cloudfront credentials
+# You can refer to Marsha's documentation to know what are these variables:
+# https://github.com/openfun/marsha/blob/master/docs/env.md#django_cloudfront_access_key_id
+# CloudFront User (has to be a root user, cannot be an IAM user)
+# DJANGO_CLOUDFRONT_ACCESS_KEY_ID: YourCloudfrontAccessKeyId
+# DJANGO_CLOUDFRONT_URL: https://yourCloudfrontUrl
+# DJANGO_CLOUDFRONT_PRIVATE_KEY:
+
+# JWT Token
+DJANGO_JWT_SIGNING_KEY: {{ lookup('password', '/dev/null length=50') }}


### PR DESCRIPTION
## Purpose

The manifests we use to deploy marsha on our k8s was managed by arnold
    (openfun/arnold). We are moving app from arnold to their respective
    github repository. The marsha tray is in src/tray and is tested with
    circleci.

## Proposal

- [x] bootstrap arnold tray

