### PR TITLE
🔧(back) configure saml_fer settings wantNameId and allowRepeatAttributeName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- configure wantNameId and allowRepeatAttributeName for saml_fer 
+  security settings
+
 ## [4.0.0-beta.14] - 2023-01-25
 
 ## Added

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -599,6 +599,14 @@ class Base(Configuration):
             default=True,
             environ_name="SOCIAL_AUTH_SAML_FER_SECURITY_CONFIG_REJECT_DEPRECATED_ALGORITHM",
         ),
+        "wantNameId": values.BooleanValue(
+            default=True,
+            environ_name="SOCIAL_AUTH_SAML_FER_SECURITY_CONFIG_WANT_NAME_ID",
+        ),
+        "allowRepeatAttributeName": values.BooleanValue(
+            default=False,
+            environ_name="SOCIAL_AUTH_SAML_FER_SECURITY_CONFIG_ALLOW_REPEAT_ATTRIBUTE_NAME",
+        ),
     }
 
     # SOCIAL_AUTH_SAML_FER_SP_ENTITY_ID should be a URL that includes a domain name you own


### PR DESCRIPTION
## Purpose

We want to be able to configure security settings wantNameId and allowRepeatAttributeName used by the saml backend in python social auth. wantNameId defines if the presence of a name identifier is required and allowRepeatAttributeName defines if it is allowed to repeat attributes in the response.

## Proposal

- [x]  configure saml_fer settings wantNameId and allowRepeatAttributeName

