### PR TITLE
add refresh token in the challenge response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Bug on chat messages synchronisation
 - Static files exclusion
 - Impossible to decode JWT token, there is no jwt to decode
+- Add refresh token in the challenge response
 
 ### Removed
 

--- a/src/backend/marsha/core/serializers/account.py
+++ b/src/backend/marsha/core/serializers/account.py
@@ -8,7 +8,7 @@ from rest_framework_simplejwt.serializers import TokenVerifySerializer
 from rest_framework_simplejwt.settings import api_settings
 
 from ..models import ConsumerSite, Organization, OrganizationAccess
-from ..simple_jwt.tokens import ChallengeToken, LTIUserToken, UserAccessToken
+from ..simple_jwt.tokens import ChallengeToken, LTIUserToken, UserRefreshToken
 from .base import ReadOnlyModelSerializer
 
 
@@ -22,13 +22,14 @@ class ChallengeTokenSerializer(TokenVerifySerializer):
         token = ChallengeToken(attrs["token"])
 
         try:
-            user_access_token = UserAccessToken.for_user_id(
+            user_refresh_token = UserRefreshToken.for_user_id(
                 token.payload[api_settings.USER_ID_CLAIM],
             )
         except KeyError as exc:
             raise TokenError(exc.args[0]) from exc
 
-        data["access"] = str(user_access_token)
+        data["refresh"] = str(user_refresh_token)
+        data["access"] = str(user_refresh_token.access_token)
 
         return data
 

--- a/src/backend/marsha/core/simple_jwt/tokens.py
+++ b/src/backend/marsha/core/simple_jwt/tokens.py
@@ -465,21 +465,11 @@ class LTIUserToken(AccessToken):
         return token
 
 
-class UserAccessToken(AccessToken):
+class UserTokenMixin:
     """
-    User access JWT.
-
-    For now, we stay with the same attributes as the original AccessToken for
-    backward compatibility:
-    ```
-        token_type = "access"
-        lifetime = api_settings.ACCESS_TOKEN_LIFETIME
-    ```
-
-    Note: `api_settings.USER_ID_CLAIM` is currently `resource_id`.
+    Methods dedicated to user JWT. They are both used by the UserAccessToken
+    and the UserRefreshToken classes.
     """
-
-    token_type = "user_access"  # nosec
 
     @classmethod
     def for_user_id(cls, user_id):
@@ -505,6 +495,21 @@ class UserAccessToken(AccessToken):
         token.payload["user_id"] = user_id
         return token
 
+
+class UserAccessToken(UserTokenMixin, AccessToken):
+    """
+    User access JWT.
+
+    For now, we stay with the same attributes as the original AccessToken for
+    backward compatibility:
+    ```
+        token_type = "access"
+        lifetime = api_settings.ACCESS_TOKEN_LIFETIME
+    ```
+    """
+
+    token_type = "user_access"  # nosec
+
     def verify(self):
         """Performs additional validation steps to test payload content."""
         super().verify()
@@ -513,7 +518,7 @@ class UserAccessToken(AccessToken):
             raise TokenError(_("Malformed user token"))
 
 
-class UserRefreshToken(MarshaRefreshToken):
+class UserRefreshToken(UserTokenMixin, MarshaRefreshToken):
     """Refresh token for user authentication, which relies on our own `UserAccessToken`."""
 
     access_token_class = UserAccessToken

--- a/src/backend/marsha/core/tests/test_api_challenge_token.py
+++ b/src/backend/marsha/core/tests/test_api_challenge_token.py
@@ -3,7 +3,7 @@
 from django.test import TestCase
 
 from marsha.core.simple_jwt.factories import ChallengeTokenFactory
-from marsha.core.simple_jwt.tokens import ChallengeToken, UserAccessToken
+from marsha.core.simple_jwt.tokens import ChallengeToken, UserAccessToken, UserRefreshToken
 
 
 class ChallengeAuthenticationViewTestCase(TestCase):
@@ -31,7 +31,9 @@ class ChallengeAuthenticationViewTestCase(TestCase):
         )
         self.assertEqual(response.status_code, 200)
 
-        access_token = response.json()["access"]
-        user_token = UserAccessToken(access_token)
+        response_data = response.json()
+        # Verify tokens
+        user_token = UserAccessToken(response_data["access"])
+        UserRefreshToken(response_data["refresh"])
 
         self.assertEqual(user_token.payload["user_id"], challenge.payload["user_id"])

--- a/src/backend/marsha/core/tests/test_api_challenge_token.py
+++ b/src/backend/marsha/core/tests/test_api_challenge_token.py
@@ -3,7 +3,11 @@
 from django.test import TestCase
 
 from marsha.core.simple_jwt.factories import ChallengeTokenFactory
-from marsha.core.simple_jwt.tokens import ChallengeToken, UserAccessToken, UserRefreshToken
+from marsha.core.simple_jwt.tokens import (
+    ChallengeToken,
+    UserAccessToken,
+    UserRefreshToken,
+)
 
 
 class ChallengeAuthenticationViewTestCase(TestCase):

--- a/src/frontend/apps/standalone_site/src/__mock__/fetchMockAuth.mock.ts
+++ b/src/frontend/apps/standalone_site/src/__mock__/fetchMockAuth.mock.ts
@@ -10,7 +10,10 @@ jest.mock('react-router-dom', () => ({
 }));
 
 export default () => {
-  fetchMock.post('/api/auth/challenge/', { access: 'some-access' });
+  fetchMock.post('/api/auth/challenge/', {
+    access: 'some-access',
+    refresh: 'some-refresh',
+  });
   fetchMock.get('/api/users/whoami/', {
     date_joined: 'date_joined',
     email: 'email',

--- a/src/frontend/apps/standalone_site/src/features/Authentication/api/validateChallenge/index.spec.ts
+++ b/src/frontend/apps/standalone_site/src/features/Authentication/api/validateChallenge/index.spec.ts
@@ -25,8 +25,12 @@ describe('validateChallenge()', () => {
   });
 
   it('returns the access token', async () => {
-    fetchMock.post('/api/auth/challenge/', { access: 'some access token' });
+    const tokenPair = {
+      access: 'some access token',
+      refresh: 'some refresh token',
+    };
+    fetchMock.post('/api/auth/challenge/', tokenPair);
 
-    expect(await validateChallenge('some_code')).toEqual('some access token');
+    expect(await validateChallenge('some_code')).toEqual(tokenPair);
   });
 });

--- a/src/frontend/apps/standalone_site/src/features/Authentication/api/validateChallenge/index.ts
+++ b/src/frontend/apps/standalone_site/src/features/Authentication/api/validateChallenge/index.ts
@@ -1,15 +1,15 @@
-import { fetchWrapper } from 'lib-components';
+import { fetchWrapper, TokenResponse } from 'lib-components';
 
-interface ValidateChallengeResponse {
-  access: string;
-}
-
-const isValidateChallenge = (
-  response: unknown,
-): response is ValidateChallengeResponse => {
+const isValidateChallenge = (response: unknown): response is TokenResponse => {
   if (response && typeof response === 'object') {
-    const access: unknown = (response as ValidateChallengeResponse).access;
-    if (access && typeof access === 'string') {
+    const access: unknown = (response as TokenResponse).access;
+    const refresh: unknown = (response as TokenResponse).refresh;
+    if (
+      access &&
+      typeof access === 'string' &&
+      refresh &&
+      typeof refresh === 'string'
+    ) {
       return true;
     }
   }
@@ -32,7 +32,7 @@ export const validateChallenge = async (token: string) => {
 
   const responseContent: unknown = await response.json();
   if (isValidateChallenge(responseContent)) {
-    return responseContent.access;
+    return responseContent;
   }
 
   throw new Error('Missing access token in response.');

--- a/src/frontend/apps/standalone_site/src/features/Authentication/components/Authenticator.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Authentication/components/Authenticator.spec.tsx
@@ -81,7 +81,10 @@ describe('<Authenticator />', () => {
     expect(screen.getByRole('status')).toBeInTheDocument();
 
     //  resolve challenge
-    challengeDeferred.resolve({ access: 'some-access' });
+    challengeDeferred.resolve({
+      access: 'some-access',
+      refresh: 'some-refresh',
+    });
 
     await waitFor(() =>
       expect(fetchMock.lastCall()![0]).toEqual('/api/users/whoami/'),
@@ -115,7 +118,10 @@ describe('<Authenticator />', () => {
       screen.queryByText('/some/other/path/?some=query'),
     ).not.toBeInTheDocument();
 
-    fetchMock.post('/api/auth/challenge/', { access: 'some-access' });
+    fetchMock.post('/api/auth/challenge/', {
+      access: 'some-access',
+      refresh: 'some-refresh',
+    });
 
     fetchMock.get('/api/users/whoami/', {
       date_joined: 'date_joined',
@@ -150,7 +156,10 @@ describe('<Authenticator />', () => {
 
     expect(screen.getByText('login page')).toBeInTheDocument();
 
-    fetchMock.post('/api/auth/challenge/', { access: 'some-access2' });
+    fetchMock.post('/api/auth/challenge/', {
+      access: 'some-access2',
+      refresh: 'some-refresh2',
+    });
 
     fetchMock.get('/api/users/whoami/', {
       date_joined: 'date_joined',
@@ -161,6 +170,9 @@ describe('<Authenticator />', () => {
       is_superuser: false,
       organization_accesses: [],
     });
+
+    // refresh token url is called and should return a 401 to be redirected to the login page
+    fetchMock.mock('/account/api/token/refresh/', 401);
 
     //  unmount components to mock the redirection after authentication (and init the new location)
     //  this is mandatory to take the new location.search into account

--- a/src/frontend/apps/standalone_site/src/features/Authentication/components/Authenticator.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Authentication/components/Authenticator.tsx
@@ -33,7 +33,7 @@ export const Authenticator = ({ children }: PropsWithChildren<unknown>) => {
     currentUser: state.currentUser,
     setCurrentUser: state.setCurrentUser,
   }));
-  const { jwt, setJwt, resetJwt } = useJwt();
+  const { jwt, setJwt, setRefreshJwt, resetJwt } = useJwt();
 
   useEffect(() => {
     if (jwt) {
@@ -41,7 +41,9 @@ export const Authenticator = ({ children }: PropsWithChildren<unknown>) => {
     }
 
     const fetchJwt = async (validationToken: string) => {
-      setJwt(await validateChallenge(validationToken));
+      const response = await validateChallenge(validationToken);
+      setJwt(response.access);
+      setRefreshJwt(response.refresh);
     };
 
     if (code) {
@@ -50,7 +52,7 @@ export const Authenticator = ({ children }: PropsWithChildren<unknown>) => {
       getLocalStorage()?.setItem(TARGET_URL_STORAGE_KEY, pathname + search);
       history.push(routes.LOGIN.path);
     }
-  }, [code, history, jwt, pathname, search, setJwt]);
+  }, [code, history, jwt, pathname, search, setJwt, setRefreshJwt]);
 
   useEffect(() => {
     if (!jwt || currentUser) {


### PR DESCRIPTION
## Purpose

The response for the challenge request was not returning a refresh token
but only an access one. Every user connecting with shibboleth have no
refresh token and are deconnected fron the standalone site once the
access token is expired. So fix this, the challenge response has now a
refresh token.

## Proposal

- [x] add refresh token in the challenge response
- [x] manage refresh token in challenge response
