### PR TITLE
🔧(tray) set limit to marsha pod resources

### DIFF
--- a/src/tray/vars/all/main.yml
+++ b/src/tray/vars/all/main.yml
@@ -54,22 +54,29 @@ marsha_prefetch_saml_fer_metadata_cronjob_schedule: "0 */6 * * *"
 marsha_media_volume_size: 2Gi
 marsha_static_volume_size: 2Gi
 
+marsha_app_resources:
+  requests:
+    cpu: 50m
+    memory: 500Mi
+  limits:
+    cpu: 1
+    memory: 2.5Gi
+
 # -- resources
-{% set app_resources = {
+{% set job_resources = {
   "requests": {
     "cpu": "50m",
     "memory": "500Mi"
   }
 } %}
 
-marsha_app_resources: "{{ app_resources }}"
-marsha_app_job_db_migrate_resources: "{{ app_resources }}"
-marsha_app_cronjob_check_harvested_resources: "{{ app_resources }}"
-marsha_app_cronjob_check_live_idle_resources: "{{ app_resources }}"
-marsha_app_cronjob_check_live_state_resources: "{{ app_resources }}"
-marsha_app_cronjob_clean_mediapackages_resources: "{{ app_resources }}"
-marsha_app_cronjob_clean_aws_elemental_stack_resources: "{{ app_resources }}"
-marsha_app_cronjob_prefetch_saml_fer_metadata_resources: "{{ app_resources }}"
+marsha_app_job_db_migrate_resources: "{{ job_resources }}"
+marsha_app_cronjob_check_harvested_resources: "{{ job_resources }}"
+marsha_app_cronjob_check_live_idle_resources: "{{ job_resources }}"
+marsha_app_cronjob_check_live_state_resources: "{{ job_resources }}"
+marsha_app_cronjob_clean_mediapackages_resources: "{{ job_resources }}"
+marsha_app_cronjob_clean_aws_elemental_stack_resources: "{{ job_resources }}"
+marsha_app_cronjob_prefetch_saml_fer_metadata_resources: "{{ job_resources }}"
 
 marsha_nginx_resources:
   requests:


### PR DESCRIPTION
## Purpose

We first separate job and pod resources. We want to set limits on pod but not on jobs. On pods, we set limits, configurable in each customer environment. This limit is set to 1 for CPU because marsha needs lot of CPU to start and the memory is set to 2.5Gb, it's a quite hight but this is what we need for now.


## Proposal

- [x] set limit to marsha pod resources
