### PR TITLE
✨(feature) video permissions for the standalone site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Add a check on deposited file size when uploading content
 - helpers frontend api error handling
 - Add accepted formats in the subtitles uploaders helptext
+- Standalone website:
+  - Add "video" management API endpoints permissions
 
 ### Changed
 

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -66,7 +66,7 @@ Among other things, they can:
 - 🚧 Create and manage (read/write) all the organization's access control.
 - Manage (read/write) all the users of the organization.
 - Create and manage (read/write) all the playlists of the organization.
-- Create and manage (read/write) all the videos of the organization.
+- Create and manage (read/write) all the videos of the organization and perform related video actions.
 - Create and manage (read/write) all the classrooms of the organization.
 - Create and manage (read/write) all the classroom documents of the organization.
 - 🚧 Create and manage (read/write) all the documents of the organization.
@@ -118,7 +118,7 @@ When creating a playlist, the user is automatically assigned the `ADMIN` role fo
 A playlist administrator can:
 
 - 🚧 Create and manage (read/write) all the playlist's access control.
-- Create and manage (read/write) all the videos of the playlist.
+- Create and manage (read/write) all the videos of the playlist and perform related video actions.
 - Create and manage (read/write) all the timed text track of the playlist's videos.
 - Create and manage (read/write) all the classrooms of the playlist.
 - Create and manage (read/write) all the classroom documents of the playlist.
@@ -132,7 +132,7 @@ A playlist administrator can:
 The playlist instructor is added by a playlist administrator. They can:
 
 - 🚧 Read all the playlist's access control.
-- 🚧 Read all the videos of the playlist.
+- Create and manage (read/write) all the videos of the playlist and perform related video actions.
 - 🚧 Read all the timed text track of the playlist's videos.
 - 🚧 Read all the classrooms of the playlist.
 - 🚧 Read all the classroom documents of the playlist.

--- a/src/backend/marsha/core/api/video.py
+++ b/src/backend/marsha/core/api/video.py
@@ -71,6 +71,8 @@ class VideoViewSet(APIViewMixin, ObjectPkMixin, viewsets.ModelViewSet):
         the current user has the authorization to access endpoint.
         """
         if self.action in ["retrieve"]:
+            # DEV WARNING: please ensure to also update the permissions in the
+            # `VideoConsumer` websocket consumer.
             permission_classes = [
                 # With LTI: anyone with a valid token for the video can access
                 permissions.IsTokenResourceRouteObject

--- a/src/backend/marsha/core/permissions.py
+++ b/src/backend/marsha/core/permissions.py
@@ -321,20 +321,18 @@ class IsParamsOrganizationInstructorOrAdmin(
     """
 
 
-class IsParamsPlaylistAdmin(permissions.BasePermission):
+class BaseIsParamsPlaylistRole(permissions.BasePermission):
     """
-    Allow a request to proceed. Permission class.
-
     Permission to allow a request to proceed only if the user provides the ID for an existing
-    playlist, and has an access to this playlist with an administrator role.
+    playlist, and has access to this playlist with a specific role.
     """
+
+    role_filter = {}
 
     def has_permission(self, request, view):
         """
-        Allow the request.
-
         Allow the request only if the playlist from the params of body of the request exists
-        and the current logged in user is one of its administrators.
+        and the current logged-in user has a specific role.
         """
         try:
             uuid.UUID(request.user.id)
@@ -345,10 +343,25 @@ class IsParamsPlaylistAdmin(permissions.BasePermission):
             "playlist"
         )
         return models.PlaylistAccess.objects.filter(
-            role=ADMINISTRATOR,
+            **self.role_filter,
             playlist__id=playlist_id,
             user__id=request.user.id,
         ).exists()
+
+
+class IsParamsPlaylistAdmin(HasAdminRoleMixIn, BaseIsParamsPlaylistRole):
+    """
+    Allow access to user with admin role on the playlist provided in parameters.
+    """
+
+
+class IsParamsPlaylistAdminOrInstructor(
+    HasAdminOrInstructorRoleMixIn,
+    BaseIsParamsPlaylistRole,
+):
+    """
+    Allow access to user with admin or instructor role on the playlist provided in parameters.
+    """
 
 
 class IsParamsPlaylistAdminThroughOrganization(permissions.BasePermission):
@@ -498,6 +511,13 @@ class BaseIsObjectPlaylistRole(BaseIsPlaylistRole):
 
 class IsObjectPlaylistAdmin(HasAdminRoleMixIn, BaseIsObjectPlaylistRole):
     """Allow request when the user has admin role on the object's playlist."""
+
+
+class IsObjectPlaylistAdminOrInstructor(
+    HasAdminOrInstructorRoleMixIn,
+    BaseIsObjectPlaylistRole,
+):
+    """Allow request when the user has admin or instructor role on the object's playlist."""
 
 
 class BaseIsPlaylistOrganizationRole(permissions.BasePermission):

--- a/src/backend/marsha/core/permissions.py
+++ b/src/backend/marsha/core/permissions.py
@@ -558,51 +558,6 @@ class IsObjectPlaylistOrganizationAdmin(
     """
 
 
-class IsVideoPlaylistAdmin(permissions.BasePermission):
-    """
-    Allow a request to proceed. Permission class.
-
-    Permission to allow a request to proceed only if the user is an admin for the playlist
-    the video is a part of.
-    """
-
-    def has_permission(self, request, view):
-        """
-        Allow the request.
-
-        Allow the request only if there is a video id in the path of the request, which exists,
-        and if the current user is an admin for the playlist this video is a part of.
-        """
-        return models.PlaylistAccess.objects.filter(
-            role=ADMINISTRATOR,
-            playlist__videos__id=view.get_object_pk(),
-            user__id=request.user.id,
-        ).exists()
-
-
-class IsVideoOrganizationAdmin(permissions.BasePermission):
-    """
-    Allow a request to proceed. Permission class.
-
-    Permission to allow a request to proceed only if the user is an admin for the organization
-    linked to the playlist the video is a part of.
-    """
-
-    def has_permission(self, request, view):
-        """
-        Allow the request.
-
-        Allow the request only if there is a video id in the path of the request, which exists,
-        and if the current user is an admin for the organization linked to the playlist this video
-        is a part of.
-        """
-        return models.OrganizationAccess.objects.filter(
-            role=ADMINISTRATOR,
-            organization__playlists__videos__id=view.get_object_pk(),
-            user__id=request.user.id,
-        ).exists()
-
-
 class IsRelatedVideoPlaylistAdmin(permissions.BasePermission):
     """
     Allow a request to proceed. Permission class.

--- a/src/backend/marsha/core/serializers/video.py
+++ b/src/backend/marsha/core/serializers/video.py
@@ -241,12 +241,21 @@ class VideoSerializer(VideoBaseSerializer):
     timed_text_tracks = TimedTextTrackSerializer(
         source="timedtexttracks", many=True, read_only=True
     )
-    shared_live_medias = SharedLiveMediaSerializer(many=True, read_only=True)
+    shared_live_medias = serializers.SerializerMethodField()
     playlist = PlaylistLiteSerializer(read_only=True)
     has_transcript = serializers.SerializerMethodField()
     live_info = serializers.SerializerMethodField()
     xmpp = serializers.SerializerMethodField()
     title = serializers.CharField(allow_blank=False, allow_null=False, max_length=255)
+
+    def get_shared_live_medias(self, instance):
+        """Get shared live media for a video sorted by reverse uploaded_on."""
+        shared_live_medias = instance.shared_live_medias.all().order_by("-uploaded_on")
+        return SharedLiveMediaSerializer(
+            shared_live_medias,
+            many=True,
+            context=self.context,
+        ).data
 
     def validate_starting_at(self, value):
         """Add extra controls for starting_at field."""

--- a/src/backend/marsha/core/tests/api/video/test_create.py
+++ b/src/backend/marsha/core/tests/api/video/test_create.py
@@ -187,8 +187,51 @@ class VideoCreateAPITest(TestCase):
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
-        self.assertEqual(models.Video.objects.count(), 0)
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(models.Video.objects.count(), 1)
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(
+            response.json(),
+            {
+                "active_shared_live_media": None,
+                "active_shared_live_media_page": None,
+                "active_stamp": None,
+                "allow_recording": True,
+                "description": "",
+                "estimated_duration": None,
+                "has_chat": True,
+                "has_live_media": True,
+                "has_transcript": False,
+                "id": str(models.Video.objects.get().id),
+                "is_public": False,
+                "is_ready_to_show": False,
+                "is_recording": False,
+                "is_scheduled": False,
+                "join_mode": "approval",
+                "live_info": {},
+                "live_state": None,
+                "live_type": None,
+                "participants_asking_to_join": [],
+                "participants_in_discussion": [],
+                "playlist": {
+                    "id": str(playlist.id),
+                    "lti_id": playlist.lti_id,
+                    "title": playlist.title,
+                },
+                "recording_time": 0,
+                "shared_live_medias": [],
+                "should_use_subtitle_as_transcript": False,
+                "show_download": True,
+                "starting_at": None,
+                "thumbnail": None,
+                "timed_text_tracks": [],
+                "title": "Some video",
+                "upload_state": "pending",
+                "urls": None,
+                "xmpp": None,
+                "tags": [],
+                "license": None,
+            },
+        )
 
     def test_api_video_create_by_organization_admin(self):
         """

--- a/src/backend/marsha/core/tests/api/video/test_destroy.py
+++ b/src/backend/marsha/core/tests/api/video/test_destroy.py
@@ -101,7 +101,7 @@ class VideoDestroyAPITest(TestCase):
         """
         Delete video by playlist instructor.
 
-        Users with an instructor role on a playlist should not be able to delete videos.
+        Users with an instructor role on a playlist should be able to delete videos.
         """
         user = factories.UserFactory()
         playlist = factories.PlaylistFactory()
@@ -119,8 +119,8 @@ class VideoDestroyAPITest(TestCase):
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
-        self.assertEqual(models.Video.objects.count(), 1)
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(models.Video.objects.count(), 0)
+        self.assertEqual(response.status_code, 204)
 
     def test_api_video_delete_by_organization_admin(self):
         """

--- a/src/backend/marsha/core/tests/api/video/test_destroy.py
+++ b/src/backend/marsha/core/tests/api/video/test_destroy.py
@@ -196,7 +196,7 @@ class VideoDestroyAPITest(TestCase):
 
         response = self.client.delete("/api/videos/")
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, 405)
         self.assertTrue(models.Video.objects.filter(id=video.id).exists())
 
     def test_api_video_delete_list_token_user(self):
@@ -210,7 +210,7 @@ class VideoDestroyAPITest(TestCase):
         response = self.client.delete(
             "/api/videos/", HTTP_AUTHORIZATION=f"Bearer {jwt_token}"
         )
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 405)
         self.assertTrue(models.Video.objects.filter(id=video.id).exists())
 
     def test_api_video_delete_list_staff_or_user(self):
@@ -221,5 +221,5 @@ class VideoDestroyAPITest(TestCase):
 
             response = self.client.delete("/api/videos/")
 
-            self.assertEqual(response.status_code, 401)
+            self.assertEqual(response.status_code, 405)
         self.assertTrue(models.Video.objects.filter(id=video.id).exists())

--- a/src/backend/marsha/core/tests/api/video/test_initiate_upload.py
+++ b/src/backend/marsha/core/tests/api/video/test_initiate_upload.py
@@ -270,15 +270,41 @@ class VideoInitiateUploadAPITest(TestCase):
                 {"filename": "video_file", "mimetype": "", "size": 100},
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 200)
         self.assertEqual(
             json.loads(response.content),
-            {"detail": "You do not have permission to perform this action."},
+            {
+                "url": "https://test-marsha-source.s3.amazonaws.com/",
+                "fields": {
+                    "acl": "private",
+                    "key": (
+                        "27a23f52-3379-46a2-94fa-697b59cfe3c7/video/27a23f52-3379-46a2-94fa-"
+                        "697b59cfe3c7/1533686400"
+                    ),
+                    "x-amz-algorithm": "AWS4-HMAC-SHA256",
+                    "x-amz-credential": "aws-access-key-id/20180808/eu-west-1/s3/aws4_request",
+                    "x-amz-date": "20180808T000000Z",
+                    "policy": (
+                        "eyJleHBpcmF0aW9uIjogIjIwMTgtMDgtMDlUMDA6MDA6MDBaIiwgImNvbmRpdGlvbnMiOiBbe"
+                        "yJhY2wiOiAicHJpdmF0ZSJ9LCBbInN0YXJ0cy13aXRoIiwgIiRDb250ZW50LVR5cGUiLCAidm"
+                        "lkZW8vIl0sIFsiY29udGVudC1sZW5ndGgtcmFuZ2UiLCAwLCAxMDczNzQxODI0XSwgeyJidWN"
+                        "rZXQiOiAidGVzdC1tYXJzaGEtc291cmNlIn0sIHsia2V5IjogIjI3YTIzZjUyLTMzNzktNDZh"
+                        "Mi05NGZhLTY5N2I1OWNmZTNjNy92aWRlby8yN2EyM2Y1Mi0zMzc5LTQ2YTItOTRmYS02OTdiN"
+                        "TljZmUzYzcvMTUzMzY4NjQwMCJ9LCB7IngtYW16LWFsZ29yaXRobSI6ICJBV1M0LUhNQUMtU0"
+                        "hBMjU2In0sIHsieC1hbXotY3JlZGVudGlhbCI6ICJhd3MtYWNjZXNzLWtleS1pZC8yMDE4MDg"
+                        "wOC9ldS13ZXN0LTEvczMvYXdzNF9yZXF1ZXN0In0sIHsieC1hbXotZGF0ZSI6ICIyMDE4MDgw"
+                        "OFQwMDAwMDBaIn1dfQ=="
+                    ),
+                    "x-amz-signature": (
+                        "8db66b80ad0afcaef57542df9da257976ab21bc3b8b0105f3bb6bdafe95964b9"
+                    ),
+                },
+            },
         )
 
-        # The upload state of the video has not changed
+        # The upload state of the video has been reset
         video.refresh_from_db()
-        self.assertEqual(video.upload_state, "ready")
+        self.assertEqual(video.upload_state, "pending")
 
     def test_api_video_initiate_upload_by_playlist_admin(self):
         """Playlist admins can retrieve an upload policy."""

--- a/src/backend/marsha/core/tests/api/video/test_live_participants_asking_to_join.py
+++ b/src/backend/marsha/core/tests/api/video/test_live_participants_asking_to_join.py
@@ -5,10 +5,20 @@ from django.test import TestCase
 
 from marsha.core.api.video import channel_layers_utils
 from marsha.core.defaults import DENIED
-from marsha.core.factories import UserFactory, VideoFactory
+from marsha.core.factories import (
+    ConsumerSiteAccessFactory,
+    OrganizationAccessFactory,
+    OrganizationFactory,
+    PlaylistAccessFactory,
+    UserFactory,
+    VideoFactory,
+    WebinarVideoFactory,
+)
+from marsha.core.models import ADMINISTRATOR, INSTRUCTOR, STUDENT
 from marsha.core.simple_jwt.factories import (
     InstructorOrAdminLtiTokenFactory,
     StudentLtiTokenFactory,
+    UserAccessTokenFactory,
 )
 
 
@@ -16,6 +26,177 @@ class VideoParticipantsAskingToJoinAPITest(TestCase):
     """Tests API for persisting the participants list asking to join a live."""
 
     maxDiff = None
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.some_organization = OrganizationFactory()
+        cls.some_video = WebinarVideoFactory(
+            playlist__organization=cls.some_organization,
+        )
+
+    def assert_user_cannot_manage_participants(self, user, video):
+        """Assert the user cannot manage participants (POST and DELETE)."""
+
+        jwt_token = UserAccessTokenFactory(user=user)
+
+        # Test POST
+        response = self.client.post(
+            f"/api/videos/{video.id}/participants-asking-to-join/",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+            data={
+                "id": "1",
+                "name": "Student",
+            },
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 403)
+
+        # Test DELETE
+        response = self.client.delete(
+            f"/api/videos/{video.id}/participants-asking-to-join/",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+            data={
+                "id": "1",
+                "name": "Student",
+            },
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 403)
+
+    def assert_user_can_manage_participants(self, user, video):
+        """Assert the user can manage participants (POST and DELETE)."""
+        with mock.patch.object(
+            channel_layers_utils, "dispatch_video_to_groups"
+        ) as mock_dispatch_video_to_groups:
+            jwt_token = UserAccessTokenFactory(user=user)
+
+            # Test POST
+            response = self.client.post(
+                f"/api/videos/{video.id}/participants-asking-to-join/",
+                HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+                data={
+                    "id": "1",
+                    "name": "Student",
+                },
+                content_type="application/json",
+            )
+            video.refresh_from_db()
+            mock_dispatch_video_to_groups.assert_called_once_with(video)
+
+            self.assertEqual(response.status_code, 200)
+
+            content = response.json()
+
+            self.assertListEqual(
+                content["participants_asking_to_join"],
+                [
+                    {
+                        "id": "1",
+                        "name": "Student",
+                    }
+                ],
+            )
+
+            # Test DELETE
+            mock_dispatch_video_to_groups.reset_mock()
+            response = self.client.delete(
+                f"/api/videos/{video.id}/participants-asking-to-join/",
+                HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+                data={
+                    "id": "1",
+                    "name": "Student",
+                },
+                content_type="application/json",
+            )
+            video.refresh_from_db()
+            mock_dispatch_video_to_groups.assert_called_once_with(video)
+
+            self.assertEqual(response.status_code, 200)
+
+            content = response.json()
+            self.assertListEqual(content["participants_asking_to_join"], [])
+
+    def test_manage_participants_by_random_user(self):
+        """Authenticated user without access cannot manage participants."""
+        user = UserFactory()
+
+        self.assert_user_cannot_manage_participants(user, self.some_video)
+
+    def test_manage_participants_by_organization_student(self):
+        """Organization students cannot manage participants."""
+        organization_access = OrganizationAccessFactory(
+            organization=self.some_organization,
+            role=STUDENT,
+        )
+
+        self.assert_user_cannot_manage_participants(
+            organization_access.user, self.some_video
+        )
+
+    def test_manage_participants_by_organization_instructor(self):
+        """Organization instructors cannot manage participants."""
+        organization_access = OrganizationAccessFactory(
+            organization=self.some_organization,
+            role=INSTRUCTOR,
+        )
+
+        self.assert_user_cannot_manage_participants(
+            organization_access.user, self.some_video
+        )
+
+    def test_manage_participants_by_organization_administrator(self):
+        """Organization administrators can manage participants."""
+        organization_access = OrganizationAccessFactory(
+            organization=self.some_organization,
+            role=ADMINISTRATOR,
+        )
+
+        self.assert_user_can_manage_participants(
+            organization_access.user, self.some_video
+        )
+
+    def test_manage_participants_by_consumer_site_any_role(self):
+        """Consumer site roles cannot manage participants."""
+        consumer_site_access = ConsumerSiteAccessFactory(
+            consumer_site=self.some_video.playlist.consumer_site,
+        )
+
+        self.assert_user_cannot_manage_participants(
+            consumer_site_access.user, self.some_video
+        )
+
+    def test_manage_participants_by_playlist_student(self):
+        """Playlist student cannot manage participants."""
+        playlist_access = PlaylistAccessFactory(
+            playlist=self.some_video.playlist,
+            role=STUDENT,
+        )
+
+        self.assert_user_cannot_manage_participants(
+            playlist_access.user, self.some_video
+        )
+
+    def test_manage_participants_by_playlist_instructor(self):
+        """Playlist instructor cannot manage participants."""
+        playlist_access = PlaylistAccessFactory(
+            playlist=self.some_video.playlist,
+            role=INSTRUCTOR,
+        )
+
+        self.assert_user_can_manage_participants(playlist_access.user, self.some_video)
+
+    def test_manage_participants_by_playlist_admin(self):
+        """Playlist administrator can manage participants."""
+        playlist_access = PlaylistAccessFactory(
+            playlist=self.some_video.playlist,
+            role=ADMINISTRATOR,
+        )
+
+        self.assert_user_can_manage_participants(playlist_access.user, self.some_video)
 
     def test_api_video_participants_post_asking_to_join_anonymous(self):
         """An anonymous user can not set participants."""

--- a/src/backend/marsha/core/tests/api/video/test_retrieve.py
+++ b/src/backend/marsha/core/tests/api/video/test_retrieve.py
@@ -1127,7 +1127,50 @@ class VideoRetrieveAPITest(TestCase):
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {
+                "active_shared_live_media": None,
+                "active_shared_live_media_page": None,
+                "active_stamp": None,
+                "allow_recording": True,
+                "description": video.description,
+                "estimated_duration": None,
+                "has_chat": True,
+                "has_live_media": True,
+                "has_transcript": False,
+                "id": str(video.id),
+                "is_public": False,
+                "is_ready_to_show": False,
+                "is_recording": False,
+                "is_scheduled": False,
+                "join_mode": "approval",
+                "live_info": {},
+                "live_state": None,
+                "live_type": None,
+                "participants_asking_to_join": [],
+                "participants_in_discussion": [],
+                "playlist": {
+                    "id": str(video.playlist.id),
+                    "lti_id": playlist.lti_id,
+                    "title": playlist.title,
+                },
+                "recording_time": 0,
+                "shared_live_medias": [],
+                "should_use_subtitle_as_transcript": False,
+                "show_download": True,
+                "starting_at": None,
+                "thumbnail": None,
+                "timed_text_tracks": [],
+                "title": video.title,
+                "upload_state": "pending",
+                "urls": None,
+                "xmpp": None,
+                "tags": [],
+                "license": None,
+            },
+        )
 
     def test_api_video_read_detail_by_playlist_admin(self):
         """Playlist admins can get individual videos."""

--- a/src/backend/marsha/core/tests/api/video/test_start_live.py
+++ b/src/backend/marsha/core/tests/api/video/test_start_live.py
@@ -8,7 +8,7 @@ from django.test import TestCase, override_settings
 
 from boto3.exceptions import Boto3Error
 
-from marsha.core import api, factories
+from marsha.core import api, factories, models
 from marsha.core.api import timezone
 from marsha.core.defaults import (
     HARVESTED,
@@ -23,7 +23,10 @@ from marsha.core.defaults import (
     STOPPED,
 )
 from marsha.core.factories import LiveSessionFactory
-from marsha.core.simple_jwt.factories import InstructorOrAdminLtiTokenFactory
+from marsha.core.simple_jwt.factories import (
+    InstructorOrAdminLtiTokenFactory,
+    UserAccessTokenFactory,
+)
 from marsha.core.utils.time_utils import to_timestamp
 
 
@@ -31,6 +34,156 @@ class VideoStartLiveAPITest(TestCase):
     """Test the "start live" API of the video object."""
 
     maxDiff = None
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.some_organization = factories.OrganizationFactory()
+        cls.some_video = factories.WebinarVideoFactory(
+            playlist__organization=cls.some_organization,
+        )
+
+    def assert_user_cannot_start_live(self, user, video):
+        """Assert the user cannot start the live."""
+
+        jwt_token = UserAccessTokenFactory(user=user)
+        response = self.client.post(
+            f"/api/videos/{video.pk}/start-live/",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+
+        self.assertEqual(response.status_code, 403)
+
+    @override_settings(LIVE_CHAT_ENABLED=True)
+    def assert_user_can_start_live(self, user, video):
+        """Assert the user can start the live."""
+        self.assertNotEqual(video.live_state, STARTING)
+
+        with mock.patch.object(api.video, "start_live_channel"), mock.patch.object(
+            api.video, "create_live_stream"
+        ) as mock_create_live_stream, mock.patch.object(
+            api.video, "wait_medialive_channel_is_created"
+        ) as mock_wait_medialive_channel_is_created, mock.patch(
+            "marsha.core.serializers.xmpp_utils.generate_jwt"
+        ) as mock_jwt_encode, mock.patch.object(
+            api.video, "create_room"
+        ) as mock_create_room, mock.patch(
+            "marsha.websocket.utils.channel_layers_utils.dispatch_video_to_groups"
+        ) as mock_dispatch_video_to_groups:
+            mock_jwt_encode.return_value = "xmpp_jwt"
+            mock_create_live_stream.return_value = {
+                "medialive": {
+                    "input": {
+                        "id": "medialive_input_1",
+                        "endpoints": [
+                            "https://live_endpoint1",
+                            "https://live_endpoint2",
+                        ],
+                    },
+                    "channel": {"id": "medialive_channel_1"},
+                },
+                "mediapackage": {
+                    "id": "mediapackage_channel_1",
+                    "endpoints": {
+                        "hls": {
+                            "id": "endpoint1",
+                            "url": "https://channel_endpoint1/live.m3u8",
+                        },
+                    },
+                },
+            }
+            jwt_token = UserAccessTokenFactory(user=user)
+            response = self.client.post(
+                f"/api/videos/{video.id}/start-live/",
+                HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+            )
+            mock_create_room.assert_called_with(video.id)
+            mock_wait_medialive_channel_is_created.assert_called_with(
+                "medialive_channel_1"
+            )
+            mock_dispatch_video_to_groups.assert_has_calls(
+                [mock.call(video), mock.call(video)]
+            )
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+
+        self.assertEqual(content["live_state"], STARTING)
+
+    def test_start_live_by_anonymous_user(self):
+        """Anonymous users cannot start a live."""
+        response = self.client.post(f"/api/videos/{self.some_video.pk}/start-live/")
+
+        self.assertEqual(response.status_code, 401)
+
+    def test_start_live_by_random_user(self):
+        """Authenticated user without access cannot start a live."""
+        user = factories.UserFactory()
+
+        self.assert_user_cannot_start_live(user, self.some_video)
+
+    def test_start_live_by_organization_student(self):
+        """Organization students cannot start a live."""
+        organization_access = factories.OrganizationAccessFactory(
+            organization=self.some_organization,
+            role=models.STUDENT,
+        )
+
+        self.assert_user_cannot_start_live(organization_access.user, self.some_video)
+
+    def test_start_live_by_organization_instructor(self):
+        """Organization instructors cannot start a live."""
+        organization_access = factories.OrganizationAccessFactory(
+            organization=self.some_organization,
+            role=models.INSTRUCTOR,
+        )
+
+        self.assert_user_cannot_start_live(organization_access.user, self.some_video)
+
+    def test_start_live_by_organization_administrator(self):
+        """Organization administrators can start a live."""
+        organization_access = factories.OrganizationAccessFactory(
+            organization=self.some_organization,
+            role=models.ADMINISTRATOR,
+        )
+
+        self.assert_user_can_start_live(organization_access.user, self.some_video)
+
+    def test_start_live_by_consumer_site_any_role(self):
+        """Consumer site roles cannot start a live."""
+        consumer_site_access = factories.ConsumerSiteAccessFactory(
+            consumer_site=self.some_video.playlist.consumer_site,
+        )
+
+        self.assert_user_cannot_start_live(consumer_site_access.user, self.some_video)
+
+    def test_start_live_by_playlist_student(self):
+        """Playlist student cannot start a live."""
+        playlist_access = factories.PlaylistAccessFactory(
+            playlist=self.some_video.playlist,
+            role=models.STUDENT,
+        )
+
+        self.assert_user_cannot_start_live(playlist_access.user, self.some_video)
+
+    def test_start_live_by_playlist_instructor(self):
+        """Playlist instructor cannot start a live."""
+        playlist_access = factories.PlaylistAccessFactory(
+            playlist=self.some_video.playlist,
+            role=models.INSTRUCTOR,
+        )
+
+        self.assert_user_can_start_live(playlist_access.user, self.some_video)
+
+    def test_start_live_by_playlist_admin(self):
+        """Playlist administrator can start a live."""
+        playlist_access = factories.PlaylistAccessFactory(
+            playlist=self.some_video.playlist,
+            role=models.ADMINISTRATOR,
+        )
+
+        self.assert_user_can_start_live(playlist_access.user, self.some_video)
 
     @override_settings(LIVE_CHAT_ENABLED=True)
     @override_settings(XMPP_BOSH_URL="https://xmpp-server.com/http-bind")

--- a/src/backend/marsha/core/tests/api/video/test_stats.py
+++ b/src/backend/marsha/core/tests/api/video/test_stats.py
@@ -3,10 +3,20 @@ from unittest import mock
 
 from django.test import TestCase, override_settings
 
-from marsha.core.factories import UserFactory, VideoFactory
+from marsha.core.factories import (
+    ConsumerSiteAccessFactory,
+    OrganizationAccessFactory,
+    OrganizationFactory,
+    PlaylistAccessFactory,
+    UserFactory,
+    VideoFactory,
+    WebinarVideoFactory,
+)
+from marsha.core.models import ADMINISTRATOR, INSTRUCTOR, STUDENT
 from marsha.core.simple_jwt.factories import (
     InstructorOrAdminLtiTokenFactory,
     StudentLtiTokenFactory,
+    UserAccessTokenFactory,
 )
 
 
@@ -14,6 +24,136 @@ class TestApiVideoStats(TestCase):
     """Tests for the Video stats API of the Marsha project."""
 
     maxDiff = None
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.some_organization = OrganizationFactory()
+        cls.some_video = WebinarVideoFactory(
+            playlist__organization=cls.some_organization,
+        )
+
+    def assert_user_cannot_get_stats(self, user, video):
+        """Assert the user cannot get the stats."""
+
+        jwt_token = UserAccessTokenFactory(user=user)
+        response = self.client.get(
+            f"/api/videos/{video.pk}/stats/",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+
+        self.assertEqual(response.status_code, 403)
+
+    @override_settings(
+        STAT_BACKEND="marsha.core.stats.dummy_backend",
+        STAT_BACKEND_SETTINGS={
+            "any": "data",
+            "another": "data",
+            "nested": {"any": "data"},
+        },
+    )
+    def assert_user_can_get_stats(self, user, video):
+        """Assert the user can get the stats."""
+        received_stats = {
+            "data": "any",
+            "with_number": 123,
+        }
+
+        with mock.patch(
+            "marsha.core.serializers.xmpp_utils.generate_jwt"
+        ) as mock_jwt_encode, mock.patch(
+            "marsha.core.stats.dummy_backend"
+        ) as mock_stats_backend:
+            mock_jwt_encode.return_value = "xmpp_jwt"
+            mock_stats_backend.return_value = received_stats
+
+            jwt_token = UserAccessTokenFactory(user=user)
+            response = self.client.get(
+                f"/api/videos/{video.id}/stats/",
+                HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+            )
+
+            mock_stats_backend.assert_called_once_with(
+                video, any="data", another="data", nested={"any": "data"}
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), received_stats)
+
+    def test_stats_by_anonymous_user(self):
+        """Anonymous users cannot get stats."""
+        response = self.client.get(f"/api/videos/{self.some_video.pk}/stats/")
+
+        self.assertEqual(response.status_code, 401)
+
+    def test_stats_by_random_user(self):
+        """Authenticated user without access cannot get stats."""
+        user = UserFactory()
+
+        self.assert_user_cannot_get_stats(user, self.some_video)
+
+    def test_stats_by_organization_student(self):
+        """Organization students cannot get stats."""
+        organization_access = OrganizationAccessFactory(
+            organization=self.some_organization,
+            role=STUDENT,
+        )
+
+        self.assert_user_cannot_get_stats(organization_access.user, self.some_video)
+
+    def test_stats_by_organization_instructor(self):
+        """Organization instructors cannot get stats."""
+        organization_access = OrganizationAccessFactory(
+            organization=self.some_organization,
+            role=INSTRUCTOR,
+        )
+
+        self.assert_user_cannot_get_stats(organization_access.user, self.some_video)
+
+    def test_stats_by_organization_administrator(self):
+        """Organization administrators can get stats."""
+        organization_access = OrganizationAccessFactory(
+            organization=self.some_organization,
+            role=ADMINISTRATOR,
+        )
+
+        self.assert_user_can_get_stats(organization_access.user, self.some_video)
+
+    def test_stats_by_consumer_site_any_role(self):
+        """Consumer site roles cannot get stats."""
+        consumer_site_access = ConsumerSiteAccessFactory(
+            consumer_site=self.some_video.playlist.consumer_site,
+        )
+
+        self.assert_user_cannot_get_stats(consumer_site_access.user, self.some_video)
+
+    def test_stats_by_playlist_student(self):
+        """Playlist student cannot get stats."""
+        playlist_access = PlaylistAccessFactory(
+            playlist=self.some_video.playlist,
+            role=STUDENT,
+        )
+
+        self.assert_user_cannot_get_stats(playlist_access.user, self.some_video)
+
+    def test_stats_by_playlist_instructor(self):
+        """Playlist instructor cannot get stats."""
+        playlist_access = PlaylistAccessFactory(
+            playlist=self.some_video.playlist,
+            role=INSTRUCTOR,
+        )
+
+        self.assert_user_can_get_stats(playlist_access.user, self.some_video)
+
+    def test_stats_by_playlist_admin(self):
+        """Playlist administrator can get stats."""
+        playlist_access = PlaylistAccessFactory(
+            playlist=self.some_video.playlist,
+            role=ADMINISTRATOR,
+        )
+
+        self.assert_user_can_get_stats(playlist_access.user, self.some_video)
 
     def test_api_video_stats_anonymous(self):
         """An anonymous user can not get video stats."""

--- a/src/backend/marsha/core/tests/api/video/test_update.py
+++ b/src/backend/marsha/core/tests/api/video/test_update.py
@@ -1092,9 +1092,9 @@ class VideoUpdateAPITest(TestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 200)
         video.refresh_from_db()
-        self.assertEqual(video.title, "existing title")
+        self.assertEqual(video.title, "updated title")
 
     def test_api_video_patch_by_playlist_admin(self):
         """Playlist admins can patch videos on the API."""
@@ -1182,9 +1182,9 @@ class VideoUpdateAPITest(TestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 200)
         video.refresh_from_db()
-        self.assertEqual(video.title, "existing title")
+        self.assertEqual(video.title, "updated title")
 
     def test_api_video_put_by_playlist_admin(self):
         """Playlist admins can update videos on the API."""

--- a/src/backend/marsha/websocket/tests/test_consumers_video.py
+++ b/src/backend/marsha/websocket/tests/test_consumers_video.py
@@ -51,8 +51,9 @@ class VideoConsumerTest(TransactionTestCase):
         return ThumbnailFactory(**kwargs)
 
     @sync_to_async
-    def _get_thumbnail_serializer_data(self, thumbnail, context={}):
+    def _get_thumbnail_serializer_data(self, thumbnail, context=None):
         """Serialize thumbnail model and return the serialized data."""
+        context = context or {}
         serializer = ThumbnailSerializer(thumbnail, context=context)
         return serializer.data
 
@@ -62,8 +63,9 @@ class VideoConsumerTest(TransactionTestCase):
         return TimedTextTrackFactory(**kwargs)
 
     @sync_to_async
-    def _get_timed_text_track_serializer_data(self, thumbnail, context={}):
+    def _get_timed_text_track_serializer_data(self, thumbnail, context=None):
         """Serialize timed text track model and return the serialized data."""
+        context = context or {}
         serializer = TimedTextTrackSerializer(thumbnail, context=context)
         return serializer.data
 


### PR DESCRIPTION
## Purpose

Permissions regarding videos' endpoint are made for LTI access, it needs to be updated to match future standalone site access.

## Proposal

- [x] Refactor the `IsVideoPlaylistAdmin` and `IsVideoOrganizationAdmin` to use `IsObjectPlaylist[...]` equivalent.
- [x] Allow all "specific actions" to playlist administrators and instructors
- [x] Add new permission tests 
    - [x] start_live
    - [x] stop_live
    - [x] harvest_live
    - [x] live_to_vod
    - [x] pairing_secret
    - [x] start_sharing
    - [x] navigate_sharing
    - [x] end_sharing
    - [x] participants_asking_to_join
    - [x] participants_in_discussion
    - [x] start_recording
    - [x] stop_recording
    - [x] stats
- [x] Add same permissions to the websocket part

