### PR TITLE
💬(frontend) add format list to subtitle uploaders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Add a check on timedtexttrack file size when uploading content
 - Add a check on deposited file size when uploading content 
 - helpers frontend api error handling
+- Add accepted formats in the subtitles uploaders helptext
 
 ### Changed
 

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/UploadClosedCaptions/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/UploadClosedCaptions/index.spec.tsx
@@ -58,7 +58,7 @@ describe('<UploadClosedCaptions />', () => {
     expect(mockSetInfoWidgetModalProvider).toHaveBeenCalledTimes(1);
     expect(mockSetInfoWidgetModalProvider).toHaveBeenLastCalledWith({
       title: 'Closed captions',
-      text: 'This widget allows you upload closed captions for the video.',
+      text: `This widget allows you upload closed captions for the video. Accepted formats : MicroDVD SUB (.sub) - SubRip (.srt) - SubViewer (.sbv) - WebVTT (.vtt) - SubStation Alpha (.ssa and .ass) - SAMI (.smi) aka Synchronized Accessible Media Interchange - LRC (.lrc) aka LyRiCs - JSON (.json)`,
       refWidget: expect.any(HTMLDivElement),
     });
   });

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/UploadClosedCaptions/index.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/UploadClosedCaptions/index.tsx
@@ -7,8 +7,11 @@ import { LocalizedTimedTextTrackUpload } from '../../LocalizedTimedTextTrackUplo
 
 const messages = defineMessages({
   info: {
-    defaultMessage:
-      'This widget allows you upload closed captions for the video.',
+    defaultMessage: `This widget allows you upload closed captions for the video.
+      Accepted formats : MicroDVD SUB (.sub) - SubRip (.srt) - SubViewer (.sbv)
+      - WebVTT (.vtt) - SubStation Alpha (.ssa and .ass) - SAMI (.smi) aka Synchronized 
+      Accessible Media Interchange
+      - LRC (.lrc) aka LyRiCs - JSON (.json)`,
     description: 'Info of the widget used for uploading closed captions.',
     id: 'components.UploadClosedCaptions.info',
   },

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/UploadSubtitles/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/UploadSubtitles/index.spec.tsx
@@ -61,7 +61,7 @@ describe('<UploadSubtitles />', () => {
     expect(mockSetInfoWidgetModalProvider).toHaveBeenCalledTimes(1);
     expect(mockSetInfoWidgetModalProvider).toHaveBeenLastCalledWith({
       title: 'Subtitles',
-      text: 'This widget allows you upload subtitles for the video. Toggle to use as transcripts can be disabled because there is no subtitle or at least one transcript exists.',
+      text: `This widget allows you upload subtitles for the video. Toggle to use as transcripts can be disabled because there is no subtitle or at least one transcript exists. Accepted formats : MicroDVD SUB (.sub) - SubRip (.srt) - SubViewer (.sbv) - WebVTT (.vtt) - SubStation Alpha (.ssa and .ass) - SAMI (.smi) aka Synchronized Accessible Media Interchange - LRC (.lrc) aka LyRiCs - JSON (.json)`,
       refWidget: expect.any(HTMLDivElement),
     });
   });

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/UploadSubtitles/index.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/UploadSubtitles/index.tsx
@@ -11,7 +11,11 @@ const messages = defineMessages({
   info: {
     defaultMessage: `This widget allows you upload subtitles for the video.
     Toggle to use as transcripts can be disabled because there
-    is no subtitle or at least one transcript exists.`,
+    is no subtitle or at least one transcript exists.
+    Accepted formats : MicroDVD SUB (.sub) - SubRip (.srt) - SubViewer (.sbv)
+      - WebVTT (.vtt) - SubStation Alpha (.ssa and .ass) - SAMI (.smi) aka Synchronized 
+      Accessible Media Interchange
+      - LRC (.lrc) aka LyRiCs - JSON (.json)`,
     description: 'Info of the widget used for uploading subtitles.',
     id: 'components.UploadSubtitles.info',
   },

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/UploadTranscripts/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/UploadTranscripts/index.spec.tsx
@@ -59,7 +59,7 @@ describe('<UploadTranscripts />', () => {
     expect(mockSetInfoWidgetModalProvider).toHaveBeenCalledTimes(1);
     expect(mockSetInfoWidgetModalProvider).toHaveBeenLastCalledWith({
       title: 'Transcripts',
-      text: 'This widget allows you upload transcripts for the video.',
+      text: `This widget allows you upload transcripts for the video. Accepted formats : MicroDVD SUB (.sub) - SubRip (.srt) - SubViewer (.sbv) - WebVTT (.vtt) - SubStation Alpha (.ssa and .ass) - SAMI (.smi) aka Synchronized Accessible Media Interchange - LRC (.lrc) aka LyRiCs - JSON (.json)`,
       refWidget: expect.any(HTMLDivElement),
     });
   });

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/UploadTranscripts/index.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/UploadTranscripts/index.tsx
@@ -7,7 +7,11 @@ import { LocalizedTimedTextTrackUpload } from '../../LocalizedTimedTextTrackUplo
 
 const messages = defineMessages({
   info: {
-    defaultMessage: 'This widget allows you upload transcripts for the video.',
+    defaultMessage: `This widget allows you upload transcripts for the video.
+    Accepted formats : MicroDVD SUB (.sub) - SubRip (.srt) - SubViewer (.sbv)
+      - WebVTT (.vtt) - SubStation Alpha (.ssa and .ass) - SAMI (.smi) aka Synchronized 
+      Accessible Media Interchange
+      - LRC (.lrc) aka LyRiCs - JSON (.json)`,
     description: 'Info of the widget used for uploading transcripts.',
     id: 'components.UploadTranscripts.info',
   },


### PR DESCRIPTION
Format cannot be checked on these files, but a more specific help text can be convenient

## Purpose

See https://github.com/openfun/marsha/issues/1921

## Proposal

- [x] improve helptext on subtitle uploaders

![Screenshot from 2023-02-14 18-56-31](https://user-images.githubusercontent.com/9515777/218818911-2d00b530-6cc4-4849-b4b2-9b878988eb67.png)

