### PR TITLE
🐛(backend) allow timed text tracks OPTIONS

### DIFF
--- a/src/backend/marsha/core/api/timed_text_track.py
+++ b/src/backend/marsha/core/api/timed_text_track.py
@@ -46,7 +46,7 @@ class TimedTextTrackViewSet(
     def get_permissions(self):
         """Instantiate and return the list of permissions that this view requires."""
         if self.action == "metadata":
-            permission_classes = [permissions.ResourceIsAuthenticated]
+            permission_classes = [permissions.UserOrResourceIsAuthenticated]
         elif self.action in ["create", "list"]:
             permission_classes = [
                 permissions.IsTokenInstructor


### PR DESCRIPTION
## Purpose

Allow standalone users to make an OPTIONS call to the timed text track API.

This was missed in the API migration to standalone access.

## Proposal

- [x] Allow OPTIONS call to all authenticated users


