### PR TITLE
Chat sync bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Rework Markdown UI
 - Allow playlist admin/instructor to manage thumbnails through API
 
+### Fixed
+
+- Bug on chat messages synchronisation
+
 ## [4.0.0-beta.16] - 2023-02-17
 
 ### Added

--- a/src/frontend/packages/lib_video/src/components/live/common/Chat/ChatConversationDisplayer/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/live/common/Chat/ChatConversationDisplayer/index.spec.tsx
@@ -46,6 +46,30 @@ describe('<ChatConversationDisplayer />', () => {
     }
   });
 
+  it('displays correctly message history group.', () => {
+    render(<ChatConversationDisplayer />);
+
+    for (let i = 0; i < 5; i++) {
+      act(() =>
+        useChatItemState.getState().addMessage({
+          content: `This is example message n°${i}`,
+          sender: `John Doe`,
+          sentAt: DateTime.fromISO(`2020-01-01T12:10:1${i}`),
+        }),
+      );
+    }
+
+    expect(screen.getByText(`John Doe`)).toBeInTheDocument();
+    expect(screen.getByText(`(12:10)`)).toBeInTheDocument();
+    expect(screen.getByText(`This is example message n°0`)).toBeInTheDocument();
+
+    for (let i = 1; i < 5; i++) {
+      expect(
+        screen.getByText(`This is example message n°${i}`),
+      ).toBeInTheDocument();
+    }
+  });
+
   it('scrolls down to bottom, when scroll bar is previously set to bottom.', () => {
     render(<ChatConversationDisplayer />);
 

--- a/src/frontend/packages/lib_video/src/components/live/common/Chat/ChatMessageGroupItem/index.tsx
+++ b/src/frontend/packages/lib_video/src/components/live/common/Chat/ChatMessageGroupItem/index.tsx
@@ -1,5 +1,5 @@
 import { Box } from 'grommet';
-import React, { useMemo } from 'react';
+import React from 'react';
 
 import { ChatMessageGroupType } from 'hooks/useChatItemsStore';
 
@@ -14,26 +14,22 @@ export const ChatMessageGroupItem = ({
   msgGroup,
 }: ChatMessageGroupItemProps) => {
   const firstMessage = msgGroup.messages[0];
-  const memo = useMemo(
-    () => (
-      <Box
-        margin={{
-          vertical: '5px',
-          horizontal: '20px',
-        }}
-      >
-        <ChatMessageMetadatas
-          msgDatetime={firstMessage.sentAt}
-          msgSender={msgGroup.sender}
-        />
-        <Box gap="5px">
-          {msgGroup.messages.map((msg, index) => (
-            <ChatMessage key={index} message={msg} />
-          ))}
-        </Box>
+  return (
+    <Box
+      margin={{
+        vertical: '5px',
+        horizontal: '20px',
+      }}
+    >
+      <ChatMessageMetadatas
+        msgDatetime={firstMessage.sentAt}
+        msgSender={msgGroup.sender}
+      />
+      <Box gap="5px">
+        {msgGroup.messages.map((msg, index) => (
+          <ChatMessage key={index} message={msg} />
+        ))}
       </Box>
-    ),
-    [firstMessage.sentAt, msgGroup.sender, msgGroup.messages],
+    </Box>
   );
-  return memo;
 };


### PR DESCRIPTION
## Purpose

See issue https://github.com/openfun/marsha/issues/2025

> Problematic Behavior : During a webinar, messages seem to not be sent in real-time on the chat. You usually have to refresh the page to view them.

Actually there is no need to refresh, but just to reload and update the component in charge of adding messages to groups. This happens when the same user sends a message right after its last one.

## Proposal

I added these prints to the ChatMessageGroupItem component to see if sending a new message would trigger the component update :

```
useEffect(() => {
    console.log(
      'Messages length triggered by length : ',
      msgGroup.messages.length,
    );
  }, [msgGroup.messages.length]);

  useEffect(() => {
    console.log(
      'Messages length triggered by messages : ',
      msgGroup.messages.length,
    );
  }, [msgGroup.messages]);
```

The first one printed a message each time I wrote into the chat. The second one was only triggered at a new ChatGroup creation.
So in the next useMemo function, I added the right trigger to update the component.

