### PR TITLE
Feature/qbey/timed text track permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Allow playlist instructor to manage shared live media through API
+- Allow playlist instructor to manage timed text tracks through API
 
 ## [4.0.0-beta.16] - 2023-02-17
 

--- a/src/backend/marsha/core/api/timed_text_track.py
+++ b/src/backend/marsha/core/api/timed_text_track.py
@@ -51,8 +51,8 @@ class TimedTextTrackViewSet(
             permission_classes = [
                 permissions.IsTokenInstructor
                 | permissions.IsTokenAdmin
+                | permissions.IsParamsVideoAdminOrInstructorThroughPlaylist
                 | permissions.IsParamsVideoAdminThroughOrganization
-                | permissions.IsParamsVideoAdminThroughPlaylist
             ]
         elif self.action in [
             "destroy",
@@ -64,7 +64,7 @@ class TimedTextTrackViewSet(
             permission_classes = [
                 permissions.IsTokenResourceRouteObjectRelatedVideo
                 & (permissions.IsTokenInstructor | permissions.IsTokenAdmin)
-                | permissions.IsRelatedVideoPlaylistAdmin
+                | permissions.IsRelatedVideoPlaylistAdminOrInstructor
                 | permissions.IsRelatedVideoOrganizationAdmin
             ]
         elif self.action is None:

--- a/src/backend/marsha/core/tests/api/timed_text_tracks/test_create.py
+++ b/src/backend/marsha/core/tests/api/timed_text_tracks/test_create.py
@@ -138,7 +138,7 @@ class TimedTextTrackCreateAPITest(TestCase):
         """
         Playlist instructor token user creates a timed text track for a video.
 
-        A user with a user token, who is a playlist instructor, cannot create a timed
+        A user with a user token, who is a playlist instructor, can create a timed
         text track for a video that belongs to that playlist.
         """
         user = factories.UserFactory()
@@ -157,8 +157,22 @@ class TimedTextTrackCreateAPITest(TestCase):
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
-        self.assertEqual(response.status_code, 403)
-        self.assertEqual(TimedTextTrack.objects.count(), 0)
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(TimedTextTrack.objects.count(), 1)
+        self.assertEqual(
+            response.json(),
+            {
+                "id": str(TimedTextTrack.objects.first().id),
+                "active_stamp": None,
+                "is_ready_to_show": False,
+                "mode": "st",
+                "language": "fr",
+                "upload_state": "pending",
+                "source_url": None,
+                "url": None,
+                "video": str(video.id),
+            },
+        )
 
     def test_api_timed_text_track_create_by_video_playlist_admin(self):
         """
@@ -185,9 +199,8 @@ class TimedTextTrackCreateAPITest(TestCase):
 
         self.assertEqual(response.status_code, 201)
         self.assertEqual(TimedTextTrack.objects.count(), 1)
-        content = json.loads(response.content)
         self.assertEqual(
-            content,
+            response.json(),
             {
                 "id": str(TimedTextTrack.objects.first().id),
                 "active_stamp": None,

--- a/src/backend/marsha/core/tests/api/timed_text_tracks/test_delete.py
+++ b/src/backend/marsha/core/tests/api/timed_text_tracks/test_delete.py
@@ -141,7 +141,7 @@ class TimedTextTrackDeleteAPITest(TestCase):
         """
         Playlist instructor token user deletes a timed text track for a video.
 
-        A user with a user token, who is a playlist instructor, cannot delete a timed
+        A user with a user token, who is a playlist instructor, can delete a timed
         text track for a video that belongs to that playlist.
         """
         user = factories.UserFactory()
@@ -162,8 +162,8 @@ class TimedTextTrackDeleteAPITest(TestCase):
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
-        self.assertEqual(response.status_code, 403)
-        self.assertEqual(TimedTextTrack.objects.count(), 1)
+        self.assertEqual(response.status_code, 204)
+        self.assertEqual(TimedTextTrack.objects.count(), 0)
 
     def test_api_timed_text_track_delete_by_video_playlist_admin(self):
         """

--- a/src/backend/marsha/core/tests/api/timed_text_tracks/test_retrieve.py
+++ b/src/backend/marsha/core/tests/api/timed_text_tracks/test_retrieve.py
@@ -361,7 +361,7 @@ class TimedTextTrackRetrieveAPITest(TestCase):
         """
         Playlist instructor token user gets a single timed text track.
 
-        A user with a user token, who is a playlist instructor, cannot get
+        A user with a user token, who is a playlist instructor, can get
         a single timed text track linked to a video in that playlist.
         """
         user = factories.UserFactory()
@@ -371,7 +371,7 @@ class TimedTextTrackRetrieveAPITest(TestCase):
         factories.PlaylistAccessFactory(
             user=user, playlist=playlist, role=models.INSTRUCTOR
         )
-        track = TimedTextTrackFactory(video=video)
+        track = TimedTextTrackFactory(mode="cc", video=video)
 
         jwt_token = UserAccessTokenFactory(user=user)
 
@@ -380,7 +380,21 @@ class TimedTextTrackRetrieveAPITest(TestCase):
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {
+                "active_stamp": None,
+                "id": str(track.id),
+                "is_ready_to_show": False,
+                "language": track.language,
+                "mode": "cc",
+                "source_url": None,
+                "upload_state": "pending",
+                "url": None,
+                "video": str(video.id),
+            },
+        )
 
     def test_api_timed_text_track_read_detail_by_video_playlist_admin(self):
         """

--- a/src/backend/marsha/core/tests/api/timed_text_tracks/test_update.py
+++ b/src/backend/marsha/core/tests/api/timed_text_tracks/test_update.py
@@ -165,7 +165,7 @@ class TimedTextTrackUpdateAPITest(TestCase):
         """
         Playlist instructor token user updates a timed text track.
 
-        A user with a user token, who is a playlist instructor, cannot update
+        A user with a user token, who is a playlist instructor, can update
         a timed text track for a video that belongs to that playlist.
         """
         user = factories.UserFactory()
@@ -183,7 +183,7 @@ class TimedTextTrackUpdateAPITest(TestCase):
             f"/api/timedtexttracks/{track.id}/",
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
-        data = json.loads(response.content)
+        data = response.json()
         data["language"] = "en"
 
         response = self.client.put(
@@ -192,9 +192,9 @@ class TimedTextTrackUpdateAPITest(TestCase):
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             content_type="application/json",
         )
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 200)
         track.refresh_from_db()
-        self.assertEqual(track.language, "fr")
+        self.assertEqual(track.language, "en")
 
     def test_api_timed_text_track_update_by_video_playlist_admin(self):
         """
@@ -218,7 +218,7 @@ class TimedTextTrackUpdateAPITest(TestCase):
             f"/api/timedtexttracks/{track.id}/",
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
-        data = json.loads(response.content)
+        data = response.json()
         data["language"] = "en"
 
         response = self.client.put(


### PR DESCRIPTION
## Purpose

Now playlist administrator/instructors can access playlist's video, we need to update related endpoints.

## Proposal

- [x] Rewrite TimedTextTrackViewSet to look like other updated ViewSet (ie regroup permissions, querysets, ...)
- [x] Add permission for playlist instructor access

