### PR TITLE
✨(frontend) display lti link in lti context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - configure wantNameId and allowRepeatAttributeName for saml_fer 
   security settings
 - Add a lti link to classroom in the standalone website
-- Invite link for BBB available in every context
+- Invite link for classroom available in every context
 - Add a check on classroom document file size when uploading content
 - Configure teachers role lookup to create organization access
+- LTI link for classroom available in every context
 
 ## [4.0.0-beta.14] - 2023-01-25
 

--- a/src/backend/marsha/e2e/test_lti_bbb.py
+++ b/src/backend/marsha/e2e/test_lti_bbb.py
@@ -358,6 +358,7 @@ def test_lti_bbb_create_enabled(page: Page, live_server: LiveServer, settings):
     assert "BBB classroom joined!" in bbb_classroom_page.content()
     bbb_classroom_page.close()
 
+    expect(page.get_by_text("LTI link for this classroom:")).to_be_visible()
     invite_link_button = page.get_by_role(
         "button", name="Invite someone with this link:"
     )

--- a/src/backend/marsha/e2e/test_site.py
+++ b/src/backend/marsha/e2e/test_site.py
@@ -155,6 +155,7 @@ def test_site_classroom_invite_link(context: BrowserContext, live_server: LiveSe
     page.wait_for_selector("text=My Contents")
     page.get_by_text("Classroom test").click()
 
+    expect(page.get_by_text("LTI link for this classroom:")).to_be_visible()
     invite_link_button = page.get_by_role(
         "button", name="Invite someone with this link:"
     )

--- a/src/frontend/packages/lib_classroom/src/components/ClassroomForm/index.spec.tsx
+++ b/src/frontend/packages/lib_classroom/src/components/ClassroomForm/index.spec.tsx
@@ -1,7 +1,6 @@
 import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import fetchMock from 'fetch-mock';
-import { useCurrentResourceContext } from 'lib-components';
 import { render, Deferred } from 'lib-tests';
 import { DateTime, Duration, Settings } from 'luxon';
 import React from 'react';
@@ -26,13 +25,7 @@ jest.mock('lib-components', () => ({
       },
     },
   }),
-  useCurrentResourceContext: jest.fn(),
 }));
-
-const mockedUseCurrentResource =
-  useCurrentResourceContext as jest.MockedFunction<
-    typeof useCurrentResourceContext
-  >;
 
 jest.mock('components/UploadDocuments', () => ({
   UploadDocuments: () => <p>Upload Documents.</p>,
@@ -55,11 +48,6 @@ describe('<ClassroomForm />', () => {
 
   it('creates a classroom with updated values', async () => {
     const classroom = classroomMockFactory({ id: '1', started: false });
-    mockedUseCurrentResource.mockReturnValue([
-      {
-        isFromWebsite: false,
-      },
-    ] as any);
 
     const deferredPatch = new Deferred();
     fetchMock.patch('/api/classrooms/1/create/', deferredPatch.promise);
@@ -145,11 +133,6 @@ describe('<ClassroomForm />', () => {
       .set({ second: 0, millisecond: 0 });
     const estimatedDuration = Duration.fromObject({ minutes: 30 });
     const classroom = classroomMockFactory({ id: '1', started: false });
-    mockedUseCurrentResource.mockReturnValue([
-      {
-        isFromWebsite: false,
-      },
-    ] as any);
 
     const deferredPatch = new Deferred();
     fetchMock.patch('/api/classrooms/1/', deferredPatch.promise);
@@ -299,11 +282,6 @@ describe('<ClassroomForm />', () => {
       starting_at: startingAt.toISO(),
       estimated_duration: estimatedDuration.toFormat('hh:mm:ss'),
     });
-    mockedUseCurrentResource.mockReturnValue([
-      {
-        isFromWebsite: false,
-      },
-    ] as any);
 
     const deferredPatch = new Deferred();
     fetchMock.patch('/api/classrooms/1/', deferredPatch.promise);
@@ -378,11 +356,6 @@ describe('<ClassroomForm />', () => {
       starting_at: startingAt.toISO(),
       estimated_duration: estimatedDuration.toFormat('hh:mm:ss'),
     });
-    mockedUseCurrentResource.mockReturnValue([
-      {
-        isFromWebsite: false,
-      },
-    ] as any);
 
     const deferredPatch = new Deferred();
     fetchMock.patch('/api/classrooms/1/', deferredPatch.promise);
@@ -432,11 +405,6 @@ describe('<ClassroomForm />', () => {
 
   it('shows an error when classroom title is missing', () => {
     const classroom = classroomMockFactory({ title: null, id: '1' });
-    mockedUseCurrentResource.mockReturnValue([
-      {
-        isFromWebsite: false,
-      },
-    ] as any);
 
     const deferredPatch = new Deferred();
     fetchMock.patch('/api/classrooms/1/create/', deferredPatch.promise);
@@ -463,11 +431,6 @@ describe('<ClassroomForm />', () => {
       id: '1',
       invite_token: 'my-token',
     });
-    mockedUseCurrentResource.mockReturnValue([
-      {
-        isFromWebsite: true,
-      },
-    ] as any);
     render(<ClassroomForm classroom={classroom} />);
 
     expect(
@@ -497,11 +460,6 @@ describe('<ClassroomForm />', () => {
         ).toISO(),
       }),
     ];
-    mockedUseCurrentResource.mockReturnValue([
-      {
-        isFromWebsite: false,
-      },
-    ] as any);
 
     const { rerender } = render(<ClassroomForm classroom={classroom} />);
 

--- a/src/frontend/packages/lib_classroom/src/components/DashboardClassroomForm/index.spec.tsx
+++ b/src/frontend/packages/lib_classroom/src/components/DashboardClassroomForm/index.spec.tsx
@@ -1,7 +1,6 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import fetchMock from 'fetch-mock';
-import { useCurrentResourceContext } from 'lib-components';
 import { render, Deferred } from 'lib-tests';
 import { Settings } from 'luxon';
 import React from 'react';
@@ -23,13 +22,7 @@ jest.mock('lib-components', () => ({
       },
     },
   }),
-  useCurrentResourceContext: jest.fn(),
 }));
-
-const mockedUseCurrentResource =
-  useCurrentResourceContext as jest.MockedFunction<
-    typeof useCurrentResourceContext
-  >;
 
 jest.mock('components/UploadDocuments', () => ({
   UploadDocuments: () => <p>Upload Documents.</p>,
@@ -52,11 +45,6 @@ describe('<DashboardClassroomForm />', () => {
 
   it('creates a classroom with updated values', async () => {
     const classroom = classroomMockFactory({ id: '1', started: false });
-    mockedUseCurrentResource.mockReturnValue([
-      {
-        isFromWebsite: false,
-      },
-    ] as any);
 
     const deferredPatch = new Deferred();
     fetchMock.patch('/api/classrooms/1/create/', deferredPatch.promise);
@@ -156,11 +144,6 @@ describe('<DashboardClassroomForm />', () => {
 
   it('shows an error when classroom title is missing', () => {
     const classroom = classroomMockFactory({ title: null, id: '1' });
-    mockedUseCurrentResource.mockReturnValue([
-      {
-        isFromWebsite: false,
-      },
-    ] as any);
 
     const deferredPatch = new Deferred();
     fetchMock.patch('/api/classrooms/1/create/', deferredPatch.promise);

--- a/src/frontend/packages/lib_classroom/src/components/DashboardClassroomInfos/index.spec.tsx
+++ b/src/frontend/packages/lib_classroom/src/components/DashboardClassroomInfos/index.spec.tsx
@@ -1,5 +1,4 @@
 import { screen } from '@testing-library/react';
-import { useCurrentResourceContext } from 'lib-components';
 import { render } from 'lib-tests';
 import React from 'react';
 
@@ -7,27 +6,12 @@ import { classroomInfosMockFactory } from 'utils/tests/factories';
 
 import DashboardClassroomInfos from '.';
 
-jest.mock('lib-components', () => ({
-  ...jest.requireActual('lib-components'),
-  useCurrentResourceContext: jest.fn(),
-}));
-
-const mockedUseCurrentResource =
-  useCurrentResourceContext as jest.MockedFunction<
-    typeof useCurrentResourceContext
-  >;
-
 describe('<DashboardClassroomInfos />', () => {
   afterEach(() => {
     jest.resetAllMocks();
   });
 
   it('displays the content for classroom infos', () => {
-    mockedUseCurrentResource.mockReturnValue([
-      {
-        isFromWebsite: false,
-      },
-    ] as any);
     const classroomInfos = classroomInfosMockFactory();
     render(
       <DashboardClassroomInfos
@@ -49,28 +33,19 @@ describe('<DashboardClassroomInfos />', () => {
       screen.queryByText('Invite someone with this link:'),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByText('LTI link for this classroom:'),
-    ).not.toBeInTheDocument();
+      screen.getByText('LTI link for this classroom:'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('https://localhost/lti/classrooms/1'),
+    ).toBeInTheDocument();
   });
 
   it('displays invite link', () => {
-    mockedUseCurrentResource.mockReturnValue([
-      {
-        isFromWebsite: true,
-      },
-    ] as any);
     render(<DashboardClassroomInfos inviteToken="my-token" classroomId="1" />);
 
     expect(
       screen.getByText('Invite someone with this link:'),
     ).toBeInTheDocument();
     expect(screen.getByText(/invite\/my-token/i)).toBeInTheDocument();
-
-    expect(
-      screen.getByText('LTI link for this classroom:'),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText('https://localhost/lti/classrooms/1'),
-    ).toBeInTheDocument();
   });
 });

--- a/src/frontend/packages/lib_classroom/src/components/DashboardClassroomInstructor/index.spec.tsx
+++ b/src/frontend/packages/lib_classroom/src/components/DashboardClassroomInstructor/index.spec.tsx
@@ -1,9 +1,5 @@
 import { fireEvent, screen } from '@testing-library/react';
 import fetchMock from 'fetch-mock';
-import {
-  useCurrentResourceContext,
-  ltiInstructorTokenMockFactory,
-} from 'lib-components';
 import { render, Deferred } from 'lib-tests';
 import React from 'react';
 
@@ -24,13 +20,7 @@ jest.mock('lib-components', () => ({
       },
     },
   }),
-  useCurrentResourceContext: jest.fn(),
 }));
-
-const mockedUseCurrentResource =
-  useCurrentResourceContext as jest.MockedFunction<
-    typeof useCurrentResourceContext
-  >;
 
 jest.mock('components/DashboardClassroomForm', () => {
   const DashboardClassroomForm = () => <p>classroom form</p>;
@@ -122,13 +112,6 @@ describe('<DashboardClassroomInstructor />', () => {
   });
 
   it('Displays invite link depend state', () => {
-    mockedUseCurrentResource.mockReturnValue([
-      {
-        ...ltiInstructorTokenMockFactory(),
-        isFromWebsite: true,
-      },
-    ] as any);
-
     const classroom = classroomMockFactory({
       id: '1',
       started: true,

--- a/src/frontend/packages/lib_classroom/src/components/DashboardCopyClipboard/index.spec.tsx
+++ b/src/frontend/packages/lib_classroom/src/components/DashboardCopyClipboard/index.spec.tsx
@@ -1,20 +1,9 @@
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { useCurrentResourceContext } from 'lib-components';
 import { render } from 'lib-tests';
 import React from 'react';
 
 import DashboardCopyClipboard from '.';
-
-jest.mock('lib-components', () => ({
-  ...jest.requireActual('lib-components'),
-  useCurrentResourceContext: jest.fn(),
-}));
-
-const mockedUseCurrentResource =
-  useCurrentResourceContext as jest.MockedFunction<
-    typeof useCurrentResourceContext
-  >;
 
 // Even if its depreciated, it's what is used under-the-hood in the clipboard.js librairy
 document.execCommand = jest.fn();
@@ -34,12 +23,6 @@ describe('<DashboardCopyClipboard />', () => {
   });
 
   it('should display invite and lti links in standalone site context', () => {
-    mockedUseCurrentResource.mockReturnValue([
-      {
-        isFromWebsite: true,
-      },
-    ] as any);
-
     render(<DashboardCopyClipboard inviteToken="my-token" classroomId="1" />);
 
     const copyInviteButton = screen.getByRole('button', {
@@ -78,38 +61,7 @@ describe('<DashboardCopyClipboard />', () => {
     expect(document.execCommand).toHaveBeenLastCalledWith('copy');
   });
 
-  it('should only display invite link in lti context', () => {
-    mockedUseCurrentResource.mockReturnValue([
-      {
-        isFromWebsite: false,
-      },
-    ] as any);
-
-    render(<DashboardCopyClipboard inviteToken="my-token" classroomId="1" />);
-
-    expect(
-      screen.getByText('Invite someone with this link:'),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        'http://dummy.com/my-contents/classroom/1/invite/my-token',
-      ),
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByText('LTI link for this classroom:'),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByText('http://dummy.com/lti/classrooms/1'),
-    ).not.toBeInTheDocument();
-  });
-
   it('should not display invite link if no invite token', () => {
-    mockedUseCurrentResource.mockReturnValue([
-      {
-        isFromWebsite: true,
-      },
-    ] as any);
-
     render(<DashboardCopyClipboard inviteToken="" classroomId="1" />);
 
     expect(

--- a/src/frontend/packages/lib_classroom/src/components/DashboardCopyClipboard/index.tsx
+++ b/src/frontend/packages/lib_classroom/src/components/DashboardCopyClipboard/index.tsx
@@ -1,6 +1,6 @@
 import { Box } from 'grommet';
 import { Nullable } from 'lib-common';
-import { CopyClipboard, useCurrentResourceContext } from 'lib-components';
+import { CopyClipboard } from 'lib-components';
 import React from 'react';
 import { toast } from 'react-hot-toast';
 import { defineMessages, useIntl } from 'react-intl';
@@ -38,8 +38,6 @@ const DashboardCopyClipboard = ({
   classroomId,
 }: DashboardCopyClipboardProps) => {
   const intl = useIntl();
-  const [context] = useCurrentResourceContext();
-  const { isFromWebsite } = context;
 
   const inviteLink = inviteToken
     ? `${window.location.origin}/my-contents/classroom/${classroomId}/invite/${inviteToken}`
@@ -66,24 +64,22 @@ const DashboardCopyClipboard = ({
           }}
         />
       )}
-      {isFromWebsite && (
-        <CopyClipboard
-          copyId={`ltiLink-${classroomId}`}
-          text={ltiLink}
-          title={intl.formatMessage(messages.ltiLinkLabel)}
-          withLabel={true}
-          onSuccess={() => {
-            toast(intl.formatMessage(messages.ltiLinkCopiedSuccess), {
-              icon: '📋',
-            });
-          }}
-          onError={(event) => {
-            toast.error(event.text, {
-              position: 'bottom-center',
-            });
-          }}
-        />
-      )}
+      <CopyClipboard
+        copyId={`ltiLink-${classroomId}`}
+        text={ltiLink}
+        title={intl.formatMessage(messages.ltiLinkLabel)}
+        withLabel={true}
+        onSuccess={() => {
+          toast(intl.formatMessage(messages.ltiLinkCopiedSuccess), {
+            icon: '📋',
+          });
+        }}
+        onError={(event) => {
+          toast.error(event.text, {
+            position: 'bottom-center',
+          });
+        }}
+      />
     </Box>
   );
 };


### PR DESCRIPTION
## Purpose

We want the instructors to get a lti link for the classrooms in every contexts : lti or standalone site.

## Proposal

Remove isFromWebsite check in DashboardCopyClipboard

