### PR TITLE
🐛(back) manage header cache on public resources view

### DIFF
--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -415,6 +415,7 @@ class Base(Configuration):
 
     # Cache
     APP_DATA_CACHE_DURATION = values.Value(60)  # 60 secondes
+    PUBLIC_RESOURCE_DOMAIN_CACHE_DURATION = values.Value(90)  # 90 seconds
     VIDEO_ATTENDANCES_CACHE_DURATION = values.Value(300)  # 5 minutes
 
     SENTRY_DSN = values.Value(None)


### PR DESCRIPTION
## Purpose

In commit b6b993b when a public resource is fetch and own in a consumer_site, we changed the header to allow to embedded it in an iframe using the CSP frame-ancestor header. But we didn't managed the cache. So on the first request, we query the DB to retrieve the video and then we check if there is a consumer_site. But then, for the next requests we have a cache and we didn't query the DB anymore and we loose the consumer_site information and the headers are unchanged. To fix this, we save the domain in a dedicated cache and we use this cache to determine if the current resource is owned in a consumer_site and use its domain to change the response headers.

## Proposal

- [x] manage header cache on public resources view
