### PR TITLE
:bug:(backend) change xapi endpoints status code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - standalone website:
   - banner homepage with dynamic text
 
+### Changed
+
+- change xapi endpoints status code when no LRS from 501 to 200 
+
 ### Fixed
 
 - lti:

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -21,6 +21,7 @@
 - [Anthony Le Courric](https://github.com/AntoLC) <freelance.anthony@gmail.com>
 - [Alfred Pichard](https://github.com/AlfredPichard) <alfred.pichard@polyconseil.fr>
 - [Théo Clement](https://github.com/Kitero) <theoclementtheo@gmail.com>
+- [Henri Baudesson](https://github.com/polyhb) <henri.baudesson@polyconseil.fr>
 
 - [Renovate Bot](https://renovatebot.com) <bot@renovateapp.com>
 - [Renovate Bot](https://renovatebot.com) <29139614+renovate[bot]@users.noreply.github.com>

--- a/src/backend/marsha/core/api/xapi.py
+++ b/src/backend/marsha/core/api/xapi.py
@@ -79,10 +79,8 @@ class XAPIStatementView(APIViewMixin, APIView):
         xapi_logger.info(json.dumps(xapi_statement.get_statement()))
 
         if not consumer_site.lrs_url or not consumer_site.lrs_auth_token:
-            return Response(
-                {"reason": "LRS is not configured. This endpoint is not usable."},
-                status=501,
-            )
+            logger.info("LRS is not configured.")
+            return Response(status=200)
 
         xapi = XAPI(
             consumer_site.lrs_url,
@@ -99,6 +97,6 @@ class XAPIStatementView(APIViewMixin, APIView):
                 message,
                 extra={"response": e.response.text, "status": e.response.status_code},
             )
-            return Response({"status": message}, status=501)
+            return Response({"status": message}, status=500)
 
         return Response(status=204)

--- a/src/backend/marsha/core/tests/test_api_xapi_statement.py
+++ b/src/backend/marsha/core/tests/test_api_xapi_statement.py
@@ -27,7 +27,7 @@ class XAPIStatementApiTest(TestCase):
         )
 
     def test_xapi_statement_with_no_lrs_configured(self):
-        """If no LRS configured a 501 status code should be returned."""
+        """If no LRS configured a 200 status code should be returned."""
         video = VideoFactory()
         jwt_token = StudentLtiTokenFactory(resource=video)
 
@@ -48,7 +48,7 @@ class XAPIStatementApiTest(TestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(response.status_code, 501)
+        self.assertEqual(response.status_code, 200)
 
     def test_xapi_statement_api_with_invalid_payload(self):
         """Payload should follow a given pattern."""
@@ -133,7 +133,7 @@ class XAPIStatementApiTest(TestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(response.status_code, 501)
+        self.assertEqual(response.status_code, 500)
         self.assertEqual(
             response.json().get("status"), "Impossible to send xAPI request to LRS."
         )


### PR DESCRIPTION
## Purpose

The xapi endpoints return a 501 status code if no LRS is configured. This a while we are not using LRS configuration anymore but we use special loggers for this purpose.

## Proposal

Change return status code from 501 to 200 in this case, in order to reduce pollution in logs.

- [x] change return status code from 501 to 200
- [x] typo on status code when request to LRS failed

