### PR TITLE
🐛(front) fix duplicated intl message id in HomeBanner

### DIFF
--- a/src/frontend/apps/standalone_site/src/features/HomePage/components/HomePage.tsx
+++ b/src/frontend/apps/standalone_site/src/features/HomePage/components/HomePage.tsx
@@ -29,7 +29,7 @@ const messages = defineMessages({
   BannerDesc: {
     defaultMessage: 'Online courses to discover, learn, progress and succeed',
     description: 'Desc banner homepage',
-    id: 'features.HomePage.BannerTitle',
+    id: 'features.HomePage.BannerDesc',
   },
 });
 


### PR DESCRIPTION
## Purpose

In the HomeBanner, two translation messages are having the same id, we can't translate both in crowdin.

## Proposal

- [x] fix duplicated intl message id in HomeBanner

