### PR TITLE
♻️(front) change DashboardTabStatistics label to display viewers

### DIFF
--- a/src/frontend/packages/lib_video/src/components/common/DashboardControlPane/DashboardTabStatistics/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/DashboardControlPane/DashboardTabStatistics/index.spec.tsx
@@ -1,0 +1,74 @@
+import { screen } from '@testing-library/react';
+import fetchMock from 'fetch-mock';
+import { videoMockFactory } from 'lib-components';
+import { Deferred, render } from 'lib-tests';
+import React from 'react';
+
+import { wrapInVideo } from 'utils/wrapInVideo';
+
+import { DashboardTabStatistics } from '.';
+
+describe('DashboardTabStatistics', () => {
+  afterEach(() => {
+    fetchMock.restore();
+  });
+  it('displays the number of viewers', async () => {
+    const video = videoMockFactory();
+
+    const deferred = new Deferred();
+
+    fetchMock.mock(`/api/videos/${video.id}/stats/`, deferred.promise);
+
+    render(wrapInVideo(<DashboardTabStatistics />, video));
+
+    // Loader
+    expect(screen.getByRole('status')).toBeInTheDocument();
+
+    deferred.resolve({
+      nb_views: 3,
+    });
+
+    expect(await screen.findByText('Viewers')).toBeInTheDocument();
+    expect(screen.getByText(3)).toBeInTheDocument();
+  });
+
+  it('displays one viewer', async () => {
+    const video = videoMockFactory();
+
+    const deferred = new Deferred();
+
+    fetchMock.mock(`/api/videos/${video.id}/stats/`, deferred.promise);
+
+    render(wrapInVideo(<DashboardTabStatistics />, video));
+
+    // Loader
+    expect(screen.getByRole('status')).toBeInTheDocument();
+
+    deferred.resolve({
+      nb_views: 1,
+    });
+
+    expect(await screen.findByText('Viewer')).toBeInTheDocument();
+    expect(screen.getByText(1)).toBeInTheDocument();
+  });
+
+  it('displays no viewer', async () => {
+    const video = videoMockFactory();
+
+    const deferred = new Deferred();
+
+    fetchMock.mock(`/api/videos/${video.id}/stats/`, deferred.promise);
+
+    render(wrapInVideo(<DashboardTabStatistics />, video));
+
+    // Loader
+    expect(screen.getByRole('status')).toBeInTheDocument();
+
+    deferred.resolve({
+      nb_views: 0,
+    });
+
+    expect(await screen.findByText('Viewers')).toBeInTheDocument();
+    expect(screen.getByText(0)).toBeInTheDocument();
+  });
+});

--- a/src/frontend/packages/lib_video/src/components/common/DashboardControlPane/DashboardTabStatistics/index.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/DashboardControlPane/DashboardTabStatistics/index.tsx
@@ -1,15 +1,16 @@
 import { Box, Grid, Text } from 'grommet';
 import { useCurrentVideo } from 'hooks';
-import React from 'react';
+import { Loader } from 'lib-components';
+import React, { useState } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 
 import { useStatsVideo } from 'hooks/useVideoStats';
 
 const messages = defineMessages({
   viewersStatsDescription: {
-    defaultMessage: 'People present on the whole webinar',
-    description:
-      'Description of the number of people present on the whole webinar',
+    defaultMessage:
+      '{viewers, plural, =0 {Viewers} one {Viewer} other {Viewers}}',
+    description: 'Description of the number of viewers',
     id: 'components.DashboardControlPane.DashboardTabStatistics.viewersStatsDescription',
   },
 });
@@ -23,18 +24,27 @@ interface Metric {
 type MetricsDataType = Metric[][];
 
 export const DashboardTabStatistics = () => {
-  const video = useCurrentVideo();
-  const stats = useStatsVideo(video.id);
   const intl = useIntl();
+  const video = useCurrentVideo();
+  const [metrics, setMetrics] = useState<MetricsDataType>([]);
+  const { isLoading } = useStatsVideo(video.id, {
+    onSuccess(data) {
+      setMetrics([
+        [
+          {
+            value: data.nb_views,
+            description: intl.formatMessage(messages.viewersStatsDescription, {
+              viewers: data.nb_views,
+            }),
+          },
+        ],
+      ]);
+    },
+  });
 
-  const metrics: MetricsDataType = [
-    [
-      {
-        value: stats.data?.nb_views || 0,
-        description: intl.formatMessage(messages.viewersStatsDescription),
-      },
-    ],
-  ];
+  if (isLoading) {
+    return <Loader />;
+  }
 
   return (
     <React.Fragment>

--- a/src/frontend/packages/lib_video/src/components/common/DashboardControlPane/index.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/DashboardControlPane/index.tsx
@@ -7,7 +7,7 @@ import { defineMessages, useIntl } from 'react-intl';
 import { VideoWidgetProvider } from 'components/common/VideoWidgetProvider';
 
 import { DashboardLiveTabAttendance } from './DashboardLiveTabAttendance';
-import { DashboardTabStatistics } from './DashboardTabStatistics/DashboardTabStatistics';
+import { DashboardTabStatistics } from './DashboardTabStatistics';
 
 export const enum PaneTabs {
   STATS = 'statistics',


### PR DESCRIPTION
## Purpose

In the DashboardTabStatistics we are displaying the number of viewers for a video, not the number of people present on the whole webinar. Also the component is a bit refactor and test is added.

## Proposal

- [x] change DashboardTabStatistics label to display viewers

