### PR TITLE
🐛(website) fix disconnection when multiple tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - redirect to error page when VOD is deleted
+- Manage disconnection when multiple tabs were open on standalone site
 
 ## [4.0.0-beta.18] - 2023-03-06
 

--- a/src/frontend/apps/lti_site/apps/.cookiecutter/{{cookiecutter.app_name}}/data/queries/index.spec.tsx
+++ b/src/frontend/apps/lti_site/apps/.cookiecutter/{{cookiecutter.app_name}}/data/queries/index.spec.tsx
@@ -23,9 +23,7 @@ let Wrapper: WrapperComponent<Element>;
 
 describe('queries', () => {
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
 
     const queryClient = new QueryClient({
       defaultOptions: {

--- a/src/frontend/apps/lti_site/apps/deposit/api/useDepositedFileMetadata/index.spec.tsx
+++ b/src/frontend/apps/lti_site/apps/deposit/api/useDepositedFileMetadata/index.spec.tsx
@@ -23,9 +23,7 @@ let Wrapper: WrapperComponent<Element>;
 
 describe('useDepositedFileMetadata', () => {
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
 
     const queryClient = new QueryClient({
       defaultOptions: {

--- a/src/frontend/apps/lti_site/apps/deposit/data/queries/index.spec.tsx
+++ b/src/frontend/apps/lti_site/apps/deposit/data/queries/index.spec.tsx
@@ -27,9 +27,7 @@ let Wrapper: WrapperComponent<Element>;
 
 describe('queries', () => {
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
 
     const queryClient = new QueryClient({
       defaultOptions: {

--- a/src/frontend/apps/lti_site/apps/deposit/data/sideEffects/createDepositedFile/index.ts
+++ b/src/frontend/apps/lti_site/apps/deposit/data/sideEffects/createDepositedFile/index.ts
@@ -14,7 +14,7 @@ export const createDepositedFile = async (file: {
     `${API_ENDPOINT}/${modelName.DepositedFiles}/`,
     {
       headers: {
-        Authorization: `Bearer ${useJwt.getState().jwt}`,
+        Authorization: `Bearer ${useJwt.getState().getJwt()}`,
         'Content-Type': 'application/json',
       },
       method: 'POST',

--- a/src/frontend/apps/lti_site/apps/markdown/components/RedirectOnLoad/index.spec.tsx
+++ b/src/frontend/apps/lti_site/apps/markdown/components/RedirectOnLoad/index.spec.tsx
@@ -37,9 +37,7 @@ const mockedUseCurrentResourceContext =
 
 describe('<RedirectOnLoad />', () => {
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
   });
 
   afterEach(() => {

--- a/src/frontend/apps/lti_site/apps/markdown/components/RedirectOnLoad/index.tsx
+++ b/src/frontend/apps/lti_site/apps/markdown/components/RedirectOnLoad/index.tsx
@@ -47,7 +47,7 @@ export const RedirectOnLoad = ({
   }
 
   // Deal with missing JWT (the resource may be not available yet)
-  if (!useJwt.getState().jwt) {
+  if (!useJwt.getState().getJwt()) {
     return <Redirect push to={MARKDOWN_NOT_FOUND_ROUTE()} />;
   }
 

--- a/src/frontend/apps/lti_site/components/App/AppContentLoader/index.tsx
+++ b/src/frontend/apps/lti_site/components/App/AppContentLoader/index.tsx
@@ -62,7 +62,7 @@ const AppContent = () => {
   else throw new Error(intlShape.formatMessage(messages.errorAppSet));
 
   const decodedJwt = useMemo(() => {
-    const jwt = useJwt.getState().jwt;
+    const jwt = useJwt.getState().getJwt();
     if (jwt) {
       return useJwt.getState().getDecodedJwt();
     }
@@ -100,7 +100,7 @@ const AppContentLoader = () => {
 
   //  load it from the store to prevent having a dependency and recompute decodedJwt
   const decodedJwt = useMemo(() => {
-    const jwt = useJwt.getState().jwt;
+    const jwt = useJwt.getState().getJwt();
     if (jwt) {
       setIsLoaded(true);
       return useJwt.getState().getDecodedJwt();

--- a/src/frontend/apps/lti_site/components/App/AppInitializer/index.spec.tsx
+++ b/src/frontend/apps/lti_site/components/App/AppInitializer/index.spec.tsx
@@ -53,8 +53,8 @@ describe('<AppInitializer />', () => {
     expect(useDocument.getState().documents).toEqual({});
     expect(useAttendance.getState().delay).toEqual(10000);
     expect(useMaintenance.getState().isActive).toEqual(false);
-    expect(useJwt.getState().jwt).toBeUndefined();
-    expect(useJwt.getState().refreshJwt).toBeUndefined();
+    expect(useJwt.getState().getJwt()).toBeUndefined();
+    expect(useJwt.getState().getRefreshJwt()).toBeUndefined();
 
     render(
       <AppInitializer jwt="jwt" refresh_token="refresh_token">
@@ -82,7 +82,7 @@ describe('<AppInitializer />', () => {
     });
     expect(useAttendance.getState().delay).toEqual(6);
     expect(useMaintenance.getState().isActive).toEqual(true);
-    expect(useJwt.getState().jwt).toEqual('jwt');
-    expect(useJwt.getState().refreshJwt).toEqual('refresh_token');
+    expect(useJwt.getState().getJwt()).toEqual('jwt');
+    expect(useJwt.getState().getRefreshJwt()).toEqual('refresh_token');
   });
 });

--- a/src/frontend/apps/lti_site/data/queries/index.spec.tsx
+++ b/src/frontend/apps/lti_site/data/queries/index.spec.tsx
@@ -40,9 +40,7 @@ let Wrapper: WrapperComponent<Element>;
 
 describe('queries', () => {
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
 
     const queryClient = new QueryClient({
       defaultOptions: {

--- a/src/frontend/apps/lti_site/data/sideEffects/deleteTimedTextTrack/index.spec.ts
+++ b/src/frontend/apps/lti_site/data/sideEffects/deleteTimedTextTrack/index.spec.ts
@@ -5,9 +5,7 @@ import { deleteTimedTextTrack } from '.';
 
 describe('sideEffects/deleteTimedTextTrack', () => {
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
   });
 
   afterEach(() => fetchMock.restore());

--- a/src/frontend/apps/lti_site/data/sideEffects/deleteTimedTextTrack/index.ts
+++ b/src/frontend/apps/lti_site/data/sideEffects/deleteTimedTextTrack/index.ts
@@ -15,7 +15,7 @@ export const deleteTimedTextTrack = async (timedtexttrack: TimedText) => {
     `${API_ENDPOINT}/${modelName.TIMEDTEXTTRACKS}/${timedtexttrack.id}/`,
     {
       headers: {
-        Authorization: `Bearer ${useJwt.getState().jwt}`,
+        Authorization: `Bearer ${useJwt.getState().getJwt()}`,
       },
       method: 'DELETE',
     },

--- a/src/frontend/apps/lti_site/data/sideEffects/getResourceList/index.spec.tsx
+++ b/src/frontend/apps/lti_site/data/sideEffects/getResourceList/index.spec.tsx
@@ -33,9 +33,7 @@ describe('sideEffects/getResourceList', () => {
   });
 
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
   });
 
   afterEach(() => fetchMock.restore());

--- a/src/frontend/apps/lti_site/data/sideEffects/getResourceList/index.ts
+++ b/src/frontend/apps/lti_site/data/sideEffects/getResourceList/index.ts
@@ -29,7 +29,7 @@ export const getResourceList = async (
       `${endpoint}?limit=${params.limit}&offset=${params.offset}`,
       {
         headers: {
-          Authorization: `Bearer ${useJwt.getState().jwt}`,
+          Authorization: `Bearer ${useJwt.getState().getJwt()}`,
           'Content-Type': 'application/json',
         },
       },

--- a/src/frontend/apps/lti_site/data/sideEffects/pollForTrack/index.spec.tsx
+++ b/src/frontend/apps/lti_site/data/sideEffects/pollForTrack/index.spec.tsx
@@ -21,10 +21,7 @@ jest.mock('lib-components', () => ({
 
 describe('sideEffects/pollForTrack', () => {
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
-
+    useJwt.getState().setJwt('some token');
     jest.clearAllMocks();
     jest.useFakeTimers();
   });

--- a/src/frontend/apps/lti_site/data/sideEffects/pollForTrack/index.tsx
+++ b/src/frontend/apps/lti_site/data/sideEffects/pollForTrack/index.tsx
@@ -24,7 +24,7 @@ export async function pollForTrack<
       `${API_ENDPOINT}/${resourceName}/${resourceId}/`,
       {
         headers: {
-          Authorization: `Bearer ${useJwt.getState().jwt}`,
+          Authorization: `Bearer ${useJwt.getState().getJwt()}`,
         },
       },
     );

--- a/src/frontend/apps/standalone_site/src/features/Authentication/api/basicLogin/index.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Authentication/api/basicLogin/index.spec.tsx
@@ -74,7 +74,7 @@ describe('features/Authentication/api/basicLogin', () => {
       });
       expect(result.current.status).toEqual('success');
 
-      const jwt = useJwt.getState().jwt;
+      const jwt = useJwt.getState().getJwt();
       expect(jwt).toEqual('some access token');
     });
 

--- a/src/frontend/apps/standalone_site/src/features/Authentication/api/logout/index.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Authentication/api/logout/index.spec.tsx
@@ -17,15 +17,15 @@ describe('logout()', () => {
     fetchMock.post('/account/api/logout/', 500);
 
     await expect(logout()).rejects.toThrow('Fail to logout user.');
-    expect(useJwt.getState().jwt).toEqual(undefined);
-    expect(useJwt.getState().refreshJwt).toEqual(undefined);
+    expect(useJwt.getState().getJwt()).toEqual(undefined);
+    expect(useJwt.getState().getRefreshJwt()).toEqual(undefined);
   });
 
   it('clear jwt store on success', async () => {
     fetchMock.post('/account/api/logout/', 200);
 
     await expect(logout()).resolves.toEqual(undefined);
-    expect(useJwt.getState().jwt).toEqual(undefined);
-    expect(useJwt.getState().refreshJwt).toEqual(undefined);
+    expect(useJwt.getState().getJwt()).toEqual(undefined);
+    expect(useJwt.getState().getRefreshJwt()).toEqual(undefined);
   });
 });

--- a/src/frontend/apps/standalone_site/src/features/Authentication/api/logout/index.ts
+++ b/src/frontend/apps/standalone_site/src/features/Authentication/api/logout/index.ts
@@ -1,7 +1,7 @@
 import { fetchWrapper, useJwt } from 'lib-components';
 
 export const logout = async () => {
-  const refreshToken = useJwt.getState().refreshJwt;
+  const refreshToken = useJwt.getState().getRefreshJwt();
   useJwt.getState().resetJwt();
 
   const response = await fetchWrapper('/account/api/logout/', {

--- a/src/frontend/apps/standalone_site/src/features/Authentication/components/Login.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Authentication/components/Login.spec.tsx
@@ -49,9 +49,9 @@ describe('<Login />', () => {
     render(<Login />);
 
     await waitFor(() => {
-      expect(useJwt.getState().jwt).toBe('my access');
+      expect(useJwt.getState().getJwt()).toBe('my access');
     });
-    expect(useJwt.getState().refreshJwt).toBe('my refresh Jwt2');
+    expect(useJwt.getState().getRefreshJwt()).toBe('my refresh Jwt2');
     expect(mockHistoryPush).toHaveBeenCalledWith('/');
   });
 
@@ -65,9 +65,9 @@ describe('<Login />', () => {
     render(<Login />);
 
     await waitFor(() => {
-      expect(useJwt.getState().jwt).toBe(undefined);
+      expect(useJwt.getState().getJwt()).toBe(undefined);
     });
-    expect(useJwt.getState().refreshJwt).toBe(undefined);
+    expect(useJwt.getState().getRefreshJwt()).toBe(undefined);
     expect(screen.getByText(/My LoginForm/i)).toBeInTheDocument();
   });
 });

--- a/src/frontend/apps/standalone_site/src/features/Playlist/features/UpdatePlaylist/components/AddUserAccessForm.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Playlist/features/UpdatePlaylist/components/AddUserAccessForm.spec.tsx
@@ -10,9 +10,7 @@ import { AddUserAccessForm } from './AddUserAccessForm';
 
 describe('AddUserAccessForm', () => {
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'json web token',
-    });
+    useJwt.getState().setJwt('json web token');
     jest.clearAllMocks();
     fetchMock.restore();
   });

--- a/src/frontend/apps/standalone_site/src/features/PortabilityRequests/api/useLtiUserAssociations.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/PortabilityRequests/api/useLtiUserAssociations.spec.tsx
@@ -19,9 +19,7 @@ describe('features/PortabilityRequests/api/useLtiUserAssociations', () => {
   });
 
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
 
     const queryClient = new QueryClient({
       defaultOptions: {
@@ -43,6 +41,7 @@ describe('features/PortabilityRequests/api/useLtiUserAssociations', () => {
   afterEach(() => {
     fetchMock.restore();
     jest.resetAllMocks();
+    useJwt.getState().resetJwt();
   });
 
   describe('useCreateLtiUserAssociation', () => {

--- a/src/frontend/apps/standalone_site/src/features/PortabilityRequests/api/usePortabilityRequests.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/PortabilityRequests/api/usePortabilityRequests.spec.tsx
@@ -23,9 +23,7 @@ describe('features/PortabilityRequests/api/usePortabilityRequests', () => {
   });
 
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
 
     const queryClient = new QueryClient({
       defaultOptions: {
@@ -47,6 +45,7 @@ describe('features/PortabilityRequests/api/usePortabilityRequests', () => {
   afterEach(() => {
     fetchMock.restore();
     jest.resetAllMocks();
+    useJwt.getState().resetJwt();
   });
 
   describe('acceptPortabilityRequest', () => {

--- a/src/frontend/apps/standalone_site/src/features/PortabilityRequests/components/ItemTableRow.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/PortabilityRequests/components/ItemTableRow.spec.tsx
@@ -14,9 +14,7 @@ import { ItemTableRow } from './ItemTableRow';
 
 describe('<ItemTableRow />', () => {
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
   });
 
   afterEach(() => {

--- a/src/frontend/apps/standalone_site/src/features/PortabilityRequests/hooks/useLtiUserAssociationJwtQueryParam.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/PortabilityRequests/hooks/useLtiUserAssociationJwtQueryParam.spec.tsx
@@ -27,14 +27,13 @@ describe('features/PortabilityRequests/hooks/useLtiUserAssociationJwtQueryParam'
   });
 
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
   });
 
   afterEach(() => {
     fetchMock.restore();
     jest.resetAllMocks();
+    useJwt.getState().resetJwt();
   });
 
   describe('useLtiUserAssociationJwtQueryParam', () => {

--- a/src/frontend/apps/standalone_site/src/features/Profile/features/AccountSettings/api/resetPassword.ts
+++ b/src/frontend/apps/standalone_site/src/features/Profile/features/AccountSettings/api/resetPassword.ts
@@ -6,7 +6,7 @@ export const resetPassword = async (
   newPassword: Maybe<string>,
   passwordValidation: Maybe<string>,
 ) => {
-  const jwt = useJwt.getState().jwt;
+  const jwt = useJwt.getState().getJwt();
 
   const response = await fetchWrapper('/account/api/password/change/', {
     headers: {

--- a/src/frontend/packages/lib_classroom/src/data/queries/index.spec.tsx
+++ b/src/frontend/packages/lib_classroom/src/data/queries/index.spec.tsx
@@ -29,9 +29,7 @@ let Wrapper: WrapperComponent<Element>;
 
 describe('queries', () => {
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
 
     const queryClient = new QueryClient({
       defaultOptions: {

--- a/src/frontend/packages/lib_classroom/src/data/sideEffects/createClassroomDocument/index.ts
+++ b/src/frontend/packages/lib_classroom/src/data/sideEffects/createClassroomDocument/index.ts
@@ -12,7 +12,7 @@ export const createClassroomDocument = async (file: {
   size: number;
   classroom: Classroom['id'];
 }) => {
-  const jwt = useJwt.getState().jwt;
+  const jwt = useJwt.getState().getJwt();
   if (!jwt) {
     throw new Error('No JWT found');
   }

--- a/src/frontend/packages/lib_components/src/common/queries/actionOne.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/queries/actionOne.spec.tsx
@@ -9,9 +9,8 @@ describe('queries/actionOne', () => {
   afterEach(() => fetchMock.restore());
 
   it('requests the resource, handles the response and resolves with a success', async () => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
+
     const objectToUpdate = { object: 'data' };
     fetchMock.mock('/api/model-name/1/action/', { key: 'value' });
 
@@ -35,9 +34,8 @@ describe('queries/actionOne', () => {
   });
 
   it('allows empty request body', async () => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
+
     fetchMock.mock('/api/model-name/1/action/', { key: 'value' });
 
     const response = await actionOne({
@@ -58,9 +56,8 @@ describe('queries/actionOne', () => {
   });
 
   it('allows defining request method', async () => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
+
     const objectToUpdate = { object: 'data' };
     fetchMock.mock('/api/model-name/1/action/', { key: 'value' });
 
@@ -85,9 +82,8 @@ describe('queries/actionOne', () => {
   });
 
   it('requests the resource list without JWT token', async () => {
-    useJwt.setState({
-      jwt: undefined,
-    });
+    useJwt.getState().resetJwt();
+
     const objectToUpdate = { object: 'data' };
     fetchMock.mock('/api/model-name/1/action/', { key: 'value' });
 
@@ -110,9 +106,8 @@ describe('queries/actionOne', () => {
   });
 
   it('resolves with a failure and handles it when it fails to get the resource (local)', async () => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
+
     const objectToUpdate = { object: 'data' };
     fetchMock.mock(
       '/api/model-name/1/action/',
@@ -140,9 +135,8 @@ describe('queries/actionOne', () => {
   });
 
   it('resolves with a failure and handles it when it fails to get the resource (api)', async () => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
+
     const objectToUpdate = { object: 'data' };
     fetchMock.mock('/api/model-name/1/action/', 404);
 

--- a/src/frontend/packages/lib_components/src/common/queries/actionOne.tsx
+++ b/src/frontend/packages/lib_components/src/common/queries/actionOne.tsx
@@ -21,7 +21,7 @@ export const actionOne = async <T, K>({
   method,
   object,
 }: Variables<K>): Promise<T> => {
-  const jwt = useJwt.getState().jwt;
+  const jwt = useJwt.getState().getJwt();
   const init: RequestInit = {
     headers: {
       'Content-Type': 'application/json',

--- a/src/frontend/packages/lib_components/src/common/queries/createOne.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/queries/createOne.spec.tsx
@@ -9,9 +9,8 @@ describe('queries/createOne', () => {
   afterEach(() => fetchMock.restore());
 
   it('creates the resource, handles the response and resolves with a success', async () => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
+
     const objectToCreate = { objets: 'data' };
     fetchMock.mock('/api/model-name/', { key: 'value' });
 
@@ -33,9 +32,8 @@ describe('queries/createOne', () => {
   });
 
   it('creates the resource without JWT token', async () => {
-    useJwt.setState({
-      jwt: undefined,
-    });
+    useJwt.getState().resetJwt();
+
     const objectToCreate = { objets: 'data' };
     fetchMock.mock('/api/model-name/', { key: 'value' });
 
@@ -56,9 +54,8 @@ describe('queries/createOne', () => {
   });
 
   it('resolves with a failure and handles it when it fails to create the resource (local)', async () => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
+
     const objectToCreate = { objets: 'data' };
     fetchMock.mock(
       '/api/model-name/',
@@ -84,9 +81,8 @@ describe('queries/createOne', () => {
   });
 
   it('resolves with a 404 and handles it when it fails to create the resource (api)', async () => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
+
     const objectToCreate = { objets: 'data' };
     fetchMock.mock('/api/model-name/', 404);
 
@@ -124,9 +120,8 @@ describe('queries/createOne', () => {
   });
 
   it('resolves with a 400 and handles it when it fails to create the resource (api)', async () => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
+
     const objectToCreate = { objets: 'data' };
     fetchMock.mock('/api/model-name/', {
       body: JSON.stringify({ error: 'An error occured!' }),

--- a/src/frontend/packages/lib_components/src/common/queries/createOne.tsx
+++ b/src/frontend/packages/lib_components/src/common/queries/createOne.tsx
@@ -12,7 +12,7 @@ export const createOne = async <T, K>({
   name,
   object,
 }: Variables<K>): Promise<T> => {
-  const jwt = useJwt.getState().jwt;
+  const jwt = useJwt.getState().getJwt();
   const response = await fetchWrapper(`/api/${name}/`, {
     headers: {
       'Content-Type': 'application/json',

--- a/src/frontend/packages/lib_components/src/common/queries/deleteOne.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/queries/deleteOne.spec.tsx
@@ -9,9 +9,8 @@ describe('queries/deleteOne', () => {
   afterEach(() => fetchMock.restore());
 
   it('deletes the resource', async () => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
+
     fetchMock.mock('/api/model-name/123/', 204, { method: 'DELETE' });
 
     await deleteOne({
@@ -30,9 +29,8 @@ describe('queries/deleteOne', () => {
   });
 
   it('deletes the resource without JWT token', async () => {
-    useJwt.setState({
-      jwt: undefined,
-    });
+    useJwt.getState().resetJwt();
+
     fetchMock.mock('/api/model-name/123/', 403, { method: 'DELETE' });
 
     let thrownError;
@@ -66,9 +64,8 @@ describe('queries/deleteOne', () => {
   });
 
   it('resolves with a failure and handles it when it fails to delete the resource (local)', async () => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
+
     fetchMock.mock(
       '/api/model-name/123/',
       Promise.reject(new Error('Failed to perform the request')),
@@ -92,9 +89,8 @@ describe('queries/deleteOne', () => {
   });
 
   it('resolves with a 400 and handles it when it fails to delete the resource (api)', async () => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
+
     fetchMock.mock('/api/model-name/123/', {
       body: JSON.stringify({ error: 'An error occured!' }),
       status: 400,

--- a/src/frontend/packages/lib_components/src/common/queries/deleteOne.ts
+++ b/src/frontend/packages/lib_components/src/common/queries/deleteOne.ts
@@ -10,7 +10,7 @@ export const deleteOne = async ({
   name: string;
   id: string;
 }): Promise<undefined> => {
-  const jwt = useJwt.getState().jwt;
+  const jwt = useJwt.getState().getJwt();
   const response = await fetchWrapper(`/api/${name}/${id}/`, {
     headers: {
       'Content-Type': 'application/json',

--- a/src/frontend/packages/lib_components/src/common/queries/fetchList.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/queries/fetchList.spec.tsx
@@ -8,9 +8,8 @@ describe('queries/fetchList', () => {
   afterEach(() => fetchMock.restore());
 
   it('requests the resource list, handles the response and resolves with a success', async () => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
+
     fetchMock.mock('/api/model-name/?limit=999', { key: 'value' });
 
     const response = await fetchList({
@@ -30,9 +29,8 @@ describe('queries/fetchList', () => {
   });
 
   it('requests the resource list with parameters, handles the response and resolves with a success', async () => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
+
     fetchMock.mock('/api/model-name/?limit=999&key=value', { key: 'value' });
 
     const response = await fetchList({
@@ -54,9 +52,8 @@ describe('queries/fetchList', () => {
   });
 
   it('requests the resource list without JWT token', async () => {
-    useJwt.setState({
-      jwt: undefined,
-    });
+    useJwt.getState().resetJwt();
+
     fetchMock.mock('/api/model-name/?limit=999', { key: 'value' });
 
     const response = await fetchList({
@@ -75,9 +72,8 @@ describe('queries/fetchList', () => {
   });
 
   it('resolves with a failure and handles it when it fails to get the resource list (local)', async () => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
+
     fetchMock.mock(
       '/api/model-name/?limit=999',
       Promise.reject(new Error('Failed to perform the request')),
@@ -101,9 +97,8 @@ describe('queries/fetchList', () => {
   });
 
   it('resolves with a failure and handles it when it fails to get the resource list (api)', async () => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
+
     fetchMock.mock('/api/model-name/?limit=999', 404);
 
     await expect(

--- a/src/frontend/packages/lib_components/src/common/queries/fetchList.tsx
+++ b/src/frontend/packages/lib_components/src/common/queries/fetchList.tsx
@@ -19,7 +19,7 @@ export const fetchList = async <T,>({
   const name = queryKey[0];
   const queryParams = queryKey[1] || {};
 
-  const jwt = useJwt.getState().jwt;
+  const jwt = useJwt.getState().getJwt();
 
   // remove keys with undefined value
   Object.keys(queryParams).forEach(

--- a/src/frontend/packages/lib_components/src/common/queries/fetchOne.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/queries/fetchOne.spec.tsx
@@ -8,9 +8,8 @@ describe('queries/fetchOne', () => {
   afterEach(() => fetchMock.restore());
 
   it('requests the resource, handles the response and resolves with a success', async () => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
+
     fetchMock.mock('/api/model-name/1/', { key: 'value' });
 
     const response = await fetchOne({
@@ -30,9 +29,8 @@ describe('queries/fetchOne', () => {
   });
 
   it('requests the resource list without JWT token', async () => {
-    useJwt.setState({
-      jwt: undefined,
-    });
+    useJwt.getState().resetJwt();
+
     fetchMock.mock('/api/model-name/1/', { key: 'value' });
 
     const response = await fetchOne({
@@ -51,9 +49,8 @@ describe('queries/fetchOne', () => {
   });
 
   it('resolves with a failure and handles it when it fails to get the resource (local)', async () => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
+
     fetchMock.mock(
       '/api/model-name/1/',
       Promise.reject(new Error('Failed to perform the request')),
@@ -77,9 +74,8 @@ describe('queries/fetchOne', () => {
   });
 
   it('resolves with a failure and handles it when it fails to get the resource (api)', async () => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
+
     fetchMock.mock('/api/model-name/1/', 404);
 
     await expect(
@@ -100,9 +96,8 @@ describe('queries/fetchOne', () => {
   });
 
   it('requests the resource with a custom endpoint', async () => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
+
     fetchMock.mock('/api/model-name/1/action/', { key: 'value' });
 
     const response = await fetchOne({
@@ -122,9 +117,8 @@ describe('queries/fetchOne', () => {
   });
 
   it('requests the resource with a custom endpoint list without JWT token', async () => {
-    useJwt.setState({
-      jwt: undefined,
-    });
+    useJwt.getState().resetJwt();
+
     fetchMock.mock('/api/model-name/1/action/', { key: 'value' });
 
     const response = await fetchOne({
@@ -143,9 +137,8 @@ describe('queries/fetchOne', () => {
   });
 
   it('resolves with a failure with a custom endpoint and handles it when it fails to get the resource (local)', async () => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
+
     fetchMock.mock(
       '/api/model-name/1/action/',
       Promise.reject(new Error('Failed to perform the request')),
@@ -169,9 +162,8 @@ describe('queries/fetchOne', () => {
   });
 
   it('resolves with a failure with a custom endpoint and handles it when it fails to get the resource (api)', async () => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
+
     fetchMock.mock('/api/model-name/1/action/', 404);
 
     await expect(

--- a/src/frontend/packages/lib_components/src/common/queries/fetchOne.tsx
+++ b/src/frontend/packages/lib_components/src/common/queries/fetchOne.tsx
@@ -11,7 +11,7 @@ import { fetchWrapper } from './fetchWrapper';
 export const fetchOne = async <T,>({
   queryKey,
 }: QueryFunctionContext<QueryKey>): Promise<T> => {
-  const jwt = useJwt.getState().jwt;
+  const jwt = useJwt.getState().getJwt();
   const [name, id, action] = queryKey;
 
   const actionEndpoint = action ? `${String(action)}/` : '';

--- a/src/frontend/packages/lib_components/src/common/queries/fetchReconnectWrapper.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/queries/fetchReconnectWrapper.spec.tsx
@@ -20,10 +20,8 @@ describe('fetchReconnectWrapper()', () => {
     jest.resetAllMocks();
     fetchMock.restore();
 
-    useJwt.setState({
-      jwt: 'jwt initial',
-      refreshJwt: 'refreshJwt initial',
-    });
+    useJwt.getState().setJwt('jwt initial');
+    useJwt.getState().setRefreshJwt('refreshJwt initial');
   });
 
   describe('check options', () => {
@@ -42,7 +40,7 @@ describe('fetchReconnectWrapper()', () => {
         { routesInclude: [route] },
       );
 
-      expect(useJwt.getState().jwt).toBeUndefined();
+      expect(useJwt.getState().getJwt()).toBeUndefined();
     });
 
     it('checks options.routesExclude', async () => {
@@ -60,7 +58,7 @@ describe('fetchReconnectWrapper()', () => {
         { routesExclude: [route] },
       );
 
-      expect(useJwt.getState().jwt).toEqual('jwt initial');
+      expect(useJwt.getState().getJwt()).toEqual('jwt initial');
     });
 
     it('checks options.isRetry', async () => {
@@ -81,7 +79,7 @@ describe('fetchReconnectWrapper()', () => {
         { isRetry: false },
       );
 
-      expect(useJwt.getState().jwt).toEqual('jwt initial');
+      expect(useJwt.getState().getJwt()).toEqual('jwt initial');
     });
 
     it('checks options.verbose', async () => {
@@ -120,7 +118,7 @@ describe('fetchReconnectWrapper()', () => {
 
       await fetchReconnectWrapper(route);
 
-      expect(useJwt.getState().jwt).toBeUndefined();
+      expect(useJwt.getState().getJwt()).toBeUndefined();
     });
 
     it('checks when token recovery is a success with body request', async () => {
@@ -148,8 +146,8 @@ describe('fetchReconnectWrapper()', () => {
 
       expect(mockedRefreshToken).toHaveBeenCalledWith('refreshJwt initial');
 
-      expect(useJwt.getState().jwt).toEqual('new access token');
-      expect(useJwt.getState().refreshJwt).toEqual('new refresh token');
+      expect(useJwt.getState().getJwt()).toEqual('new access token');
+      expect(useJwt.getState().getRefreshJwt()).toEqual('new refresh token');
 
       expect(fetchMock.calls()[1][0]).toEqual('/api/');
       expect(fetchMock.calls()[1][1]).toEqual({
@@ -190,8 +188,8 @@ describe('fetchReconnectWrapper()', () => {
 
       expect(mockedRefreshToken).toHaveBeenCalledWith('refreshJwt initial');
 
-      expect(useJwt.getState().jwt).toEqual('new access token');
-      expect(useJwt.getState().refreshJwt).toEqual('new refresh token');
+      expect(useJwt.getState().getJwt()).toEqual('new access token');
+      expect(useJwt.getState().getRefreshJwt()).toEqual('new refresh token');
 
       expect(fetchMock.calls()[1][0]).toEqual('/api/');
       expect(fetchMock.calls()[1][1]).toEqual({
@@ -228,8 +226,8 @@ describe('fetchReconnectWrapper()', () => {
 
       expect(mockedRefreshToken).toHaveBeenCalledWith('refreshJwt initial');
 
-      expect(useJwt.getState().jwt).toEqual('new access token');
-      expect(useJwt.getState().refreshJwt).toEqual('new refresh token');
+      expect(useJwt.getState().getJwt()).toEqual('new access token');
+      expect(useJwt.getState().getRefreshJwt()).toEqual('new refresh token');
 
       expect(fetchMock.calls()[1][0]).toEqual('/api/');
       expect(fetchMock.calls()[1][1]).toEqual({
@@ -267,8 +265,8 @@ describe('fetchReconnectWrapper()', () => {
 
       expect(mockedRefreshToken).toHaveBeenCalledWith('refreshJwt initial');
 
-      expect(useJwt.getState().jwt).toEqual('new access token');
-      expect(useJwt.getState().refreshJwt).toEqual('new refresh token');
+      expect(useJwt.getState().getJwt()).toEqual('new access token');
+      expect(useJwt.getState().getRefreshJwt()).toEqual('new refresh token');
 
       expect(fetchMock.calls()[1][0]).toEqual('/api/');
       expect(fetchMock.calls()[1][1]).toEqual({
@@ -310,10 +308,8 @@ describe('fetchReconnectWrapper()', () => {
 
       expect(mockedRefreshToken).toHaveBeenCalledWith('refreshJwt initial');
 
-      useJwt.setState({
-        jwt: 'new jwt',
-        refreshJwt: 'new refresh',
-      });
+      useJwt.getState().setJwt('new jwt');
+      useJwt.getState().setRefreshJwt('new refresh');
       fetchMock.mock(
         '/api/',
         { someData: 'blabla' },
@@ -332,8 +328,8 @@ describe('fetchReconnectWrapper()', () => {
         method: 'POST',
       });
 
-      expect(useJwt.getState().jwt).toEqual('new jwt');
-      expect(useJwt.getState().refreshJwt).toEqual('new refresh');
+      expect(useJwt.getState().getJwt()).toEqual('new jwt');
+      expect(useJwt.getState().getRefreshJwt()).toEqual('new refresh');
 
       expect(await (await result).json()).toEqual({ someData: 'blabla' });
     });
@@ -366,10 +362,9 @@ describe('fetchReconnectWrapper()', () => {
 
       expect(mockedRefreshToken).toHaveBeenCalledWith('refreshJwt initial');
 
-      useJwt.setState({
-        jwt: 'new jwt',
-        refreshJwt: 'new refresh',
-      });
+      useJwt.getState().setJwt('new jwt');
+      useJwt.getState().setRefreshJwt('new refresh');
+
       fetchMock.mock(
         '/api/',
         {
@@ -392,8 +387,8 @@ describe('fetchReconnectWrapper()', () => {
         method: 'POST',
       });
 
-      expect(useJwt.getState().jwt).toBeUndefined();
-      expect(useJwt.getState().refreshJwt).toBeUndefined();
+      expect(useJwt.getState().getJwt()).toBeUndefined();
+      expect(useJwt.getState().getRefreshJwt()).toBeUndefined();
 
       const reconnect = await result;
       expect(reconnect.status).toEqual(401);

--- a/src/frontend/packages/lib_components/src/common/queries/fetchReconnectWrapper.tsx
+++ b/src/frontend/packages/lib_components/src/common/queries/fetchReconnectWrapper.tsx
@@ -49,8 +49,9 @@ export const fetchReconnectWrapper = async (
     return response;
   }
 
-  const { refreshJwt } = useJwt.getState();
-  if (refreshJwt) {
+  const refreshJwt = useJwt.getState().getRefreshJwt();
+  let jwt = useJwt.getState().getJwt();
+  if (refreshJwt && jwt) {
     try {
       const token = await refreshToken(refreshJwt);
       useJwt.getState().setJwt(token.access);
@@ -64,7 +65,7 @@ export const fetchReconnectWrapper = async (
        * - If multiple requests are made very quickly, the refresh token can be blacklisted,
        *   in this case, we try to reconnect with the potential new access token.
        */
-      const { jwt } = useJwt.getState();
+      jwt = useJwt.getState().getJwt();
       if (jwt) {
         try {
           const response = await fetchReconnect(jwt, initialRequest, init);

--- a/src/frontend/packages/lib_components/src/common/queries/metadata.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/queries/metadata.spec.tsx
@@ -8,9 +8,7 @@ describe('metadata', () => {
   afterEach(() => fetchMock.restore());
 
   it('requests the metadata, handles the response and resolves with a success', async () => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
     fetchMock.mock('/api/model-name/', { key: 'value' });
 
     const response = await metadata({
@@ -32,9 +30,8 @@ describe('metadata', () => {
   });
 
   it('requests the metadata without JWT token', async () => {
-    useJwt.setState({
-      jwt: undefined,
-    });
+    useJwt.getState().resetJwt();
+
     fetchMock.mock('/api/model-name/', { key: 'value' });
 
     const response = await metadata({
@@ -55,9 +52,7 @@ describe('metadata', () => {
   });
 
   it('resolves with a failure and handles it when it fails to get the resource (local)', async () => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
     fetchMock.mock(
       '/api/model-name/',
       Promise.reject(new Error('Failed to perform the request')),
@@ -83,9 +78,8 @@ describe('metadata', () => {
   });
 
   it('resolves with a failure and handles it when it fails to get the resource (api)', async () => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
+
     fetchMock.mock('/api/model-name/', 404);
 
     await expect(

--- a/src/frontend/packages/lib_components/src/common/queries/metadata.tsx
+++ b/src/frontend/packages/lib_components/src/common/queries/metadata.tsx
@@ -11,7 +11,7 @@ import { fetchWrapper } from './fetchWrapper';
 export const metadata = async <T,>({
   queryKey,
 }: QueryFunctionContext<QueryKey>): Promise<T> => {
-  const jwt = useJwt.getState().jwt;
+  const jwt = useJwt.getState().getJwt();
   const [name, locale] = queryKey;
   const response = await fetchWrapper(`/api/${String(name)}/`, {
     headers: {

--- a/src/frontend/packages/lib_components/src/common/queries/updateOne.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/queries/updateOne.spec.tsx
@@ -9,9 +9,8 @@ describe('queries/updateOne', () => {
   afterEach(() => fetchMock.restore());
 
   it('updates the resource, handles the response and resolves with a success', async () => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
+
     const objectToUpdate = { object: 'data' };
     fetchMock.mock('/api/model-name/1/', { key: 'value' });
 
@@ -34,9 +33,8 @@ describe('queries/updateOne', () => {
   });
 
   it('updates the resource without JWT token', async () => {
-    useJwt.setState({
-      jwt: undefined,
-    });
+    useJwt.getState().resetJwt();
+
     const objectToUpdate = { object: 'data' };
     fetchMock.mock('/api/model-name/1/', { key: 'value' });
 
@@ -58,9 +56,8 @@ describe('queries/updateOne', () => {
   });
 
   it('resolves with a failure and handles it when it fails to update the resource (local)', async () => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
+
     const objectToUpdate = { object: 'data' };
     fetchMock.mock(
       '/api/model-name/1/',
@@ -87,9 +84,8 @@ describe('queries/updateOne', () => {
   });
 
   it('resolves with a 404 and handles it when it fails to update the resource (api)', async () => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
+
     const objectToUpdate = { object: 'data' };
     fetchMock.mock('/api/model-name/1/', 404);
 
@@ -128,9 +124,8 @@ describe('queries/updateOne', () => {
   });
 
   it('resolves with a 400 and handles it when it fails to update the resource (api)', async () => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
+
     const objectToUpdate = { object: 'data' };
     fetchMock.mock('/api/model-name/1/', {
       body: JSON.stringify({ error: 'An error occured!' }),

--- a/src/frontend/packages/lib_components/src/common/queries/updateOne.tsx
+++ b/src/frontend/packages/lib_components/src/common/queries/updateOne.tsx
@@ -14,7 +14,7 @@ export const updateOne = async <T, K>({
   id,
   object,
 }: Variables<K>): Promise<T> => {
-  const jwt = useJwt.getState().jwt;
+  const jwt = useJwt.getState().getJwt();
   const response = await fetchWrapper(`/api/${name}/${id}/`, {
     headers: {
       'Content-Type': 'application/json',

--- a/src/frontend/packages/lib_components/src/data/sideEffects/fetchJitsiInfo/index.spec.tsx
+++ b/src/frontend/packages/lib_components/src/data/sideEffects/fetchJitsiInfo/index.spec.tsx
@@ -7,9 +7,7 @@ import { fetchJitsiInfo } from '.';
 
 describe('fetchJitsiInfo', () => {
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
   });
 
   afterEach(() => {

--- a/src/frontend/packages/lib_components/src/data/sideEffects/fetchJitsiInfo/index.ts
+++ b/src/frontend/packages/lib_components/src/data/sideEffects/fetchJitsiInfo/index.ts
@@ -11,7 +11,7 @@ export const fetchJitsiInfo = async (
     `${API_ENDPOINT}/videos/${video.id}/jitsi/`,
     {
       headers: {
-        Authorization: `Bearer ${useJwt.getState().jwt ?? ''}`,
+        Authorization: `Bearer ${useJwt.getState().getJwt() ?? ''}`,
         'Content-Type': 'application/json',
       },
     },

--- a/src/frontend/packages/lib_components/src/data/sideEffects/getResource/index.spec.tsx
+++ b/src/frontend/packages/lib_components/src/data/sideEffects/getResource/index.spec.tsx
@@ -21,9 +21,7 @@ const mockAddResource = addResource as jest.MockedFunction<typeof addResource>;
 
 describe('sideEffects/getResource', () => {
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
   });
 
   afterEach(() => fetchMock.restore());

--- a/src/frontend/packages/lib_components/src/data/sideEffects/getResource/index.tsx
+++ b/src/frontend/packages/lib_components/src/data/sideEffects/getResource/index.tsx
@@ -23,7 +23,7 @@ export async function getResource(
   try {
     const response = await fetchWrapper(endpoint, {
       headers: {
-        Authorization: `Bearer ${useJwt.getState().jwt ?? ''}`,
+        Authorization: `Bearer ${useJwt.getState().getJwt() ?? ''}`,
         'Content-Type': 'application/json',
       },
     });

--- a/src/frontend/packages/lib_components/src/data/sideEffects/initiateUpload/index.spec.ts
+++ b/src/frontend/packages/lib_components/src/data/sideEffects/initiateUpload/index.spec.ts
@@ -7,9 +7,7 @@ import { initiateUpload } from '.';
 
 describe('sideEffects/initiateUpload', () => {
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
   });
 
   afterEach(() => fetchMock.restore());

--- a/src/frontend/packages/lib_components/src/data/sideEffects/initiateUpload/index.ts
+++ b/src/frontend/packages/lib_components/src/data/sideEffects/initiateUpload/index.ts
@@ -28,7 +28,7 @@ export const initiateUpload = async (
         size,
       }),
       headers: {
-        Authorization: `Bearer ${useJwt.getState().jwt ?? ''}`,
+        Authorization: `Bearer ${useJwt.getState().getJwt() ?? ''}`,
         'Content-Type': 'application/json',
       },
       method: 'POST',

--- a/src/frontend/packages/lib_components/src/data/sideEffects/updateResource/index.spec.ts
+++ b/src/frontend/packages/lib_components/src/data/sideEffects/updateResource/index.spec.ts
@@ -8,9 +8,7 @@ import { updateResource } from '.';
 
 describe('sideEffects/updateResource', () => {
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
   });
 
   afterEach(() => fetchMock.restore());

--- a/src/frontend/packages/lib_components/src/data/sideEffects/updateResource/index.ts
+++ b/src/frontend/packages/lib_components/src/data/sideEffects/updateResource/index.ts
@@ -14,7 +14,7 @@ export async function updateResource<R extends Resource>(
   const response = await fetchWrapper(endpoint, {
     body: JSON.stringify(resource),
     headers: {
-      Authorization: `Bearer ${useJwt.getState().jwt ?? ''}`,
+      Authorization: `Bearer ${useJwt.getState().getJwt() ?? ''}`,
       'Content-Type': 'application/json',
     },
     method: 'PUT',

--- a/src/frontend/packages/lib_components/src/hooks/stores/useJwt/index.spec.tsx
+++ b/src/frontend/packages/lib_components/src/hooks/stores/useJwt/index.spec.tsx
@@ -1,0 +1,80 @@
+import { act, render } from '@testing-library/react';
+import React, { useEffect } from 'react';
+
+import { persistentStore as useJwt } from '.';
+
+const TestJwtComponent = ({
+  renderFnc,
+}: {
+  renderFnc: (param?: string) => void;
+}) => {
+  const { jwt } = useJwt((state) => state);
+  useEffect(() => {
+    renderFnc(jwt);
+  }, [renderFnc, jwt]);
+  return <div>My content per page is: ${jwt}</div>;
+};
+
+describe('useJwt', () => {
+  beforeEach(() => {});
+
+  afterEach(() => {
+    act(() => {
+      useJwt.getState().resetJwt();
+    });
+  });
+
+  it('Check JWT subscription re rendering', () => {
+    const mock = jest.fn();
+    const { rerender } = render(<TestJwtComponent renderFnc={mock} />);
+
+    expect(mock.mock.calls).toHaveLength(1);
+    expect(mock.mock.calls[0][0]).toBe(undefined);
+    expect(useJwt.getState().getJwt()).toEqual(undefined);
+
+    act(() => {
+      useJwt.getState().setJwt('some token');
+    });
+    rerender(<TestJwtComponent renderFnc={mock} />);
+
+    expect(mock.mock.calls).toHaveLength(2);
+    expect(mock.mock.calls[1][0]).toBe('some token');
+    expect(useJwt.getState().getJwt()).toEqual('some token');
+
+    act(() => {
+      useJwt.getState().setJwt('another token');
+    });
+    rerender(<TestJwtComponent renderFnc={mock} />);
+    expect(mock.mock.calls).toHaveLength(3);
+    expect(useJwt.getState().getJwt()).toEqual('another token');
+    expect(mock.mock.calls[2][0]).toBe('another token');
+
+    rerender(<TestJwtComponent renderFnc={mock} />);
+    // Use effect should not be called once more
+    expect(mock.mock.calls).toHaveLength(3);
+  });
+
+  it('checks change value jwt', () => {
+    expect(useJwt.getState().getJwt()).toEqual(undefined);
+
+    useJwt.getState().setJwt('some token');
+
+    expect(useJwt.getState().getJwt()).toEqual('some token');
+
+    useJwt.getState().setJwt('another token');
+
+    expect(useJwt.getState().getJwt()).toEqual('another token');
+  });
+
+  it('checks when another tab change jwt', () => {
+    expect(useJwt.getState().getJwt()).toEqual(undefined);
+
+    useJwt.getState().setJwt('some token');
+
+    expect(useJwt.getState().getJwt()).toEqual('some token');
+
+    localStorage.setItem('JWT', 'another token');
+
+    expect(useJwt.getState().getJwt()).toEqual('another token');
+  });
+});

--- a/src/frontend/packages/lib_components/src/hooks/stores/useJwt/index.ts
+++ b/src/frontend/packages/lib_components/src/hooks/stores/useJwt/index.ts
@@ -1,14 +1,18 @@
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
 
 import { DecodedJwt } from '../../../types/jwt';
 import { decodeJwt } from '../../../utils/decodeJwt';
+
+const JWT_KEY = 'JWT';
+const REFRESH_JWT_KEY = 'REFRESH_JWT';
 
 interface JwtStoreInterface {
   jwt?: string;
   refreshJwt?: string;
   internalDecodedJwt?: DecodedJwt;
+  getJwt: () => string | undefined;
   setJwt: (jwt: string) => void;
+  getRefreshJwt: () => string | undefined;
   setRefreshJwt: (jwt: string) => void;
   getDecodedJwt: () => DecodedJwt;
   resetJwt: () => void;
@@ -18,8 +22,9 @@ const localStore = create<JwtStoreInterface>((set, get) => ({
   jwt: undefined,
   refreshJwt: undefined,
   internalDecodedJwt: undefined,
-  jwtCreateTimestamp: undefined,
+  getJwt: () => get().jwt,
   setJwt: (jwt) => set((state) => ({ ...state, jwt })),
+  getRefreshJwt: () => get().refreshJwt,
   setRefreshJwt: (refreshJwt) => set((state) => ({ ...state, refreshJwt })),
   getDecodedJwt: () => {
     const currentValue = get().internalDecodedJwt;
@@ -27,7 +32,7 @@ const localStore = create<JwtStoreInterface>((set, get) => ({
       return currentValue;
     }
 
-    const decoded = decodeJwt(get().jwt);
+    const decoded = decodeJwt(get().getJwt());
     set((state) => ({ ...state, internalDecodedJwt: decoded }));
     return decoded;
   },
@@ -40,38 +45,52 @@ const localStore = create<JwtStoreInterface>((set, get) => ({
   },
 }));
 
-const persistentStore = create<JwtStoreInterface>()(
-  persist(
-    (set, get) => ({
+export const persistentStore = create<JwtStoreInterface>((set, get) => ({
+  jwt: localStorage.getItem(JWT_KEY) || undefined,
+  refreshJwt: localStorage.getItem(REFRESH_JWT_KEY) || undefined,
+  internalDecodedJwt: undefined,
+  getJwt() {
+    const jwt = localStorage.getItem(JWT_KEY) || undefined;
+    if (jwt !== get().jwt) {
+      set((state) => ({ ...state, jwt, internalDecodedJwt: undefined }));
+    }
+    return jwt;
+  },
+  setJwt: (jwt) => {
+    localStorage.setItem(JWT_KEY, jwt);
+    set((state) => ({ ...state, jwt, internalDecodedJwt: undefined }));
+  },
+  getRefreshJwt() {
+    const refreshJwt = localStorage.getItem(REFRESH_JWT_KEY) || undefined;
+    if (refreshJwt !== get().refreshJwt) {
+      set((state) => ({ ...state, refreshJwt, internalDecodedJwt: undefined }));
+    }
+    return refreshJwt;
+  },
+  setRefreshJwt: (refreshJwt) => {
+    localStorage.setItem(REFRESH_JWT_KEY, refreshJwt);
+    set((state) => ({ ...state, refreshJwt }));
+  },
+  getDecodedJwt: () => {
+    const currentValue = get().internalDecodedJwt;
+    if (currentValue) {
+      return currentValue;
+    }
+
+    const decoded = decodeJwt(get().getJwt());
+    set((state) => ({ ...state, internalDecodedJwt: decoded }));
+    return decoded;
+  },
+  resetJwt: () => {
+    localStorage.removeItem(JWT_KEY);
+    localStorage.removeItem(REFRESH_JWT_KEY);
+    set((state) => ({
+      ...state,
       jwt: undefined,
       refreshJwt: undefined,
       internalDecodedJwt: undefined,
-      jwtCreateTimestamp: undefined,
-      setJwt: (jwt) => set((state) => ({ ...state, jwt })),
-      setRefreshJwt: (refreshJwt) => set((state) => ({ ...state, refreshJwt })),
-      getDecodedJwt: () => {
-        const currentValue = get().internalDecodedJwt;
-        if (currentValue) {
-          return currentValue;
-        }
-
-        const decoded = decodeJwt(get().jwt);
-        set((state) => ({ ...state, internalDecodedJwt: decoded }));
-        return decoded;
-      },
-      resetJwt: () => {
-        persistentStore.persist.clearStorage();
-        set((state) => ({
-          ...state,
-          jwt: undefined,
-          refreshJwt: undefined,
-        }));
-      },
-    }),
-    {
-      name: 'jwt-storage',
-    },
-  ),
-);
+    }));
+  },
+}));
 
 export const useJwt = window.use_jwt_persistence ? persistentStore : localStore;

--- a/src/frontend/packages/lib_components/src/utils/serviceWorker/serviceWorkerRefreshToken/useServiceWorkerRefreshToken/index.spec.tsx
+++ b/src/frontend/packages/lib_components/src/utils/serviceWorker/serviceWorkerRefreshToken/useServiceWorkerRefreshToken/index.spec.tsx
@@ -151,8 +151,10 @@ describe('<useServiceWorkerRefreshToken />', () => {
 
     render(<TestComponent />);
 
-    await waitFor(() => expect(useJwt.getState().jwt).toBe('my new access'));
-    expect(useJwt.getState().refreshJwt).toBe('my new refresh');
+    await waitFor(() =>
+      expect(useJwt.getState().getJwt()).toBe('my new access'),
+    );
+    expect(useJwt.getState().getRefreshJwt()).toBe('my new refresh');
   });
 
   it('checks the service workers actions: LOGOUT', () => {
@@ -177,7 +179,7 @@ describe('<useServiceWorkerRefreshToken />', () => {
 
     render(<TestComponent />);
 
-    expect(useJwt.getState().jwt).toBeUndefined();
-    expect(useJwt.getState().refreshJwt).toBeUndefined();
+    expect(useJwt.getState().getJwt()).toBeUndefined();
+    expect(useJwt.getState().getRefreshJwt()).toBeUndefined();
   });
 });

--- a/src/frontend/packages/lib_markdown/src/components/MdxRenderer/index.spec.tsx
+++ b/src/frontend/packages/lib_markdown/src/components/MdxRenderer/index.spec.tsx
@@ -34,9 +34,7 @@ jest.mock('uuid', () => ({
 describe('<MdxRenderer />', () => {
   // Mock getBBox SVG for tests
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
 
     // @ts-ignore
     window.SVGElement.prototype.getBBox = () => ({

--- a/src/frontend/packages/lib_markdown/src/data/queries/index.spec.tsx
+++ b/src/frontend/packages/lib_markdown/src/data/queries/index.spec.tsx
@@ -23,9 +23,7 @@ let Wrapper: WrapperComponent<Element>;
 
 describe('queries', () => {
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
 
     const queryClient = new QueryClient({
       defaultOptions: {

--- a/src/frontend/packages/lib_markdown/src/data/sideEffects/createMarkdownImage/index.ts
+++ b/src/frontend/packages/lib_markdown/src/data/sideEffects/createMarkdownImage/index.ts
@@ -13,7 +13,7 @@ export const createMarkdownImage = async () => {
     `${API_ENDPOINT}/${modelName.MARKDOWN_IMAGES}/`,
     {
       headers: {
-        Authorization: `Bearer ${useJwt.getState().jwt}`,
+        Authorization: `Bearer ${useJwt.getState().getJwt()}`,
         'Content-Type': 'application/json',
       },
       method: 'POST',

--- a/src/frontend/packages/lib_video/src/api/createLiveSession/index.ts
+++ b/src/frontend/packages/lib_video/src/api/createLiveSession/index.ts
@@ -19,7 +19,7 @@ export const createLiveSession = async (
     language,
     anonymous_id: anonymousId,
   };
-  const jwt = useJwt.getState().jwt;
+  const jwt = useJwt.getState().getJwt();
   const response = await fetchWrapper(
     `${API_ENDPOINT}/videos/${videoId}/livesessions/`,
     {

--- a/src/frontend/packages/lib_video/src/api/createSharedLiveMedia/index.ts
+++ b/src/frontend/packages/lib_video/src/api/createSharedLiveMedia/index.ts
@@ -16,7 +16,7 @@ export const createSharedLiveMedia = async (
   const response = await fetchWrapper(`${API_ENDPOINT}/sharedlivemedias/`, {
     body: JSON.stringify(body),
     headers: {
-      Authorization: `Bearer ${useJwt.getState().jwt ?? ''}`,
+      Authorization: `Bearer ${useJwt.getState().getJwt() ?? ''}`,
       'Content-Type': 'application/json',
     },
     method: 'POST',

--- a/src/frontend/packages/lib_video/src/api/createThumbnail/index.ts
+++ b/src/frontend/packages/lib_video/src/api/createThumbnail/index.ts
@@ -23,7 +23,7 @@ export const createThumbnail = async (
     {
       body: JSON.stringify(body),
       headers: {
-        Authorization: `Bearer ${useJwt.getState().jwt ?? ''}`,
+        Authorization: `Bearer ${useJwt.getState().getJwt() ?? ''}`,
         'Content-Type': 'application/json',
       },
       method: 'POST',

--- a/src/frontend/packages/lib_video/src/api/createTimedTextTrack/index.spec.ts
+++ b/src/frontend/packages/lib_video/src/api/createTimedTextTrack/index.spec.ts
@@ -5,9 +5,7 @@ import { createTimedTextTrack } from '.';
 
 describe('sideEffects/createTimedTextTrack()', () => {
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
   });
 
   afterEach(() => fetchMock.restore());

--- a/src/frontend/packages/lib_video/src/api/createTimedTextTrack/index.ts
+++ b/src/frontend/packages/lib_video/src/api/createTimedTextTrack/index.ts
@@ -28,7 +28,7 @@ export const createTimedTextTrack = async (
     {
       body: JSON.stringify(body),
       headers: {
-        Authorization: `Bearer ${useJwt.getState().jwt ?? ''}`,
+        Authorization: `Bearer ${useJwt.getState().getJwt() ?? ''}`,
         'Content-Type': 'application/json',
       },
       method: 'POST',

--- a/src/frontend/packages/lib_video/src/api/harvestLive/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/api/harvestLive/index.spec.tsx
@@ -5,9 +5,7 @@ import { harvestLive } from '.';
 
 describe('harvestLive', () => {
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
   });
 
   afterEach(() => fetchMock.restore());

--- a/src/frontend/packages/lib_video/src/api/harvestLive/index.tsx
+++ b/src/frontend/packages/lib_video/src/api/harvestLive/index.tsx
@@ -5,7 +5,7 @@ export const harvestLive = async (video: Video) => {
     `${API_ENDPOINT}/videos/${video.id}/harvest-live/`,
     {
       headers: {
-        Authorization: `Bearer ${useJwt.getState().jwt ?? ''}`,
+        Authorization: `Bearer ${useJwt.getState().getJwt() ?? ''}`,
         'Content-Type': 'application/json',
       },
       method: 'POST',

--- a/src/frontend/packages/lib_video/src/api/initiateLive/index.spec.ts
+++ b/src/frontend/packages/lib_video/src/api/initiateLive/index.spec.ts
@@ -11,9 +11,7 @@ import { initiateLive } from '.';
 
 describe('sideEffects/initiateLive', () => {
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
   });
 
   afterEach(() => fetchMock.restore());

--- a/src/frontend/packages/lib_video/src/api/initiateLive/index.ts
+++ b/src/frontend/packages/lib_video/src/api/initiateLive/index.ts
@@ -19,7 +19,7 @@ export const initiateLive = async (
     `${API_ENDPOINT}/videos/${video.id}/initiate-live/`,
     {
       headers: {
-        Authorization: `Bearer ${useJwt.getState().jwt ?? ''}`,
+        Authorization: `Bearer ${useJwt.getState().getJwt() ?? ''}`,
         'Content-Type': 'application/json',
       },
       method: 'POST',

--- a/src/frontend/packages/lib_video/src/api/navigateSharingDoc/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/api/navigateSharingDoc/index.spec.tsx
@@ -5,9 +5,7 @@ import { navigateSharingDoc } from '.';
 
 describe('navigateSharingDoc', () => {
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
   });
 
   afterEach(() => fetchMock.restore());

--- a/src/frontend/packages/lib_video/src/api/navigateSharingDoc/index.ts
+++ b/src/frontend/packages/lib_video/src/api/navigateSharingDoc/index.ts
@@ -8,7 +8,7 @@ export const navigateSharingDoc = async (
     `${API_ENDPOINT}/videos/${video.id}/navigate-sharing/`,
     {
       headers: {
-        Authorization: `Bearer ${useJwt.getState().jwt ?? ''}`,
+        Authorization: `Bearer ${useJwt.getState().getJwt() ?? ''}`,
         'Content-Type': 'application/json',
       },
       method: 'PATCH',

--- a/src/frontend/packages/lib_video/src/api/publishLiveToVod/index.spec.ts
+++ b/src/frontend/packages/lib_video/src/api/publishLiveToVod/index.spec.ts
@@ -5,9 +5,7 @@ import { publishLiveToVod } from '.';
 
 describe('publishLiveToVod', () => {
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
   });
 
   afterEach(() => fetchMock.restore());

--- a/src/frontend/packages/lib_video/src/api/publishLiveToVod/index.ts
+++ b/src/frontend/packages/lib_video/src/api/publishLiveToVod/index.ts
@@ -5,7 +5,7 @@ export const publishLiveToVod = async (video: Video) => {
     `${API_ENDPOINT}/videos/${video.id}/live-to-vod/`,
     {
       headers: {
-        Authorization: `Bearer ${useJwt.getState().jwt ?? ''}`,
+        Authorization: `Bearer ${useJwt.getState().getJwt() ?? ''}`,
         'Content-Type': 'application/json',
       },
       method: 'POST',

--- a/src/frontend/packages/lib_video/src/api/pushAttendance/index.spec.ts
+++ b/src/frontend/packages/lib_video/src/api/pushAttendance/index.spec.ts
@@ -6,9 +6,7 @@ import { pushAttendance } from '.';
 
 describe('pushAttendance', () => {
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
   });
 
   afterEach(() => fetchMock.restore());

--- a/src/frontend/packages/lib_video/src/api/pushAttendance/index.ts
+++ b/src/frontend/packages/lib_video/src/api/pushAttendance/index.ts
@@ -19,7 +19,7 @@ export const pushAttendance = async (
   const response = await fetchWrapper(endpoint, {
     body: JSON.stringify({ live_attendance: liveAttendance, language }),
     headers: {
-      Authorization: `Bearer ${useJwt.getState().jwt ?? ''}`,
+      Authorization: `Bearer ${useJwt.getState().getJwt() ?? ''}`,
       'Content-Type': 'application/json',
     },
     method: 'POST',

--- a/src/frontend/packages/lib_video/src/api/setLiveSessionDisplayName/index.spec.ts
+++ b/src/frontend/packages/lib_video/src/api/setLiveSessionDisplayName/index.spec.ts
@@ -7,9 +7,7 @@ import { setLiveSessionDisplayName } from '.';
 
 describe('setLiveSessionDisplayName', () => {
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
   });
 
   afterEach(() => fetchMock.restore());

--- a/src/frontend/packages/lib_video/src/api/setLiveSessionDisplayName/index.ts
+++ b/src/frontend/packages/lib_video/src/api/setLiveSessionDisplayName/index.ts
@@ -23,7 +23,7 @@ export const setLiveSessionDisplayName = async (
     {
       body: JSON.stringify(body),
       headers: {
-        Authorization: `Bearer ${useJwt.getState().jwt ?? ''}`,
+        Authorization: `Bearer ${useJwt.getState().getJwt() ?? ''}`,
         'Content-Type': 'application/json',
       },
       method: 'PUT',

--- a/src/frontend/packages/lib_video/src/api/startLive/index.spec.ts
+++ b/src/frontend/packages/lib_video/src/api/startLive/index.spec.ts
@@ -5,9 +5,7 @@ import { startLive } from '.';
 
 describe('sideEffects/startLive', () => {
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
   });
 
   afterEach(() => fetchMock.restore());

--- a/src/frontend/packages/lib_video/src/api/startLive/index.ts
+++ b/src/frontend/packages/lib_video/src/api/startLive/index.ts
@@ -10,7 +10,7 @@ export const startLive = async (video: Video): Promise<Video> => {
     `${API_ENDPOINT}/videos/${video.id}/start-live/`,
     {
       headers: {
-        Authorization: `Bearer ${useJwt.getState().jwt ?? ''}`,
+        Authorization: `Bearer ${useJwt.getState().getJwt() ?? ''}`,
         'Content-Type': 'application/json',
       },
       method: 'POST',

--- a/src/frontend/packages/lib_video/src/api/stopLive/index.spec.ts
+++ b/src/frontend/packages/lib_video/src/api/stopLive/index.spec.ts
@@ -5,9 +5,7 @@ import { stopLive } from '.';
 
 describe('sideEffects/stopLive', () => {
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
   });
 
   afterEach(() => fetchMock.restore());

--- a/src/frontend/packages/lib_video/src/api/stopLive/index.tsx
+++ b/src/frontend/packages/lib_video/src/api/stopLive/index.tsx
@@ -10,7 +10,7 @@ export const stopLive = async (video: Video): Promise<Video> => {
     `${API_ENDPOINT}/videos/${video.id}/stop-live/`,
     {
       headers: {
-        Authorization: `Bearer ${useJwt.getState().jwt ?? ''}`,
+        Authorization: `Bearer ${useJwt.getState().getJwt() ?? ''}`,
         'Content-Type': 'application/json',
       },
       method: 'POST',

--- a/src/frontend/packages/lib_video/src/api/updateLiveParticipants/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/api/updateLiveParticipants/index.spec.tsx
@@ -14,9 +14,7 @@ import {
 
 describe('updateLiveParticipants', () => {
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
   });
 
   afterEach(() => fetchMock.restore());

--- a/src/frontend/packages/lib_video/src/api/updateLiveParticipants/index.tsx
+++ b/src/frontend/packages/lib_video/src/api/updateLiveParticipants/index.tsx
@@ -18,7 +18,7 @@ const updateLiveParticipants = async (
     {
       body: JSON.stringify(participant),
       headers: {
-        Authorization: `Bearer ${useJwt.getState().jwt ?? ''}`,
+        Authorization: `Bearer ${useJwt.getState().getJwt() ?? ''}`,
         'Content-Type': 'application/json',
       },
       method,

--- a/src/frontend/packages/lib_video/src/api/updateLiveSession/index.ts
+++ b/src/frontend/packages/lib_video/src/api/updateLiveSession/index.ts
@@ -26,7 +26,7 @@ export const updateLiveSession = async (
   const response = await fetchWrapper(endpoint, {
     body: JSON.stringify(body),
     headers: {
-      Authorization: `Bearer ${useJwt.getState().jwt ?? ''}`,
+      Authorization: `Bearer ${useJwt.getState().getJwt() ?? ''}`,
       'Content-Type': 'application/json',
     },
     method: 'PATCH',

--- a/src/frontend/packages/lib_video/src/api/useCreateVideo/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/api/useCreateVideo/index.spec.tsx
@@ -23,9 +23,7 @@ let Wrapper: WrapperComponent<Element>;
 
 describe('useCreateVideo', () => {
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
 
     const queryClient = new QueryClient({
       defaultOptions: {

--- a/src/frontend/packages/lib_video/src/api/useDeleteSharedLiveMedia/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/api/useDeleteSharedLiveMedia/index.spec.tsx
@@ -22,9 +22,7 @@ let Wrapper: WrapperComponent<Element>;
 
 describe('useDeleteSharedLiveMedia', () => {
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
 
     const queryClient = new QueryClient({
       defaultOptions: {

--- a/src/frontend/packages/lib_video/src/api/useDeleteThumbnail/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/api/useDeleteThumbnail/index.spec.tsx
@@ -22,9 +22,7 @@ let Wrapper: WrapperComponent<Element>;
 
 describe('useDeleteThumbnail', () => {
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
 
     const queryClient = new QueryClient({
       defaultOptions: {

--- a/src/frontend/packages/lib_video/src/api/useDeleteTimedTextTrack/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/api/useDeleteTimedTextTrack/index.spec.tsx
@@ -22,9 +22,7 @@ let Wrapper: WrapperComponent<Element>;
 
 describe('useDeleteTimedTextTracks', () => {
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
 
     const queryClient = new QueryClient({
       defaultOptions: {

--- a/src/frontend/packages/lib_video/src/api/useFetchTimedTextTrackLanguageChoices/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/api/useFetchTimedTextTrackLanguageChoices/index.spec.tsx
@@ -22,9 +22,7 @@ let Wrapper: WrapperComponent<Element>;
 
 describe('useFetchTimedTextTrackLanguageChoices', () => {
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
 
     const queryClient = new QueryClient({
       defaultOptions: {

--- a/src/frontend/packages/lib_video/src/api/useLiveAttendances/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/api/useLiveAttendances/index.spec.tsx
@@ -22,9 +22,7 @@ let Wrapper: WrapperComponent<Element>;
 
 describe('useLiveAttendances', () => {
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
 
     const queryClient = new QueryClient({
       defaultOptions: {

--- a/src/frontend/packages/lib_video/src/api/useLiveSessions/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/api/useLiveSessions/index.spec.tsx
@@ -25,9 +25,7 @@ let Wrapper: WrapperComponent<Element>;
 
 describe('useLiveSessions', () => {
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
 
     const queryClient = new QueryClient({
       defaultOptions: {

--- a/src/frontend/packages/lib_video/src/api/usePairingVideo/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/api/usePairingVideo/index.spec.tsx
@@ -22,9 +22,7 @@ let Wrapper: WrapperComponent<Element>;
 
 describe('usePairingingVideo', () => {
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
 
     const queryClient = new QueryClient({
       defaultOptions: {

--- a/src/frontend/packages/lib_video/src/api/useStartLiveRecording/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/api/useStartLiveRecording/index.spec.tsx
@@ -22,9 +22,7 @@ let Wrapper: WrapperComponent<Element>;
 
 describe('useStartLiveRecording', () => {
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
 
     const queryClient = new QueryClient({
       defaultOptions: {

--- a/src/frontend/packages/lib_video/src/api/useStartSharingMedia/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/api/useStartSharingMedia/index.spec.tsx
@@ -26,9 +26,7 @@ let Wrapper: WrapperComponent<Element>;
 
 describe('useStartSharingMedia', () => {
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
 
     const queryClient = new QueryClient({
       defaultOptions: {

--- a/src/frontend/packages/lib_video/src/api/useStopLiveRecording/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/api/useStopLiveRecording/index.spec.tsx
@@ -22,9 +22,7 @@ let Wrapper: WrapperComponent<Element>;
 
 describe('useStopLiveRecording', () => {
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
 
     const queryClient = new QueryClient({
       defaultOptions: {

--- a/src/frontend/packages/lib_video/src/api/useStopSharingMedia/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/api/useStopSharingMedia/index.spec.tsx
@@ -26,9 +26,7 @@ let Wrapper: WrapperComponent<Element>;
 
 describe('useStopSharingMedia', () => {
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
 
     const queryClient = new QueryClient({
       defaultOptions: {

--- a/src/frontend/packages/lib_video/src/api/useThumbnailMetadata/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/api/useThumbnailMetadata/index.spec.tsx
@@ -22,9 +22,7 @@ let Wrapper: WrapperComponent<Element>;
 
 describe('useThumbnailMetadata', () => {
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
 
     const queryClient = new QueryClient({
       defaultOptions: {

--- a/src/frontend/packages/lib_video/src/api/useTimedTextMetadata/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/api/useTimedTextMetadata/index.spec.tsx
@@ -22,9 +22,7 @@ let Wrapper: WrapperComponent<Element>;
 
 describe('useTimedTextMetadata', () => {
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
 
     const queryClient = new QueryClient({
       defaultOptions: {

--- a/src/frontend/packages/lib_video/src/api/useUpdateSharedLiveMedia/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/api/useUpdateSharedLiveMedia/index.spec.tsx
@@ -22,9 +22,7 @@ let Wrapper: WrapperComponent<Element>;
 
 describe('useUpdateSharedLiveMedia', () => {
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
 
     const queryClient = new QueryClient({
       defaultOptions: {

--- a/src/frontend/packages/lib_video/src/api/useUpdateVideo/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/api/useUpdateVideo/index.spec.tsx
@@ -22,9 +22,7 @@ let Wrapper: WrapperComponent<Element>;
 
 describe('useUpdateVideo', () => {
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
 
     const queryClient = new QueryClient({
       defaultOptions: {

--- a/src/frontend/packages/lib_video/src/api/useVideoMetadata/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/api/useVideoMetadata/index.spec.tsx
@@ -22,9 +22,7 @@ let Wrapper: WrapperComponent<Element>;
 
 describe('useVideoMetadata', () => {
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
 
     const queryClient = new QueryClient({
       defaultOptions: {

--- a/src/frontend/packages/lib_video/src/api/useVideos/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/api/useVideos/index.spec.tsx
@@ -23,9 +23,7 @@ let Wrapper: WrapperComponent<Element>;
 
 describe('queries', () => {
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
 
     const queryClient = new QueryClient({
       defaultOptions: {

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/index.spec.tsx
@@ -38,9 +38,7 @@ const languageChoices = [
 
 describe('<VideoWidgetProvider />', () => {
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
 
     fetchMock.mock(
       '/api/timedtexttracks/',

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/LivePairing/LivePairingButton/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/LivePairing/LivePairingButton/index.spec.tsx
@@ -12,9 +12,7 @@ describe('<DashboardLivePairing />', () => {
   beforeEach(() => {
     jest.useFakeTimers();
 
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
   });
 
   afterEach(() => {

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/LivePairing/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/LivePairing/index.spec.tsx
@@ -11,9 +11,7 @@ import { LivePairing } from '.';
 
 describe('LivePairing', () => {
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
   });
   it('displays the appairing button', () => {
     const video = videoMockFactory({

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/UploadVideo/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/UploadVideo/index.spec.tsx
@@ -56,9 +56,7 @@ jest.mock('hooks/useInfoWidgetModal', () => ({
 
 describe('<UploadVideo />', () => {
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
   });
 
   afterEach(() => {

--- a/src/frontend/packages/lib_video/src/components/common/VideoWizard/CreateVOD/LicenseSelect/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWizard/CreateVOD/LicenseSelect/index.spec.tsx
@@ -30,9 +30,7 @@ const licenseChoices = [
 
 describe('<LicenseSelect />', () => {
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
   });
 
   afterEach(() => {

--- a/src/frontend/packages/lib_video/src/components/live/Student/StudentLiveStarter/StudentLiveAdvertising/StudentLiveRegistration/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/live/Student/StudentLiveStarter/StudentLiveAdvertising/StudentLiveRegistration/index.spec.tsx
@@ -48,9 +48,7 @@ const mockedDecodeJwt = decodeJwt as jest.MockedFunction<typeof decodeJwt>;
 
 describe('<StudentLiveRegistration />', () => {
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
     useCurrentUser.setState({
       currentUser: {
         email: null,

--- a/src/frontend/packages/lib_video/src/components/vod/Teacher/Dashboard.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/vod/Teacher/Dashboard.spec.tsx
@@ -57,9 +57,7 @@ const languageChoices = [
 
 describe('<Dashboard />', () => {
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
     fetchMock.mock(
       `/api/timedtexttracks/`,
       {

--- a/src/frontend/packages/lib_video/src/hooks/useVideoStats/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/hooks/useVideoStats/index.spec.tsx
@@ -10,9 +10,7 @@ let Wrapper: WrapperComponent<Element>;
 
 describe('useStatsVideo', () => {
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'some token',
-    });
+    useJwt.getState().setJwt('some token');
 
     const queryClient = new QueryClient({
       defaultOptions: {

--- a/src/frontend/packages/lib_video/src/utils/getOrInitAnonymousId.ts
+++ b/src/frontend/packages/lib_video/src/utils/getOrInitAnonymousId.ts
@@ -9,7 +9,7 @@ import {
 import { getAnonymousId, setAnonymousId } from './localstorage';
 
 export const getOrInitAnonymousId = () => {
-  const jwt = useJwt.getState().jwt;
+  const jwt = useJwt.getState().getJwt();
   const user = useCurrentUser.getState().currentUser;
   let anonymousId =
     user !== AnonymousUser.ANONYMOUS ? user?.anonymous_id : undefined;


### PR DESCRIPTION
## Purpose

When multiple tabs are open on the website,
if a tab stays inactive during 5mn (access token lifetime), when it gets the focus back we are disconnected.
It is because the access token is not valid anymore, and the refresh token has been updated by the other tab.

## Proposal

To fix this, we directly use localStorage to retrieve the jwt, to be sure to always use an up to date JWT.

- [x] directly use localStorage

