### PR TITLE
🐛(back) change schema url_name used by swagger view

### DIFF
--- a/src/backend/marsha/development/urls.py
+++ b/src/backend/marsha/development/urls.py
@@ -14,7 +14,7 @@ urlpatterns = [
     path("api/schema/", SpectacularAPIView.as_view(), name="schema"),
     path(
         "api/schema/swagger-ui/",
-        SpectacularSwaggerView.as_view(url_name="schema"),
+        SpectacularSwaggerView.as_view(url_name="development:schema"),
         name="swagger-ui",
     ),
 ]


### PR DESCRIPTION
## Purpose

To display the schema, the swagger view is using the spectacular view. To know which one to use, it uses its name and the reverseurl django mechanism. Since we moved it in the development application, the name has changed and must be prefixed by `development:`


## Proposal

- [x] change schema url_name used by swagger view
