### PR TITLE
🥅(frontend) utility apiResponseHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Create lib-markdown package
 - Add a check on timedtexttrack file size when uploading content
 - Add a check on deposited file size when uploading content 
+- helpers frontend api error handling
 
 ### Changed
 

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Create/ClassRoomCreateForm.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Create/ClassRoomCreateForm.spec.tsx
@@ -148,11 +148,9 @@ describe('<ClassRoomCreateForm />', () => {
     );
 
     // Wait for the mocked playlist to be fetched
-    await waitFor(() => {
-      expect(
-        screen.getByRole('option', { selected: false }),
-      ).toBeInTheDocument();
-    });
+    expect(
+      await screen.findByRole('option', { selected: false }),
+    ).toBeInTheDocument();
 
     // Select the mocked playlist
     fireEvent.click(screen.getByRole('option', { selected: false }));
@@ -163,11 +161,56 @@ describe('<ClassRoomCreateForm />', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /Add classroom/i }));
 
-    await waitFor(() => {
-      expect(
-        screen.getByText(/Sorry, an error has occurred. Please try again./i),
-      ).toBeInTheDocument();
+    expect(
+      await screen.findByText(
+        /Sorry, an error has occurred. Please try again./i,
+      ),
+    ).toBeInTheDocument();
+
+    expect(consoleError).toHaveBeenCalled();
+  });
+
+  test('error permission', async () => {
+    fetchMock.post('/api/classrooms/', {
+      status: 403,
+      body: {
+        detail: "Vous n'avez pas la permission d'effectuer cette action.",
+      },
     });
+
+    render(<ClassRoomCreateForm onSubmit={jest.fn()} />);
+
+    deferred.resolve(playlistsResponse);
+
+    fireEvent.change(screen.getByRole('textbox', { name: /title/i }), {
+      target: { value: 'my title' },
+    });
+
+    fireEvent.click(
+      screen.getByLabelText(/Choose the playlist./i, { selector: 'button' }),
+    );
+
+    // Wait for the mocked playlist to be fetched
+    expect(
+      await screen.findByRole('option', { selected: false }),
+    ).toBeInTheDocument();
+
+    // Select the mocked playlist
+    fireEvent.click(screen.getByRole('option', { selected: false }));
+
+    expect(
+      screen.queryByText(
+        /Sorry, you don't have the permission to create a classroom./i,
+      ),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Add classroom/i }));
+
+    expect(
+      await screen.findByText(
+        /Sorry, you don't have the permission to create a classroom./i,
+      ),
+    ).toBeInTheDocument();
 
     expect(consoleError).toHaveBeenCalled();
   });

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Create/ClassRoomCreateForm.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Create/ClassRoomCreateForm.tsx
@@ -47,6 +47,13 @@ const messages = defineMessages({
     description: 'Text when there is an error.',
     id: 'features.Contents.features.ClassRooms.ClassroomCreateForm.Error',
   },
+  ErrorPermission: {
+    defaultMessage:
+      "Sorry, you don't have the permission to create a classroom.",
+    description:
+      'Text when there is a permission error while creating a classroom.',
+    id: 'features.Contents.features.ClassRooms.ClassroomCreateForm.ErrorPermission',
+  },
 });
 
 type ClassroomCreate = {
@@ -54,6 +61,10 @@ type ClassroomCreate = {
   title: string;
   description?: string;
 };
+
+enum ETypeError {
+  PERMISSION = "Vous n'avez pas la permission d'effectuer cette action.",
+}
 
 interface ClassroomCreateFormProps {
   onSubmit: () => void;
@@ -123,6 +134,10 @@ const ClassroomCreateForm = ({ onSubmit }: ClassroomCreateFormProps) => {
     ]);
   }, [playlistResponse]);
 
+  const errorMessages = {
+    [ETypeError.PERMISSION]: intl.formatMessage(messages.ErrorPermission),
+  };
+
   return (
     <Fragment>
       {(errorClassroom || errorPlaylist) && (
@@ -135,7 +150,8 @@ const ClassroomCreateForm = ({ onSubmit }: ClassroomCreateFormProps) => {
         >
           <Alert size="42rem" color="#df8c00" />
           <Text weight="bold" size="small">
-            {intl.formatMessage(messages.Error)}
+            {errorMessages[errorClassroom?.detail as ETypeError] ||
+              intl.formatMessage(messages.Error)}
           </Text>
         </Box>
       )}

--- a/src/frontend/packages/lib_classroom/src/data/queries/index.tsx
+++ b/src/frontend/packages/lib_classroom/src/data/queries/index.tsx
@@ -1,4 +1,3 @@
-import { ClassroomDocumentMetadata } from 'lib-classroom/src/types/ClassroomAppData';
 import { Maybe } from 'lib-common';
 import {
   APIList,
@@ -19,6 +18,7 @@ import {
   ClassroomDocument,
   ClassroomModelName,
   metadata,
+  FetchResponseError,
 } from 'lib-components';
 import {
   useMutation,
@@ -27,6 +27,8 @@ import {
   useQueryClient,
   UseQueryOptions,
 } from 'react-query';
+
+import { ClassroomDocumentMetadata } from 'types/ClassroomAppData';
 
 type ClassroomsResponse = APIList<ClassroomLite>;
 type UseClassroomsParams = {
@@ -85,12 +87,7 @@ type UseCreateClassroomData = {
   description?: string;
   lti_id?: string;
 };
-type UseCreateClassroomError =
-  | { code: 'exception' }
-  | {
-      code: 'invalid';
-      errors: { [key in keyof UseCreateClassroomData]?: string[] }[];
-    };
+type UseCreateClassroomError = FetchResponseError<UseCreateClassroomData>;
 type UseCreateClassroomOptions = UseMutationOptions<
   Classroom,
   UseCreateClassroomError,

--- a/src/frontend/packages/lib_components/src/common/queries/actionOne.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/queries/actionOne.spec.tsx
@@ -1,6 +1,7 @@
 import fetchMock from 'fetch-mock';
 
 import { useJwt } from 'hooks/stores/useJwt';
+import { FetchResponseError } from 'utils/errors/exception';
 
 import { actionOne } from './actionOne';
 
@@ -146,7 +147,6 @@ describe('queries/actionOne', () => {
     fetchMock.mock('/api/model-name/1/action/', 404);
 
     let thrownError;
-
     try {
       await actionOne({
         name: 'model-name',
@@ -155,10 +155,19 @@ describe('queries/actionOne', () => {
         object: objectToUpdate,
       });
     } catch (error) {
-      thrownError = error;
+      if (error instanceof FetchResponseError) {
+        thrownError = error.error;
+      }
     }
 
-    expect(thrownError).toEqual({ code: 'exception' });
+    expect(thrownError).toEqual({
+      code: 'exception',
+      message: 'Not Found',
+      status: 404,
+      response: expect.objectContaining({
+        status: 404,
+      }),
+    });
 
     expect(fetchMock.lastCall()?.[0]).toEqual('/api/model-name/1/action/');
     expect(fetchMock.lastCall()?.[1]).toEqual({

--- a/src/frontend/packages/lib_components/src/common/queries/actionOne.tsx
+++ b/src/frontend/packages/lib_components/src/common/queries/actionOne.tsx
@@ -1,5 +1,6 @@
 import { useJwt } from 'hooks/stores/useJwt';
 
+import { fetchResponseHandler } from './fetchResponseHandler';
 import { fetchWrapper } from './fetchWrapper';
 
 /**
@@ -31,15 +32,8 @@ export const actionOne = async <T, K>({
   if (object) {
     init.body = JSON.stringify(object);
   }
-  const response = await fetchWrapper(`/api/${name}/${id}/${action}/`, init);
 
-  if (!response.ok) {
-    if (response.status === 400) {
-      throw { code: 'invalid', ...(await response.json()) };
-    }
-
-    throw { code: 'exception' };
-  }
-
-  return (await response.json()) as T;
+  return await fetchResponseHandler(
+    await fetchWrapper(`/api/${name}/${id}/${action}/`, init),
+  );
 };

--- a/src/frontend/packages/lib_components/src/common/queries/createOne.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/queries/createOne.spec.tsx
@@ -1,6 +1,7 @@
 import fetchMock from 'fetch-mock';
 
 import { useJwt } from 'hooks/stores/useJwt';
+import { FetchResponseError } from 'utils/errors/exception';
 
 import { createOne } from './createOne';
 
@@ -97,10 +98,19 @@ describe('queries/createOne', () => {
         object: objectToCreate,
       });
     } catch (error) {
-      thrownError = error;
+      if (error instanceof FetchResponseError) {
+        thrownError = error.error;
+      }
     }
 
-    expect(thrownError).toEqual({ code: 'exception' });
+    expect(thrownError).toEqual({
+      code: 'exception',
+      response: expect.objectContaining({
+        status: 404,
+      }),
+      message: 'Not Found',
+      status: 404,
+    });
 
     expect(fetchMock.lastCall()?.[0]).toEqual('/api/model-name/');
     expect(fetchMock.lastCall()?.[1]).toEqual({
@@ -131,12 +141,19 @@ describe('queries/createOne', () => {
         object: objectToCreate,
       });
     } catch (error) {
-      thrownError = error;
+      if (error instanceof FetchResponseError) {
+        thrownError = error.error;
+      }
     }
 
     expect(thrownError).toEqual({
       code: 'invalid',
+      message: 'Bad Request',
       error: 'An error occured!',
+      status: 400,
+      response: expect.objectContaining({
+        status: 400,
+      }),
     });
 
     expect(fetchMock.lastCall()?.[0]).toEqual('/api/model-name/');

--- a/src/frontend/packages/lib_components/src/common/queries/createOne.tsx
+++ b/src/frontend/packages/lib_components/src/common/queries/createOne.tsx
@@ -1,5 +1,6 @@
 import { useJwt } from 'hooks/stores/useJwt';
 
+import { fetchResponseHandler } from './fetchResponseHandler';
 import { fetchWrapper } from './fetchWrapper';
 
 interface Variables<K> {
@@ -21,13 +22,5 @@ export const createOne = async <T, K>({
     body: JSON.stringify(object),
   });
 
-  if (!response.ok) {
-    if (response.status === 400) {
-      throw { code: 'invalid', ...(await response.json()) };
-    }
-
-    throw { code: 'exception' };
-  }
-
-  return (await response.json()) as T;
+  return await fetchResponseHandler(response);
 };

--- a/src/frontend/packages/lib_components/src/common/queries/deleteOne.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/queries/deleteOne.spec.tsx
@@ -1,6 +1,7 @@
 import fetchMock from 'fetch-mock';
 
 import { useJwt } from 'hooks/stores/useJwt';
+import { FetchResponseError } from 'utils/errors/exception';
 
 import { deleteOne } from './deleteOne';
 
@@ -41,10 +42,19 @@ describe('queries/deleteOne', () => {
         id: '123',
       });
     } catch (error) {
-      thrownError = error;
+      if (error instanceof FetchResponseError) {
+        thrownError = error.error;
+      }
     }
 
-    expect(thrownError).toEqual({ code: 'exception' });
+    expect(thrownError).toEqual({
+      code: 'exception',
+      status: 403,
+      message: 'Forbidden',
+      response: expect.objectContaining({
+        status: 403,
+      }),
+    });
 
     expect(fetchMock.lastCall()?.[0]).toEqual('/api/model-name/123/');
     expect(fetchMock.lastCall()?.[1]).toEqual({
@@ -98,12 +108,18 @@ describe('queries/deleteOne', () => {
         id: '123',
       });
     } catch (error) {
-      thrownError = error;
+      if (error instanceof FetchResponseError) {
+        thrownError = error.error;
+      }
     }
 
     expect(thrownError).toEqual({
       code: 'invalid',
-      error: 'An error occured!',
+      message: 'Bad Request',
+      status: 400,
+      response: expect.objectContaining({
+        status: 400,
+      }),
     });
 
     expect(fetchMock.lastCall()?.[0]).toEqual('/api/model-name/123/');

--- a/src/frontend/packages/lib_components/src/common/queries/deleteOne.ts
+++ b/src/frontend/packages/lib_components/src/common/queries/deleteOne.ts
@@ -1,5 +1,6 @@
 import { useJwt } from 'hooks/stores/useJwt';
 
+import { fetchResponseHandler } from './fetchResponseHandler';
 import { fetchWrapper } from './fetchWrapper';
 
 export const deleteOne = async ({
@@ -18,13 +19,9 @@ export const deleteOne = async ({
     method: 'DELETE',
   });
 
-  if (!response.ok) {
-    if (response.status === 400) {
-      throw { code: 'invalid', ...(await response.json()) };
-    }
-
-    throw { code: 'exception' };
-  }
+  await fetchResponseHandler(response, {
+    withoutBody: true,
+  });
 
   return undefined;
 };

--- a/src/frontend/packages/lib_components/src/common/queries/fetchList.tsx
+++ b/src/frontend/packages/lib_components/src/common/queries/fetchList.tsx
@@ -3,6 +3,7 @@ import { QueryFunctionContext } from 'react-query';
 
 import { useJwt } from 'hooks/stores/useJwt';
 
+import { fetchResponseHandler } from './fetchResponseHandler';
 import { fetchWrapper } from './fetchWrapper';
 
 export type FetchListQueryKey =
@@ -38,9 +39,7 @@ export const fetchList = async <T,>({
     },
   );
 
-  if (!response.ok) {
-    throw new Error(`Failed to get list of ${name}.`);
-  }
-
-  return (await response.json()) as T;
+  return await fetchResponseHandler(response, {
+    errorMessage: `Failed to get list of ${name}.`,
+  });
 };

--- a/src/frontend/packages/lib_components/src/common/queries/fetchOne.tsx
+++ b/src/frontend/packages/lib_components/src/common/queries/fetchOne.tsx
@@ -2,6 +2,7 @@ import { QueryKey, QueryFunctionContext } from 'react-query';
 
 import { useJwt } from 'hooks/stores/useJwt';
 
+import { fetchResponseHandler } from './fetchResponseHandler';
 import { fetchWrapper } from './fetchWrapper';
 
 /**
@@ -23,9 +24,7 @@ export const fetchOne = async <T,>({
     },
   });
 
-  if (!response.ok) {
-    throw new Error(`Failed to get ${endpoint}.`);
-  }
-
-  return (await response.json()) as T;
+  return await fetchResponseHandler(response, {
+    errorMessage: `Failed to get ${endpoint}.`,
+  });
 };

--- a/src/frontend/packages/lib_components/src/common/queries/fetchResponseHandler.spec.ts
+++ b/src/frontend/packages/lib_components/src/common/queries/fetchResponseHandler.spec.ts
@@ -1,0 +1,220 @@
+import fetchMock from 'fetch-mock';
+
+import { FetchResponseError } from 'utils/errors/exception';
+
+import { fetchResponseHandler } from './fetchResponseHandler';
+
+describe('fetchResponseHandler', () => {
+  afterEach(() => fetchMock.restore());
+
+  it('checks a successful request', async () => {
+    fetchMock.mock('/test/anything', {
+      body: { name: 'John' },
+      headers: { 'content-type': 'application/json' },
+    });
+    const response = await fetchResponseHandler(await fetch('/test/anything'));
+    expect(response).toEqual({ name: 'John' });
+  });
+
+  it('checks a failed request 400', async () => {
+    fetchMock.mock('/test/anything', {
+      body: { name: 'John' },
+      headers: { 'content-type': 'application/json' },
+      status: 400,
+    });
+
+    let thrownError;
+    try {
+      await fetchResponseHandler(await fetch('/test/anything'));
+    } catch (error) {
+      if (error instanceof FetchResponseError) {
+        thrownError = error.error;
+      }
+    }
+
+    expect(thrownError).toEqual({
+      code: 'invalid',
+      message: 'Bad Request',
+      name: 'John',
+      status: 400,
+      response: expect.objectContaining({
+        status: 400,
+      }),
+    });
+  });
+
+  it('checks a failed request 500', async () => {
+    fetchMock.mock('/test/anything', {
+      body: { name: 'John' },
+      headers: { 'content-type': 'application/json' },
+      status: 500,
+    });
+
+    let thrownError;
+    try {
+      await fetchResponseHandler(await fetch('/test/anything'));
+    } catch (error) {
+      if (error instanceof FetchResponseError) {
+        thrownError = error.error;
+      }
+    }
+
+    expect(thrownError).toEqual({
+      code: 'exception',
+      message: 'Internal Server Error',
+      name: 'John',
+      status: 500,
+      response: expect.objectContaining({
+        status: 500,
+      }),
+    });
+  });
+
+  it('checks a failed request without body', async () => {
+    fetchMock.mock('/test/anything', 500);
+
+    let thrownError;
+    try {
+      await fetchResponseHandler(await fetch('/test/anything'));
+    } catch (error) {
+      if (error instanceof FetchResponseError) {
+        thrownError = error.error;
+      }
+    }
+
+    expect(thrownError).toEqual({
+      code: 'exception',
+      message: 'Internal Server Error',
+      status: 500,
+      response: expect.objectContaining({
+        status: 500,
+      }),
+    });
+  });
+
+  describe('apiHelper options', () => {
+    it('checks options.errorMessage as string', async () => {
+      fetchMock.mock('/test/anything', 500);
+
+      let thrownError;
+      try {
+        await fetchResponseHandler(await fetch('/test/anything'), {
+          errorMessage: 'Test error',
+        });
+      } catch (error) {
+        if (error instanceof FetchResponseError) {
+          thrownError = error.error;
+        }
+      }
+
+      expect(thrownError).toEqual({
+        code: 'exception',
+        message: 'Test error',
+        status: 500,
+        response: expect.objectContaining({
+          status: 500,
+        }),
+      });
+    });
+
+    it('checks options.errorMessage as dict matching', async () => {
+      fetchMock.mock('/test/anything', 500);
+
+      let thrownError;
+      try {
+        await fetchResponseHandler(await fetch('/test/anything'), {
+          errorMessage: { 500: 'Error 500' },
+        });
+      } catch (error) {
+        if (error instanceof FetchResponseError) {
+          thrownError = error.error;
+        }
+      }
+
+      expect(thrownError).toEqual({
+        code: 'exception',
+        message: 'Error 500',
+        status: 500,
+        response: expect.objectContaining({
+          status: 500,
+        }),
+      });
+    });
+
+    it('checks options.errorMessage as dict not matching', async () => {
+      fetchMock.mock('/test/anything', 500);
+
+      let thrownError;
+      try {
+        await fetchResponseHandler(await fetch('/test/anything'), {
+          errorMessage: { 400: 'Error 400' },
+        });
+      } catch (error) {
+        if (error instanceof FetchResponseError) {
+          thrownError = error.error;
+        }
+      }
+
+      expect(thrownError).toEqual({
+        code: 'exception',
+        message: 'Internal Server Error',
+        status: 500,
+        response: expect.objectContaining({
+          status: 500,
+        }),
+      });
+    });
+
+    it('checks options.invalidStatus', async () => {
+      fetchMock.mock('/test/anything', 500);
+
+      let thrownError;
+      try {
+        await fetchResponseHandler(await fetch('/test/anything'), {
+          invalidStatus: [500],
+        });
+      } catch (error) {
+        if (error instanceof FetchResponseError) {
+          thrownError = error.error;
+        }
+      }
+
+      expect(thrownError).toEqual({
+        code: 'invalid',
+        message: 'Internal Server Error',
+        status: 500,
+        response: expect.objectContaining({
+          status: 500,
+        }),
+      });
+    });
+
+    it('checks options.withoutBody', async () => {
+      fetchMock.mock('/test/anything', {
+        body: { name: 'John' },
+        headers: { 'content-type': 'application/json' },
+        status: 500,
+      });
+
+      let thrownError;
+      try {
+        await fetchResponseHandler(await fetch('/test/anything'), {
+          withoutBody: true,
+        });
+      } catch (error) {
+        if (error instanceof FetchResponseError) {
+          thrownError = error.error;
+        }
+      }
+
+      expect(thrownError).toEqual({
+        code: 'exception',
+        message: 'Internal Server Error',
+        status: 500,
+        response: expect.objectContaining({
+          status: 500,
+        }),
+      });
+    });
+  });
+});

--- a/src/frontend/packages/lib_components/src/common/queries/fetchResponseHandler.ts
+++ b/src/frontend/packages/lib_components/src/common/queries/fetchResponseHandler.ts
@@ -1,0 +1,51 @@
+import { FetchResponseError } from 'utils/errors/exception';
+
+interface fetchResponseHandlerOptions {
+  errorMessage?: string | { [key: number]: string }; // 'Bad Request' | { 400: 'Bad Request', 401: 'Unauthorized' }
+  invalidStatus?: number[];
+  withoutBody?: boolean;
+}
+
+export const fetchResponseHandler = async <T>(
+  response: Response,
+  options?: fetchResponseHandlerOptions,
+): Promise<T> => {
+  const { errorMessage, invalidStatus, withoutBody } = { ...options };
+
+  if (response.ok) {
+    if (withoutBody) {
+      return {} as unknown as T;
+    } else {
+      return (await response.json()) as T;
+    }
+  }
+
+  let bodyResponse;
+  try {
+    bodyResponse = withoutBody ? undefined : ((await response.json()) as T);
+  } catch (e) {
+    bodyResponse = {};
+  }
+
+  let message = '';
+  if (errorMessage) {
+    message = errorMessage[response.status] || '';
+    if (!message) {
+      message = typeof errorMessage === 'string' ? errorMessage : '';
+    }
+  }
+  if (!message) {
+    message = response.statusText || 'Unknown error';
+  }
+
+  throw new FetchResponseError({
+    code:
+      response.status === 400 || invalidStatus?.includes(response.status)
+        ? 'invalid'
+        : 'exception',
+    status: response.status,
+    message,
+    response: response,
+    ...bodyResponse,
+  });
+};

--- a/src/frontend/packages/lib_components/src/common/queries/index.ts
+++ b/src/frontend/packages/lib_components/src/common/queries/index.ts
@@ -4,5 +4,6 @@ export * from './deleteOne';
 export * from './fetchList';
 export * from './fetchOne';
 export * from './fetchWrapper';
+export * from './fetchResponseHandler';
 export * from './metadata';
 export * from './updateOne';

--- a/src/frontend/packages/lib_components/src/common/queries/metadata.tsx
+++ b/src/frontend/packages/lib_components/src/common/queries/metadata.tsx
@@ -2,6 +2,7 @@ import { QueryKey, QueryFunctionContext } from 'react-query';
 
 import { useJwt } from 'hooks/stores/useJwt';
 
+import { fetchResponseHandler } from './fetchResponseHandler';
 import { fetchWrapper } from './fetchWrapper';
 
 /**
@@ -21,9 +22,7 @@ export const metadata = async <T,>({
     method: 'OPTIONS',
   });
 
-  if (!response.ok) {
-    throw new Error(`Failed to get metadata for /${String(name)}/.`);
-  }
-
-  return (await response.json()) as T;
+  return await fetchResponseHandler(response, {
+    errorMessage: `Failed to get metadata for /${String(name)}/.`,
+  });
 };

--- a/src/frontend/packages/lib_components/src/common/queries/updateOne.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/queries/updateOne.spec.tsx
@@ -1,6 +1,7 @@
 import fetchMock from 'fetch-mock';
 
 import { useJwt } from 'hooks/stores/useJwt';
+import { FetchResponseError } from 'utils/errors/exception';
 
 import { updateOne } from './updateOne';
 
@@ -101,10 +102,19 @@ describe('queries/updateOne', () => {
         object: objectToUpdate,
       });
     } catch (error) {
-      thrownError = error;
+      if (error instanceof FetchResponseError) {
+        thrownError = error.error;
+      }
     }
 
-    expect(thrownError).toEqual({ code: 'exception' });
+    expect(thrownError).toEqual({
+      code: 'exception',
+      message: 'Not Found',
+      status: 404,
+      response: expect.objectContaining({
+        status: 404,
+      }),
+    });
 
     expect(fetchMock.lastCall()?.[0]).toEqual('/api/model-name/1/');
     expect(fetchMock.lastCall()?.[1]).toEqual({
@@ -136,12 +146,19 @@ describe('queries/updateOne', () => {
         object: objectToUpdate,
       });
     } catch (error) {
-      thrownError = error;
+      if (error instanceof FetchResponseError) {
+        thrownError = error.error;
+      }
     }
 
     expect(thrownError).toEqual({
       code: 'invalid',
+      message: 'Bad Request',
       error: 'An error occured!',
+      status: 400,
+      response: expect.objectContaining({
+        status: 400,
+      }),
     });
 
     expect(fetchMock.lastCall()?.[0]).toEqual('/api/model-name/1/');

--- a/src/frontend/packages/lib_components/src/common/queries/updateOne.tsx
+++ b/src/frontend/packages/lib_components/src/common/queries/updateOne.tsx
@@ -1,5 +1,6 @@
 import { useJwt } from 'hooks/stores/useJwt';
 
+import { fetchResponseHandler } from './fetchResponseHandler';
 import { fetchWrapper } from './fetchWrapper';
 
 interface Variables<K> {
@@ -23,13 +24,5 @@ export const updateOne = async <T, K>({
     body: JSON.stringify(object),
   });
 
-  if (!response.ok) {
-    if (response.status === 400) {
-      throw { code: 'invalid', ...(await response.json()) };
-    }
-
-    throw { code: 'exception' };
-  }
-
-  return (await response.json()) as T;
+  return await fetchResponseHandler(response);
 };

--- a/src/frontend/packages/lib_components/src/utils/errors/exception.ts
+++ b/src/frontend/packages/lib_components/src/utils/errors/exception.ts
@@ -4,3 +4,37 @@ export class ShouldNotHappen extends Error {
     super(`this should not happen: ${val as string}`);
   }
 }
+
+export interface IFetchResponseError<T = unknown> {
+  code: string;
+  status: number;
+  response: Response;
+  message: string;
+  detail?: string;
+  errors?: { [key in keyof T]?: string[] }[];
+}
+
+export class FetchResponseError<T = unknown>
+  extends Error
+  implements IFetchResponseError<T>
+{
+  code: IFetchResponseError['code'];
+  status: IFetchResponseError['status'];
+  response: IFetchResponseError['response'];
+  detail?: IFetchResponseError['detail'];
+  errors?: IFetchResponseError['errors'];
+  error?: IFetchResponseError<T>;
+
+  constructor(error: IFetchResponseError<T>) {
+    super(error.message);
+
+    this.name = 'FetchResponseError';
+    this.error = error;
+    this.code = error.code;
+    this.status = error.status;
+    this.response = error.response;
+    this.detail = error.detail;
+    this.message = error.message;
+    this.errors = error.errors;
+  }
+}


### PR DESCRIPTION
## Purpose

We didn't get enough information from the api response to handle errors.
This commit adds a helper to handle the api response and return a consistent error object.

## Proposal

Before we had something like that:
```
throw new Error(`Failed to get ${endpoint}.`);
// or
throw { code: 'exception' };
```
Now we have that ([definition](https://github.com/openfun/marsha/blob/feature/anthony/apiResponseHandler/src/frontend/packages/lib_components/src/utils/errors/exception.ts#L28)):
```
 FetchResponseError extends Error{
  code: string;
  status: number;
  response: Response;
  message: string;
  detail?: string;
  errors?: { [key in keyof T]?: string[] }[];
  error?: IFetchResponseError

  // From Object Error
  name: string;
  cause?: Error;
  stack?: string;
}
```
To get a value:
```
 console.debug('errorClassroom', errorClassroom?.detail);
```
To print the error object values, you can do that:
```
 console.debug('errorClassroom', errorClassroom?.error);
```

[exceptionhandler.webm](https://user-images.githubusercontent.com/25994652/217876326-04a4994d-5a96-4b84-88df-7dc2b1504f2c.webm)

