### PR TITLE
✨(lib-video) use id3 tags for document sharing / end live

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - use lib-common theme in LTI
 - change docker base image to use a debian lite one
 - Allow public resource to be embedded in a iframe
+- use live video Id3 tags to share document and end stream
 
 ### Fixed
 

--- a/src/aws/user.tf
+++ b/src/aws/user.tf
@@ -131,7 +131,8 @@ resource "aws_iam_user_policy" "live-streaming-policies" {
         "medialive:ListInputs",
         "medialive:TagResource",
         "medialive:ListInputSecurityGroups",
-        "medialive:ListChannels"
+        "medialive:ListChannels",
+        "medialive:BatchUpdateSchedule"
       ],
       "Effect": "Allow",
       "Resource": "*"

--- a/src/backend/marsha/core/api/video.py
+++ b/src/backend/marsha/core/api/video.py
@@ -48,6 +48,7 @@ from ..utils.medialive_utils import (
     delete_mediapackage_channel,
     start_live_channel,
     stop_live_channel,
+    update_id3_tags,
     wait_medialive_channel_is_created,
 )
 from ..utils.time_utils import to_timestamp
@@ -269,7 +270,9 @@ class VideoViewSet(APIViewMixin, ObjectPkMixin, viewsets.ModelViewSet):
                     arity=2,
                 )
             )
+
         channel_layers_utils.dispatch_video_to_groups(serializer.instance)
+        update_id3_tags(serializer.instance)
 
     def create(self, request, *args, **kwargs):
         """Create one video based on the request payload."""
@@ -454,6 +457,7 @@ class VideoViewSet(APIViewMixin, ObjectPkMixin, viewsets.ModelViewSet):
         channel_layers_utils.dispatch_video_to_groups(video)
 
         serializer = self.get_serializer(video)
+        update_id3_tags(video)
         return Response(serializer.data)
 
     @action(methods=["post"], detail=True, url_path="stop-live")
@@ -495,6 +499,7 @@ class VideoViewSet(APIViewMixin, ObjectPkMixin, viewsets.ModelViewSet):
         channel_layers_utils.dispatch_video_to_groups(video)
         serializer = self.get_serializer(video)
 
+        update_id3_tags(video)
         return Response(serializer.data)
 
     @action(methods=["post"], detail=True, url_path="harvest-live")
@@ -663,6 +668,7 @@ class VideoViewSet(APIViewMixin, ObjectPkMixin, viewsets.ModelViewSet):
             video.live_state = defaults.RUNNING
             live_info.update({"started_at": stamp})
             live_info.pop("stopped_at", None)
+            update_id3_tags(video)
 
             # if keys with no timeout were cached for this video, it needs to be reinitialized
             key_cache_video = f"{defaults.VIDEO_ATTENDANCE_KEY_CACHE}{video.id}"
@@ -776,6 +782,7 @@ class VideoViewSet(APIViewMixin, ObjectPkMixin, viewsets.ModelViewSet):
         serializer = self.get_serializer(video)
 
         channel_layers_utils.dispatch_video_to_groups(video)
+        update_id3_tags(video)
         return Response(serializer.data)
 
     @action(methods=["patch"], detail=True, url_path="navigate-sharing")
@@ -815,6 +822,8 @@ class VideoViewSet(APIViewMixin, ObjectPkMixin, viewsets.ModelViewSet):
         serializer = self.get_serializer(video)
 
         channel_layers_utils.dispatch_video_to_groups(video)
+        update_id3_tags(video)
+
         return Response(serializer.data)
 
     @action(methods=["patch"], detail=True, url_path="end-sharing")
@@ -845,7 +854,9 @@ class VideoViewSet(APIViewMixin, ObjectPkMixin, viewsets.ModelViewSet):
         video.save()
 
         serializer = self.get_serializer(video)
+
         channel_layers_utils.dispatch_video_to_groups(video)
+        update_id3_tags(video)
         return Response(serializer.data)
 
     @action(

--- a/src/backend/marsha/core/serializers/shared_live_media.py
+++ b/src/backend/marsha/core/serializers/shared_live_media.py
@@ -128,3 +128,12 @@ class SharedLiveMediaSerializer(
             )
 
         return urls
+
+
+class SharedLiveMediaId3TagsSerializer(serializers.ModelSerializer):
+    """Serializer to display a shared live media model in id3 Tags."""
+
+    class Meta:  # noqa
+        model = SharedLiveMedia
+        fields = ("id",)
+        read_only_fields = ("id",)

--- a/src/backend/marsha/core/serializers/video.py
+++ b/src/backend/marsha/core/serializers/video.py
@@ -23,7 +23,10 @@ from ..models import Thumbnail, Video
 from ..utils import cloudfront_utils, jitsi_utils, time_utils, xmpp_utils
 from .base import TimestampField, get_video_cloudfront_url_params
 from .playlist import PlaylistLiteSerializer
-from .shared_live_media import SharedLiveMediaSerializer
+from .shared_live_media import (
+    SharedLiveMediaId3TagsSerializer,
+    SharedLiveMediaSerializer,
+)
 from .thumbnail import ThumbnailSerializer
 from .timed_text_track import TimedTextTrackSerializer
 
@@ -447,6 +450,27 @@ class VideoSelectLTISerializer(VideoBaseSerializer):
         return self.context["request"].build_absolute_uri(
             reverse("video_lti_view", args=[obj.id]),
         )
+
+
+class VideoId3TagsSerializer(serializers.ModelSerializer):
+    """A serializer to display a Video resource in id3 tags."""
+
+    class Meta:
+        model = Video
+        fields = (
+            "active_shared_live_media",
+            "active_shared_live_media_page",
+            "id",
+            "live_state",
+        )
+        read_only_fields = (
+            "active_shared_live_media",
+            "active_shared_live_media_page",
+            "id",
+            "live_state",
+        )
+
+    active_shared_live_media = SharedLiveMediaId3TagsSerializer(read_only=True)
 
 
 class ParticipantSerializer(serializers.Serializer):

--- a/src/backend/marsha/core/tests/api/live_sessions/test_list_attendances.py
+++ b/src/backend/marsha/core/tests/api/live_sessions/test_list_attendances.py
@@ -10,6 +10,7 @@ from django.core.cache import cache
 from django.test import override_settings
 from django.utils import timezone
 
+from marsha.core import api
 from marsha.core.defaults import JITSI, RAW, RUNNING, STOPPED
 from marsha.core.factories import (
     AnonymousLiveSessionFactory,
@@ -955,12 +956,13 @@ class LiveSessionLListAttendancesApiTest(LiveSessionApiTestCase):
             "state": "running",
         }
         signature = generate_hash("shared secret", json.dumps(data).encode("utf-8"))
-        response = self.client.patch(
-            f"/api/videos/{video.id}/update-live-state/",
-            data,
-            content_type="application/json",
-            HTTP_X_MARSHA_SIGNATURE=signature,
-        )
+        with mock.patch.object(api.video, "update_id3_tags"):
+            response = self.client.patch(
+                f"/api/videos/{video.id}/update-live-state/",
+                data,
+                content_type="application/json",
+                HTTP_X_MARSHA_SIGNATURE=signature,
+            )
         self.assertEqual(response.status_code, 200)
 
         # results aren't cached anymore

--- a/src/backend/marsha/core/tests/api/video/test_shared_live_media.py
+++ b/src/backend/marsha/core/tests/api/video/test_shared_live_media.py
@@ -5,6 +5,7 @@ from unittest import mock
 
 from django.test import TestCase, override_settings
 
+from marsha.core import api
 from marsha.core.api.video import channel_layers_utils
 from marsha.core.defaults import (
     DELETED,
@@ -695,9 +696,12 @@ class TestVideoSharedLiveMedia(TestCase):
         )
         with mock.patch.object(
             channel_layers_utils, "dispatch_video_to_groups"
-        ) as mock_dispatch_video_to_groups, mock.patch(
+        ) as mock_dispatch_video_to_groups, mock.patch.object(
+            api.video, "update_id3_tags"
+        ) as mock_update_id3_tags, mock.patch(
             "marsha.core.serializers.xmpp_utils.generate_jwt"
         ) as mock_jwt_encode:
+            mock_update_id3_tags.assert_not_called()
             mock_jwt_encode.return_value = "xmpp_jwt"
             response = self.client.patch(
                 f"/api/videos/{shared_live_media.video.id}/start-sharing/",
@@ -1073,9 +1077,12 @@ class TestVideoSharedLiveMedia(TestCase):
 
         with mock.patch.object(
             channel_layers_utils, "dispatch_video_to_groups"
-        ) as mock_dispatch_video_to_groups, mock.patch(
+        ) as mock_dispatch_video_to_groups, mock.patch.object(
+            api.video, "update_id3_tags"
+        ) as mock_update_id3_tags, mock.patch(
             "marsha.core.serializers.xmpp_utils.generate_jwt"
         ) as mock_jwt_encode:
+            mock_update_id3_tags.assert_not_called()
             mock_jwt_encode.return_value = "xmpp_jwt"
             response = self.client.patch(
                 f"/api/videos/{shared_live_media.video.id}/navigate-sharing/",
@@ -1472,9 +1479,12 @@ class TestVideoSharedLiveMedia(TestCase):
 
         with mock.patch.object(
             channel_layers_utils, "dispatch_video_to_groups"
-        ) as mock_dispatch_video_to_groups, mock.patch(
+        ) as mock_dispatch_video_to_groups, mock.patch.object(
+            api.video, "update_id3_tags"
+        ) as mock_update_id3_tags, mock.patch(
             "marsha.core.serializers.xmpp_utils.generate_jwt"
         ) as mock_jwt_encode:
+            mock_update_id3_tags.assert_not_called()
             mock_jwt_encode.return_value = "xmpp_jwt"
             response = self.client.patch(
                 f"/api/videos/{shared_live_media.video.id}/end-sharing/",

--- a/src/backend/marsha/core/tests/api/video/test_start_live.py
+++ b/src/backend/marsha/core/tests/api/video/test_start_live.py
@@ -64,13 +64,16 @@ class VideoStartLiveAPITest(TestCase):
             api.video, "create_live_stream"
         ) as mock_create_live_stream, mock.patch.object(
             api.video, "wait_medialive_channel_is_created"
-        ) as mock_wait_medialive_channel_is_created, mock.patch(
+        ) as mock_wait_medialive_channel_is_created, mock.patch.object(
+            api.video, "update_id3_tags"
+        ) as mock_update_id3_tags, mock.patch(
             "marsha.core.serializers.xmpp_utils.generate_jwt"
         ) as mock_jwt_encode, mock.patch.object(
             api.video, "create_room"
         ) as mock_create_room, mock.patch(
             "marsha.websocket.utils.channel_layers_utils.dispatch_video_to_groups"
         ) as mock_dispatch_video_to_groups:
+            mock_update_id3_tags.assert_not_called()
             mock_jwt_encode.return_value = "xmpp_jwt"
             mock_create_live_stream.return_value = {
                 "medialive": {
@@ -210,13 +213,16 @@ class VideoStartLiveAPITest(TestCase):
             api.video, "create_live_stream"
         ) as mock_create_live_stream, mock.patch.object(
             api.video, "wait_medialive_channel_is_created"
-        ) as mock_wait_medialive_channel_is_created, mock.patch(
+        ) as mock_wait_medialive_channel_is_created, mock.patch.object(
+            api.video, "update_id3_tags"
+        ) as mock_update_id3_tags, mock.patch(
             "marsha.core.serializers.xmpp_utils.generate_jwt"
         ) as mock_jwt_encode, mock.patch.object(
             api.video, "create_room"
         ) as mock_create_room, mock.patch(
             "marsha.websocket.utils.channel_layers_utils.dispatch_video_to_groups"
         ) as mock_dispatch_video_to_groups:
+            mock_update_id3_tags.assert_not_called()
             mock_jwt_encode.return_value = "xmpp_jwt"
             mock_create_live_stream.return_value = {
                 "medialive": {
@@ -377,10 +383,13 @@ class VideoStartLiveAPITest(TestCase):
             "marsha.core.serializers.xmpp_utils.generate_jwt"
         ) as mock_jwt_encode, mock.patch.object(
             api.video, "create_room"
-        ) as mock_create_room, mock.patch(
+        ) as mock_create_room, mock.patch.object(
+            api.video, "update_id3_tags"
+        ) as mock_update_id3_tags, mock.patch(
             "marsha.websocket.utils.channel_layers_utils.dispatch_video_to_groups"
         ) as mock_dispatch_video_to_groups:
             mock_jwt_encode.return_value = "xmpp_jwt"
+            mock_update_id3_tags.assert_not_called()
             mock_create_live_stream.assert_not_called()
             mock_create_room.assert_not_called()
 
@@ -522,7 +531,9 @@ class VideoStartLiveAPITest(TestCase):
             api.video, "create_live_stream"
         ) as mock_create_live_stream, mock.patch.object(
             api.video, "wait_medialive_channel_is_created"
-        ), mock.patch(
+        ), mock.patch.object(
+            api.video, "update_id3_tags"
+        ) as mock_update_id3_tags, mock.patch(
             "marsha.core.serializers.xmpp_utils.generate_jwt"
         ) as mock_jwt_encode, mock.patch.object(
             api.video, "create_room"
@@ -532,6 +543,7 @@ class VideoStartLiveAPITest(TestCase):
             mock_jwt_encode.return_value = "xmpp_jwt"
             mock_create_live_stream.assert_not_called()
             mock_create_room.assert_not_called()
+            mock_update_id3_tags.assert_not_called()
 
             response = self.client.post(
                 f"/api/videos/{video.id}/start-live/",
@@ -675,13 +687,16 @@ class VideoStartLiveAPITest(TestCase):
             api.video, "create_live_stream"
         ) as mock_create_live_stream, mock.patch.object(
             api.video, "wait_medialive_channel_is_created"
-        ) as mock_wait_medialive_channel_is_created, mock.patch(
+        ) as mock_wait_medialive_channel_is_created, mock.patch.object(
+            api.video, "update_id3_tags"
+        ) as mock_update_id3_tags, mock.patch(
             "marsha.core.serializers.xmpp_utils.generate_jwt"
         ) as mock_jwt_encode, mock.patch.object(
             api.video, "create_room"
         ) as mock_create_room, mock.patch(
             "marsha.websocket.utils.channel_layers_utils.dispatch_video_to_groups"
         ) as mock_dispatch_video_to_groups:
+            mock_update_id3_tags.assert_not_called()
             mock_jwt_encode.return_value = "xmpp_jwt"
             mock_create_live_stream.return_value = {
                 "medialive": {

--- a/src/backend/marsha/core/tests/api/video/test_stop_live.py
+++ b/src/backend/marsha/core/tests/api/video/test_stop_live.py
@@ -78,7 +78,10 @@ class VideoAPITest(TestCase):
 
         with mock.patch.object(api.video, "stop_live_channel"), mock.patch(
             "marsha.websocket.utils.channel_layers_utils.dispatch_video_to_groups"
-        ) as mock_dispatch_video_to_groups:
+        ) as mock_dispatch_video_to_groups, mock.patch.object(
+            api.video, "update_id3_tags"
+        ) as mock_update_id3_tags:
+            mock_update_id3_tags.assert_not_called()
             jwt_token = UserAccessTokenFactory(user=user)
             response = self.client.post(
                 f"/api/videos/{video.id}/stop-live/",
@@ -252,7 +255,7 @@ class VideoAPITest(TestCase):
         now = datetime(2021, 11, 16, tzinfo=timezone.utc)
         with mock.patch.object(timezone, "now", return_value=now), mock.patch.object(
             api.video, "stop_live_channel"
-        ), mock.patch(
+        ), mock.patch.object(api.video, "update_id3_tags"), mock.patch(
             "marsha.websocket.utils.channel_layers_utils.dispatch_video_to_groups"
         ) as mock_dispatch_video_to_groups:
             response = self.client.post(
@@ -409,7 +412,7 @@ class VideoAPITest(TestCase):
         # stop a live video,
         with mock.patch.object(timezone, "now", return_value=stop), mock.patch.object(
             api.video, "stop_live_channel"
-        ), mock.patch(
+        ), mock.patch.object(api.video, "update_id3_tags"), mock.patch(
             "marsha.websocket.utils.channel_layers_utils.dispatch_video_to_groups"
         ) as mock_dispatch_video_to_groups:
             response = self.client.post(

--- a/src/backend/marsha/core/tests/api/video/test_update_live_state.py
+++ b/src/backend/marsha/core/tests/api/video/test_update_live_state.py
@@ -6,7 +6,7 @@ from unittest import mock
 
 from django.test import TestCase, override_settings
 
-from marsha.core import factories
+from marsha.core import api, factories
 from marsha.core.api import timezone
 from marsha.core.defaults import (
     HARVESTED,
@@ -74,7 +74,10 @@ class VideoUpdateLiveStateAPITest(TestCase):
         now = datetime(2018, 8, 8, tzinfo=timezone.utc)
         with mock.patch.object(timezone, "now", return_value=now), mock.patch(
             "marsha.websocket.utils.channel_layers_utils.dispatch_video_to_groups"
-        ) as mock_dispatch_video_to_groups:
+        ) as mock_dispatch_video_to_groups, mock.patch.object(
+            api.video, "update_id3_tags"
+        ) as mock_update_id3_tags:
+            mock_update_id3_tags.assert_not_called()
             response = self.client.patch(
                 f"/api/videos/{video.id}/update-live-state/",
                 data,
@@ -159,7 +162,10 @@ class VideoUpdateLiveStateAPITest(TestCase):
         new_start = timezone.now() + timedelta(minutes=20)
         with mock.patch.object(timezone, "now", return_value=new_start), mock.patch(
             "marsha.websocket.utils.channel_layers_utils.dispatch_video_to_groups"
-        ) as mock_dispatch_video_to_groups:
+        ) as mock_dispatch_video_to_groups, mock.patch.object(
+            api.video, "update_id3_tags"
+        ) as mock_update_id3_tags:
+            mock_update_id3_tags.assert_not_called()
             response = self.client.patch(
                 f"/api/videos/{video.id}/update-live-state/",
                 data,

--- a/src/backend/marsha/core/utils/medialive_profiles/medialive-720p.json
+++ b/src/backend/marsha/core/utils/medialive_profiles/medialive-720p.json
@@ -70,6 +70,7 @@
               "RestartDelay": 5
             }
           },
+          "HlsId3SegmentTagging": "ENABLED",
           "IndexNSegments": 15,
           "InputLossAction": "EMIT_OUTPUT",
           "IvInManifest": "INCLUDE",

--- a/src/frontend/packages/lib_components/src/data/stores/useVideo/index.tsx
+++ b/src/frontend/packages/lib_components/src/data/stores/useVideo/index.tsx
@@ -8,7 +8,7 @@ import {
 } from 'data/stores/actions';
 import { modelName } from 'types/models';
 import { StoreState } from 'types/stores';
-import { Video } from 'types/tracks';
+import { Video, Id3VideoType } from 'types/tracks';
 
 type VideoStateResource = {
   [modelName.VIDEOS]: {
@@ -19,6 +19,10 @@ type VideoStateResource = {
 type VideoState = StoreState<Video> &
   VideoStateResource & {
     getVideo: (video: Nullable<Video>) => Video;
+    id3Video: Nullable<Id3VideoType>;
+    setId3Video: (id3Video: Nullable<Id3VideoType>) => void;
+    isWatchingVideo: boolean;
+    setIsWatchingVideo: (isWatching: boolean) => void;
   };
 
 export const useVideo = create<VideoState>((set, get) => ({
@@ -55,4 +59,12 @@ export const useVideo = create<VideoState>((set, get) => ({
   removeResource: (video: Video) =>
     set(removeResource(get(), modelName.VIDEOS, video) as VideoStateResource),
   [modelName.VIDEOS]: {},
+  isWatchingVideo: false,
+  setIsWatchingVideo: (isWatching: boolean) => {
+    set((state) => ({ ...state, isWatchingVideo: isWatching }));
+  },
+  id3Video: null,
+  setId3Video: (video: Nullable<Id3VideoType>) => {
+    set((state) => ({ ...state, id3Video: video }));
+  },
 }));

--- a/src/frontend/packages/lib_components/src/types/tracks.ts
+++ b/src/frontend/packages/lib_components/src/types/tracks.ts
@@ -254,6 +254,11 @@ export interface Live extends Omit<Video, 'live_state' | 'live_type'> {
   live_type: LiveModeType;
 }
 
+export type Id3VideoType = Pick<
+  Video,
+  'live_state' | 'active_shared_live_media' | 'active_shared_live_media_page'
+>;
+
 export interface LiveJitsi extends Omit<Live, 'live_type' | 'live_info'> {
   live_type: LiveModeType.JITSI;
   live_info: {

--- a/src/frontend/packages/lib_video/src/components/live/Student/StudentLiveStarter/StudentLiveWrapper/UpdateCurrentSharedLiveMediaPage/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/live/Student/StudentLiveStarter/StudentLiveWrapper/UpdateCurrentSharedLiveMediaPage/index.spec.tsx
@@ -4,6 +4,7 @@ import {
   videoMockFactory,
   liveState,
   LiveModeType,
+  useVideo,
 } from 'lib-components';
 import { render } from 'lib-tests';
 import React from 'react';
@@ -77,6 +78,71 @@ describe('<UpdateCurrentSharedLiveMediaPage />', () => {
     expect(mockUseSharedMediaCurrentPage).toHaveBeenCalledWith({
       page: 3,
       imageUrl: `https://example.com/sharedLiveMedia/${sharedLiveMedia.id}/3`,
+    });
+  });
+
+  it('set the page with id3 tags', () => {
+    const videoId = faker.datatype.uuid();
+    const sharedLiveMedia = sharedLiveMediaMockFactory({ video: videoId });
+    const video = videoMockFactory({
+      id: videoId,
+      active_shared_live_media: sharedLiveMedia,
+      active_shared_live_media_page: 1,
+      shared_live_medias: [sharedLiveMedia],
+      live_state: liveState.RUNNING,
+      live_type: LiveModeType.JITSI,
+    });
+
+    useVideo.getState().setId3Video({
+      active_shared_live_media: { id: sharedLiveMedia.id },
+      active_shared_live_media_page: 1,
+      live_state: liveState.RUNNING,
+    });
+    useVideo.getState().setIsWatchingVideo(true);
+
+    const { rerender } = render(
+      wrapInVideo(
+        <SharedMediaCurrentPageProvider
+          value={{
+            page: 2,
+            imageUrl: `https://example.com/sharedLiveMedia/${sharedLiveMedia.id}/2`,
+          }}
+        >
+          <UpdateCurrentSharedLiveMediaPage />
+        </SharedMediaCurrentPageProvider>,
+        video,
+      ),
+    );
+
+    expect(mockUseSharedMediaCurrentPage).toHaveBeenCalledWith({
+      page: 1,
+      imageUrl: `https://example.com/sharedLiveMedia/${sharedLiveMedia.id}/1`,
+    });
+
+    useVideo.getState().setId3Video({
+      active_shared_live_media: { id: sharedLiveMedia.id },
+      active_shared_live_media_page: 2,
+      live_state: liveState.RUNNING,
+    });
+
+    // it simulates an update of the video object
+    rerender(
+      wrapInVideo(
+        <SharedMediaCurrentPageProvider
+          value={{
+            page: 2,
+            imageUrl: `https://example.com/sharedLiveMedia/${sharedLiveMedia.id}/2`,
+          }}
+        >
+          <UpdateCurrentSharedLiveMediaPage />
+        </SharedMediaCurrentPageProvider>,
+        { ...video, active_shared_live_media_page: 1 },
+      ),
+    );
+
+    expect(mockUseSharedMediaCurrentPage).toHaveBeenCalledWith({
+      page: 2,
+      imageUrl: `https://example.com/sharedLiveMedia/${sharedLiveMedia.id}/2`,
     });
   });
 });

--- a/src/frontend/packages/lib_video/src/components/live/Student/StudentLiveStarter/StudentLiveWrapper/UpdateCurrentSharedLiveMediaPage/index.tsx
+++ b/src/frontend/packages/lib_video/src/components/live/Student/StudentLiveStarter/StudentLiveWrapper/UpdateCurrentSharedLiveMediaPage/index.tsx
@@ -1,3 +1,4 @@
+import { useVideo } from 'lib-components';
 import { useEffect } from 'react';
 
 import { useCurrentLive } from 'hooks/useCurrentVideo';
@@ -6,9 +7,11 @@ import { useSharedMediaCurrentPage } from 'hooks/useSharedMediaCurrentPage';
 export const UpdateCurrentSharedLiveMediaPage = () => {
   const live = useCurrentLive();
   const [_, setSharedCurrentPage] = useSharedMediaCurrentPage();
+  const { isWatchingVideo, id3Video } = useVideo();
 
   useEffect(() => {
     if (
+      !isWatchingVideo &&
       live.active_shared_live_media_page &&
       live.active_shared_live_media &&
       live.active_shared_live_media.urls
@@ -19,10 +22,32 @@ export const UpdateCurrentSharedLiveMediaPage = () => {
         imageUrl: live.active_shared_live_media.urls.pages[pageNumber],
       });
     }
+    if (
+      isWatchingVideo &&
+      id3Video?.active_shared_live_media?.id &&
+      id3Video.active_shared_live_media_page
+    ) {
+      const pages = live.shared_live_medias.find(
+        (media) => media.id === id3Video.active_shared_live_media?.id,
+      )?.urls?.pages;
+      const pageNumber = id3Video.active_shared_live_media_page;
+
+      if (!pages) {
+        return;
+      }
+      setSharedCurrentPage({
+        page: pageNumber,
+        imageUrl: pages[pageNumber],
+      });
+    }
   }, [
+    isWatchingVideo,
+    id3Video?.active_shared_live_media?.id,
+    id3Video?.active_shared_live_media_page,
     live.active_shared_live_media,
     live.active_shared_live_media_page,
     setSharedCurrentPage,
+    live.shared_live_medias,
   ]);
 
   return null;

--- a/src/frontend/packages/lib_video/src/components/live/Student/StudentLiveStarter/StudentLiveWrapper/index.tsx
+++ b/src/frontend/packages/lib_video/src/components/live/Student/StudentLiveStarter/StudentLiveWrapper/index.tsx
@@ -1,6 +1,6 @@
 import { Box, Layer } from 'grommet';
 import { Nullable } from 'lib-common';
-import { useAppConfig } from 'lib-components';
+import { useAppConfig, useVideo } from 'lib-components';
 import React, { ReactNode, useEffect, useRef, useState } from 'react';
 import { useIntl } from 'react-intl';
 
@@ -39,6 +39,8 @@ export const StudentLiveWrapper: React.FC<StudentLiveWrapperProps> = ({
   const intl = useIntl();
   const appData = useAppConfig();
   const live = useCurrentLive();
+  const { isWatchingVideo, id3Video } = useVideo();
+
   const mainElementRef = useRef<Nullable<HTMLDivElement>>(null);
 
   const { configPanel, currentItem, setPanelVisibility } = useLivePanelState(
@@ -109,7 +111,11 @@ export const StudentLiveWrapper: React.FC<StudentLiveWrapperProps> = ({
   }
 
   let secondElement: ReactNode;
-  if (live.active_shared_live_media && live.active_shared_live_media_page) {
+  if (
+    !isWatchingVideo &&
+    live.active_shared_live_media &&
+    live.active_shared_live_media_page
+  ) {
     if (!live.active_shared_live_media.urls) {
       throw new MissingSharedLiveSessionUrls(
         'Missing shared live session urls during a sharing.',
@@ -121,6 +127,29 @@ export const StudentLiveWrapper: React.FC<StudentLiveWrapperProps> = ({
         initialPage={live.active_shared_live_media_page}
         pages={live.active_shared_live_media.urls.pages}
       >
+        <UpdateCurrentSharedLiveMediaPage />
+      </SharedMediaExplorer>
+    );
+  }
+
+  if (
+    isWatchingVideo &&
+    id3Video?.active_shared_live_media?.id &&
+    id3Video.active_shared_live_media_page
+  ) {
+    const pages = live.shared_live_medias.find(
+      (media) => media.id === id3Video.active_shared_live_media?.id,
+    )?.urls?.pages;
+    const pageNumber = id3Video.active_shared_live_media_page;
+
+    if (!pages) {
+      throw new MissingSharedLiveSessionUrls(
+        'Missing shared live session urls during a sharing.',
+      );
+    }
+
+    secondElement = (
+      <SharedMediaExplorer initialPage={pageNumber} pages={pages}>
         <UpdateCurrentSharedLiveMediaPage />
       </SharedMediaExplorer>
     );

--- a/src/frontend/packages/lib_video/src/components/live/Student/StudentLiveStarter/index.tsx
+++ b/src/frontend/packages/lib_video/src/components/live/Student/StudentLiveStarter/index.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { Maybe } from 'lib-common';
-import { JoinMode, liveState } from 'lib-components';
+import { JoinMode, liveState, useVideo } from 'lib-components';
 import { DateTime } from 'luxon';
 import React, { useEffect, useMemo } from 'react';
 import { useIntl } from 'react-intl';
@@ -27,6 +27,7 @@ export const StudentLiveStarter = ({ playerType }: StudentLiveStarterProps) => {
   const intl = useIntl();
   const live = useCurrentLive();
   const session = useLiveSession();
+  const id3Video = useVideo((state) => state.id3Video);
   const liveScheduleStartDate = useMemo(() => {
     if (!live.starting_at) {
       return undefined;
@@ -169,14 +170,15 @@ export const StudentLiveStarter = ({ playerType }: StudentLiveStarterProps) => {
     !liveScheduleStartDate;
 
   if (
-    ([
+    id3Video?.live_state !== liveState.RUNNING &&
+    (([
       liveState.STOPPING,
       liveState.STOPPED,
       liveState.HARVESTING,
       liveState.HARVESTED,
     ].includes(live.live_state) &&
       isScheduledPassed) ||
-    !isStarted
+      !isStarted)
   ) {
     return <StudentLiveAdvertising />;
   } else if (


### PR DESCRIPTION
## Purpose

During a webinar, there is a latency of few seconds between what happen in the instructor side (in jitsi) and what a student is seeing. Without any interactivity this is not a problem but once the instructor start sharing a document then this latency can be a problem. The document is display and the explanation about what is display by the instructor can come few seconds later.

## Proposal

We would like to use id3 tags to sync events with the live stream video.

- [x] use id3 tags instead of object video for document sharing
- [x] use id3 tags instead of object video for ending stream

