### PR TITLE
🐛(LTI) manage deleted video

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- redirect to error page when VOD is deleted
+
 ## [4.0.0-beta.18] - 2023-03-06
 
 ### Changed

--- a/src/frontend/apps/lti_site/components/RedirectOnLoad/RedirectVideo.spec.tsx
+++ b/src/frontend/apps/lti_site/components/RedirectOnLoad/RedirectVideo.spec.tsx
@@ -217,6 +217,44 @@ describe('RedirectVideo', () => {
     screen.getByText('Error Component: notFound');
   });
 
+  it('redirects to the error view when the video is deleted', () => {
+    mockedUseCurrentResourceContext.mockReturnValue([
+      {
+        permissions: {
+          can_update: false,
+        },
+      },
+    ] as any);
+    const video = videoMockFactory({
+      upload_state: uploadState.DELETED,
+      is_ready_to_show: false,
+    });
+
+    render(<RedirectVideo video={video} />, {
+      routerOptions: {
+        routes: [
+          {
+            path: DASHBOARD_ROUTE(modelName.VIDEOS),
+            render: () => <span>dashboard</span>,
+          },
+          {
+            path: FULL_SCREEN_ERROR_ROUTE(),
+            render: ({ match }) => (
+              <span>{`Error Component: ${match.params.code}`}</span>
+            ),
+          },
+          {
+            path: PLAYER_ROUTE(modelName.VIDEOS),
+            render: () => <span>video player</span>,
+          },
+          { path: VIDEO_WIZARD_ROUTE(), render: () => <span>wizard</span> },
+        ],
+      },
+    });
+
+    screen.getByText('Error Component: videoDeleted');
+  });
+
   it('redirects to the player view when the starting date is set to past', () => {
     const startingAtPast = new Date();
     startingAtPast.setFullYear(startingAtPast.getFullYear() - 10);

--- a/src/frontend/apps/lti_site/components/RedirectOnLoad/RedirectVideo.tsx
+++ b/src/frontend/apps/lti_site/components/RedirectOnLoad/RedirectVideo.tsx
@@ -22,6 +22,11 @@ interface RedirectVideoProps {
 export const RedirectVideo = ({ video }: RedirectVideoProps) => {
   const [context] = useCurrentResourceContext();
 
+  if (video.upload_state === uploadState.DELETED) {
+    // A deleted video cannot be used
+    return <Redirect push to={FULL_SCREEN_ERROR_ROUTE('videoDeleted')} />;
+  }
+
   if (
     (video.live_type ||
       video.is_ready_to_show ||

--- a/src/frontend/apps/lti_site/components/RedirectOnLoad/index.spec.tsx
+++ b/src/frontend/apps/lti_site/components/RedirectOnLoad/index.spec.tsx
@@ -93,7 +93,8 @@ describe('<RedirectOnLoad />', () => {
   });
 
   it('redirects users to the player when the video can be shown', () => {
-    for (const state of Object.values(uploadState)) {
+    const { DELETED: _deleted, ...displayableUploadState } = uploadState;
+    for (const state of Object.values(displayableUploadState)) {
       mockedUseAppConfig.mockReturnValue({
         state: appState.SUCCESS,
         video: { is_ready_to_show: true, upload_state: state },


### PR DESCRIPTION
## Purpose

When a video object has the value deleted in the upload_state, we want to display a page explaining that this video is not available anymore

## Proposal

Redirect to an appropriate error page when we detect that upload_state has the value deleted.

- [x] redirect to an error page

