### PR TITLE
Configure sentry in standalone site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   - List the lives in the contents section (#2104)
   - Live session model
   - Livesession backend rewrite
+  - Add sentry
 - Add a License Manager widget for LTI VOD view
 - Add a title to the classroom file dropzone
 - Add can_edit property on a serialized video

--- a/src/backend/marsha/core/tests/test_api_get_frontend_configuration.py
+++ b/src/backend/marsha/core/tests/test_api_get_frontend_configuration.py
@@ -1,0 +1,55 @@
+"""Tests for the get_frontend_configuration API."""
+from django.test import TestCase, override_settings
+
+from waffle.testutils import override_switch
+
+from marsha.core.defaults import SENTRY
+
+
+@override_settings(
+    SENTRY_DSN="https://sentry.dsn",
+    ENVIRONMENT="development",
+    RELEASE="1.2.3",
+)
+class TestGetFrontendConfiguration(TestCase):
+    """Test the get_frontend_configuration API."""
+
+    maxDiff = None
+
+    @override_switch(SENTRY, active=True)
+    def test_api_get_frontend_configuration_sentry_active(self):
+        """
+        Anonymous users should be able to access the API.
+
+        With sentry active, the response should contain the sentry configuration.
+        """
+        response = self.client.get("/api/config/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertDictEqual(
+            response.json(),
+            {
+                "environment": "development",
+                "release": "1.2.3",
+                "sentry_dsn": "https://sentry.dsn",
+            },
+        )
+
+    @override_switch(SENTRY, active=False)
+    def test_api_get_frontend_configuration_sentry_inactive(self):
+        """
+        Anonymous users should be able to access the API.
+
+        With sentry inactive, the response should not contain the sentry configuration.
+        """
+        response = self.client.get("/api/config/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertDictEqual(
+            response.json(),
+            {
+                "environment": "development",
+                "release": "1.2.3",
+                "sentry_dsn": None,
+            },
+        )

--- a/src/backend/marsha/urls.py
+++ b/src/backend/marsha/urls.py
@@ -23,6 +23,7 @@ from marsha.core.api import (
     UserViewSet,
     VideoViewSet,
     XAPIStatementView,
+    get_frontend_configuration,
     pairing_challenge,
     recording_slices_manifest,
     recording_slices_state,
@@ -131,6 +132,7 @@ urlpatterns = [
         recording_slices_state,
         name="recording_slices_state",
     ),
+    path("api/config/", get_frontend_configuration, name="sentry_config"),
     path("api/", include(router.urls)),
     path(
         f"api/{models.Video.RESOURCE_NAME}/<uuid:video_id>/",

--- a/src/frontend/apps/lti_site/components/App/AppInitializer/index.tsx
+++ b/src/frontend/apps/lti_site/components/App/AppInitializer/index.tsx
@@ -64,7 +64,7 @@ export const AppInitializer = (
         release: appConfig.release,
       });
       Sentry.configureScope((scope) =>
-        scope.setExtra('application', 'frontend'),
+        scope.setExtra('application', 'standalone'),
       );
 
       setIsSentryReady(true);

--- a/src/frontend/apps/standalone_site/src/App.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/App.spec.tsx
@@ -3,6 +3,7 @@ import fetchMock from 'fetch-mock';
 import { useCurrentUser, userMockFactory } from 'lib-components';
 
 import fetchMockAuth from '__mock__/fetchMockAuth.mock';
+import { FrontendConfiguration } from 'components/Sentry';
 
 import App from './App';
 
@@ -14,6 +15,11 @@ const consoleWarn = jest
 
 window.scrollTo = jest.fn();
 window.isCDNLoaded = true;
+
+jest.mock('@sentry/browser', () => ({
+  init: jest.fn(),
+  configureScope: jest.fn(),
+}));
 
 const someResponse = {
   count: 1,
@@ -32,6 +38,12 @@ const someResponse = {
   ],
 };
 
+const frontendConfiguration: FrontendConfiguration = {
+  environment: 'some environment',
+  release: 'some release',
+  sentry_dsn: null,
+};
+
 describe('<App />', () => {
   beforeEach(() => {
     useCurrentUser.setState({
@@ -39,6 +51,7 @@ describe('<App />', () => {
     });
 
     fetchMock.get('/api/classrooms/?limit=5&offset=0', someResponse);
+    fetchMock.get('/api/config/', frontendConfiguration);
   });
 
   afterEach(() => {

--- a/src/frontend/apps/standalone_site/src/App.tsx
+++ b/src/frontend/apps/standalone_site/src/App.tsx
@@ -7,6 +7,7 @@ import { QueryClient, QueryClientProvider } from 'react-query';
 import { ReactQueryDevtools } from 'react-query/devtools';
 import { BrowserRouter } from 'react-router-dom';
 
+import { SentryLoader } from 'components/Sentry';
 import { ContentSpinner } from 'components/Spinner';
 import { DEFAULT_LANGUAGE } from 'conf/global';
 import { AppRoutes } from 'routes';
@@ -79,6 +80,7 @@ const App = () => {
     >
       <QueryClientProvider client={queryClient}>
         <ReactQueryDevtools />
+        <SentryLoader />
         <Grommet theme={themeExtended}>
           <Toaster
             toastOptions={{

--- a/src/frontend/apps/standalone_site/src/components/Sentry/SentryLoader.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/components/Sentry/SentryLoader.spec.tsx
@@ -1,0 +1,65 @@
+import * as Sentry from '@sentry/browser';
+import { waitFor } from '@testing-library/react';
+import fetchMock from 'fetch-mock';
+import { render } from 'lib-tests';
+import React from 'react';
+
+import { SentryLoader } from '.';
+
+const mockInit = jest.spyOn(Sentry, 'init').mockImplementation();
+const mockConfigureScope = jest
+  .spyOn(Sentry, 'configureScope')
+  .mockImplementation();
+
+describe('SentryLoader', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+    fetchMock.restore();
+  });
+
+  it('should init Sentry when active', async () => {
+    fetchMock.get('/api/config/', {
+      environment: 'some environment',
+      release: 'some release',
+      sentry_dsn: 'some dsn',
+    });
+
+    render(<SentryLoader />);
+
+    expect(fetchMock.called('/api/config/')).toBe(true);
+    await waitFor(() => {
+      expect(mockInit).toHaveBeenCalledWith({
+        dsn: 'some dsn',
+        environment: 'some environment',
+        release: 'some release',
+      });
+    });
+
+    expect(mockConfigureScope).toHaveBeenCalledWith(expect.any(Function));
+    expect(mockConfigureScope.mock.calls[0][0]).toEqual(expect.any(Function));
+    const passedFunction = mockConfigureScope.mock.calls[0][0];
+    const scope = { setExtra: jest.fn() } as any;
+    passedFunction(scope);
+    expect(scope.setExtra).toHaveBeenCalledWith('application', 'standalone');
+  });
+
+  it('should not init Sentry when not active', async () => {
+    fetchMock.get(
+      '/api/config/',
+      {
+        environment: 'some environment',
+        release: 'some release',
+        sentry_dsn: null,
+      },
+      { overwriteRoutes: true },
+    );
+    render(<SentryLoader />);
+
+    expect(fetchMock.called('/api/config/')).toBe(true);
+    await waitFor(() => {
+      expect(mockInit).not.toHaveBeenCalled();
+    });
+
+    expect(mockConfigureScope).not.toHaveBeenCalled();
+  });
+});

--- a/src/frontend/apps/standalone_site/src/components/Sentry/SentryLoader.tsx
+++ b/src/frontend/apps/standalone_site/src/components/Sentry/SentryLoader.tsx
@@ -1,0 +1,50 @@
+import * as Sentry from '@sentry/browser';
+import { fetchWrapper, useSentry } from 'lib-components';
+import { useEffect } from 'react';
+
+export type FrontendConfiguration = {
+  sentry_dsn: string | null;
+  environment: string;
+  release: string;
+};
+
+export const getFrontendConfiguration =
+  async (): Promise<FrontendConfiguration> => {
+    const response = await fetchWrapper(`/api/config/`, {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to get sentry config : ${response.status}.`);
+    }
+
+    return (await response.json()) as FrontendConfiguration;
+  };
+
+export const SentryLoader = () => {
+  const setIsSentryReady = useSentry((state) => state.setIsSentryReady);
+
+  useEffect(() => {
+    const initSentry = async () => {
+      const { environment, release, sentry_dsn } =
+        await getFrontendConfiguration();
+      if (sentry_dsn) {
+        Sentry.init({
+          dsn: sentry_dsn,
+          environment: environment,
+          release: release,
+        });
+        Sentry.configureScope((scope) =>
+          scope.setExtra('application', 'standalone'),
+        );
+
+        setIsSentryReady(true);
+      }
+    };
+    initSentry();
+  }, [setIsSentryReady]);
+
+  return null;
+};

--- a/src/frontend/apps/standalone_site/src/components/Sentry/index.tsx
+++ b/src/frontend/apps/standalone_site/src/components/Sentry/index.tsx
@@ -1,0 +1,1 @@
+export * from './SentryLoader';


### PR DESCRIPTION
## Purpose

Add sentry to the standalone site

Fixes #1982

## Proposal

Use a public API endpoint to get sentry config allows us to initialize it sooner than with a jwt.
Also jwt related errors will be sent.

- [x] Add an API endpoint to retrieve sentry config
- [x] Load and init sentry in the standalone site

