### PR TITLE
Change docker env name in circle config and optimize e2e jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,11 +9,11 @@ aliases:
     # Nota bene: you'll need to define the following secrets environment vars
     # in CircleCI interface:
     #
-    #   - DOCKER_USER
-    #   - DOCKER_PASS
+    #   - DOCKER_HUB_USER
+    #   - DOCKER_HUB_PASS
     run:
       name: Login to DockerHub
-      command: echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
+      command: echo "$DOCKER_HUB_PASS" | docker login -u "$DOCKER_HUB_USER" --password-stdin
 
 # Configuration file anchors
 generate-version-file: &generate-version-file
@@ -48,8 +48,8 @@ jobs:
       # stay in python 3.8
       - image: cimg/python:3.8
         auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
+          username: $DOCKER_HUB_USER
+          password: $DOCKER_HUB_PASS
     working_directory: ~/marsha
     steps:
       - checkout
@@ -76,8 +76,8 @@ jobs:
     docker:
       - image: cimg/base:2022.04
         auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
+          username: $DOCKER_HUB_USER
+          password: $DOCKER_HUB_PASS
     working_directory: ~/marsha
     steps:
       - checkout
@@ -91,8 +91,8 @@ jobs:
     docker:
       - image: debian:stretch
         auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
+          username: $DOCKER_HUB_USER
+          password: $DOCKER_HUB_PASS
     working_directory: ~/marsha
     steps:
       - checkout
@@ -107,8 +107,8 @@ jobs:
     docker:
       - image: renovate/renovate
         auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
+          username: $DOCKER_HUB_USER
+          password: $DOCKER_HUB_PASS
     working_directory: ~/marsha
     steps:
       - checkout
@@ -123,8 +123,8 @@ jobs:
     docker:
       - image: cimg/base:2022.04
         auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
+          username: $DOCKER_HUB_USER
+          password: $DOCKER_HUB_PASS
     working_directory: ~/marsha
     steps:
       # Checkout repository sources
@@ -190,8 +190,8 @@ jobs:
     docker:
       - image: cimg/base:2022.04
         auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
+          username: $DOCKER_HUB_USER
+          password: $DOCKER_HUB_PASS
     working_directory: ~/marsha
     steps:
       # Checkout repository sources
@@ -220,8 +220,8 @@ jobs:
     docker:
       - image: cimg/python:3.10.7
         auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
+          username: $DOCKER_HUB_USER
+          password: $DOCKER_HUB_PASS
     working_directory: ~/marsha/src/backend
     steps:
       - checkout:
@@ -242,8 +242,8 @@ jobs:
     docker:
       - image: cimg/python:3.10.7
         auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
+          username: $DOCKER_HUB_USER
+          password: $DOCKER_HUB_PASS
         environment:
           DJANGO_SETTINGS_MODULE: marsha.settings
           PYTHONPATH: /home/circleci/marsha/src/backend
@@ -293,8 +293,8 @@ jobs:
     docker:
       - image: cimg/python:3.10.7
         auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
+          username: $DOCKER_HUB_USER
+          password: $DOCKER_HUB_PASS
     working_directory: ~/marsha/src/backend
     steps:
       - checkout:
@@ -322,8 +322,8 @@ jobs:
     docker:
       - image: cimg/python:3.10.7
         auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
+          username: $DOCKER_HUB_USER
+          password: $DOCKER_HUB_PASS
         environment:
           DJANGO_SETTINGS_MODULE: marsha.settings
           PYTHONPATH: /home/circleci/marsha/src/backend
@@ -345,8 +345,8 @@ jobs:
           DJANGO_MARKDOWN_ENABLED: 1
       - image: cimg/postgres:10.20
         auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
+          username: $DOCKER_HUB_USER
+          password: $DOCKER_HUB_PASS
         environment:
           POSTGRES_DB: marsha
           POSTGRES_USER: marsha_user
@@ -385,8 +385,8 @@ jobs:
     docker:
       - image: cimg/node:16.15
         auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
+          username: $DOCKER_HUB_USER
+          password: $DOCKER_HUB_PASS
         environment:
           BUILD_PATH: ../../../backend/marsha/static/js/build/site/
     working_directory: ~/marsha/src/frontend
@@ -436,8 +436,8 @@ jobs:
     docker:
       - image: cimg/node:16.15
         auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
+          username: $DOCKER_HUB_USER
+          password: $DOCKER_HUB_PASS
         environment:
           BUILD_PATH: ../../../backend/marsha/static/js/build/site/
     working_directory: ~/marsha/src/frontend
@@ -478,8 +478,8 @@ jobs:
     docker:
       - image: cimg/node:16.15
         auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
+          username: $DOCKER_HUB_USER
+          password: $DOCKER_HUB_PASS
     working_directory: ~/marsha/src/mail
     steps:
       - checkout:
@@ -508,8 +508,8 @@ jobs:
     docker:
       - image: cimg/node:16.15
         auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
+          username: $DOCKER_HUB_USER
+          password: $DOCKER_HUB_PASS
     working_directory: ~/marsha/src/frontend
     steps:
       - checkout:
@@ -533,8 +533,8 @@ jobs:
     docker:
       - image: cimg/node:16.15
         auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
+          username: $DOCKER_HUB_USER
+          password: $DOCKER_HUB_PASS
     working_directory: ~/marsha/src/frontend
     parallelism: 4
     resource_class: large
@@ -616,8 +616,8 @@ jobs:
     docker:
       - image: cimg/node:16.15
         auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
+          username: $DOCKER_HUB_USER
+          password: $DOCKER_HUB_PASS
     working_directory: ~/marsha/src/frontend
     resource_class: large
     steps:
@@ -639,8 +639,8 @@ jobs:
     docker:
       - image: mcr.microsoft.com/playwright:focal
         auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
+          username: $DOCKER_HUB_USER
+          password: $DOCKER_HUB_PASS
         environment:
           DJANGO_SETTINGS_MODULE: marsha.settings
           PYTHONPATH: /home/circleci/marsha/src/backend
@@ -666,8 +666,8 @@ jobs:
           BUILD_PATH: ../../../backend/marsha/static/js/build/site/
       - image: cimg/postgres:10.20
         auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
+          username: $DOCKER_HUB_USER
+          password: $DOCKER_HUB_PASS
         environment:
           POSTGRES_DB: marsha
           POSTGRES_USER: marsha_user
@@ -758,8 +758,8 @@ jobs:
     docker:
       - image: cimg/node:16.16
         auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
+          username: $DOCKER_HUB_USER
+          password: $DOCKER_HUB_PASS
       # Run on the highest version of node available on AWS Lambda
       # https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Runtime
     working_directory: ~/marsha/src/aws/lambda-configure
@@ -785,8 +785,8 @@ jobs:
     docker:
       - image: cimg/node:16.16
         auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
+          username: $DOCKER_HUB_USER
+          password: $DOCKER_HUB_PASS
       # Run on the highest version of node available on AWS Lambda
       # https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Runtime
     working_directory: ~/marsha/src/aws/lambda-complete
@@ -812,8 +812,8 @@ jobs:
     docker:
       - image: cimg/node:16.16
         auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
+          username: $DOCKER_HUB_USER
+          password: $DOCKER_HUB_PASS
       # Run on the highest version of node available on AWS Lambda
       # https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Runtime
     working_directory: ~/marsha/src/aws/lambda-medialive
@@ -838,8 +838,8 @@ jobs:
     docker:
       - image: cimg/node:16.16
         auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
+          username: $DOCKER_HUB_USER
+          password: $DOCKER_HUB_PASS
       # Run on the highest version of node available on AWS Lambda
       # https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Runtime
     working_directory: ~/marsha/src/aws/lambda-mediapackage
@@ -864,8 +864,8 @@ jobs:
     docker:
       - image: cimg/node:16.16
         auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
+          username: $DOCKER_HUB_USER
+          password: $DOCKER_HUB_PASS
       # Run on the highest version of node available on AWS Lambda
       # https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Runtime
     working_directory: ~/marsha/src/aws/lambda-elemental-routing
@@ -890,8 +890,8 @@ jobs:
     docker:
       - image: cimg/node:16.16
         auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
+          username: $DOCKER_HUB_USER
+          password: $DOCKER_HUB_PASS
       # Run on the highest version of node available on AWS Lambda
       # https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Runtime
     working_directory: ~/marsha/src/aws/lambda-configure
@@ -912,8 +912,8 @@ jobs:
     docker:
       - image: cimg/node:16.16
         auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
+          username: $DOCKER_HUB_USER
+          password: $DOCKER_HUB_PASS
       # Run on the highest version of node available on AWS Lambda
       # https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Runtime
     working_directory: ~/marsha/src/aws/lambda-convert
@@ -931,8 +931,8 @@ jobs:
     docker:
       - image: cimg/node:16.16
         auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
+          username: $DOCKER_HUB_USER
+          password: $DOCKER_HUB_PASS
       # Run on the highest version of node available on AWS Lambda
       # https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Runtime
     working_directory: ~/marsha/src/aws/lambda-complete
@@ -953,8 +953,8 @@ jobs:
     docker:
       - image: cimg/node:16.16
         auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
+          username: $DOCKER_HUB_USER
+          password: $DOCKER_HUB_PASS
       # Run on the highest version of node available on AWS Lambda
       # https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Runtime
     working_directory: ~/marsha/src/aws/lambda-medialive
@@ -975,8 +975,8 @@ jobs:
     docker:
       - image: cimg/node:16.16
         auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
+          username: $DOCKER_HUB_USER
+          password: $DOCKER_HUB_PASS
       # Run on the highest version of node available on AWS Lambda
       # https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Runtime
     working_directory: ~/marsha/src/aws/lambda-mediapackage
@@ -997,8 +997,8 @@ jobs:
     docker:
       - image: cimg/node:16.16
         auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
+          username: $DOCKER_HUB_USER
+          password: $DOCKER_HUB_PASS
       # Run on the highest version of node available on AWS Lambda
       # https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Runtime
     working_directory: ~/marsha/src/aws/lambda-elemental-routing
@@ -1021,8 +1021,8 @@ jobs:
     docker:
       - image: crowdin/cli:3.7.10
         auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
+          username: $DOCKER_HUB_USER
+          password: $DOCKER_HUB_PASS
     working_directory: ~/marsha
     steps:
       - checkout:
@@ -1038,8 +1038,8 @@ jobs:
     docker:
       - image: cimg/base:2022.04
         auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
+          username: $DOCKER_HUB_USER
+          password: $DOCKER_HUB_PASS
     working_directory: ~/marsha
     steps:
       - checkout
@@ -1103,8 +1103,8 @@ jobs:
     docker:
       - image: cimg/base:2022.04
         auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
+          username: $DOCKER_HUB_USER
+          password: $DOCKER_HUB_PASS
     working_directory: ~/marsha
     steps:
       # Checkout repository sources

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -672,7 +672,7 @@ jobs:
           POSTGRES_DB: marsha
           POSTGRES_USER: marsha_user
           POSTGRES_PASSWORD: pass
-    working_directory: ~/marsha/src/backend
+    working_directory: /home/circleci/marsha/src/frontend
     parameters:
       browser:
         description: "Playwright browser"
@@ -684,7 +684,15 @@ jobs:
         type: string
     steps:
       - checkout:
-          path: ~/marsha
+          path: /home/circleci/marsha
+      - get_last_packages_commit:
+          filename: packages-last-commit.txt
+      - restore_cache:
+          keys:
+            - front-dependencies-{{ .Environment.CACHE_VERSION }}-{{ checksum "yarn.lock" }}
+      - restore_cache:
+          keys:
+            - front-libs-{{ .Environment.CACHE_VERSION }}-{{ checksum "packages-last-commit.txt" }}
       - run: # Can be removed when switching to mcr.microsoft.com/playwright:jammy
           name: Install Python 3.10
           command: apt update && apt upgrade -y && apt install -y software-properties-common && add-apt-repository -y 'ppa:deadsnakes/ppa' && apt install -y python3.10 python3.10-dev build-essential
@@ -696,29 +704,20 @@ jobs:
           command: apt-get update && apt-get install -y pkg-config libxml2-dev libxmlsec1-openssl libxmlsec1-dev
       - run:
           name: Install e2e dependencies
+          working_directory: /home/circleci/marsha/src/backend
           command: python3.10 -m pip install --user .[dev,e2e]
       - run:
-          name: Install front-end dependencies
-          working_directory: ~/marsha/src/frontend
-          command: yarn install --frozen-lockfile
-      - run:
           name: Build front-end LTI application
-          working_directory: ~/marsha/src/frontend
-          command: yarn build-lti
-      - run:
-          name: Build lib_tests
-          working_directory: ~/marsha/src/frontend
-          command: yarn build-tests
+          command: yarn workspace marsha run build
       - run:
           name: Build front-end site application
-          working_directory: ~/marsha/src/frontend
-          command: yarn build-site
+          command: yarn workspace standalone_site run build
       - run:
           name: Copy iframe resizer
-          working_directory: ~/marsha/src/frontend
           command: yarn workspace marsha run copy-iframe-resizer
       - run:
           name: Ensure << parameters.browser >> browser is installed
+          working_directory: /home/circleci/marsha/src/backend
           command: python3.10 -m playwright install "<< parameters.browser >>"
       - run:
           name: Install dockerize
@@ -730,7 +729,7 @@ jobs:
           name: Copy e2e media files
           command: |
             mkdir -p /data/media \
-            && cp -r marsha/e2e/media /data/media/e2e
+            && cp -r /home/circleci/marsha/src/backend/marsha/e2e/media /data/media/e2e
       - when:
           condition:
             equal: [chrome, << parameters.browser_channel >>]
@@ -740,9 +739,11 @@ jobs:
                 command: apt update
             - run:
                 name: Install chrome
+                working_directory: ~/marsha/src/backend
                 command: python3.10 -m playwright install chrome
       - run:
           name: Run e2e tests
+          working_directory: /home/circleci/marsha/src/backend
           command: |
             dockerize \
               -wait tcp://localhost:5432 \
@@ -751,7 +752,7 @@ jobs:
                 --browser-channel "<< parameters.browser_channel >>" \
                 --browser "<< parameters.browser >>" marsha/e2e
       - store_artifacts:
-          path: ~/marsha/src/backend/test-results
+          path: /home/circleci/marsha/src/backend/test-results
 
   # ---- Lambda related jobs ----
   test-lambda-configure:
@@ -1381,6 +1382,8 @@ workflows:
               only: /.*/
       - test-e2e:
           name: test-e2e-firefox
+          requires:
+            - build-libs
           browser: firefox
           browser_channel: firefox
           filters:
@@ -1388,6 +1391,8 @@ workflows:
               only: /.*/
       - test-e2e:
           name: test-e2e-chromium
+          requires:
+            - build-libs
           browser: chromium
           browser_channel: chrome
           filters:
@@ -1395,6 +1400,8 @@ workflows:
               only: /.*/
       - test-e2e:
           name: test-e2e-webkit
+          requires:
+            - build-libs
           browser: webkit
           browser_channel: webkit
           filters:


### PR DESCRIPTION
## Purpose

For future usage of arnold binary in our CI we muste change variable used to connect to docker hub, they are conflicting with environment variable declare in arnold binary.
Also, an improvement is made in e2e tests. We stop building front libs again and again and we use instead the cache created in the `build-libs` job. For this the `working_directory` is changed in e2e tests to use the front directory.

## Proposal

- [x] rename docker environment variable in circle config
- [x] stop building front libs in e2e tests
