### PR TITLE
🐛(frontend) in case of a restarted live, wait for the hls to be ready…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - bug on the textarea description of the live video
 - aws fargate loggroup region
 - fix recording action buttons style
+- student live polling a stopped live beeing restarted
 
 ## [4.0.0-beta.15] - 2023-02-02
 

--- a/src/frontend/packages/lib_video/src/api/pollForLive/index.tsx
+++ b/src/frontend/packages/lib_video/src/api/pollForLive/index.tsx
@@ -1,16 +1,14 @@
-import { fetchWrapper, VideoUrls } from 'lib-components';
+import { VideoUrls } from 'lib-components';
 
 import { POLL_FOR_LIVE_TIMEOUT } from 'conf/sideEffects';
+import { resumeLive } from 'utils/resumeLive';
 
 export const pollForLive = async (
   urls: VideoUrls,
   timeout: number = POLL_FOR_LIVE_TIMEOUT,
 ): Promise<null> => {
   try {
-    const response = await fetchWrapper(urls.manifests.hls);
-    if (response.status === 404) {
-      throw new Error('missing manifest');
-    }
+    await resumeLive(urls.manifests.hls);
   } catch (error) {
     await new Promise((resolve) => window.setTimeout(resolve, timeout));
     return await pollForLive(urls);

--- a/src/frontend/packages/lib_video/src/components/live/Teacher/Wrapper/Controls/TeacherLiveControlBar/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/live/Teacher/Wrapper/Controls/TeacherLiveControlBar/index.spec.tsx
@@ -86,13 +86,17 @@ describe('<TeacherLiveControlBar />', () => {
   });
 
   it('polls for live when live is running and show live feedback button', async () => {
-    fetchMock.get('some_url', 404);
+    fetchMock.get('https://testing.m3u8', 404);
     useLivePanelState.setState({
       availableItems: [LivePanelItem.CHAT, LivePanelItem.VIEWERS_LIST],
     });
 
     const mockedVideo = videoMockFactory({
-      urls: { manifests: { hls: 'some_url' }, mp4: {}, thumbnails: {} },
+      urls: {
+        manifests: { hls: 'https://testing.m3u8' },
+        mp4: {},
+        thumbnails: {},
+      },
       live_state: liveState.RUNNING,
       live_type: LiveModeType.RAW,
     });
@@ -116,7 +120,33 @@ describe('<TeacherLiveControlBar />', () => {
       screen.queryByRole('button', { name: 'Show live feedback' }),
     ).not.toBeInTheDocument();
 
-    fetchMock.get('some_url', 200, { overwriteRoutes: true });
+    fetchMock.get(
+      'https://testing.m3u8',
+      `
+      #EXTM3U
+      #EXT-X-VERSION:3
+      #EXT-X-INDEPENDENT-SEGMENTS
+      #EXT-X-STREAM-INF:BANDWIDTH=1404480,AVERAGE-BANDWIDTH=1205600,RESOLUTION=854x480,FRAME-RATE=24.000,CODECS="avc1.640029,mp4a.40.2"
+      dev-manu_030aaea4-bb0b-4915-88a4-521fc8b59366_1637050264_hls_1.m3u8
+      #EXT-X-STREAM-INF:BANDWIDTH=4440449,AVERAGE-BANDWIDTH=3735564,RESOLUTION=1280x720,FRAME-RATE=24.000,CODECS="avc1.640029,mp4a.40.2"
+      dev-manu_030aaea4-bb0b-4915-88a4-521fc8b59366_1637050264_hls_2.m3u8
+      #EXT-X-STREAM-INF:BANDWIDTH=518276,AVERAGE-BANDWIDTH=455345,RESOLUTION=426x240,FRAME-RATE=24.000,CODECS="avc1.4D401E,mp4a.40.2"
+      dev-manu_030aaea4-bb0b-4915-88a4-521fc8b59366_1637050264_hls_3.m3u8
+      `,
+      { overwriteRoutes: true },
+    );
+    fetchMock.mock(
+      'https://dev-manu_030aaea4-bb0b-4915-88a4-521fc8b59366_1637050264_hls_1.m3u8/',
+      `
+      #EXTM3U
+      #EXT-X-VERSION:3
+      #EXT-X-TARGETDURATION:4
+      #EXT-X-MEDIA-SEQUENCE:848
+      #EXT-X-DISCONTINUITY-SEQUENCE:21
+      #EXTINF:1.500,
+      dev-manu_030aaea4-bb0b-4915-88a4-521fc8b59366_1637050264_hls_1_848.ts?m=1637050263
+      `,
+    );
     jest.advanceTimersToNextTimer();
 
     await screen.findByRole('button', { name: 'Show live feedback' });

--- a/src/frontend/packages/lib_video/src/utils/resumeLive.ts
+++ b/src/frontend/packages/lib_video/src/utils/resumeLive.ts
@@ -1,4 +1,3 @@
-import { getResource, modelName, Video } from 'lib-components';
 // module responsible to fetch an HLS manifest and detect when tag
 // EXT-X-ENDLIST has been removed in it.
 import { Parser } from 'm3u8-parser';
@@ -7,28 +6,12 @@ const regex = /^(https.*)\/.*\.m3u8$/;
 
 const fetchManifest = async (manifestUrl: string) => {
   const manifest = await fetch(manifestUrl).then((response) => response.text());
+
   const hlsParser = new Parser();
   hlsParser.push(manifest);
   hlsParser.end();
 
   return hlsParser.manifest;
-};
-
-export const resumeLive = async (video: Video) => {
-  const manifestUrl = video.urls?.manifests.hls;
-  if (!manifestUrl) {
-    throw new Error('');
-  }
-
-  const mainManifest = await fetchManifest(manifestUrl);
-  const firstManifest = mainManifest.playlists[0].uri;
-  const matches = manifestUrl.match(regex);
-  if (!matches) {
-    throw new Error('');
-  }
-
-  await pollEndedManifest(`${matches[1]}/${firstManifest}`);
-  await getResource(modelName.VIDEOS, video.id);
 };
 
 const pollEndedManifest = async (manifestUrl: string) => {
@@ -38,4 +21,15 @@ const pollEndedManifest = async (manifestUrl: string) => {
     await new Promise((resolve) => window.setTimeout(resolve, 2500));
     await pollEndedManifest(manifestUrl);
   }
+};
+
+export const resumeLive = async (manifestUrl: string) => {
+  const mainManifest = await fetchManifest(manifestUrl);
+  const firstManifest = mainManifest.playlists[0].uri;
+  const matches = manifestUrl.match(regex);
+  if (!matches) {
+    throw new Error(`Invalid manifest url ${manifestUrl}`);
+  }
+
+  await pollEndedManifest(`${matches[1]}/${firstManifest}`);
 };


### PR DESCRIPTION
## Purpose

When the teacher restart a stopped live, student could endup polling the old
manifest and getting only the last chunk of the live, ending with a 3 to 4 sec
video and not the live.

## Proposal

Properly wait for a manifest to be fetch without the EXT-X-ENDLIST tag.

