### PR TITLE
✨(backend) add playlist accesses API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - LTI link for classroom available in every context
 - standalone website:
   - banner homepage with dynamic text
+  - add "playlist access" management API endpoints
 - Arnold tray to manage definition directly in marsha repository
 - Install and configure scoutapm
-
 
 ### Changed
 
@@ -39,6 +39,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Removed
 
 - service worker from lti site and standalone site
+
 
 ## [4.0.0-beta.14] - 2023-01-25
 

--- a/src/backend/marsha/core/api/__init__.py
+++ b/src/backend/marsha/core/api/__init__.py
@@ -8,6 +8,7 @@ from .lti_user_association import *  # noqa isort:skip
 from .pairing_challenge import *  # noqa isort:skip
 from .portability_request import *  # noqa isort:skip
 from .playlist import *  # noqa isort:skip
+from .playlist_access import *  # noqa isort:skip
 from .shared_live_media import *  # noqa isort:skip
 from .thumbnail import *  # noqa isort:skip
 from .timed_text_track import *  # noqa isort:skip

--- a/src/backend/marsha/core/api/playlist_access.py
+++ b/src/backend/marsha/core/api/playlist_access.py
@@ -1,0 +1,92 @@
+"""Declare API endpoints for playlist access with Django RestFramework viewsets."""
+from django.db.models import Q
+
+import django_filters
+from rest_framework import filters, viewsets
+
+from .. import permissions, serializers
+from ..models import ADMINISTRATOR, INSTRUCTOR, PlaylistAccess
+from ..permissions import IsParamsPlaylistAdminThroughOrganization
+from .base import APIViewMixin, ObjectPkMixin
+
+
+class PlaylistAccessFilter(django_filters.FilterSet):
+    """Filter for PlaylistAccess."""
+
+    playlist_id = django_filters.UUIDFilter(field_name="playlist_id")
+
+    class Meta:
+        model = PlaylistAccess
+        fields = []
+
+
+class PlaylistAccessViewSet(APIViewMixin, ObjectPkMixin, viewsets.ModelViewSet):
+    """ViewSet for all playlist-related interactions."""
+
+    permission_classes = [permissions.NotAllowed]
+    queryset = PlaylistAccess.objects.all().select_related("user", "playlist")
+    serializer_class = serializers.PlaylistAccessSerializer
+    filter_backends = [
+        filters.OrderingFilter,
+        django_filters.rest_framework.DjangoFilterBackend,
+    ]
+    ordering_fields = ["created_on", "playlist__title", "role", "user__last_name"]
+    ordering = ["created_on"]
+    filterset_class = PlaylistAccessFilter
+
+    def get_permissions(self):
+        """
+        Manage permissions for built-in DRF methods.
+
+        Default to the actions' self defined permissions if applicable or
+        to the ViewSet's default permissions.
+        """
+        if self.action in ["list", "retrieve"]:
+            permission_classes = [permissions.UserIsAuthenticated]
+        elif self.action in ["create"]:
+            permission_classes = [
+                permissions.IsParamsPlaylistAdmin
+                | IsParamsPlaylistAdminThroughOrganization
+            ]
+        elif self.action in ["destroy", "partial_update", "update"]:
+            permission_classes = [
+                # users who are playlist administrators of the playlist
+                permissions.IsObjectPlaylistAdmin
+                # or users who are administrators of the playlist organization
+                | permissions.IsObjectPlaylistOrganizationAdmin
+            ]
+        else:
+            try:
+                permission_classes = getattr(self, str(self.action)).kwargs.get(
+                    "permission_classes"
+                )
+            except AttributeError:
+                permission_classes = self.permission_classes
+        return [permission() for permission in permission_classes]
+
+    def _get_list_queryset(self):
+        """Build the queryset used on the list action."""
+        queryset = (
+            super()
+            .get_queryset()
+            .filter(
+                Q(
+                    playlist__organization__user_accesses__user_id=self.request.user.id,
+                    playlist__organization__user_accesses__role=ADMINISTRATOR,
+                )
+                | Q(
+                    playlist__user_accesses__user_id=self.request.user.id,
+                    playlist__user_accesses__role__in=[ADMINISTRATOR, INSTRUCTOR],
+                )
+            )
+            .distinct()
+        )
+
+        return queryset
+
+    def get_queryset(self):
+        """Redefine the queryset to use based on the current action."""
+        if self.action in ["list", "retrieve"]:
+            return self._get_list_queryset()
+
+        return super().get_queryset()

--- a/src/backend/marsha/core/serializers/__init__.py
+++ b/src/backend/marsha/core/serializers/__init__.py
@@ -6,6 +6,7 @@ from .file import *  # noqa isort:skip
 from .live_session import *  # noqa isort:skip
 from .pairing_challenge import *  # noqa isort:skip
 from .playlist import *  # noqa isort:skip
+from .playlist_access import *  # noqa isort:skip
 from .portability_request import *  # noqa isort:skip
 from .shared_live_media import *  # noqa isort:skip
 from .thumbnail import *  # noqa isort:skip

--- a/src/backend/marsha/core/serializers/playlist_access.py
+++ b/src/backend/marsha/core/serializers/playlist_access.py
@@ -1,0 +1,36 @@
+"""Structure of PlaylistAccess model API responses with Django Rest Framework serializers."""
+
+from rest_framework import serializers
+
+from ..models import Playlist, PlaylistAccess, User
+from .account import UserSerializer
+from .base import ReadWritePrimaryKeyRelatedField
+from .playlist import PlaylistLiteSerializer
+
+
+class PlaylistAccessSerializer(serializers.ModelSerializer):
+    """Serializer for the PlaylistAccess model."""
+
+    class Meta:
+        """Meta for PlaylistAccessSerializer."""
+
+        model = PlaylistAccess
+        fields = [
+            "id",
+            "user",
+            "playlist",
+            "role",
+        ]
+
+    playlist = ReadWritePrimaryKeyRelatedField(
+        PlaylistLiteSerializer,
+        queryset=Playlist.objects.all(),
+        required=False,
+        allow_null=True,
+    )
+    user = ReadWritePrimaryKeyRelatedField(
+        UserSerializer,
+        queryset=User.objects.all(),
+        required=False,
+        allow_null=True,
+    )

--- a/src/backend/marsha/core/tests/api/playlist_accesses/test_create.py
+++ b/src/backend/marsha/core/tests/api/playlist_accesses/test_create.py
@@ -1,0 +1,216 @@
+"""Tests for the PlaylistAccess create API of the Marsha project."""
+
+from django.test import TestCase
+
+from marsha.core import factories, models
+from marsha.core.simple_jwt.factories import UserAccessTokenFactory
+
+
+class PlaylistAccessCreateAPITest(TestCase):
+    """Test the create API for playlist access objects."""
+
+    maxDiff = None
+
+    def assert_user_cant_create_playlist_access(self, playlist, user):
+        """Assert a user cannot create a playlist access with a POST request."""
+        jwt_token = UserAccessTokenFactory(user=user)
+
+        response = self.client.post(
+            "/api/playlist-accesses/",
+            {
+                "playlist": str(playlist.pk),
+                "user": str(user.pk),
+                "role": models.ADMINISTRATOR,
+            },
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_create_playlist_access_by_anonymous_user(self):
+        """Anonymous users cannot create playlist access."""
+        playlist = factories.PlaylistFactory()
+        user = factories.UserFactory()
+
+        response = self.client.post(
+            "/api/playlist-accesses/",
+            {
+                "playlist": str(playlist.pk),
+                "user": str(user.pk),
+                "role": models.ADMINISTRATOR,
+            },
+        )
+        self.assertEqual(response.status_code, 401)
+
+    def test_create_playlist_access_by_random_logged_in_user(self):
+        """
+        Random logged-in users.
+
+        Cannot create access for playlist they have no role in.
+        """
+        playlist = factories.PlaylistFactory()
+        user = factories.UserFactory()
+
+        self.assert_user_cant_create_playlist_access(playlist, user)
+
+    def test_create_playlist_access_by_organization_student(self):
+        """Organization students cannot create playlist access."""
+        organization_access = factories.OrganizationAccessFactory(
+            role=models.STUDENT,
+        )
+        playlist = factories.PlaylistFactory(
+            organization=organization_access.organization,
+        )
+
+        self.assert_user_cant_create_playlist_access(playlist, organization_access.user)
+
+    def test_create_playlist_access_by_organization_instructor(self):
+        """Organization instructors cannot create playlist access."""
+        organization_access = factories.OrganizationAccessFactory(
+            role=models.INSTRUCTOR,
+        )
+        playlist = factories.PlaylistFactory(
+            organization=organization_access.organization,
+        )
+
+        self.assert_user_cant_create_playlist_access(playlist, organization_access.user)
+
+    def test_create_playlist_access_by_organization_administrator(self):
+        """Organization administrators can create playlist access."""
+        user = factories.UserFactory()
+        organization_access = factories.OrganizationAccessFactory(
+            role=models.ADMINISTRATOR,
+            user=user,
+        )
+        playlist = factories.PlaylistFactory(
+            organization=organization_access.organization,
+        )
+
+        jwt_token = UserAccessTokenFactory(user=user)
+
+        self.assertEqual(models.PlaylistAccess.objects.count(), 0)
+
+        response = self.client.post(
+            "/api/playlist-accesses/",
+            {
+                "playlist": str(playlist.pk),
+                "user": str(user.pk),
+                "role": models.ADMINISTRATOR,
+            },
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(models.PlaylistAccess.objects.count(), 1)
+
+        created_playlist_access = models.PlaylistAccess.objects.first()
+        self.assertEqual(
+            response.json(),
+            {
+                "id": str(created_playlist_access.pk),
+                "playlist": {
+                    "id": str(playlist.pk),
+                    "lti_id": playlist.lti_id,
+                    "title": playlist.title,
+                },
+                "user": {
+                    "id": str(user.pk),
+                    "date_joined": user.date_joined.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                    "email": user.email,
+                    "full_name": user.get_full_name(),
+                    "is_staff": False,
+                    "is_superuser": False,
+                    "organization_accesses": [
+                        {
+                            "organization": str(organization_access.organization.pk),
+                            "organization_name": organization_access.organization.name,
+                            "role": "administrator",
+                            "user": str(user.pk),
+                        }
+                    ],
+                },
+                "role": models.ADMINISTRATOR,
+            },
+        )
+
+    def test_create_playlist_access_by_consumer_site_any_role(self):
+        """Consumer site roles cannot create playlist access."""
+        user = factories.UserFactory()
+        consumer_site_access = factories.ConsumerSiteAccessFactory(
+            user=user,
+        )
+        playlist = factories.PlaylistFactory(
+            consumer_site=consumer_site_access.consumer_site,
+        )
+
+        self.assert_user_cant_create_playlist_access(playlist, user)
+
+    def test_create_playlist_access_by_playlist_student(self):
+        """Playlist students cannot create playlist access."""
+        playlist_access = factories.PlaylistAccessFactory(
+            role=models.STUDENT,
+        )
+
+        self.assert_user_cant_create_playlist_access(
+            playlist_access.playlist, playlist_access.user
+        )
+
+    def test_create_playlist_access_by_playlist_instructor(self):
+        """Playlist instructors cannot create playlist access."""
+        playlist_access = factories.PlaylistAccessFactory(
+            role=models.INSTRUCTOR,
+        )
+
+        self.assert_user_cant_create_playlist_access(
+            playlist_access.playlist, playlist_access.user
+        )
+
+    def test_create_playlist_access_by_playlist_administrator(self):
+        """Playlist administrators can create playlist access."""
+        user = factories.UserFactory()
+        playlist_access = factories.PlaylistAccessFactory(
+            role=models.ADMINISTRATOR,
+        )
+
+        # The user with right is not the same as the user to create
+        # access for.
+        jwt_token = UserAccessTokenFactory(user=playlist_access.user)
+
+        self.assertEqual(models.PlaylistAccess.objects.count(), 1)
+
+        response = self.client.post(
+            "/api/playlist-accesses/",
+            {
+                "playlist": str(playlist_access.playlist.pk),
+                "user": str(user.pk),
+                "role": models.ADMINISTRATOR,
+            },
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(models.PlaylistAccess.objects.count(), 2)
+
+        created_playlist_access = models.PlaylistAccess.objects.exclude(
+            pk=playlist_access.pk,
+        ).first()
+        self.assertEqual(
+            response.json(),
+            {
+                "id": str(created_playlist_access.pk),
+                "playlist": {
+                    "id": str(playlist_access.playlist.pk),
+                    "lti_id": playlist_access.playlist.lti_id,
+                    "title": playlist_access.playlist.title,
+                },
+                "user": {
+                    "id": str(user.pk),
+                    "date_joined": user.date_joined.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                    "email": user.email,
+                    "full_name": user.get_full_name(),
+                    "is_staff": False,
+                    "is_superuser": False,
+                    "organization_accesses": [],
+                },
+                "role": models.ADMINISTRATOR,
+            },
+        )

--- a/src/backend/marsha/core/tests/api/playlist_accesses/test_delete.py
+++ b/src/backend/marsha/core/tests/api/playlist_accesses/test_delete.py
@@ -1,0 +1,154 @@
+"""Tests for the PlaylistAccess delete API of the Marsha project."""
+
+from django.test import TestCase
+
+from marsha.core import factories, models
+from marsha.core.simple_jwt.factories import UserAccessTokenFactory
+
+
+class PlaylistAccessDeleteAPITest(TestCase):
+    """Test the delete API for playlist access objects."""
+
+    maxDiff = None
+
+    def assert_user_cant_delete_playlist_access(self, user, playlist_access):
+        """Assert a user cannot delete a playlist access with a DELETE request."""
+        jwt_token = UserAccessTokenFactory(user=user)
+
+        response = self.client.delete(
+            f"/api/playlist-accesses/{str(playlist_access.pk)}/",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_delete_playlist_access_by_anonymous_user(self):
+        """Anonymous users cannot delete playlist access."""
+        playlist_access_to_delete = factories.PlaylistAccessFactory()
+
+        response = self.client.delete(
+            f"/api/playlist-accesses/{str(playlist_access_to_delete.pk)}/",
+        )
+
+        self.assertEqual(response.status_code, 401)
+
+    def test_delete_playlist_access_by_random_logged_in_user(self):
+        """
+        Random logged-in users.
+
+        Cannot delete access for playlist they have no role in.
+        """
+        user = factories.UserFactory()
+        playlist_access_to_delete = factories.PlaylistAccessFactory()
+
+        self.assert_user_cant_delete_playlist_access(user, playlist_access_to_delete)
+
+    def test_delete_playlist_access_by_organization_student(self):
+        """Organization students cannot delete playlist access."""
+        organization_access = factories.OrganizationAccessFactory(
+            role=models.STUDENT,
+        )
+        playlist_access_to_delete = factories.PlaylistAccessFactory(
+            playlist__organization=organization_access.organization,
+        )
+
+        self.assert_user_cant_delete_playlist_access(
+            organization_access.user, playlist_access_to_delete
+        )
+
+    def test_delete_playlist_access_by_organization_instructor(self):
+        """Organization instructors cannot delete playlist access."""
+        organization_access = factories.OrganizationAccessFactory(
+            role=models.INSTRUCTOR,
+        )
+        playlist_access_to_delete = factories.PlaylistAccessFactory(
+            playlist__organization=organization_access.organization,
+        )
+
+        self.assert_user_cant_delete_playlist_access(
+            organization_access.user, playlist_access_to_delete
+        )
+
+    def test_delete_playlist_access_by_organization_administrator(self):
+        """Organization administrators can delete playlist access."""
+        organization_access = factories.OrganizationAccessFactory(
+            role=models.ADMINISTRATOR,
+        )
+        playlist_access_to_delete = factories.PlaylistAccessFactory(
+            playlist__organization=organization_access.organization,
+        )
+
+        jwt_token = UserAccessTokenFactory(user=organization_access.user)
+
+        self.assertEqual(models.PlaylistAccess.objects.count(), 1)
+
+        response = self.client.delete(
+            f"/api/playlist-accesses/{str(playlist_access_to_delete.pk)}/",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+
+        self.assertEqual(response.status_code, 204)
+        self.assertEqual(models.PlaylistAccess.objects.count(), 0)
+
+    def test_delete_playlist_access_by_consumer_site_any_role(self):
+        """Consumer site roles cannot delete playlist access."""
+        consumer_site_access = factories.ConsumerSiteAccessFactory()
+        playlist_access_to_delete = factories.PlaylistAccessFactory(
+            playlist__consumer_site=consumer_site_access.consumer_site,
+        )
+
+        self.assert_user_cant_delete_playlist_access(
+            consumer_site_access.user, playlist_access_to_delete
+        )
+
+    def test_delete_playlist_access_by_playlist_student(self):
+        """Playlist students cannot delete playlist access."""
+        playlist_access = factories.PlaylistAccessFactory(
+            role=models.STUDENT,
+        )
+        playlist_access_to_delete = factories.PlaylistAccessFactory(
+            playlist=playlist_access.playlist,
+        )
+
+        self.assert_user_cant_delete_playlist_access(
+            playlist_access.user, playlist_access_to_delete
+        )
+
+    def test_delete_playlist_access_by_playlist_instructor(self):
+        """Playlist instructors cannot delete playlist access."""
+        playlist_access = factories.PlaylistAccessFactory(
+            role=models.INSTRUCTOR,
+        )
+        playlist_access_to_delete = factories.PlaylistAccessFactory(
+            playlist=playlist_access.playlist,
+        )
+
+        self.assert_user_cant_delete_playlist_access(
+            playlist_access.user, playlist_access_to_delete
+        )
+
+    def test_delete_playlist_access_by_playlist_administrator(self):
+        """Playlist administrators can delete playlist access."""
+        playlist_access = factories.PlaylistAccessFactory(
+            role=models.ADMINISTRATOR,
+        )
+        playlist_access_to_delete = factories.PlaylistAccessFactory(
+            playlist=playlist_access.playlist,
+        )
+
+        jwt_token = UserAccessTokenFactory(user=playlist_access.user)
+
+        self.assertEqual(models.PlaylistAccess.objects.count(), 2)
+
+        response = self.client.delete(
+            f"/api/playlist-accesses/{str(playlist_access_to_delete.pk)}/",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+
+        self.assertEqual(response.status_code, 204)
+        self.assertEqual(models.PlaylistAccess.objects.count(), 1)
+
+        self.assertFalse(
+            models.PlaylistAccess.objects.exclude(
+                pk=playlist_access.pk,
+            ).exists()
+        )

--- a/src/backend/marsha/core/tests/api/playlist_accesses/test_list.py
+++ b/src/backend/marsha/core/tests/api/playlist_accesses/test_list.py
@@ -1,0 +1,379 @@
+"""Tests for the PlaylistAccess list API of the Marsha project."""
+
+from django.test import TestCase
+
+from marsha.core import factories, models
+from marsha.core.simple_jwt.factories import UserAccessTokenFactory
+
+
+class PlaylistAccessListAPITest(TestCase):
+    """Test the list API for playlist access objects."""
+
+    maxDiff = None
+
+    def assert_user_cant_list_playlist_access(self, user):
+        """Assert that a GET request returns an empty list."""
+        jwt_token = UserAccessTokenFactory(user=user)
+
+        response = self.client.get(
+            "/api/playlist-accesses/",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertDictEqual(
+            response.json(),
+            {"count": 0, "next": None, "previous": None, "results": []},
+        )
+
+    def assertGetReturnsOrderedAccessList(self, user, expected_access):
+        """Assert that a GET request returns a list of `expected_access`."""
+        jwt_token = UserAccessTokenFactory(user=user)
+
+        response = self.client.get(
+            "/api/playlist-accesses/",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+        self.assertEqual(response.status_code, 200)
+
+        response_data = response.json()
+
+        self.assertEqual(
+            response_data["count"],
+            len(expected_access),
+        )
+        self.assertEqual(
+            response_data["results"],
+            [
+                {
+                    "id": str(access.pk),
+                    "playlist": {
+                        "id": str(access.playlist.pk),
+                        "lti_id": access.playlist.lti_id,
+                        "title": access.playlist.title,
+                    },
+                    "user": {
+                        "id": str(access.user.pk),
+                        "date_joined": access.user.date_joined.strftime(
+                            "%Y-%m-%dT%H:%M:%S.%fZ"
+                        ),
+                        "email": access.user.email,
+                        "full_name": access.user.get_full_name(),
+                        "is_staff": False,
+                        "is_superuser": False,
+                        "organization_accesses": [],
+                    },
+                    "role": access.role,
+                }
+                for access in expected_access
+            ],
+        )
+
+    def test_list_playlist_access_by_anonymous_user(self):
+        """Anonymous users cannot list playlist access."""
+
+        response = self.client.get("/api/playlist-accesses/")
+        self.assertEqual(response.status_code, 401)
+
+    def test_list_playlist_access_by_random_logged_in_user(self):
+        """
+        Random logged-in users.
+
+        Cannot list access for playlist they have no role in.
+        """
+        user = factories.UserFactory()
+
+        self.assert_user_cant_list_playlist_access(user)
+
+    def test_list_playlist_access_by_organization_student(self):
+        """Organization students cannot list playlist access."""
+        organization_access = factories.OrganizationAccessFactory(
+            role=models.STUDENT,
+        )
+
+        self.assert_user_cant_list_playlist_access(organization_access.user)
+
+    def test_list_playlist_access_by_organization_instructor(self):
+        """Organization instructors cannot list playlist access."""
+        organization_access = factories.OrganizationAccessFactory(
+            role=models.INSTRUCTOR,
+        )
+
+        self.assert_user_cant_list_playlist_access(organization_access.user)
+
+    def test_list_playlist_access_by_organization_administrator(self):
+        """Organization administrators can list playlist access."""
+        user = factories.UserFactory()
+        organization_access = factories.OrganizationAccessFactory(
+            role=models.ADMINISTRATOR,
+            user=user,
+        )
+
+        # Populate the database with a playlist access
+        admin_access = factories.PlaylistAccessFactory(
+            role=models.ADMINISTRATOR,
+            playlist__organization=organization_access.organization,
+        )
+        instructor_access = factories.PlaylistAccessFactory(
+            role=models.INSTRUCTOR,
+            playlist__organization=organization_access.organization,
+        )
+        student_access = factories.PlaylistAccessFactory(
+            role=models.STUDENT,
+            playlist__organization=organization_access.organization,
+        )
+
+        # Other organization playlist access
+        factories.PlaylistAccessFactory()
+
+        self.assertGetReturnsOrderedAccessList(
+            organization_access.user,
+            [admin_access, instructor_access, student_access],
+        )
+
+    def test_list_playlist_access_by_consumer_site_any_role(self):
+        """Consumer site roles cannot list playlist access."""
+        consumer_site_access = factories.ConsumerSiteAccessFactory()
+
+        self.assert_user_cant_list_playlist_access(consumer_site_access.user)
+
+    def test_list_playlist_access_by_playlist_student(self):
+        """Playlist students cannot list playlist access."""
+        playlist_access = factories.PlaylistAccessFactory(
+            role=models.STUDENT,
+        )
+
+        self.assert_user_cant_list_playlist_access(playlist_access.user)
+
+    def test_list_playlist_access_by_playlist_instructor(self):
+        """Playlist instructors cannot list playlist access."""
+        playlist_access = factories.PlaylistAccessFactory(
+            role=models.INSTRUCTOR,
+        )
+
+        # Populate the database with a playlist access
+        admin_access = factories.PlaylistAccessFactory(
+            role=models.ADMINISTRATOR,
+            playlist=playlist_access.playlist,
+        )
+        instructor_access = factories.PlaylistAccessFactory(
+            role=models.INSTRUCTOR,
+            playlist=playlist_access.playlist,
+        )
+        student_access = factories.PlaylistAccessFactory(
+            role=models.STUDENT,
+            playlist=playlist_access.playlist,
+        )
+
+        # Other playlist access
+        factories.PlaylistAccessFactory(
+            playlist__organization=playlist_access.playlist.organization,
+        )
+
+        self.assertGetReturnsOrderedAccessList(
+            playlist_access.user,
+            [playlist_access, admin_access, instructor_access, student_access],
+        )
+
+    def test_list_playlist_access_by_playlist_administrator(self):
+        """Playlist administrators can list playlist access."""
+        playlist_access = factories.PlaylistAccessFactory(
+            role=models.ADMINISTRATOR,
+        )
+
+        # Populate the database with a playlist access
+        admin_access = factories.PlaylistAccessFactory(
+            role=models.ADMINISTRATOR,
+            playlist=playlist_access.playlist,
+        )
+        instructor_access = factories.PlaylistAccessFactory(
+            role=models.INSTRUCTOR,
+            playlist=playlist_access.playlist,
+        )
+        student_access = factories.PlaylistAccessFactory(
+            role=models.STUDENT,
+            playlist=playlist_access.playlist,
+        )
+
+        # Other playlist access
+        factories.PlaylistAccessFactory(
+            playlist__organization=playlist_access.playlist.organization,
+        )
+
+        self.assertGetReturnsOrderedAccessList(
+            playlist_access.user,
+            [playlist_access, admin_access, instructor_access, student_access],
+        )
+
+    def test_results_not_duplicated(self):
+        """Results are not duplicated when a user has multiple accesses."""
+        organization_access = factories.OrganizationAccessFactory(
+            role=models.ADMINISTRATOR,
+        )
+        consumer_site_access = factories.ConsumerSiteAccessFactory(
+            role=models.ADMINISTRATOR,
+            user=organization_access.user,
+        )
+        playlist_access = factories.PlaylistAccessFactory(
+            role=models.ADMINISTRATOR,
+            user=organization_access.user,
+            playlist__organization=organization_access.organization,
+            playlist__consumer_site=consumer_site_access.consumer_site,
+        )
+
+        jwt_token = UserAccessTokenFactory(user=playlist_access.user)
+
+        response = self.client.get(
+            "/api/playlist-accesses/",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+        self.assertEqual(response.status_code, 200)
+        response_data = response.json()
+
+        self.assertEqual(
+            response_data["count"],
+            1,
+        )
+
+    def test_filters(self):
+        """Results are filtered."""
+        playlist_access_1 = factories.PlaylistAccessFactory(
+            role=models.ADMINISTRATOR,
+        )
+        factories.PlaylistAccessFactory(
+            role=models.ADMINISTRATOR,
+            user=playlist_access_1.user,
+        )
+
+        jwt_token = UserAccessTokenFactory(user=playlist_access_1.user)
+
+        # Without filter
+        response = self.client.get(
+            "/api/playlist-accesses/",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+        self.assertEqual(response.status_code, 200)
+        response_data = response.json()
+
+        self.assertEqual(
+            response_data["count"],
+            2,
+        )
+
+        # With filter
+        response = self.client.get(
+            f"/api/playlist-accesses/?playlist_id={playlist_access_1.playlist_id}",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+        self.assertEqual(response.status_code, 200)
+        response_data = response.json()
+
+        self.assertEqual(
+            response_data["count"],
+            1,
+        )
+        self.assertEqual(
+            response_data["results"][0]["id"],
+            str(playlist_access_1.id),
+        )
+
+    def test_orderings(self):
+        """Results are sorted like expected."""
+        organization_access = factories.OrganizationAccessFactory(
+            role=models.ADMINISTRATOR,
+        )
+
+        playlist_access_1 = factories.PlaylistAccessFactory(
+            playlist__organization=organization_access.organization,
+            role=models.ADMINISTRATOR,
+            user__last_name="A",
+            playlist__title="A",
+        )
+        playlist_access_2 = factories.PlaylistAccessFactory(
+            playlist__organization=organization_access.organization,
+            role=models.STUDENT,
+            user__last_name="C",
+            playlist__title="D",
+        )
+        playlist_access_3 = factories.PlaylistAccessFactory(
+            playlist__organization=organization_access.organization,
+            role=models.INSTRUCTOR,
+            user__last_name="B",
+            playlist__title="C",
+        )
+        playlist_access_4 = factories.PlaylistAccessFactory(
+            playlist__organization=organization_access.organization,
+            role=models.ADMINISTRATOR,
+            user__last_name="D",
+            playlist__title="B",
+        )
+
+        jwt_token = UserAccessTokenFactory(user=organization_access.user)
+
+        # Without ordering
+        response = self.client.get(
+            "/api/playlist-accesses/",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+        self.assertEqual(response.status_code, 200)
+
+        self.assertEqual(
+            [result["id"] for result in response.json()["results"]],
+            [
+                str(playlist_access_1.id),
+                str(playlist_access_2.id),
+                str(playlist_access_3.id),
+                str(playlist_access_4.id),
+            ],
+        )
+
+        # With ordering on user last name
+        response = self.client.get(
+            "/api/playlist-accesses/?ordering=user__last_name",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+        self.assertEqual(response.status_code, 200)
+
+        self.assertEqual(
+            [result["id"] for result in response.json()["results"]],
+            [
+                str(playlist_access_1.id),
+                str(playlist_access_3.id),
+                str(playlist_access_2.id),
+                str(playlist_access_4.id),
+            ],
+        )
+
+        # With ordering on playlist title
+        response = self.client.get(
+            "/api/playlist-accesses/?ordering=playlist__title",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+        self.assertEqual(response.status_code, 200)
+
+        self.assertEqual(
+            [result["id"] for result in response.json()["results"]],
+            [
+                str(playlist_access_1.id),
+                str(playlist_access_4.id),
+                str(playlist_access_3.id),
+                str(playlist_access_2.id),
+            ],
+        )
+
+        # With ordering on role
+        response = self.client.get(
+            "/api/playlist-accesses/?ordering=role",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+        self.assertEqual(response.status_code, 200)
+
+        # Same ID may not be on same spot so test role instead
+        self.assertEqual(
+            [result["role"] for result in response.json()["results"]],
+            [
+                models.ADMINISTRATOR,
+                models.ADMINISTRATOR,
+                models.INSTRUCTOR,
+                models.STUDENT,
+            ],
+        )

--- a/src/backend/marsha/core/tests/api/playlist_accesses/test_retrieve.py
+++ b/src/backend/marsha/core/tests/api/playlist_accesses/test_retrieve.py
@@ -1,0 +1,225 @@
+"""Tests for the PlaylistAccess retrieve API of the Marsha project."""
+
+from django.test import TestCase
+
+from marsha.core import factories, models
+from marsha.core.simple_jwt.factories import UserAccessTokenFactory
+
+
+class PlaylistAccessRetrieveAPITest(TestCase):
+    """Test the retrieve API for playlist access objects."""
+
+    maxDiff = None
+
+    def assert_user_cant_retrieve_playlist_access(self, user, playlist_access):
+        """Assert a user cannot retrieve a playlist access with a GET request."""
+        jwt_token = UserAccessTokenFactory(user=user)
+
+        response = self.client.get(
+            f"/api/playlist-accesses/{str(playlist_access.pk)}/",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_retrieve_playlist_access_by_anonymous_user(self):
+        """Anonymous users cannot retrieve playlist access."""
+        playlist_access = factories.PlaylistAccessFactory()
+
+        response = self.client.get(
+            f"/api/playlist-accesses/{str(playlist_access.pk)}/",
+        )
+        self.assertEqual(response.status_code, 401)
+
+    def test_retrieve_playlist_access_by_random_logged_in_user(self):
+        """
+        Random logged-in users.
+
+        Cannot retrieve access for playlist they have no role in.
+        """
+        user = factories.UserFactory()
+        playlist_access = factories.PlaylistAccessFactory()
+
+        self.assert_user_cant_retrieve_playlist_access(user, playlist_access)
+
+    def test_retrieve_playlist_access_by_organization_student(self):
+        """Organization students cannot retrieve playlist access."""
+        organization_access = factories.OrganizationAccessFactory(
+            role=models.STUDENT,
+        )
+        playlist_access = factories.PlaylistAccessFactory(
+            playlist__organization=organization_access.organization,
+        )
+
+        self.assert_user_cant_retrieve_playlist_access(
+            organization_access.user, playlist_access
+        )
+
+    def test_retrieve_playlist_access_by_organization_instructor(self):
+        """Organization instructors cannot retrieve playlist access."""
+        organization_access = factories.OrganizationAccessFactory(
+            role=models.INSTRUCTOR,
+        )
+        playlist_access = factories.PlaylistAccessFactory(
+            playlist__organization=organization_access.organization,
+        )
+
+        self.assert_user_cant_retrieve_playlist_access(
+            organization_access.user, playlist_access
+        )
+
+    def test_retrieve_playlist_access_by_organization_administrator(self):
+        """Organization administrators can retrieve playlist access."""
+        organization_access = factories.OrganizationAccessFactory(
+            role=models.ADMINISTRATOR,
+        )
+        playlist_access = factories.PlaylistAccessFactory(
+            playlist__organization=organization_access.organization,
+            user=organization_access.user,
+        )
+
+        jwt_token = UserAccessTokenFactory(user=organization_access.user)
+
+        response = self.client.get(
+            f"/api/playlist-accesses/{str(playlist_access.pk)}/",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        self.assertEqual(
+            response.json(),
+            {
+                "id": str(playlist_access.pk),
+                "playlist": {
+                    "id": str(playlist_access.playlist.pk),
+                    "lti_id": playlist_access.playlist.lti_id,
+                    "title": playlist_access.playlist.title,
+                },
+                "user": {
+                    "id": str(playlist_access.user.pk),
+                    "date_joined": playlist_access.user.date_joined.strftime(
+                        "%Y-%m-%dT%H:%M:%S.%fZ"
+                    ),
+                    "email": playlist_access.user.email,
+                    "full_name": playlist_access.user.get_full_name(),
+                    "is_staff": False,
+                    "is_superuser": False,
+                    "organization_accesses": [
+                        {
+                            "organization": str(organization_access.organization.pk),
+                            "organization_name": organization_access.organization.name,
+                            "role": "administrator",
+                            "user": str(playlist_access.user.pk),
+                        }
+                    ],
+                },
+                "role": playlist_access.role,
+            },
+        )
+
+    def test_retrieve_playlist_access_by_consumer_site_any_role(self):
+        """Consumer site roles cannot retrieve playlist access."""
+        consumer_site_access = factories.ConsumerSiteAccessFactory()
+        playlist_access = factories.PlaylistAccessFactory(
+            playlist__consumer_site=consumer_site_access.consumer_site,
+        )
+
+        self.assert_user_cant_retrieve_playlist_access(
+            consumer_site_access.user, playlist_access
+        )
+
+    def test_retrieve_playlist_access_by_playlist_student(self):
+        """Playlist students cannot retrieve playlist access."""
+        playlist_access = factories.PlaylistAccessFactory(
+            role=models.STUDENT,
+        )
+
+        self.assert_user_cant_retrieve_playlist_access(
+            playlist_access.user, playlist_access
+        )
+
+    def test_retrieve_playlist_access_by_playlist_instructor(self):
+        """Playlist instructors cannot retrieve playlist access."""
+        playlist_access = factories.PlaylistAccessFactory(
+            role=models.INSTRUCTOR,
+        )
+
+        playlist_access_to_retrieve = factories.PlaylistAccessFactory(
+            playlist=playlist_access.playlist,
+        )
+
+        jwt_token = UserAccessTokenFactory(user=playlist_access.user)
+
+        response = self.client.get(
+            f"/api/playlist-accesses/{str(playlist_access_to_retrieve.pk)}/",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        self.assertEqual(
+            response.json(),
+            {
+                "id": str(playlist_access_to_retrieve.pk),
+                "playlist": {
+                    "id": str(playlist_access_to_retrieve.playlist.pk),
+                    "lti_id": playlist_access_to_retrieve.playlist.lti_id,
+                    "title": playlist_access_to_retrieve.playlist.title,
+                },
+                "user": {
+                    "id": str(playlist_access_to_retrieve.user.pk),
+                    "date_joined": playlist_access_to_retrieve.user.date_joined.strftime(
+                        "%Y-%m-%dT%H:%M:%S.%fZ"
+                    ),
+                    "email": playlist_access_to_retrieve.user.email,
+                    "full_name": playlist_access_to_retrieve.user.get_full_name(),
+                    "is_staff": False,
+                    "is_superuser": False,
+                    "organization_accesses": [],
+                },
+                "role": playlist_access_to_retrieve.role,
+            },
+        )
+
+    def test_retrieve_playlist_access_by_playlist_administrator(self):
+        """Playlist administrators can retrieve playlist access."""
+        playlist_access = factories.PlaylistAccessFactory(
+            role=models.ADMINISTRATOR,
+        )
+
+        playlist_access_to_retrieve = factories.PlaylistAccessFactory(
+            playlist=playlist_access.playlist,
+        )
+
+        jwt_token = UserAccessTokenFactory(user=playlist_access.user)
+
+        response = self.client.get(
+            f"/api/playlist-accesses/{str(playlist_access_to_retrieve.pk)}/",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        self.assertEqual(
+            response.json(),
+            {
+                "id": str(playlist_access_to_retrieve.pk),
+                "playlist": {
+                    "id": str(playlist_access_to_retrieve.playlist.pk),
+                    "lti_id": playlist_access_to_retrieve.playlist.lti_id,
+                    "title": playlist_access_to_retrieve.playlist.title,
+                },
+                "user": {
+                    "id": str(playlist_access_to_retrieve.user.pk),
+                    "date_joined": playlist_access_to_retrieve.user.date_joined.strftime(
+                        "%Y-%m-%dT%H:%M:%S.%fZ"
+                    ),
+                    "email": playlist_access_to_retrieve.user.email,
+                    "full_name": playlist_access_to_retrieve.user.get_full_name(),
+                    "is_staff": False,
+                    "is_superuser": False,
+                    "organization_accesses": [],
+                },
+                "role": playlist_access_to_retrieve.role,
+            },
+        )

--- a/src/backend/marsha/core/tests/api/playlist_accesses/test_update.py
+++ b/src/backend/marsha/core/tests/api/playlist_accesses/test_update.py
@@ -1,0 +1,214 @@
+"""Tests for the PlaylistAccess update API of the Marsha project."""
+
+from django.test import TestCase
+
+from marsha.core import factories, models
+from marsha.core.simple_jwt.factories import UserAccessTokenFactory
+
+
+class PlaylistAccessUpdateAPITest(TestCase):
+    """Test the update API for playlist access objects."""
+
+    maxDiff = None
+
+    def assert_user_cant_update_playlist_access(self, user, playlist_access):
+        """Assert a user cannot update a playlist access with a PUT request."""
+        jwt_token = UserAccessTokenFactory(user=user)
+
+        response = self.client.put(
+            f"/api/playlist-accesses/{str(playlist_access.pk)}/",
+            {"role": models.INSTRUCTOR},
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_update_playlist_access_by_anonymous_user(self):
+        """Anonymous users cannot update playlist access."""
+        playlist_access = factories.PlaylistAccessFactory()
+
+        response = self.client.put(
+            f"/api/playlist-accesses/{str(playlist_access.pk)}/",
+            {"role": models.INSTRUCTOR},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 401)
+
+    def test_update_playlist_access_by_random_logged_in_user(self):
+        """
+        Random logged-in users.
+
+        Cannot update access for playlist they have no role in.
+        """
+        user = factories.UserFactory()
+        playlist_access = factories.PlaylistAccessFactory()
+
+        self.assert_user_cant_update_playlist_access(user, playlist_access)
+
+    def test_update_playlist_access_by_organization_student(self):
+        """Organization students cannot update playlist access."""
+        organization_access = factories.OrganizationAccessFactory(
+            role=models.STUDENT,
+        )
+        playlist_access = factories.PlaylistAccessFactory(
+            playlist__organization=organization_access.organization,
+        )
+
+        self.assert_user_cant_update_playlist_access(
+            organization_access.user, playlist_access
+        )
+
+    def test_update_playlist_access_by_organization_instructor(self):
+        """Organization instructors cannot update playlist access."""
+        organization_access = factories.OrganizationAccessFactory(
+            role=models.INSTRUCTOR,
+        )
+        playlist_access = factories.PlaylistAccessFactory(
+            playlist__organization=organization_access.organization,
+        )
+
+        self.assert_user_cant_update_playlist_access(
+            organization_access.user, playlist_access
+        )
+
+    def test_update_playlist_access_by_organization_administrator(self):
+        """Organization administrators can update playlist access."""
+        organization_access = factories.OrganizationAccessFactory(
+            role=models.ADMINISTRATOR,
+        )
+        playlist_access = factories.PlaylistAccessFactory(
+            playlist__organization=organization_access.organization,
+            user=organization_access.user,
+            role=models.INSTRUCTOR,
+        )
+
+        jwt_token = UserAccessTokenFactory(user=organization_access.user)
+
+        response = self.client.put(
+            f"/api/playlist-accesses/{str(playlist_access.pk)}/",
+            {"role": models.STUDENT},
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        self.assertEqual(
+            response.json(),
+            {
+                "id": str(playlist_access.pk),
+                "playlist": {
+                    "id": str(playlist_access.playlist.pk),
+                    "lti_id": playlist_access.playlist.lti_id,
+                    "title": playlist_access.playlist.title,
+                },
+                "user": {
+                    "id": str(playlist_access.user.pk),
+                    "date_joined": playlist_access.user.date_joined.strftime(
+                        "%Y-%m-%dT%H:%M:%S.%fZ"
+                    ),
+                    "email": playlist_access.user.email,
+                    "full_name": playlist_access.user.get_full_name(),
+                    "is_staff": False,
+                    "is_superuser": False,
+                    "organization_accesses": [
+                        {
+                            "organization": str(organization_access.organization.pk),
+                            "organization_name": organization_access.organization.name,
+                            "role": "administrator",
+                            "user": str(playlist_access.user.pk),
+                        }
+                    ],
+                },
+                "role": models.STUDENT,
+            },
+        )
+
+    def test_update_playlist_access_by_consumer_site_any_role(self):
+        """Consumer site roles cannot update playlist access."""
+        consumer_site_access = factories.ConsumerSiteAccessFactory()
+        playlist_access = factories.PlaylistAccessFactory(
+            playlist__consumer_site=consumer_site_access.consumer_site,
+        )
+
+        playlist_access_to_update = factories.PlaylistAccessFactory(
+            playlist=playlist_access.playlist,
+        )
+
+        self.assert_user_cant_update_playlist_access(
+            playlist_access.user, playlist_access_to_update
+        )
+
+    def test_update_playlist_access_by_playlist_student(self):
+        """Playlist students cannot update playlist access."""
+        playlist_access = factories.PlaylistAccessFactory(
+            role=models.STUDENT,
+        )
+
+        playlist_access_to_update = factories.PlaylistAccessFactory(
+            playlist=playlist_access.playlist,
+        )
+
+        self.assert_user_cant_update_playlist_access(
+            playlist_access.user, playlist_access_to_update
+        )
+
+    def test_update_playlist_access_by_playlist_instructor(self):
+        """Playlist instructors cannot update playlist access."""
+        playlist_access = factories.PlaylistAccessFactory(
+            role=models.INSTRUCTOR,
+        )
+
+        playlist_access_to_update = factories.PlaylistAccessFactory(
+            playlist=playlist_access.playlist,
+        )
+
+        self.assert_user_cant_update_playlist_access(
+            playlist_access.user, playlist_access_to_update
+        )
+
+    def test_update_playlist_access_by_playlist_administrator(self):
+        """Playlist administrators can update playlist access."""
+        playlist_access = factories.PlaylistAccessFactory(
+            role=models.ADMINISTRATOR,
+        )
+
+        playlist_access_to_update = factories.PlaylistAccessFactory(
+            role=models.INSTRUCTOR,
+            playlist=playlist_access.playlist,
+        )
+
+        jwt_token = UserAccessTokenFactory(user=playlist_access.user)
+
+        response = self.client.put(
+            f"/api/playlist-accesses/{str(playlist_access_to_update.pk)}/",
+            {"role": models.STUDENT},
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        self.assertEqual(
+            response.json(),
+            {
+                "id": str(playlist_access_to_update.pk),
+                "playlist": {
+                    "id": str(playlist_access_to_update.playlist.pk),
+                    "lti_id": playlist_access_to_update.playlist.lti_id,
+                    "title": playlist_access_to_update.playlist.title,
+                },
+                "user": {
+                    "id": str(playlist_access_to_update.user.pk),
+                    "date_joined": playlist_access_to_update.user.date_joined.strftime(
+                        "%Y-%m-%dT%H:%M:%S.%fZ"
+                    ),
+                    "email": playlist_access_to_update.user.email,
+                    "full_name": playlist_access_to_update.user.get_full_name(),
+                    "is_staff": False,
+                    "is_superuser": False,
+                    "organization_accesses": [],
+                },
+                "role": models.STUDENT,
+            },
+        )

--- a/src/backend/marsha/urls.py
+++ b/src/backend/marsha/urls.py
@@ -15,6 +15,7 @@ from marsha.core.api import (
     DocumentViewSet,
     LiveSessionViewSet,
     OrganizationViewSet,
+    PlaylistAccessViewSet,
     PlaylistViewSet,
     PortabilityResourceViewSet,
     SharedLiveMediaViewSet,
@@ -64,6 +65,9 @@ router.register(
 router.register(models.Thumbnail.RESOURCE_NAME, ThumbnailViewSet, basename="thumbnails")
 router.register("organizations", OrganizationViewSet, basename="organizations")
 router.register("playlists", PlaylistViewSet, basename="playlists")
+router.register(
+    "playlist-accesses", PlaylistAccessViewSet, basename="playlist_accesses"
+)
 router.register(
     "portability-requests", PortabilityResourceViewSet, basename="portability_requests"
 )


### PR DESCRIPTION
## Purpose

This introduces the API endpoints to manage authorization for playlist and their related objects.


## Proposal

Organization admin can list, retrieve, create, update, delete 
Playlist admin can list, retrieve, create, update, delete for their playlists
Playlist instructor can list and retrieve only.

- [x] Add related permissions
- [x] Add playlist access viewset
