### PR TITLE
♻️(back) allow public resource to be embedded in a iframe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - make all packages shakeable
 - use lib-common theme in LTI
 - change docker base image to use a debian lite one
+- Allow public resource to be embedded in a iframe
 
 ### Fixed
 

--- a/src/backend/marsha/core/tests/test_views_public_document.py
+++ b/src/backend/marsha/core/tests/test_views_public_document.py
@@ -10,7 +10,7 @@ from django.test import TestCase
 from marsha.core.simple_jwt.tokens import ResourceAccessToken, ResourceRefreshToken
 
 from ..defaults import STATE_CHOICES
-from ..factories import DocumentFactory
+from ..factories import DocumentFactory, OrganizationFactory, PlaylistFactory
 
 
 # We don't enforce arguments documentation in tests
@@ -28,6 +28,7 @@ class DocumentPublicViewTestCase(TestCase):
             id="301b5f4f-b9f1-4a5f-897d-f8f1bf22c396",
             playlist__title="playlist-003",
             playlist__lti_id="course-v1:ufr+mathematics+00001",
+            playlist__consumer_site__domain="trusted_domain.com",
             is_public=True,
             title="document-001",
             upload_state=random.choice([s[0] for s in STATE_CHOICES]),
@@ -37,6 +38,12 @@ class DocumentPublicViewTestCase(TestCase):
         response = self.client.get(f"/documents/{document.pk}")
 
         self.assertEqual(response.status_code, 200)
+        self.assertIn("Content-Security-Policy", response.headers)
+        self.assertNotIn("X-Frame-Options", response.headers)
+        self.assertEqual(
+            response.headers["Content-Security-Policy"],
+            "frame-ancestors trusted_domain.com *.trusted_domain.com;",
+        )
         self.assertContains(response, "<html>")
         content = response.content.decode("utf-8")
 
@@ -71,6 +78,72 @@ class DocumentPublicViewTestCase(TestCase):
                 },
                 "url": (
                     "https://abc.cloudfront.net/301b5f4f-b9f1-4a5f-897d-f8f1bf22c396"
+                    "/document/1569309880?response-content-disposition=attachment%3B"
+                    "+filename%3Dplaylist-003_document-001"
+                ),
+            },
+        )
+        self.assertEqual(context.get("modelName"), "documents")
+        self.assertIsNone(context.get("context_id"))
+        self.assertIsNone(context.get("consumer_site"))
+
+    def test_public_document_without_consumer_site(self):
+        """Public document without consumer site should have x-frame-options header"""
+        organization = OrganizationFactory()
+        playlist = PlaylistFactory(
+            title="playlist-003",
+            lti_id=None,
+            organization=organization,
+            consumer_site=None,
+        )
+        document = DocumentFactory(
+            playlist=playlist,
+            is_public=True,
+            title="document-001",
+            upload_state=random.choice([s[0] for s in STATE_CHOICES]),
+            uploaded_on="2019-09-24 07:24:40+00",
+        )
+
+        response = self.client.get(f"/documents/{document.pk}")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn("Content-Security-Policy", response.headers)
+        self.assertIn("X-Frame-Options", response.headers)
+        self.assertEqual(response.headers["X-Frame-Options"], "DENY")
+        self.assertContains(response, "<html>")
+        content = response.content.decode("utf-8")
+
+        match = re.search(
+            '<div id="marsha-frontend-data" data-context="(.*)">', content
+        )
+
+        context = json.loads(unescape(match.group(1)))
+        jwt_token = ResourceAccessToken(context.get("jwt"))
+        ResourceRefreshToken(context.get("refresh_token"))  # Must not raise
+
+        self.assertEqual(
+            jwt_token.payload["permissions"],
+            {"can_access_dashboard": False, "can_update": False},
+        )
+        self.assertEqual(context.get("state"), "success")
+        self.assertEqual(
+            context.get("resource"),
+            {
+                "active_stamp": "1569309880",
+                "is_ready_to_show": True,
+                "show_download": True,
+                "id": str(document.pk),
+                "upload_state": document.upload_state,
+                "title": document.title,
+                "extension": None,
+                "filename": "playlist-003_document-001",
+                "playlist": {
+                    "id": str(document.playlist.pk),
+                    "title": "playlist-003",
+                    "lti_id": None,
+                },
+                "url": (
+                    f"https://abc.cloudfront.net/{document.pk}"
                     "/document/1569309880?response-content-disposition=attachment%3B"
                     "+filename%3Dplaylist-003_document-001"
                 ),


### PR DESCRIPTION
## Purpose

Public resource view is protected with the clickjacking protection middleware. We want to allow consumer_site owner to embedded resources related to their consumer_site in an iframe on their domain and subdomain. To do that, if a consumer_site exists, we deactivate the clickjacking middleware and we configure the Content-Security-Policy frame-ancestors with the consumer_site domain and all subdomains. If there is no consumer_site, like for public resources contained in a playlist managed on the standalone_site, then we don't allow to embedded the resource in an iframe at all.

## Proposal

- [x] allow public resource to be embedded in a iframe

Fixes #2033 
