### PR TITLE
🔨(terraform) use configured region for fargate definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - the Renater IdP sort is case-insensitive
+- aws fargate loggroup region
 
 ## [4.0.0-beta.15] - 2023-02-02
 

--- a/src/aws/ecs.tf
+++ b/src/aws/ecs.tf
@@ -30,7 +30,7 @@ resource "aws_ecs_task_definition" "marsha_ffmpeg_transmux_definition" {
       "secretOptions": null,
       "options": {
         "awslogs-group": "/ecs/${terraform.workspace}-fargate-ffmpeg-transmux",
-        "awslogs-region": "eu-west-1",
+        "awslogs-region": "${data.aws_region.current.name}",
         "awslogs-stream-prefix": "ecs"
       }
     },


### PR DESCRIPTION
## Purpose

Fargate task logs region was hardcoded in eu-west-1.

## Proposal

Use the region configured in the env variables instead.
