### PR TITLE
🔧(backend) editable SAML FER teacher role lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Add a lti link to classroom in the standalone website
 - Invite link for BBB available in every context
 - Add a check on classroom document file size when uploading content
+- Configure teachers role lookup to create organization access
 
 ## [4.0.0-beta.14] - 2023-01-25
 

--- a/src/backend/marsha/account/apps.py
+++ b/src/backend/marsha/account/apps.py
@@ -1,7 +1,10 @@
 """Defines the django app config for the ``account`` app."""
 
 from django.apps import AppConfig
+from django.core import checks as django_checks
 from django.utils.translation import gettext_lazy as _
+
+from . import checks
 
 
 class AccountConfig(AppConfig):
@@ -10,3 +13,7 @@ class AccountConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "marsha.account"
     verbose_name = _("Account")
+
+    def ready(self):
+        super().ready()
+        django_checks.register(checks.teacher_role_setting_check, "account")

--- a/src/backend/marsha/account/checks.py
+++ b/src/backend/marsha/account/checks.py
@@ -1,0 +1,35 @@
+"""Django checks for the account application of project marsha."""
+from django.conf import settings
+from django.core.checks import Warning as ChecksWarning
+
+from social_edu_federation.defaults import EduPersonAffiliationEnum
+
+
+def teacher_role_setting_check(*args, **kwargs):  # pylint: disable=unused-argument
+    """
+    Check that the SOCIAL_AUTH_SAML_FER_TEACHER_ROLES setting defines
+    a list with expected values.
+    """
+    existing_roles = sorted(
+        [role.value for role in EduPersonAffiliationEnum.__members__.values()]
+    )
+
+    if not all(
+        role in existing_roles for role in settings.SOCIAL_AUTH_SAML_FER_TEACHER_ROLES
+    ):
+        missing_roles = set(settings.SOCIAL_AUTH_SAML_FER_TEACHER_ROLES) - set(
+            existing_roles
+        )
+        return [
+            ChecksWarning(
+                f"{missing_roles} not available to detect teacher through SAML FER.",
+                hint=(
+                    "You should consider fixing the `SOCIAL_AUTH_SAML_FER_TEACHER_ROLES`"
+                    f" setting to use one of `{existing_roles}` value."
+                ),
+                obj="marsha.account.social_pipeline.organization.create_organization_from_saml",
+                id="marsha.account.social_pipeline.W001",
+            )
+        ]
+
+    return []

--- a/src/backend/marsha/account/social_pipeline/organization.py
+++ b/src/backend/marsha/account/social_pipeline/organization.py
@@ -1,10 +1,9 @@
 """Marsha's specific Python Social Auth pipeline steps for Organization"""
 import logging
 
+from django.conf import settings
 from django.db import IntegrityError
 from django.db.transaction import atomic
-
-from social_edu_federation.defaults import EduPersonAffiliationEnum
 
 from marsha.account.models import IdpOrganizationAssociation
 from marsha.core.models import INSTRUCTOR, STUDENT, Organization, OrganizationAccess
@@ -135,7 +134,10 @@ def create_organization_from_saml(
             role=INSTRUCTOR
             if (
                 details.get("roles", None)
-                and EduPersonAffiliationEnum.TEACHER.value in details["roles"]
+                and any(
+                    role in details["roles"]
+                    for role in settings.SOCIAL_AUTH_SAML_FER_TEACHER_ROLES
+                )
             )
             else STUDENT,
         )

--- a/src/backend/marsha/account/tests/test_checks.py
+++ b/src/backend/marsha/account/tests/test_checks.py
@@ -1,0 +1,37 @@
+"""Tests the `account` application checks."""
+from django.core.checks import Warning as ChecksWarning
+from django.test import TestCase, override_settings
+
+from ..checks import teacher_role_setting_check
+
+
+class CheckTestCase(TestCase):
+    """Test case for the `account` application checks."""
+
+    @override_settings(SOCIAL_AUTH_SAML_FER_TEACHER_ROLES=["teacher"])
+    def test_teacher_role_setting_properly_defined(self):
+        """Asserts the check returns an empty list when the setting is properly defined."""
+        self.assertListEqual(teacher_role_setting_check(), [])
+
+    @override_settings(SOCIAL_AUTH_SAML_FER_TEACHER_ROLES=["teacher", "invalid"])
+    def test_teacher_role_setting_with_invalid_value(self):
+        """Asserts the check returns a warning when the setting is not properly defined."""
+        self.assertListEqual(
+            teacher_role_setting_check(),
+            [
+                ChecksWarning(
+                    "{'invalid'} not available to detect teacher through SAML FER.",
+                    hint=(
+                        "You should consider fixing the `SOCIAL_AUTH_SAML_FER_TEACHER_ROLES`"
+                        " setting to use one of `['affiliate', 'alum', 'emeritus', 'employee',"
+                        " 'faculty', 'library-walk-in', 'member', 'registered-reader',"
+                        " 'researcher', 'retired', 'staff', 'student', 'teacher']` value."
+                    ),
+                    obj=(
+                        "marsha.account.social_pipeline.organization"
+                        ".create_organization_from_saml"
+                    ),
+                    id="marsha.account.social_pipeline.W001",
+                )
+            ],
+        )

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -573,6 +573,7 @@ class Base(Configuration):
         "social_edu_federation.django.metadata_store.CachedMetadataStore"
     )
     SOCIAL_AUTH_SAML_FER_REDIRECT_IS_HTTPS = values.BooleanValue(False)
+    SOCIAL_AUTH_SAML_FER_TEACHER_ROLES = values.ListValue(["teacher"])
 
     SOCIAL_AUTH_SAML_FER_SECURITY_CONFIG = {
         "authnRequestsSigned": values.BooleanValue(


### PR DESCRIPTION
## Purpose

When logging through Renater for the first time, organization access is provided, but most of the time the `teacher` role is not properly detected. This should be easy to change in production and we should not allow only one role to give the "instructor" permission but several.

## Proposal

This allow to customize the organization teachers' roles to look for.
The default value is still `teacher` but we can now add more roles to the list in production, such as:

- `faculty`
- `employee`
- `staff`

--

- [x] Add role lookup setting
- [x] Update the organization access creation

