### PR TITLE
🐛(backend) fix idp sort being case sensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   - position modal above tooltip
 - mutualize all CronJob in a CronJobList
 - make all packages shakeable
-
-### Changed
-
 - use lib-common theme in LTI
+
+### Fixed
+
+- the Renater IdP sort is case-insensitive
 
 ## [4.0.0-beta.15] - 2023-02-02
 

--- a/src/backend/marsha/account/api.py
+++ b/src/backend/marsha/account/api.py
@@ -85,7 +85,7 @@ class SamlFerIdpListAPIView(SocialBackendViewMixin, APIView):
         # Sort the IdPs by display name
         available_idps = sorted(
             available_idps,
-            key=lambda idp: idp["edu_fed_data"]["display_name"],
+            key=lambda idp: idp["edu_fed_data"]["display_name"].casefold(),
         )
 
         base_login_url = request.build_absolute_uri(

--- a/src/backend/marsha/account/tests/api/test_saml_fer_idp_list.py
+++ b/src/backend/marsha/account/tests/api/test_saml_fer_idp_list.py
@@ -54,7 +54,7 @@ class MetadataUrlOpenMock:
             ),
         ),
         generate_idp_metadata(
-            ui_info_display_names=format_mdui_display_name("Local accepting IdP"),
+            ui_info_display_names=format_mdui_display_name("local accepting IdP"),
             organization_names=format_md_organization_name("Local organization name"),
             organization_display_names=format_md_organization_display_name(
                 "Local organization display name"
@@ -115,7 +115,7 @@ class SamlFerIdpListAPIViewTest(TestCase):
                 },
                 {
                     "id": "local-accepting-idp",
-                    "display_name": "Local accepting IdP",
+                    "display_name": "local accepting IdP",
                     "organization_name": "Local organization name",
                     "organization_display_name": "Local organization display name",
                     "logo": DEFAULT_LOGO,
@@ -149,7 +149,7 @@ class SamlFerIdpListAPIViewTest(TestCase):
             [
                 {
                     "id": "local-accepting-idp",
-                    "display_name": "Local accepting IdP",
+                    "display_name": "local accepting IdP",
                     "organization_name": "Local organization name",
                     "organization_display_name": "Local organization display name",
                     "logo": DEFAULT_LOGO,


### PR DESCRIPTION
## Purpose

Organizations are not sorted alphabetically in the login select box of Shibboleth. Nearly but not completely.

## Proposal

Remove case sensitivity from sort.

- [x] remove case sensitivity from sort

