### PR TITLE
✅ fix e2e test video play

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,7 @@ test:  ## Run django tests for the marsha project.
 .PHONY: test
 
 build-e2e: ## build the e2e container
-	@$(COMPOSE_BUILD) e2e;
+	@$(COMPOSE_BUILD) --no-cache e2e;
 .PHONY: build-e2e
 
 e2e:  ## Run e2e tests for the marsha project.


### PR DESCRIPTION
## Purpose

Our e2e test fails on circle-ci but not locally.
We need to get the same error on both.

Also, the test needs a fix, obviously.

## Proposal

- [x] Don't use docker cache to build e2e image locally
- [x] Update the request check done with firefox to verify that a video has been loaded

