### PR TITLE
💄(website) fix prefill input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - lti:
   - jwt store initialization concurrency issue with access jwt
 - ui calendar
+- standalone website:
+  - prefill input label hidden
 
 ### Removed
 

--- a/src/frontend/packages/lib_common/src/theme.ts
+++ b/src/frontend/packages/lib_common/src/theme.ts
@@ -286,9 +286,14 @@ export const theme: ThemeType = {
         height: 0.1px;
         margin: 0 1rem 0;
         transform: translateY(0.3rem);
+        z-index: 1;
       }
-      & label span[aria-label='required'] {
+      & label span[aria-hidden='true'] {
         font-size: 0.688rem;
+      }
+      & input:-webkit-autofill,
+      & input:-webkit-autofill:focus {
+        transition: background-color 600000s 0s, color 600000s 0s;
       }
       & svg {
         color: ${colorsGeneric['blue-active']};


### PR DESCRIPTION
## Purpose

![localhost_3000_login](https://user-images.githubusercontent.com/25994652/215747344-61ab6df8-044a-4bb6-bc81-7f5e461519c9.png)

Grommet change his accessibility label when the input is required, so the css was not applied anymore and the asterisk was too big:
https://github.com/grommet/grommet/blob/v2.28.0/src/js/components/FormField/FormField.js#L456
https://github.com/grommet/grommet/blob/master/src/js/components/FormField/FormField.js#L486

## Proposal

- [x] Fix: Chrome prefill input sometimes, the input label was partially hidden by the bg color
- [x] Fix: Remove the bg color from the chrome prefill
- [x] Fix: Reduce asterisk size after grommet change 


![localhost_3000_login (1)](https://user-images.githubusercontent.com/25994652/215747402-0baca0dc-3a0f-4b5e-b529-0a8acb68b908.png)

