### PR TITLE
🐛(front) correctly fetch transcript content in TranscriptReader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - tooltip position on the website context dashboard (#2136)
 - thumbnail not reset correctly on the video player (#2137)
 - display title / description when a classroom is not scheduled and not started
+- correctly fetch transcript content in TranscriptReader
 
 ## [4.0.0-beta.18] - 2023-03-06
 

--- a/src/frontend/packages/lib_video/src/api/useTranscriptReaderRequest/index.ts
+++ b/src/frontend/packages/lib_video/src/api/useTranscriptReaderRequest/index.ts
@@ -1,32 +1,22 @@
 import { fetchWrapper } from 'lib-components';
 import { useQuery, UseQueryOptions } from 'react-query';
-import { VTTCue, WebVTT } from 'vtt.js';
 
 export const useTranscriptReaderRequest = (
+  id: string,
   url: string,
-  onSuccess: (cue: VTTCue) => void,
   queryConfig?: UseQueryOptions<string, 'useTranscriptReaderRequest', string>,
 ) => {
   return useQuery({
-    queryKey: ['useTranscriptReaderRequest'],
+    queryKey: ['useTranscriptReaderRequest', id],
     queryFn: async () => {
       const response = await fetchWrapper(url);
       return await response.text();
     },
-    onSuccess: (transcriptReader: string) => {
-      if (!transcriptReader) {
-        return;
-      }
-
-      const parser = new WebVTT.Parser(window, WebVTT.StringDecoder());
-
-      parser.oncue = (cue: VTTCue) => {
-        onSuccess(cue);
-      };
-
-      parser.parse(transcriptReader);
-      parser.flush();
-    },
+    refetchInterval: false,
+    refetchIntervalInBackground: false,
+    refetchOnWindowFocus: false,
+    cacheTime: Infinity,
+    staleTime: Infinity,
     ...queryConfig,
   });
 };


### PR DESCRIPTION
## Purpose

The react-query hook useTranscriptReaderRequest didn't use a unique query key. That means that when the url was changing, this new url was not use because the stale time was not over. First, we have to use a unique query key by adding the timedtextrack id to it. Secondly the usage of the `OnSuccess` on that react-query hook is not the good solution. While no new query is made, the onSuccess is called with an empty data. To fix this issue, all the logic made on this onSuccess is moved in a `useEffect` hook in the TranscriptReader responsible to update the cues. And last, there is no reason to fetch again and again the file content, it will never change. So we can set an inifinte cache and stale time.

## Proposal

- [x] correctly fetch transcript content in TranscriptReader

