### PR TITLE
🐛(frontend) fix rounded button style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- rounded button style (#2118)
 
 ### Changed
 

--- a/src/frontend/packages/lib_common/src/theme.ts
+++ b/src/frontend/packages/lib_common/src/theme.ts
@@ -132,19 +132,21 @@ export const theme: ThemeType = {
   button: {
     default: {
       background: { color: 'white' },
-      border: { color: 'brand', width: '1px' },
+      border: { color: 'brand', width: '1px', radius: '4px' },
       color: 'blue-active',
       padding: { vertical: 'xsmall', horizontal: 'small' },
     },
     primary: {
       background: { color: 'blue-button' },
-      border: undefined,
+      border: {
+        radius: '4px',
+      },
       color: 'white',
       padding: { vertical: 'small', horizontal: 'medium' },
     },
     secondary: {
       background: { color: 'transparent' },
-      border: { color: 'brand', width: '1px' },
+      border: { color: 'brand', width: '1px', radius: '4px' },
       color: 'blue-active',
       padding: { vertical: 'xsmall', horizontal: 'small' },
     },


### PR DESCRIPTION
## Purpose

After the Grommet upgrade v2.30.0, some buttons were rounded. It seems that some global theme properties are not overloaded correctly anymore.
In this case, if a button has a `primary` prop, only the base button properties plus the `primary` properties are applied,
 the global button `properties` are not applied.

