### PR TITLE
✨ (backend) Update shared live media permission for standalone site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Allow playlist instructor to manage shared live media through API
+
 ## [4.0.0-beta.16] - 2023-02-17
 
 ### Added

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -67,6 +67,7 @@ Among other things, they can:
 - Manage (read/write) all the users of the organization.
 - Create and manage (read/write) all the playlists of the organization.
 - Create and manage (read/write) all the videos of the organization and perform related video actions.
+- Create and manage (read/write) all the shared live media of the organization's videos.
 - Create and manage (read/write) all the classrooms of the organization.
 - Create and manage (read/write) all the classroom documents of the organization.
 - 🚧 Create and manage (read/write) all the documents of the organization.
@@ -119,6 +120,7 @@ A playlist administrator can:
 
 - 🚧 Create and manage (read/write) all the playlist's access control.
 - Create and manage (read/write) all the videos of the playlist and perform related video actions.
+- Create and manage (read/write) all the shared live media of the playlist's videos.
 - Create and manage (read/write) all the timed text track of the playlist's videos.
 - Create and manage (read/write) all the classrooms of the playlist.
 - Create and manage (read/write) all the classroom documents of the playlist.
@@ -133,6 +135,7 @@ The playlist instructor is added by a playlist administrator. They can:
 
 - 🚧 Read all the playlist's access control.
 - Create and manage (read/write) all the videos of the playlist and perform related video actions.
+- Create and manage (read/write) all the shared live media of the playlist's videos.
 - 🚧 Read all the timed text track of the playlist's videos.
 - 🚧 Read all the classrooms of the playlist.
 - 🚧 Read all the classroom documents of the playlist.

--- a/src/backend/marsha/bbb/api.py
+++ b/src/backend/marsha/bbb/api.py
@@ -507,6 +507,8 @@ class ClassroomDocumentViewSet(
             HttpResponse carrying the AWS S3 upload policy as a JSON object.
 
         """
+        classroom = self.get_object()  # check permissions first
+
         serializer = serializers.ClassroomDocumentInitiateUploadSerializer(
             data=request.data
         )
@@ -517,7 +519,6 @@ class ClassroomDocumentViewSet(
         now = timezone.now()
         stamp = to_timestamp(now)
 
-        classroom = self.get_object()
         key = classroom.get_source_s3_key(
             stamp=stamp, extension=serializer.validated_data["extension"]
         )

--- a/src/backend/marsha/core/api/shared_live_media.py
+++ b/src/backend/marsha/core/api/shared_live_media.py
@@ -33,7 +33,7 @@ class SharedLiveMediaViewSet(
     """Viewset for the API of the SharedLiveMedia object."""
 
     permission_classes = [permissions.NotAllowed]
-    queryset = SharedLiveMedia.objects.all()
+    queryset = SharedLiveMedia.objects.select_related("video")
     serializer_class = serializers.SharedLiveMediaSerializer
     filter_backends = [
         filters.OrderingFilter,

--- a/src/backend/marsha/core/api/shared_live_media.py
+++ b/src/backend/marsha/core/api/shared_live_media.py
@@ -151,6 +151,8 @@ class SharedLiveMediaViewSet(
             HttpResponse carrying the AWS S3 upload policy as a JSON object.
 
         """
+        shared_live_media = self.get_object()  # check permissions first
+
         serializer = serializers.SharedLiveMediaInitiateUploadSerializer(
             data=request.data
         )
@@ -161,7 +163,6 @@ class SharedLiveMediaViewSet(
         now = timezone.now()
         stamp = to_timestamp(now)
 
-        shared_live_media = self.get_object()
         key = shared_live_media.get_source_s3_key(
             stamp=stamp, extension=serializer.validated_data["extension"]
         )

--- a/src/backend/marsha/core/api/shared_live_media.py
+++ b/src/backend/marsha/core/api/shared_live_media.py
@@ -62,20 +62,20 @@ class SharedLiveMediaViewSet(
             permission_classes = [
                 permissions.IsTokenInstructor
                 | permissions.IsTokenAdmin
+                | permissions.IsParamsVideoAdminOrInstructorThroughPlaylist
                 | permissions.IsParamsVideoAdminThroughOrganization
-                | permissions.IsParamsVideoAdminThroughPlaylist
             ]
         elif self.action in ["retrieve"]:
             permission_classes = [
                 permissions.IsTokenResourceRouteObjectRelatedVideo
-                | permissions.IsRelatedVideoPlaylistAdmin
+                | permissions.IsRelatedVideoPlaylistAdminOrInstructor
                 | permissions.IsRelatedVideoOrganizationAdmin
             ]
         elif self.action in ["destroy", "initiate_upload", "update", "partial_update"]:
             permission_classes = [
                 permissions.IsTokenResourceRouteObjectRelatedVideo
                 & (permissions.IsTokenInstructor | permissions.IsTokenAdmin)
-                | permissions.IsRelatedVideoPlaylistAdmin
+                | permissions.IsRelatedVideoPlaylistAdminOrInstructor
                 | permissions.IsRelatedVideoOrganizationAdmin
             ]
         elif self.action is None:

--- a/src/backend/marsha/core/api/thumbnail.py
+++ b/src/backend/marsha/core/api/thumbnail.py
@@ -72,13 +72,14 @@ class ThumbnailViewSet(
             HttpResponse carrying the AWS S3 upload policy as a JSON object.
 
         """
+        thumbnail = self.get_object()  # check permissions first
+
         serializer = serializers.ThumbnailSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
         now = timezone.now()
         stamp = to_timestamp(now)
 
-        thumbnail = self.get_object()
         key = thumbnail.get_source_s3_key(stamp=stamp)
 
         presigned_post = create_presigned_post(

--- a/src/backend/marsha/core/api/timed_text_track.py
+++ b/src/backend/marsha/core/api/timed_text_track.py
@@ -88,13 +88,14 @@ class TimedTextTrackViewSet(
             HttpResponse carrying the AWS S3 upload policy as a JSON object.
 
         """
+        timed_text_track = self.get_object()  # check permissions first
+
         serializer = serializers.TimedTextUploadSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
         now = timezone.now()
         stamp = to_timestamp(now)
 
-        timed_text_track = self.get_object()
         key = timed_text_track.get_source_s3_key(stamp=stamp)
 
         presigned_post = create_presigned_post(

--- a/src/backend/marsha/core/permissions.py
+++ b/src/backend/marsha/core/permissions.py
@@ -448,6 +448,15 @@ class IsParamsVideoAdminThroughPlaylist(
     """
 
 
+class IsParamsVideoAdminOrInstructorThroughPlaylist(
+    HasAdminOrInstructorRoleMixIn, BaseIsParamsVideoRoleThroughPlaylist
+):
+    """
+    Allow access to user with admin or instructor role on the video's playlist
+    provided in parameters.
+    """
+
+
 class BaseIsPlaylistRole(permissions.BasePermission):
     """Base permission class for playlist roles."""
 
@@ -595,6 +604,15 @@ class BaseIsRelatedVideoPlaylistRole(BaseIsObjectPlaylistRole):
 
 class IsRelatedVideoPlaylistAdmin(HasAdminRoleMixIn, BaseIsRelatedVideoPlaylistRole):
     """Allow request when the user has admin role on the object's video's playlist."""
+
+
+class IsRelatedVideoPlaylistAdminOrInstructor(
+    HasAdminOrInstructorRoleMixIn,
+    BaseIsRelatedVideoPlaylistRole,
+):
+    """
+    Allow request when the user has admin or instructor role on the object's video's playlist.
+    """
 
 
 class BaseIsRelatedVideoPlaylistOrganizationRole(BaseIsPlaylistOrganizationRole):

--- a/src/backend/marsha/core/tests/api/shared_live_media/test_create.py
+++ b/src/backend/marsha/core/tests/api/shared_live_media/test_create.py
@@ -124,7 +124,7 @@ class SharedLiveMediaCreateAPITest(TestCase):
         """
         Playlist instructor token user creates a shared live media for a video.
 
-        A user with a user token, who is a playlist instructor, cannot create a shared
+        A user with a user token, who is a playlist instructor, can create a shared
         live media for a video that belongs to that playlist.
         """
         user = UserFactory()
@@ -139,10 +139,26 @@ class SharedLiveMediaCreateAPITest(TestCase):
             "/api/sharedlivemedias/",
             {"video": str(video.id)},
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+            content_type="application/json",
         )
 
-        self.assertEqual(response.status_code, 403)
-        self.assertEqual(SharedLiveMedia.objects.count(), 0)
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(SharedLiveMedia.objects.count(), 1)
+        self.assertEqual(
+            response.json(),
+            {
+                "id": str(SharedLiveMedia.objects.first().id),
+                "active_stamp": None,
+                "filename": None,
+                "is_ready_to_show": False,
+                "nb_pages": None,
+                "show_download": True,
+                "title": None,
+                "upload_state": "pending",
+                "urls": None,
+                "video": str(video.id),
+            },
+        )
 
     def test_api_shared_live_media_create_by_video_playlist_admin(self):
         """

--- a/src/backend/marsha/core/tests/api/shared_live_media/test_retrieve.py
+++ b/src/backend/marsha/core/tests/api/shared_live_media/test_retrieve.py
@@ -531,7 +531,7 @@ class SharedLiveMediaRetrieveAPITest(TestCase):
         """
         Playlist instructor token user read a shared live media for a video.
 
-        A user with a user token, who is a playlist instructor, cannot read a shared
+        A user with a user token, who is a playlist instructor, can read a shared
         live media for a video that belongs to that playlist.
         """
         user = UserFactory()
@@ -548,7 +548,22 @@ class SharedLiveMediaRetrieveAPITest(TestCase):
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {
+                "id": str(SharedLiveMedia.objects.first().id),
+                "active_stamp": None,
+                "filename": None,
+                "is_ready_to_show": False,
+                "nb_pages": shared_live_media.nb_pages,
+                "show_download": True,
+                "title": None,
+                "upload_state": "pending",
+                "urls": None,
+                "video": str(video.id),
+            },
+        )
 
     def test_api_shared_live_media_read_detail_by_video_playlist_admin(self):
         """

--- a/src/backend/marsha/deposit/api.py
+++ b/src/backend/marsha/deposit/api.py
@@ -313,6 +313,8 @@ class DepositedFileViewSet(
             HttpResponse carrying the AWS S3 upload policy as a JSON object.
 
         """
+        deposited_file = self.get_object()  # check permissions first
+
         serializer = serializers.DepositedFileInitiateUploadSerializer(
             data=request.data
         )
@@ -323,7 +325,6 @@ class DepositedFileViewSet(
         now = timezone.now()
         stamp = to_timestamp(now)
 
-        deposited_file = self.get_object()
         key = deposited_file.get_source_s3_key(
             stamp=stamp, extension=serializer.validated_data["extension"]
         )

--- a/src/backend/marsha/markdown/api.py
+++ b/src/backend/marsha/markdown/api.py
@@ -321,6 +321,7 @@ class MarkdownImageViewSet(
             HttpResponse carrying the AWS S3 upload policy as a JSON object.
 
         """
+        markdown_image = self.get_object()  # check permissions first
 
         serializer = serializers.MarkdownImageUploadSerializer(
             data=request.data,
@@ -332,7 +333,6 @@ class MarkdownImageViewSet(
         now = timezone.now()
         stamp = to_timestamp(now)
 
-        markdown_image = self.get_object()
         key = markdown_image.get_source_s3_key(
             stamp=stamp,
             extension=serializer.validated_data["extension"],


### PR DESCRIPTION
## Purpose

Now playlist administrator/instructors can access playlist's video, we need to update related endpoints.

## Proposal

- [x] Rewrite SharedLiveMediaViewSet to look like other updated ViewSet (ie regroup permissions, querysets, ...)
- [x] Add permission for playlist instructor access

