### PR TITLE
💄(frontend) fix record action style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Add stats page on VOD
 - Create lib-markdown package
 - Add a check on timedtexttrack file size when uploading content
-- Add a check on deposited file size when uploading content 
+- Add a check on deposited file size when uploading content
 - helpers frontend api error handling
 - Add accepted formats in the subtitles uploaders helptext
 
@@ -31,8 +31,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - the Renater IdP sort is case-insensitive
-- bug on the textarea description of the live video 
+- bug on the textarea description of the live video
 - aws fargate loggroup region
+- fix recording action buttons style
 
 ## [4.0.0-beta.15] - 2023-02-02
 
@@ -98,7 +99,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - lti:
   - service worker 401 reconnect
-  - Add a check on video file size when uploading content 
+  - Add a check on video file size when uploading content
 
 ### Changed
 

--- a/src/frontend/packages/lib_video/src/components/live/Teacher/Wrapper/Controls/TeacherLiveRecordingActions/StartRecording/index.tsx
+++ b/src/frontend/packages/lib_video/src/components/live/Teacher/Wrapper/Controls/TeacherLiveRecordingActions/StartRecording/index.tsx
@@ -38,12 +38,12 @@ export const StartRecording = () => {
       disabled={isLoading}
       margin="auto"
       onClick={() => mutate()}
-      secondary
+      primary
       label={
         <Stack>
           <Box direction="row" flex style={{ whiteSpace: 'nowrap' }}>
             <RecordSVG
-              iconColor="red-active"
+              iconColor="white"
               width="25px"
               height="25px"
               containerStyle={{ margin: 'auto', marginRight: '8px' }}

--- a/src/frontend/packages/lib_video/src/components/live/Teacher/Wrapper/Controls/TeacherLiveRecordingActions/StopRecording/index.tsx
+++ b/src/frontend/packages/lib_video/src/components/live/Teacher/Wrapper/Controls/TeacherLiveRecordingActions/StopRecording/index.tsx
@@ -103,7 +103,11 @@ export const StopRecording = () => {
           )}
         </Stack>
       }
-      style={{ borderRadius: '25px' }}
+      style={{
+        borderRadius: '25px',
+        //  force text color to white because a disabled button uses the color props for the text color
+        color: 'white',
+      }}
     />
   );
 };


### PR DESCRIPTION
## Purpose

Start recording action label color was blue but we want it white. 
Start recording action icon was not visible either.

Stop recording action label was not visible when the button is disabled, but we want it visible.

