### PR TITLE
🐛(lib-video) thumbnail not reset on the video player

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Manage disconnection when multiple tabs were open on standalone site
 - synchronisation between pages for the VOD description widget
 - tooltip position on the website context dashboard (#2136)
+- thumbnail not reset correctly on the video player (#2137)
 
 ## [4.0.0-beta.18] - 2023-03-06
 

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/WidgetThumbnail/ThumbnailRemoveButton/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/WidgetThumbnail/ThumbnailRemoveButton/index.spec.tsx
@@ -29,8 +29,22 @@ describe('<ThumbnailRemoveButton />', () => {
     fetchMock.restore();
   });
 
+  it('checks remove button is not displayed', () => {
+    const mockedThumbnail = thumbnailMockFactory({
+      is_ready_to_show: false,
+    });
+
+    render(<ThumbnailRemoveButton thumbnail={mockedThumbnail} />);
+
+    expect(
+      screen.queryByRole('button', { name: 'Delete thumbnail' }),
+    ).not.toBeInTheDocument();
+  });
+
   it('clicks on the remove button and removal is successful', async () => {
-    const mockedThumbnail = thumbnailMockFactory();
+    const mockedThumbnail = thumbnailMockFactory({
+      is_ready_to_show: true,
+    });
     useThumbnail.getState().addResource(mockedThumbnail);
 
     fetchMock.delete(`/api/thumbnails/${mockedThumbnail.id}/`, 204);
@@ -70,7 +84,9 @@ describe('<ThumbnailRemoveButton />', () => {
   });
 
   it('clicks on the remove button and removal fails', async () => {
-    const mockedThumbnail = thumbnailMockFactory();
+    const mockedThumbnail = thumbnailMockFactory({
+      is_ready_to_show: true,
+    });
     useThumbnail.getState().addResource(mockedThumbnail);
 
     fetchMock.delete(`/api/thumbnails/${mockedThumbnail.id}/`, 500);

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/WidgetThumbnail/ThumbnailRemoveButton/index.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/WidgetThumbnail/ThumbnailRemoveButton/index.tsx
@@ -89,14 +89,16 @@ export const ThumbnailRemoveButton = ({
           }}
         />
       )}
-      <Button
-        a11yTitle={intl.formatMessage(messages.deleteButtonLabel)}
-        icon={<BinSVG width="14px" height="18px" iconColor="blue-active" />}
-        onClick={() => setShowDeleteConfirmationModal(true)}
-        plain
-        title={intl.formatMessage(messages.deleteButtonLabel)}
-        margin="small"
-      />
+      {thumbnail && thumbnail.is_ready_to_show && (
+        <Button
+          a11yTitle={intl.formatMessage(messages.deleteButtonLabel)}
+          icon={<BinSVG width="14px" height="18px" iconColor="blue-active" />}
+          onClick={() => setShowDeleteConfirmationModal(true)}
+          plain
+          title={intl.formatMessage(messages.deleteButtonLabel)}
+          margin="small"
+        />
+      )}
     </React.Fragment>
   );
 };

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/WidgetThumbnail/index.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/WidgetThumbnail/index.tsx
@@ -163,9 +163,7 @@ export const WidgetThumbnail = ({ isLive = true }: WidgetThumbnailProps) => {
                 uploadManagerState={uploadManagerState}
               />
             </Box>
-            {thumbnail && thumbnail.is_ready_to_show && (
-              <ThumbnailRemoveButton thumbnail={thumbnail} />
-            )}
+            <ThumbnailRemoveButton thumbnail={thumbnail} />
           </Stack>
         )}
 


### PR DESCRIPTION
## Purpose

Fixed issue https://github.com/openfun/marsha/issues/2131

When we remove the thumbnail in the VOD dashboard, the thumbnail of the player is not correctly updated.

## Proposal

- [x] Reretch the current video after a thumbnail is deleted
- [x] Fixed a memory leak issue during the thumbnail removing 

