### PR TITLE
🔖(beta) bump release to 4.0.0-beta.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.0.0-beta.16] - 2023-02-17
+
 ### Added
 
 - remove lib folder before rollup build to avoid stale files
@@ -1488,7 +1490,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Minor fixes and improvements on features and tests
 
-[unreleased]: https://github.com/openfun/marsha/compare/v4.0.0-beta.15...master
+[unreleased]: https://github.com/openfun/marsha/compare/v4.0.0-beta.16...master
+[4.0.0-beta.16]: https://github.com/openfun/marsha/compare/v4.0.0-beta.15...v4.0.0-beta.16
 [4.0.0-beta.15]: https://github.com/openfun/marsha/compare/v4.0.0-beta.14...v4.0.0-beta.15
 [4.0.0-beta.14]: https://github.com/openfun/marsha/compare/v4.0.0-beta.13...v4.0.0-beta.14
 [4.0.0-beta.13]: https://github.com/openfun/marsha/compare/v4.0.0-beta.12...v4.0.0-beta.13

--- a/arnold.yml
+++ b/arnold.yml
@@ -1,6 +1,6 @@
 # arnold.yml
 metadata:
   name: marsha
-  version: 4.0.0-beta.13
+  version: 4.0.0-beta.16
 source:
   path: src/tray

--- a/src/aws/lambda-complete/package.json
+++ b/src/aws/lambda-complete/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-complete",
-  "version": "4.0.0-beta.15",
+  "version": "4.0.0-beta.16",
   "engines": {
     "node": "16"
   },

--- a/src/aws/lambda-configure/package.json
+++ b/src/aws/lambda-configure/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-configure",
-  "version": "4.0.0-beta.15",
+  "version": "4.0.0-beta.16",
   "engines": {
     "node": "16"
   },

--- a/src/aws/lambda-convert/package.json
+++ b/src/aws/lambda-convert/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-convert",
-  "version": "4.0.0-beta.15",
+  "version": "4.0.0-beta.16",
   "engines": {
     "node": "16"
   },

--- a/src/aws/lambda-elemental-routing/package.json
+++ b/src/aws/lambda-elemental-routing/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-elemental-routing",
-  "version": "4.0.0-beta.15",
+  "version": "4.0.0-beta.16",
   "engines": {
     "node": "16"
   },

--- a/src/aws/lambda-medialive/package.json
+++ b/src/aws/lambda-medialive/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-medialive",
-  "version": "4.0.0-beta.15",
+  "version": "4.0.0-beta.16",
   "engines": {
     "node": "16"
   },

--- a/src/aws/lambda-mediapackage/package.json
+++ b/src/aws/lambda-mediapackage/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-mediapackage",
-  "version": "4.0.0-beta.15",
+  "version": "4.0.0-beta.16",
   "engines": {
     "node": "16"
   },

--- a/src/aws/lambda-migrate/package.json
+++ b/src/aws/lambda-migrate/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-migrate",
-  "version": "4.0.0-beta.15",
+  "version": "4.0.0-beta.16",
   "engines": {
     "node": "16"
   },

--- a/src/aws/utils/update-state/package.json
+++ b/src/aws/utils/update-state/package.json
@@ -1,7 +1,7 @@
 {
   "author": "France Université Numérique",
   "name": "aws-marsha-update-state",
-  "version": "4.0.0-beta.15",
+  "version": "4.0.0-beta.16",
   "engines": {
     "node": "16"
   },

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = marsha
 description = A FUN video provider for Open edX
-version = 4.0.0-beta.15
+version = 4.0.0-beta.16
 author = Open FUN (France Universite Numerique)
 author_email = fun.dev@fun-mooc.fr
 license = MIT

--- a/src/frontend/apps/lti_site/package.json
+++ b/src/frontend/apps/lti_site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marsha",
-  "version": "4.0.0-beta.15",
+  "version": "4.0.0-beta.16",
   "description": "🐠 a FUN LTI video provider",
   "main": "front/index.tsx",
   "scripts": {

--- a/src/frontend/apps/standalone_site/package.json
+++ b/src/frontend/apps/standalone_site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "standalone_site",
-  "version": "4.0.0-beta.15",
+  "version": "4.0.0-beta.16",
   "license": "MIT",
   "private": true,
   "devDependencies": {

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "common",
-  "version": "4.0.0-beta.15",
+  "version": "4.0.0-beta.16",
   "license": "MIT",
   "private": true,
   "workspaces": {

--- a/src/frontend/packages/lib_classroom/package.json
+++ b/src/frontend/packages/lib_classroom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lib-classroom",
-  "version": "4.0.0-beta.15",
+  "version": "4.0.0-beta.16",
   "license": "MIT",
   "directories": {
     "lib": "lib"

--- a/src/frontend/packages/lib_common/package.json
+++ b/src/frontend/packages/lib_common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lib-common",
-  "version": "4.0.0-beta.15",
+  "version": "4.0.0-beta.16",
   "license": "MIT",
   "directories": {
     "lib": "lib"

--- a/src/frontend/packages/lib_components/package.json
+++ b/src/frontend/packages/lib_components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lib-components",
-  "version": "4.0.0-beta.15",
+  "version": "4.0.0-beta.16",
   "license": "MIT",
   "directories": {
     "lib": "lib"

--- a/src/frontend/packages/lib_markdown/package.json
+++ b/src/frontend/packages/lib_markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lib-markdown",
-  "version": "4.0.0-beta.14",
+  "version": "4.0.0-beta.16",
   "license": "MIT",
   "directories": {
     "lib": "lib"

--- a/src/frontend/packages/lib_tests/package.json
+++ b/src/frontend/packages/lib_tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lib-tests",
-  "version": "4.0.0-beta.15",
+  "version": "4.0.0-beta.16",
   "license": "MIT",
   "directories": {
     "lib": "lib"

--- a/src/frontend/packages/lib_video/package.json
+++ b/src/frontend/packages/lib_video/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lib-video",
-  "version": "4.0.0-beta.15",
+  "version": "4.0.0-beta.16",
   "description": "",
   "license": "ISC",
   "directories": {

--- a/src/tray/tray.yml
+++ b/src/tray/tray.yml
@@ -1,3 +1,3 @@
 metadata:
   name: marsha
-  version: 4.0.0-beta.13
+  version: 4.0.0-beta.16


### PR DESCRIPTION
### Added

- remove lib folder before rollup build to avoid stale files
- Add stats page on VOD
- Create lib-markdown package
- Add a check on timedtexttrack file size when uploading content
- Add a check on deposited file size when uploading content
- helpers frontend api error handling
- Add accepted formats in the subtitles uploaders helptext
- Standalone website:
  - Add "video" management API endpoints permissions
- Add a check on thumbnail file size when uploading content

### Changed

- lti:
  - position modal above tooltip
- mutualize all CronJob in a CronJobList
- make all packages shakeable
- use lib-common theme in LTI
- change docker base image to use a debian lite one
- Allow public resource to be embedded in a iframe

### Fixed

- the Renater IdP sort is case-insensitive
- bug on the textarea description of the live video
- aws fargate loggroup region
- fix recording action buttons style
- student live polling a stopped live beeing restarted