### PR TITLE
🔖(beta) bump release to 4.0.0-beta.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.0.0-beta.15] - 2023-02-02
+
 ### Added
 
 - wrapper around fetch to handle 401 errors and refresh the access token
@@ -1456,7 +1458,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Minor fixes and improvements on features and tests
 
-[unreleased]: https://github.com/openfun/marsha/compare/v4.0.0-beta.14...master
+[unreleased]: https://github.com/openfun/marsha/compare/v4.0.0-beta.15...master
+[4.0.0-beta.15]: https://github.com/openfun/marsha/compare/v4.0.0-beta.14...v4.0.0-beta.15
 [4.0.0-beta.14]: https://github.com/openfun/marsha/compare/v4.0.0-beta.13...v4.0.0-beta.14
 [4.0.0-beta.13]: https://github.com/openfun/marsha/compare/v4.0.0-beta.12...v4.0.0-beta.13
 [4.0.0-beta.12]: https://github.com/openfun/marsha/compare/v4.0.0-beta.11...v4.0.0-beta.12

--- a/src/aws/lambda-complete/package.json
+++ b/src/aws/lambda-complete/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-complete",
-  "version": "4.0.0-beta.14",
+  "version": "4.0.0-beta.15",
   "engines": {
     "node": "16"
   },

--- a/src/aws/lambda-configure/package.json
+++ b/src/aws/lambda-configure/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-configure",
-  "version": "4.0.0-beta.14",
+  "version": "4.0.0-beta.15",
   "engines": {
     "node": "16"
   },

--- a/src/aws/lambda-convert/package.json
+++ b/src/aws/lambda-convert/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-convert",
-  "version": "4.0.0-beta.14",
+  "version": "4.0.0-beta.15",
   "engines": {
     "node": "16"
   },

--- a/src/aws/lambda-elemental-routing/package.json
+++ b/src/aws/lambda-elemental-routing/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-elemental-routing",
-  "version": "4.0.0-beta.14",
+  "version": "4.0.0-beta.15",
   "engines": {
     "node": "16"
   },

--- a/src/aws/lambda-medialive/package.json
+++ b/src/aws/lambda-medialive/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-medialive",
-  "version": "4.0.0-beta.14",
+  "version": "4.0.0-beta.15",
   "engines": {
     "node": "16"
   },

--- a/src/aws/lambda-mediapackage/package.json
+++ b/src/aws/lambda-mediapackage/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-mediapackage",
-  "version": "4.0.0-beta.14",
+  "version": "4.0.0-beta.15",
   "engines": {
     "node": "16"
   },

--- a/src/aws/lambda-migrate/package.json
+++ b/src/aws/lambda-migrate/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-migrate",
-  "version": "4.0.0-beta.14",
+  "version": "4.0.0-beta.15",
   "engines": {
     "node": "16"
   },

--- a/src/aws/utils/update-state/package.json
+++ b/src/aws/utils/update-state/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-update-state",
-  "version": "4.0.0-beta.14",
+  "version": "4.0.0-beta.15",
   "engines": {
     "node": "16"
   },

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = marsha
 description = A FUN video provider for Open edX
-version = 4.0.0-beta.14
+version = 4.0.0-beta.15
 author = Open FUN (France Universite Numerique)
 author_email = fun.dev@fun-mooc.fr
 license = MIT

--- a/src/frontend/apps/lti_site/package.json
+++ b/src/frontend/apps/lti_site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marsha",
-  "version": "4.0.0-beta.14",
+  "version": "4.0.0-beta.15",
   "description": "🐠 a FUN LTI video provider",
   "main": "front/index.tsx",
   "scripts": {

--- a/src/frontend/apps/standalone_site/package.json
+++ b/src/frontend/apps/standalone_site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "standalone_site",
-  "version": "4.0.0-beta.14",
+  "version": "4.0.0-beta.15",
   "license": "MIT",
   "private": true,
   "devDependencies": {

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "common",
-  "version": "4.0.0-beta.14",
+  "version": "4.0.0-beta.15",
   "license": "MIT",
   "private": true,
   "workspaces": {

--- a/src/frontend/packages/lib_classroom/package.json
+++ b/src/frontend/packages/lib_classroom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lib-classroom",
-  "version": "4.0.0-beta.14",
+  "version": "4.0.0-beta.15",
   "license": "MIT",
   "main": "lib/index.js",
   "module": "lib/index.es.js",

--- a/src/frontend/packages/lib_common/package.json
+++ b/src/frontend/packages/lib_common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lib-common",
-  "version": "4.0.0-beta.14",
+  "version": "4.0.0-beta.15",
   "license": "MIT",
   "main": "lib/index.js",
   "module": "lib/index.es.js",

--- a/src/frontend/packages/lib_components/package.json
+++ b/src/frontend/packages/lib_components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lib-components",
-  "version": "4.0.0-beta.14",
+  "version": "4.0.0-beta.15",
   "license": "MIT",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",

--- a/src/frontend/packages/lib_tests/package.json
+++ b/src/frontend/packages/lib_tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lib-tests",
-  "version": "4.0.0-beta.14",
+  "version": "4.0.0-beta.15",
   "license": "MIT",
   "main": "lib/index.js",
   "module": "lib/index.es.js",

--- a/src/frontend/packages/lib_video/package.json
+++ b/src/frontend/packages/lib_video/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lib-video",
-  "version": "4.0.0-beta.14",
+  "version": "4.0.0-beta.15",
   "description": "",
   "license": "ISC",
   "main": "lib/index.js",


### PR DESCRIPTION
### Added

- wrapper around fetch to handle 401 errors and refresh the access token
- configure wantNameId and allowRepeatAttributeName for saml_fer security settings
- Add a lti link to classroom in the standalone website
- Invite link for classroom available in every context
- Add a check on classroom document file size when uploading content
- Configure teachers role lookup to create organization access
- LTI link for classroom available in every context
- standalone website:
  - banner homepage with dynamic text
  - add "playlist access" management API endpoints
- Arnold tray to manage definition directly in marsha repository
- Install and configure scoutapm

### Changed

- change xapi endpoints status code when no LRS from 501 to 200

### Fixed

- lti:
  - jwt store initialization concurrency issue with access jwt
- ui calendar
- standalone website:
  - prefill input label hidden