### PR TITLE
🐛(lib-classroom) display title / desc in waiting room

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - synchronisation between pages for the VOD description widget
 - tooltip position on the website context dashboard (#2136)
 - thumbnail not reset correctly on the video player (#2137)
+- display title / description when a classroom is not scheduled and not started
 
 ## [4.0.0-beta.18] - 2023-03-06
 

--- a/src/frontend/packages/lib_classroom/src/components/DashboardClassroomStudent/index.spec.tsx
+++ b/src/frontend/packages/lib_classroom/src/components/DashboardClassroomStudent/index.spec.tsx
@@ -39,6 +39,8 @@ describe('<DashboardClassroomStudent />', () => {
       id: '1',
       started: false,
       ended: false,
+      title: 'Title',
+      description: 'Description',
     });
     const joinClassroomAction = jest.fn();
     const classroomEnded = jest.fn();
@@ -52,6 +54,8 @@ describe('<DashboardClassroomStudent />', () => {
       />,
     );
 
+    screen.getByText(classroom.title);
+    screen.getByText(classroom.description);
     screen.getByText('Classroom not started yet.');
     expect(joinClassroomAction).toHaveBeenCalledTimes(0);
     expect(classroomEnded).toHaveBeenCalledTimes(0);
@@ -74,8 +78,8 @@ describe('<DashboardClassroomStudent />', () => {
         classroomEnded={classroomEnded}
       />,
     );
-    screen.getByText(classroom.title!);
-    screen.getByText(classroom.description!);
+    screen.getByText(classroom.title);
+    screen.getByText(classroom.description);
     const displayedStartingDate = startingAt.toLocaleString(DateTime.DATE_HUGE);
     const displayedStartingTime = startingAt.toLocaleString(
       DateTime.TIME_24_SIMPLE,

--- a/src/frontend/packages/lib_classroom/src/components/DashboardClassroomStudent/index.tsx
+++ b/src/frontend/packages/lib_classroom/src/components/DashboardClassroomStudent/index.tsx
@@ -11,6 +11,29 @@ import {
 } from 'components/DashboardClassroomLayout';
 import { DashboardClassroomStudentCounter } from 'components/DashboardClassroomStudentCounter';
 
+const DashboardClassRoomTitleDescription = ({
+  classroom,
+}: {
+  classroom: Classroom;
+}) => {
+  return (
+    <React.Fragment>
+      <Text
+        size="large"
+        weight="bold"
+        color="blue-active"
+        textAlign="center"
+        margin={{ top: 'large' }}
+      >
+        {classroom.title}
+      </Text>
+      <Text color="blue-active" textAlign="center">
+        {classroom.description}
+      </Text>
+    </React.Fragment>
+  );
+};
+
 const messages = defineMessages({
   joinedAs: {
     defaultMessage: 'You have joined the classroom as {joinedAs}.',
@@ -116,18 +139,7 @@ const DashboardClassroomStudent = ({
     // classroom scheduled
     left = (
       <React.Fragment>
-        <Text
-          size="large"
-          weight="bold"
-          color="blue-active"
-          textAlign="center"
-          margin={{ top: 'large' }}
-        >
-          {classroom.title}
-        </Text>
-        <Text color="blue-active" textAlign="center">
-          {classroom.description}
-        </Text>
+        <DashboardClassRoomTitleDescription classroom={classroom} />
         <Box
           margin={{ top: 'large', horizontal: 'small' }}
           pad={{ vertical: 'small', horizontal: 'small' }}
@@ -148,9 +160,12 @@ const DashboardClassroomStudent = ({
   } else {
     // classroom exists but not started
     left = (
-      <DashboardClassroomMessage
-        message={intl.formatMessage(messages.classroomNotStarted)}
-      />
+      <React.Fragment>
+        <DashboardClassRoomTitleDescription classroom={classroom} />
+        <DashboardClassroomMessage
+          message={intl.formatMessage(messages.classroomNotStarted)}
+        />
+      </React.Fragment>
     );
   }
 

--- a/src/frontend/packages/lib_classroom/src/utils/tests/factories.ts
+++ b/src/frontend/packages/lib_classroom/src/utils/tests/factories.ts
@@ -10,9 +10,9 @@ import {
 
 const { READY } = uploadState;
 
-export const classroomMockFactory = (
-  classroom: Partial<Classroom> = {},
-): Classroom => {
+export const classroomMockFactory = <T extends Partial<Classroom>>(
+  classroom: T = {} as T,
+): Classroom & T => {
   return {
     id: faker.datatype.uuid(),
     playlist: playlistMockFactory(),


### PR DESCRIPTION
## Purpose

When a classroom is not scheduled, the title and description of this one are never display

## Proposal

No matter if the classroom is scheduled or not, the title and the description should always be display.

- [x] display title / description when live not start and not scheduled
