### PR TITLE
🐛(frontend) sync description widget  VOD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - redirect to error page when VOD is deleted
 - Manage disconnection when multiple tabs were open on standalone site
+- synchronisation between pages for the VOD description widget
 
 ## [4.0.0-beta.18] - 2023-03-06
 

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/DescriptionWidget/index.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/DescriptionWidget/index.tsx
@@ -1,5 +1,5 @@
 import { Video, report, TextAreaInput } from 'lib-components';
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { toast } from 'react-hot-toast';
 import { defineMessages, useIntl } from 'react-intl';
 
@@ -43,6 +43,7 @@ const messages = defineMessages({
 export const DescriptionWidget = () => {
   const video = useCurrentVideo();
   const intl = useIntl();
+  const descriptionInit = useRef(video.description);
   const [description, setDescription] = useState(video.description);
 
   const videoMutation = useUpdateVideo(video.id, {
@@ -68,6 +69,15 @@ export const DescriptionWidget = () => {
     },
     1000,
   );
+
+  useEffect(() => {
+    const isIdle = descriptionInit.current === description;
+    const isWriting = description !== video.description;
+    if (isIdle || !isWriting) {
+      setDescription(video.description);
+      descriptionInit.current = video.description;
+    }
+  }, [description, video.description]);
 
   return (
     <FoldableItem


### PR DESCRIPTION
## Purpose

See https://github.com/openfun/marsha/issues/2099
The description for the VOD is not correctly updated.

## Proposal

The solution is implemented in Live mode:
https://github.com/openfun/marsha/blob/master/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/SchedulingAndDescription/index.tsx#L99

