### PR TITLE
🚧(refacto) use nested video route

### DIFF
--- a/src/backend/marsha/core/api/timed_text_track.py
+++ b/src/backend/marsha/core/api/timed_text_track.py
@@ -84,10 +84,8 @@ class TimedTextTrackViewSet(
         if self.request.resource:  # aka we are authenticated through LTI
             queryset = queryset.filter(video__id=self.request.resource.id)
 
-        # Otherwise, we are authenticated through a user JWT.
-        # Filtering is currently not necessary as permissions enforce
-        # a "video" parameter to be present in the request.
-        # See `IsParamsVideoAdminThrough*` permissions.
+        else:
+            queryset = queryset.filter(video__id=self.kwargs["video_id"])
 
         return queryset
 

--- a/src/backend/marsha/core/permissions.py
+++ b/src/backend/marsha/core/permissions.py
@@ -410,10 +410,9 @@ class IsParamsVideoAdminThroughOrganization(permissions.BasePermission):
         the current logged in user is one of the administrators of the organization to which
         this video's playlist belongs.
         """
-        video_id = request.data.get("video") or request.query_params.get("video")
         return models.OrganizationAccess.objects.filter(
             role=ADMINISTRATOR,
-            organization__playlists__videos__id=video_id,
+            organization__playlists__videos__id=view.kwargs["video_id"],
             user__id=request.user.id,
         ).exists()
 
@@ -432,10 +431,9 @@ class BaseIsParamsVideoRoleThroughPlaylist(permissions.BasePermission):
         the current logged in user has a specific role of the playlist to which
         this video belongs.
         """
-        video_id = request.data.get("video") or request.query_params.get("video")
         return models.PlaylistAccess.objects.filter(
             **self.role_filter,
-            playlist__videos__id=video_id,
+            playlist__videos__id=view.kwargs["video_id"],
             user__id=request.user.id,
         ).exists()
 

--- a/src/backend/marsha/urls.py
+++ b/src/backend/marsha/urls.py
@@ -56,11 +56,6 @@ router.register(
     LiveSessionViewSet,
     basename="live_sessions",
 )
-router.register(
-    models.TimedTextTrack.RESOURCE_NAME,
-    TimedTextTrackViewSet,
-    basename="timed_text_tracks",
-)
 router.register(models.Thumbnail.RESOURCE_NAME, ThumbnailViewSet, basename="thumbnails")
 router.register("organizations", OrganizationViewSet, basename="organizations")
 router.register("playlists", PlaylistViewSet, basename="playlists")
@@ -78,6 +73,13 @@ router.register(
     models.SharedLiveMedia.RESOURCE_NAME,
     SharedLiveMediaViewSet,
     basename="sharedlivemedias",
+)
+
+video_related_router = DefaultRouter()
+video_related_router.register(
+    models.TimedTextTrack.RESOURCE_NAME,
+    TimedTextTrackViewSet,
+    basename="timed_text_tracks",
 )
 
 urlpatterns = [
@@ -119,6 +121,10 @@ urlpatterns = [
         name="recording_slices_state",
     ),
     path("api/", include(router.urls)),
+    path(
+        f"api/{models.Video.RESOURCE_NAME}/<str:video_id>/",
+        include(video_related_router.urls),
+    ),
     path(
         "reminders/cancel/<str:pk>/<str:key>",
         RemindersCancelView.as_view(),


### PR DESCRIPTION
## Purpose

This is an example of video related objects API route nesting.

Only the timedtexttracks API has been changed and only the related `test_list.py` updated

## Proposal



