### PR TITLE
💄(lti) position modal above tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- lti:
+  - position modal above tooltip
 - mutualize all CronJob in a CronJobList
 
 ## [4.0.0-beta.15] - 2023-02-02

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/FoldableItem/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/FoldableItem/index.spec.tsx
@@ -84,6 +84,7 @@ describe('<FoldableItem />', () => {
     expect(mockSetInfoWidgetModal).toHaveBeenCalledWith({
       title: genericTitle,
       text: genericInfoText,
+      refWidget: expect.any(HTMLDivElement),
     });
   });
 });

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/FoldableItem/index.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/FoldableItem/index.tsx
@@ -1,6 +1,6 @@
 import { Box, Button, Collapsible, Text } from 'grommet';
 import { DownArrowSVG, InfoCircleSVG } from 'lib-components';
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import styled from 'styled-components';
 
@@ -34,9 +34,11 @@ export const FoldableItem = ({
   const intl = useIntl();
   const [open, setOpen] = useState(initialOpenValue);
   const [_, setInfoWidgetModalProvider] = useInfoWidgetModal();
+  const refWidget = useRef<HTMLDivElement>(null);
 
   return (
     <Box
+      ref={refWidget}
       background="white"
       direction="column"
       round="6px"
@@ -59,6 +61,7 @@ export const FoldableItem = ({
             setInfoWidgetModalProvider({
               text: infoText,
               title,
+              refWidget: refWidget.current,
             });
           }}
           plain

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/WidgetsContainer/InfoModal/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/WidgetsContainer/InfoModal/index.spec.tsx
@@ -53,4 +53,47 @@ describe('<InfoModal />', () => {
 
     expect(mockModalOnClose).toHaveBeenCalledTimes(1);
   });
+
+  it('renders the modal above the calling components', () => {
+    const ref = {
+      current: {
+        offsetTop: 100,
+      },
+    };
+
+    render(
+      <InfoModal
+        text={genericContent}
+        title={genericTitle}
+        onModalClose={mockModalOnClose}
+        refWidget={ref.current as unknown as HTMLDivElement}
+      />,
+    );
+
+    expect(screen.getByTestId('info-modal')).toHaveStyle('margin-top: -100px');
+  });
+
+  it('renders the modal on the top if Firefox browser', () => {
+    jest
+      .spyOn(window.navigator, 'userAgent', 'get')
+      .mockReturnValue(
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/109.0',
+      );
+    const ref = {
+      current: {
+        offsetTop: 100,
+      },
+    };
+
+    render(
+      <InfoModal
+        text={genericContent}
+        title={genericTitle}
+        onModalClose={mockModalOnClose}
+        refWidget={ref.current as unknown as HTMLDivElement}
+      />,
+    );
+
+    expect(screen.getByTestId('info-modal')).toHaveStyle('margin-top: 200px');
+  });
 });

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/WidgetsContainer/InfoModal/index.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/WidgetsContainer/InfoModal/index.tsx
@@ -2,7 +2,7 @@ import { Box, Button, Layer, ResponsiveContext, Text } from 'grommet';
 import { normalizeColor } from 'grommet/utils';
 import { theme } from 'lib-common';
 import { RoundCrossSVG } from 'lib-components';
-import React from 'react';
+import React, { useCallback, useEffect } from 'react';
 import styled from 'styled-components';
 
 const StyledTitleText = styled(Text)`
@@ -17,20 +17,59 @@ interface InfoModalProps {
   text: string;
   title: string;
   onModalClose: () => void;
+  refWidget?: HTMLDivElement | null;
 }
 
-export const InfoModal = ({ text, title, onModalClose }: InfoModalProps) => {
+export const InfoModal = ({
+  text,
+  title,
+  onModalClose,
+  refWidget,
+}: InfoModalProps) => {
   const size = React.useContext(ResponsiveContext);
+  const positionAbove = 200; // px
+  const isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
+
+  useEffect(() => {
+    if (!isFirefox && refWidget) {
+      const timeout = setTimeout(() => {
+        refWidget.scrollIntoView({ block: 'center', behavior: 'smooth' });
+      }, 50);
+
+      return () => clearTimeout(timeout);
+    }
+
+    return () => null;
+  }, [refWidget, isFirefox]);
+
+  const onClose = useCallback(() => {
+    onModalClose();
+
+    if (refWidget) {
+      setTimeout(() => {
+        refWidget.scrollIntoView({ block: 'center', behavior: 'smooth' });
+      }, 200);
+    }
+  }, [onModalClose, refWidget]);
 
   return (
     <Layer
-      onEsc={onModalClose}
-      onClickOutside={onModalClose}
+      onEsc={onClose}
+      onClickOutside={onClose}
       responsive={false}
       style={{
         width: size === 'small' ? '95%' : '500px',
         border: `1px solid ${normalizeColor('blue-active', theme)}`,
+        marginTop: `${
+          refWidget?.offsetTop
+            ? isFirefox
+              ? positionAbove
+              : refWidget?.offsetTop - positionAbove
+            : 0
+        }px`,
       }}
+      position={refWidget?.offsetTop ? 'top' : 'center'}
+      data-testid="info-modal"
     >
       <Box background="bg-info" direction="column" round="6px">
         <Box
@@ -38,7 +77,7 @@ export const InfoModal = ({ text, title, onModalClose }: InfoModalProps) => {
           pad={{ horizontal: 'small', top: 'small' }}
         >
           <Button
-            onClick={onModalClose}
+            onClick={onClose}
             plain
             style={{ display: 'block', padding: 0 }}
           >

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/WidgetsContainer/index.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/WidgetsContainer/index.tsx
@@ -46,6 +46,7 @@ export const WidgetsContainer = ({ children }: WidgetsContainerProps) => {
         <InfoModal
           text={infoWidgetModal.text}
           title={infoWidgetModal.title}
+          refWidget={infoWidgetModal.refWidget}
           onModalClose={() => setInfoWidgetModal(null)}
         />
       )}

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/DownloadVideo/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/DownloadVideo/index.spec.tsx
@@ -53,6 +53,7 @@ describe('<InstructorDownloadVideo />', () => {
     expect(mockSetInfoWidgetModal).toHaveBeenCalledWith({
       title: 'Download video',
       text: 'This widget allows you to download the video, with the available quality you desire.',
+      refWidget: expect.any(HTMLDivElement),
     });
 
     const button = screen.getByRole('button', {

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/UploadClosedCaptions/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/UploadClosedCaptions/index.spec.tsx
@@ -59,6 +59,7 @@ describe('<UploadClosedCaptions />', () => {
     expect(mockSetInfoWidgetModalProvider).toHaveBeenLastCalledWith({
       title: 'Closed captions',
       text: 'This widget allows you upload closed captions for the video.',
+      refWidget: expect.any(HTMLDivElement),
     });
   });
 });

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/UploadSubtitles/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/UploadSubtitles/index.spec.tsx
@@ -62,6 +62,7 @@ describe('<UploadSubtitles />', () => {
     expect(mockSetInfoWidgetModalProvider).toHaveBeenLastCalledWith({
       title: 'Subtitles',
       text: 'This widget allows you upload subtitles for the video. Toggle to use as transcripts can be disabled because there is no subtitle or at least one transcript exists.',
+      refWidget: expect.any(HTMLDivElement),
     });
   });
 });

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/UploadTranscripts/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/UploadTranscripts/index.spec.tsx
@@ -60,6 +60,7 @@ describe('<UploadTranscripts />', () => {
     expect(mockSetInfoWidgetModalProvider).toHaveBeenLastCalledWith({
       title: 'Transcripts',
       text: 'This widget allows you upload transcripts for the video.',
+      refWidget: expect.any(HTMLDivElement),
     });
   });
 });

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/UploadVideo/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/UploadVideo/index.spec.tsx
@@ -83,6 +83,7 @@ describe('<UploadVideo />', () => {
     expect(mockSetInfoWidgetModal).toHaveBeenCalledWith({
       title: 'Video',
       text: 'This widget allows you to upload a video to replace the current one.',
+      refWidget: expect.any(HTMLDivElement),
     });
 
     screen.getByText('Video available');

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/WidgetThumbnail/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/WidgetThumbnail/index.spec.tsx
@@ -88,6 +88,7 @@ describe('<DashboardLiveWidgetThumbnail />', () => {
     expect(mockSetInfoWidgetModal).toHaveBeenCalledWith({
       title: 'Thumbnail',
       text: 'This widget allows you to change the default thumbnail used for your live. The uploaded image should have a 16:9 ratio.',
+      refWidget: expect.any(HTMLDivElement),
     });
   });
 
@@ -310,6 +311,7 @@ describe('<DashboardLiveWidgetThumbnail />', () => {
     expect(mockSetInfoWidgetModal).toHaveBeenCalledWith({
       title: 'Thumbnail',
       text: 'This widget allows you to change the default thumbnail used for your VOD. The uploaded image should have a 16:9 ratio.',
+      refWidget: expect.any(HTMLDivElement),
     });
   });
 });

--- a/src/frontend/packages/lib_video/src/hooks/useInfoWidgetModal/index.ts
+++ b/src/frontend/packages/lib_video/src/hooks/useInfoWidgetModal/index.ts
@@ -4,6 +4,7 @@ import { createStore } from 'lib-components';
 interface InformativeModal {
   title: string;
   text: string;
+  refWidget?: HTMLDivElement | null;
 }
 
 const store = createStore<Nullable<InformativeModal>>(


### PR DESCRIPTION
## Purpose

See issue: https://github.com/openfun/marsha/issues/1842

When clicking on a tooltip in the teacher dashboard, we had to scroll to see the modal that was opened. This commit fixes this issue by positioning the modal above the tooltip.

## Proposal

- [x] Chromium: Position the modal above tooltip
- [x] Firefox: Position the modal on the Top, scroll down smoothly onClose.
- [x] Tests

## Chromium

[localhost-chromium.webm](https://user-images.githubusercontent.com/25994652/217253924-e8aeacaa-680f-4348-982c-d3224307db47.webm)

## Firefox

[localhost.webm](https://user-images.githubusercontent.com/25994652/217254147-2391d9b6-34fd-4c99-9389-850339d283ac.webm)


