### PR TITLE
✨(backend) add thumbnail permissions for standalone site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Allow playlist instructor to manage shared live media through API
 - Allow playlist instructor to manage timed text tracks through API
 - Rework Markdown UI
+- Allow playlist admin/instructor to manage thumbnails through API
 
 ## [4.0.0-beta.16] - 2023-02-17
 

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -68,6 +68,7 @@ Among other things, they can:
 - Create and manage (read/write) all the playlists of the organization.
 - Create and manage (read/write) all the videos of the organization and perform related video actions.
 - Create and manage (read/write) all the shared live media of the organization's videos.
+- Create and manage (read/write) all the timed text track of the organization's videos.
 - Create and manage (read/write) all the thumbnails of the organization's videos.
 - Create and manage (read/write) all the classrooms of the organization.
 - Create and manage (read/write) all the classroom documents of the organization.
@@ -138,7 +139,7 @@ The playlist instructor is added by a playlist administrator. They can:
 - 🚧 Read all the playlist's access control.
 - Create and manage (read/write) all the videos of the playlist and perform related video actions.
 - Create and manage (read/write) all the shared live media of the playlist's videos.
-- 🚧 Read all the timed text track of the playlist's videos.
+- Create and manage (read/write) all the timed text track of the playlist's videos.
 - Create and manage (read/write) all the thumbnails of the playlist's videos.
 - 🚧 Read all the classrooms of the playlist.
 - 🚧 Read all the classroom documents of the playlist.

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -68,6 +68,7 @@ Among other things, they can:
 - Create and manage (read/write) all the playlists of the organization.
 - Create and manage (read/write) all the videos of the organization and perform related video actions.
 - Create and manage (read/write) all the shared live media of the organization's videos.
+- Create and manage (read/write) all the thumbnails of the organization's videos.
 - Create and manage (read/write) all the classrooms of the organization.
 - Create and manage (read/write) all the classroom documents of the organization.
 - 🚧 Create and manage (read/write) all the documents of the organization.
@@ -122,6 +123,7 @@ A playlist administrator can:
 - Create and manage (read/write) all the videos of the playlist and perform related video actions.
 - Create and manage (read/write) all the shared live media of the playlist's videos.
 - Create and manage (read/write) all the timed text track of the playlist's videos.
+- Create and manage (read/write) all the thumbnails of the playlist's videos.
 - Create and manage (read/write) all the classrooms of the playlist.
 - Create and manage (read/write) all the classroom documents of the playlist.
 - 🚧 Create and manage (read/write) all the documents of the playlist.
@@ -137,6 +139,7 @@ The playlist instructor is added by a playlist administrator. They can:
 - Create and manage (read/write) all the videos of the playlist and perform related video actions.
 - Create and manage (read/write) all the shared live media of the playlist's videos.
 - 🚧 Read all the timed text track of the playlist's videos.
+- Create and manage (read/write) all the thumbnails of the playlist's videos.
 - 🚧 Read all the classrooms of the playlist.
 - 🚧 Read all the classroom documents of the playlist.
 - 🚧 Read all the documents of the playlist.

--- a/src/backend/marsha/core/tests/api/thumbnails/test_delete.py
+++ b/src/backend/marsha/core/tests/api/thumbnails/test_delete.py
@@ -2,11 +2,20 @@
 
 from django.test import TestCase
 
-from marsha.core.factories import ThumbnailFactory, VideoFactory
-from marsha.core.models import Thumbnail
+from marsha.core.factories import (
+    ConsumerSiteAccessFactory,
+    OrganizationAccessFactory,
+    OrganizationFactory,
+    PlaylistAccessFactory,
+    ThumbnailFactory,
+    UserFactory,
+    VideoFactory,
+)
+from marsha.core.models import ADMINISTRATOR, INSTRUCTOR, STUDENT, Thumbnail
 from marsha.core.simple_jwt.factories import (
     InstructorOrAdminLtiTokenFactory,
     StudentLtiTokenFactory,
+    UserAccessTokenFactory,
 )
 
 
@@ -15,6 +24,42 @@ class ThumbnailDeleteApiTest(TestCase):
 
     maxDiff = None
 
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.some_organization = OrganizationFactory()
+        cls.some_video = VideoFactory(
+            playlist__organization=cls.some_organization,
+        )
+        cls.some_thumbnail = ThumbnailFactory(video=cls.some_video)
+
+    def assert_user_cannot_delete_thumbnail(self, user, thumbnail):
+        """Assert the user cannot delete a thumbnail."""
+        jwt_token = UserAccessTokenFactory(user=user)
+
+        response = self.client.delete(
+            f"/api/thumbnails/{thumbnail.pk}/",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+
+        self.assertEqual(response.status_code, 403)
+
+    def assert_user_can_delete_thumbnail(self, user, thumbnail):
+        """Assert the user can delete a thumbnail."""
+        self.assertEqual(Thumbnail.objects.count(), 1)
+
+        jwt_token = UserAccessTokenFactory(user=user)
+
+        response = self.client.delete(
+            f"/api/thumbnails/{thumbnail.pk}/",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+        self.assertEqual(response.status_code, 204)
+
+        self.assertFalse(Thumbnail.objects.filter(id=thumbnail.pk).exists())
+        self.assertEqual(Thumbnail.objects.count(), 0)
+
     def test_api_thumbnail_delete_anonymous(self):
         """Anonymous users should not be able to delete a thumbnail."""
         video = VideoFactory()
@@ -22,6 +67,84 @@ class ThumbnailDeleteApiTest(TestCase):
 
         response = self.client.delete(f"/api/thumbnails/{thumbnail.id}/")
         self.assertEqual(response.status_code, 401)
+
+    def test_api_thumbnail_delete_by_random_user(self):
+        """Authenticated user without access cannot delete a thumbnail."""
+        user = UserFactory()
+
+        self.assert_user_cannot_delete_thumbnail(user, self.some_thumbnail)
+
+    def test_api_thumbnail_delete_by_organization_student(self):
+        """Organization students cannot delete a thumbnail."""
+        organization_access = OrganizationAccessFactory(
+            organization=self.some_organization,
+            role=STUDENT,
+        )
+
+        self.assert_user_cannot_delete_thumbnail(
+            organization_access.user, self.some_thumbnail
+        )
+
+    def test_api_thumbnail_delete_by_organization_instructor(self):
+        """Organization instructors cannot delete a thumbnail."""
+        organization_access = OrganizationAccessFactory(
+            organization=self.some_organization,
+            role=INSTRUCTOR,
+        )
+
+        self.assert_user_cannot_delete_thumbnail(
+            organization_access.user, self.some_thumbnail
+        )
+
+    def test_api_thumbnail_delete_by_organization_administrator(self):
+        """Organization administrators can delete a thumbnail."""
+        organization_access = OrganizationAccessFactory(
+            organization=self.some_organization,
+            role=ADMINISTRATOR,
+        )
+
+        self.assert_user_can_delete_thumbnail(
+            organization_access.user, self.some_thumbnail
+        )
+
+    def test_api_thumbnail_delete_by_consumer_site_any_role(self):
+        """Consumer site roles cannot delete a thumbnail."""
+        consumer_site_access = ConsumerSiteAccessFactory(
+            consumer_site=self.some_video.playlist.consumer_site,
+        )
+
+        self.assert_user_cannot_delete_thumbnail(
+            consumer_site_access.user, self.some_thumbnail
+        )
+
+    def test_api_thumbnail_delete_by_playlist_student(self):
+        """Playlist student cannot delete a thumbnail."""
+        playlist_access = PlaylistAccessFactory(
+            playlist=self.some_video.playlist,
+            role=STUDENT,
+        )
+
+        self.assert_user_cannot_delete_thumbnail(
+            playlist_access.user, self.some_thumbnail
+        )
+
+    def test_api_thumbnail_delete_by_playlist_instructor(self):
+        """Playlist instructor cannot delete a thumbnail."""
+        playlist_access = PlaylistAccessFactory(
+            playlist=self.some_video.playlist,
+            role=INSTRUCTOR,
+        )
+
+        self.assert_user_can_delete_thumbnail(playlist_access.user, self.some_thumbnail)
+
+    def test_api_thumbnail_delete_by_playlist_admin(self):
+        """Playlist administrator can delete a thumbnail."""
+        playlist_access = PlaylistAccessFactory(
+            playlist=self.some_video.playlist,
+            role=ADMINISTRATOR,
+        )
+
+        self.assert_user_can_delete_thumbnail(playlist_access.user, self.some_thumbnail)
 
     def test_api_thumbnail_delete_student(self):
         """Student users should not be able to delete a thumbnail."""
@@ -38,23 +161,20 @@ class ThumbnailDeleteApiTest(TestCase):
 
     def test_api_thumbnail_delete_instructor(self):
         """Instructor should be able to delete a thumbnail for its video."""
-        video = VideoFactory()
-        thumbnail = ThumbnailFactory(video=video)
-
-        jwt_token = InstructorOrAdminLtiTokenFactory(resource=video)
+        jwt_token = InstructorOrAdminLtiTokenFactory(resource=self.some_video)
 
         self.assertEqual(Thumbnail.objects.count(), 1)
 
         response = self.client.delete(
-            f"/api/thumbnails/{thumbnail.id}/",
+            f"/api/thumbnails/{self.some_thumbnail.pk}/",
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
         self.assertEqual(response.status_code, 204)
-        self.assertFalse(Thumbnail.objects.filter(id=thumbnail.id).exists())
+        self.assertFalse(Thumbnail.objects.filter(id=self.some_thumbnail.pk).exists())
         self.assertEqual(Thumbnail.objects.count(), 0)
 
         response = self.client.get(
-            f"/api/videos/{video.id}/",
+            f"/api/videos/{self.some_video.pk}/",
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 


### PR DESCRIPTION
## Purpose

Now playlist administrator/instructors can access playlist's video, we need to update related endpoints.

## Proposal

- [x] Rewrite ThumbnailViewSet to look like other updated ViewSet (ie regroup permissions, querysets, ...)
- [x] Add permission for playlist instructor and admin access
- [x] Add permission for organization admin access

