### PR TITLE
♻️(front) replace live occurences by webinar in the standalone site

### DIFF
--- a/src/frontend/apps/standalone_site/src/features/Contents/components/Contents/Contents.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/components/Contents/Contents.spec.tsx
@@ -6,7 +6,7 @@ import Contents from './Contents';
 jest.mock('features/Contents', () => ({
   ClassRooms: () => <div>Classrooms Component</div>,
   Videos: () => <div>Videos Component</div>,
-  Lives: () => <div>Lives Component</div>,
+  Lives: () => <div>Webinars Component</div>,
 }));
 
 describe('<Contents />', () => {
@@ -14,9 +14,9 @@ describe('<Contents />', () => {
     render(<Contents />);
     expect(screen.getByText(/My Classrooms/)).toBeInTheDocument();
     expect(screen.getByText(/My Videos/)).toBeInTheDocument();
-    expect(screen.getByText(/My Lives/)).toBeInTheDocument();
+    expect(screen.getByText(/My Webinars/)).toBeInTheDocument();
     expect(screen.getByText(/Classrooms Component/i)).toBeInTheDocument();
-    expect(screen.getByText(/Lives Component/i)).toBeInTheDocument();
+    expect(screen.getByText(/Webinars Component/i)).toBeInTheDocument();
     expect(screen.getByText(/Videos Component/i)).toBeInTheDocument();
     expect(screen.getAllByText(/See Everything/i)).toHaveLength(3);
   });

--- a/src/frontend/apps/standalone_site/src/features/Contents/components/Contents/Contents.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/components/Contents/Contents.tsx
@@ -7,10 +7,10 @@ import { ClassRooms, Videos, Lives } from 'features/Contents';
 import { routes } from 'routes';
 
 const messages = defineMessages({
-  MyLives: {
-    defaultMessage: 'My Lives',
-    description: 'My contents page, my lives title',
-    id: 'features.Contents.Contents.MyLives',
+  MyWebinars: {
+    defaultMessage: 'My Webinars',
+    description: 'My contents page, my webinars title',
+    id: 'features.Contents.Contents.MyWebinars',
   },
   MyVideos: {
     defaultMessage: 'My Videos',
@@ -40,7 +40,7 @@ const Contents = () => {
     <Box margin={{ top: 'medium' }}>
       <Box margin={{ top: 'medium' }}>
         <BoxText direction="row" justify="between" margin={{ bottom: 'small' }}>
-          <Text weight="bolder">{intl.formatMessage(messages.MyLives)}</Text>
+          <Text weight="bolder">{intl.formatMessage(messages.MyWebinars)}</Text>
           <Text weight="bolder">
             <StyledLink to={`${routes.CONTENTS.subRoutes.LIVE.path}`}>
               › {intl.formatMessage(messages.SeeEverything)}

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/Read/Live.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/Read/Live.spec.tsx
@@ -8,8 +8,8 @@ describe('<Live />', () => {
   test('renders Live', () => {
     const live = videoMockFactory({
       id: '4321',
-      title: 'New live title',
-      description: 'New live description',
+      title: 'New webinar title',
+      description: 'New webinar description',
       playlist: {
         ...videoMockFactory().playlist,
         title: 'New playlist title',
@@ -24,8 +24,8 @@ describe('<Live />', () => {
     ).toHaveStyle(
       `background: url(https://example.com/default_thumbnail/240) no-repeat center / cover`,
     );
-    expect(screen.getByText('New live title')).toBeInTheDocument();
-    expect(screen.getByText('New live description')).toBeInTheDocument();
+    expect(screen.getByText('New webinar title')).toBeInTheDocument();
+    expect(screen.getByText('New webinar description')).toBeInTheDocument();
     expect(screen.getByText('New playlist title')).toBeInTheDocument();
     expect(screen.getByRole('link')).toHaveAttribute(
       'href',
@@ -36,8 +36,8 @@ describe('<Live />', () => {
   test('renders thumbnail', () => {
     const live = videoMockFactory({
       id: '4321',
-      title: 'New live title',
-      description: 'New live description',
+      title: 'New webinar title',
+      description: 'New webinar description',
       playlist: {
         ...videoMockFactory().playlist,
         title: 'New playlist title',

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/Read/Lives.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/Read/Lives.spec.tsx
@@ -20,8 +20,8 @@ const someResponse = {
   results: [
     videoMockFactory({
       id: '4321',
-      title: 'New live title',
-      description: 'New live description',
+      title: 'New webinar title',
+      description: 'New webinar description',
       playlist: {
         ...videoMockFactory().playlist,
         title: 'New playlist title',
@@ -88,7 +88,7 @@ describe('<Lives/>', () => {
     render(<Lives />);
     expect(screen.getByRole('alert', { name: /spinner/i })).toBeInTheDocument();
     expect(
-      await screen.findByText(/There is no live to display./i),
+      await screen.findByText(/There is no webinar to display./i),
     ).toBeInTheDocument();
   });
 
@@ -100,8 +100,8 @@ describe('<Lives/>', () => {
 
     render(<Lives />);
     expect(screen.getByRole('alert', { name: /spinner/i })).toBeInTheDocument();
-    expect(await screen.findByText(/New live title/)).toBeInTheDocument();
-    expect(screen.getByText(/New live description/)).toBeInTheDocument();
+    expect(await screen.findByText(/New webinar title/)).toBeInTheDocument();
+    expect(screen.getByText(/New webinar description/)).toBeInTheDocument();
     expect(
       screen.queryByLabelText('Pagination Navigation'),
     ).not.toBeInTheDocument();
@@ -151,7 +151,7 @@ describe('<Lives/>', () => {
 
     render(<Lives withPagination={false} limit={1} />);
 
-    expect(await screen.findByText(/New live title/)).toBeInTheDocument();
+    expect(await screen.findByText(/New webinar title/)).toBeInTheDocument();
   });
 
   test('api limit depend the responsive', async () => {
@@ -174,6 +174,6 @@ describe('<Lives/>', () => {
       },
     );
 
-    expect(await screen.findByText('New live title')).toBeInTheDocument();
+    expect(await screen.findByText('New webinar title')).toBeInTheDocument();
   });
 });

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/Read/Lives.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/Read/Lives.tsx
@@ -9,8 +9,8 @@ import Live from './Live';
 
 const messages = defineMessages({
   NoLive: {
-    defaultMessage: 'There is no live to display.',
-    description: 'Text when there is no live to display.',
+    defaultMessage: 'There is no webinar to display.',
+    description: 'Text when there is no webinar to display.',
     id: 'features.Contents.features.ReadLives.NoLive',
   },
 });

--- a/src/frontend/apps/standalone_site/src/routes/routes.tsx
+++ b/src/frontend/apps/standalone_site/src/routes/routes.tsx
@@ -47,8 +47,8 @@ const messages = defineMessages({
     id: 'routes.routes.menuContentsVideosLabel',
   },
   menuContentsLivesLabel: {
-    defaultMessage: 'Lives',
-    description: 'Label for the lives link in the content navigation menu',
+    defaultMessage: 'Webinars',
+    description: 'Label for the webinars link in the content navigation menu',
     id: 'routes.routes.menuContentsLivesLabel',
   },
   menuContentsClassroomLabel: {


### PR DESCRIPTION
## Purpose

On the standalone site we don't want to use the `live` keyword anymore, we want to use `webinar`. This is already the case on the deep linking menu for example.

## Proposal

- [x]  replace live occurences by webinar in the standalone site

