### PR TITLE
🐛(LTI) bug on the textarea of the live video

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - the Renater IdP sort is case-insensitive
+- bug on the textarea description of the live video 
 - aws fargate loggroup region
 
 ## [4.0.0-beta.15] - 2023-02-02

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/SchedulingAndDescription/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/SchedulingAndDescription/index.spec.tsx
@@ -109,7 +109,9 @@ describe('<SchedulingAndDescription />', () => {
       target: { value: startingAt.toLocaleString(DateTime.TIME_24_SIMPLE) },
     });
     expect(inputStartingAtTime).toHaveValue('14:00');
-    await waitFor(() => expect(fetchMock.calls()).toHaveLength(1));
+    await waitFor(() => expect(fetchMock.calls()).toHaveLength(1), {
+      timeout: 1500,
+    });
     expect(fetchMock.lastCall()![0]).toEqual('/api/videos/video_id/');
     expect(fetchMock.lastCall()![1]).toEqual({
       headers: {
@@ -151,7 +153,9 @@ describe('<SchedulingAndDescription />', () => {
     });
     expect(inputEstimatedDuration).toHaveValue('0:30');
 
-    await waitFor(() => expect(fetchMock.calls()).toHaveLength(2));
+    await waitFor(() => expect(fetchMock.calls()).toHaveLength(2), {
+      timeout: 1500,
+    });
     expect(fetchMock.lastCall()![0]).toEqual('/api/videos/video_id/');
     expect(fetchMock.lastCall()![1]).toEqual({
       headers: {
@@ -214,7 +218,9 @@ describe('<SchedulingAndDescription />', () => {
     fireEvent.change(inputStartingAtTime, {
       target: { value: startingAt.toLocaleString(DateTime.TIME_24_SIMPLE) },
     });
-    await waitFor(() => expect(fetchMock.calls()).toHaveLength(1));
+    await waitFor(() => expect(fetchMock.calls()).toHaveLength(1), {
+      timeout: 1500,
+    });
 
     expect(report).toHaveBeenCalledTimes(1);
     screen.getByText('Video update has failed !');
@@ -224,7 +230,9 @@ describe('<SchedulingAndDescription />', () => {
       target: { value: estimatedDuration.toFormat('h:mm') },
     });
     // API is called a second time, so a second fetch is performed, and a second toast comes on the screen
-    await waitFor(() => expect(fetchMock.calls()).toHaveLength(2));
+    await waitFor(() => expect(fetchMock.calls()).toHaveLength(2), {
+      timeout: 1500,
+    });
     expect(report).toHaveBeenCalledTimes(2);
     expect(screen.getAllByText('Video update has failed !')).toHaveLength(2);
   });
@@ -295,7 +303,9 @@ describe('<SchedulingAndDescription />', () => {
     userEvent.type(textArea, 'A new description');
     expect(textArea).toHaveValue('A new description');
 
-    await waitFor(() => expect(fetchMock.calls()).toHaveLength(1));
+    await waitFor(() => expect(fetchMock.calls()).toHaveLength(1), {
+      timeout: 1500,
+    });
     expect(fetchMock.lastCall()![0]).toEqual('/api/videos/video_id/');
     expect(fetchMock.lastCall()![1]).toEqual({
       headers: {
@@ -336,7 +346,9 @@ describe('<SchedulingAndDescription />', () => {
     expect(textArea).toHaveValue('An existing description');
 
     userEvent.clear(textArea);
-    await waitFor(() => expect(fetchMock.calls()).toHaveLength(1));
+    await waitFor(() => expect(fetchMock.calls()).toHaveLength(1), {
+      timeout: 1500,
+    });
     expect(fetchMock.lastCall()![0]).toEqual('/api/videos/video_id/');
     expect(fetchMock.lastCall()![1]).toEqual({
       headers: {
@@ -375,7 +387,9 @@ describe('<SchedulingAndDescription />', () => {
     expect(textArea).toHaveValue('An existing description');
 
     userEvent.type(textArea, ' and more');
-    await waitFor(() => expect(fetchMock.calls()).toHaveLength(1));
+    await waitFor(() => expect(fetchMock.calls()).toHaveLength(1), {
+      timeout: 1500,
+    });
     expect(fetchMock.lastCall()![0]).toEqual('/api/videos/video_id/');
     expect(fetchMock.lastCall()![1]).toEqual({
       headers: {

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/SchedulingAndDescription/index.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/SchedulingAndDescription/index.tsx
@@ -8,7 +8,7 @@ import {
   report,
 } from 'lib-components';
 import { DateTime, Duration } from 'luxon';
-import React, { Fragment, useEffect, useState } from 'react';
+import React, { Fragment, useRef, useState, useEffect } from 'react';
 import { toast } from 'react-hot-toast';
 import { defineMessages, useIntl } from 'react-intl';
 
@@ -69,6 +69,7 @@ const messages = defineMessages({
 export const SchedulingAndDescription = () => {
   const video = useCurrentVideo();
   const intl = useIntl();
+  const descriptionInit = useRef(video.description);
   const [description, setDescription] = useState(video.description);
 
   const videoMutation = useUpdateVideo(video.id, {
@@ -92,11 +93,17 @@ export const SchedulingAndDescription = () => {
     (updatedVideoProperty: Partial<Video>) => {
       videoMutation.mutate(updatedVideoProperty);
     },
+    1000,
   );
 
   useEffect(() => {
-    setDescription(video.description);
-  }, [video.description]);
+    const isIdle = descriptionInit.current === description;
+    const isWriting = description !== video.description;
+    if (isIdle || !isWriting) {
+      setDescription(video.description);
+      descriptionInit.current = video.description;
+    }
+  }, [description, video.description]);
 
   return (
     <FoldableItem


### PR DESCRIPTION
## Purpose

The update on the video description updated the value of the textarea, so what was written during the update was overwritten.

[localhost-8060-lti-videos-ad8f632c-6f45-472f-8c5b-aa84bdc4210d.webm](https://user-images.githubusercontent.com/25994652/217284787-4cd1a07e-c74e-4e83-aef7-d105496cf3c7.webm)

