### PR TITLE
Create a classroom invite link for an instructor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,15 +36,15 @@ generate-version-file: &generate-version-file
 
 version: 2.1
 commands:
-  get_last_packages_commit:
-    description: 'Get last commit that modified packages and stores it in File. File is used as checksum source for part of frontend caching key.'
+  get_last_frontend_commit:
+    description: 'Get last commit that modified the frontend and stores it in File. File is used as checksum source for part of frontend caching key.'
     parameters:
       filename:
         type: string
     steps:
       - run:
-          name: Get last commit that modified packages
-          command: git log -n 1 --pretty=format:%H -- packages > << parameters.filename >>
+          name: Get last commit that modified frontend
+          command: git log -n 1 --pretty=format:%H -- . > << parameters.filename >>
 jobs:
   # Git jobs
   # Check that the git history is clean and complies with our expectations
@@ -398,8 +398,6 @@ jobs:
     steps:
       - checkout:
           path: ~/marsha
-      - get_last_packages_commit:
-          filename: packages-last-commit.txt
       - restore_cache:
           keys:
             - front-dependencies-<< pipeline.parameters.cache-version >>-{{ checksum "yarn.lock" }}
@@ -440,8 +438,8 @@ jobs:
     steps:
       - checkout:
           path: ~/marsha
-      - get_last_packages_commit:
-          filename: packages-last-commit.txt
+      - get_last_frontend_commit:
+          filename: frontend-last-commit.txt
       - restore_cache:
           keys:
             - front-dependencies-<< pipeline.parameters.cache-version >>-{{ checksum "yarn.lock" }}
@@ -464,7 +462,7 @@ jobs:
           paths:
             - ../backend/marsha/static/js/build/lti_site
             - ../backend/marsha/static/js/build/site
-          key: build-front-<< pipeline.parameters.cache-version >>-{{ checksum "yarn.lock" }}
+          key: build-front-<< pipeline.parameters.cache-version >>-{{ checksum "frontend-last-commit.txt" }}
 
   # ---- mail jobs ----
   build-mails:
@@ -508,8 +506,6 @@ jobs:
     steps:
       - checkout:
           path: ~/marsha
-      - get_last_packages_commit:
-          filename: packages-last-commit.txt
       - restore_cache:
           keys:
             - front-dependencies-<< pipeline.parameters.cache-version >>-{{ checksum "yarn.lock" }}
@@ -532,8 +528,6 @@ jobs:
     steps:
       - checkout:
           path: ~/marsha
-      - get_last_packages_commit:
-          filename: packages-last-commit.txt
       - restore_cache:
           keys:
             - front-dependencies-<< pipeline.parameters.cache-version >>-{{ checksum "yarn.lock" }}
@@ -616,8 +610,6 @@ jobs:
     steps:
       - checkout:
           path: ~/marsha
-      - get_last_packages_commit:
-          filename: packages-last-commit.txt
       - restore_cache:
           keys:
             - front-dependencies-<< pipeline.parameters.cache-version >>-{{ checksum "yarn.lock" }}
@@ -677,14 +669,14 @@ jobs:
     steps:
       - checkout:
           path: /home/circleci/marsha
-      - get_last_packages_commit:
-          filename: packages-last-commit.txt
+      - get_last_frontend_commit:
+          filename: frontend-last-commit.txt
       - restore_cache:
           keys:
             - front-dependencies-<< pipeline.parameters.cache-version >>-{{ checksum "yarn.lock" }}
       - restore_cache:
           keys:
-            - build-front-<< pipeline.parameters.cache-version >>-{{ checksum "yarn.lock" }}
+            - build-front-<< pipeline.parameters.cache-version >>-{{ checksum "frontend-last-commit.txt" }}
       - run: # Can be removed when switching to mcr.microsoft.com/playwright:jammy
           name: Install Python 3.10
           command: apt update && apt upgrade -y && apt install -y software-properties-common && add-apt-repository -y 'ppa:deadsnakes/ppa' && apt install -y python3.10 python3.10-dev build-essential

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   - Invite links
   - Support sharing
   - Recordings
+- Add classroom invite link for an instructor
 
 ### Changed
 

--- a/src/backend/marsha/bbb/serializers.py
+++ b/src/backend/marsha/bbb/serializers.py
@@ -19,6 +19,7 @@ from marsha.bbb.utils.bbb_utils import (
     get_url as get_document_url,
 )
 from marsha.bbb.utils.tokens import create_classroom_stable_invite_jwt
+from marsha.core.models import INSTRUCTOR
 from marsha.core.serializers import (
     BaseInitiateUploadSerializer,
     UploadableFileWithExtensionSerializerMixin,
@@ -74,6 +75,7 @@ class ClassroomSerializer(serializers.ModelSerializer):
             # specific generated fields
             "infos",
             "invite_token",
+            "instructor_token",
         )
         read_only_fields = (
             "id",
@@ -90,6 +92,7 @@ class ClassroomSerializer(serializers.ModelSerializer):
     recordings = ClassroomRecordingSerializer(many=True, read_only=True)
     infos = serializers.SerializerMethodField()
     invite_token = serializers.SerializerMethodField()
+    instructor_token = serializers.SerializerMethodField()
     recordings = serializers.SerializerMethodField()
 
     def get_infos(self, obj):
@@ -103,6 +106,18 @@ class ClassroomSerializer(serializers.ModelSerializer):
         """Get the invite token for the classroom."""
         if self.context.get("is_admin", False):
             return str(create_classroom_stable_invite_jwt(obj))
+        return None
+
+    def get_instructor_token(self, obj):
+        """Get the instructor token for the classroom."""
+        if self.context.get("is_admin", False):
+            return str(
+                create_classroom_stable_invite_jwt(
+                    obj,
+                    role=INSTRUCTOR,
+                    permissions={"can_update": True, "can_access_dashboard": True},
+                )
+            )
         return None
 
     def get_recordings(self, obj):

--- a/src/backend/marsha/bbb/tests/api/classroom/test_create.py
+++ b/src/backend/marsha/bbb/tests/api/classroom/test_create.py
@@ -137,6 +137,7 @@ class ClassroomCreateAPITest(TestCase):
                 "title": "Some classroom",
                 "welcome_text": "Welcome!",
                 "invite_token": None,
+                "instructor_token": None,
                 "recordings": [],
             },
         )
@@ -207,6 +208,7 @@ class ClassroomCreateAPITest(TestCase):
                 "title": "Some classroom",
                 "welcome_text": "Welcome!",
                 "invite_token": None,
+                "instructor_token": None,
                 "recordings": [],
             },
         )
@@ -243,6 +245,7 @@ class ClassroomCreateAPITest(TestCase):
                 "title": "classroom two",
                 "welcome_text": "Welcome!",
                 "invite_token": None,
+                "instructor_token": None,
                 "recordings": [],
             },
         )
@@ -295,6 +298,7 @@ class ClassroomCreateAPITest(TestCase):
                 "title": "Some classroom",
                 "welcome_text": "Welcome!",
                 "invite_token": None,
+                "instructor_token": None,
                 "recordings": [],
             },
         )
@@ -331,6 +335,7 @@ class ClassroomCreateAPITest(TestCase):
                 "title": "classroom two",
                 "welcome_text": "Welcome!",
                 "invite_token": None,
+                "instructor_token": None,
                 "recordings": [],
             },
         )

--- a/src/backend/marsha/bbb/tests/api/classroom/test_retrieve.py
+++ b/src/backend/marsha/bbb/tests/api/classroom/test_retrieve.py
@@ -13,7 +13,7 @@ from marsha.core.factories import (
     PlaylistAccessFactory,
     PlaylistFactory,
 )
-from marsha.core.models import ADMINISTRATOR, NONE
+from marsha.core.models import ADMINISTRATOR, INSTRUCTOR, NONE
 from marsha.core.simple_jwt.factories import (
     InstructorOrAdminLtiTokenFactory,
     StudentLtiTokenFactory,
@@ -78,6 +78,7 @@ class ClassroomRetrieveAPITest(TestCase):
                 "starting_at": None,
                 "estimated_duration": None,
                 "invite_token": None,
+                "instructor_token": None,
                 "recordings": [],
             },
             content,
@@ -129,6 +130,7 @@ class ClassroomRetrieveAPITest(TestCase):
                 "estimated_duration": None,
                 "recordings": [],
                 "invite_token": None,
+                "instructor_token": None,
             },
             content,
         )
@@ -192,6 +194,7 @@ class ClassroomRetrieveAPITest(TestCase):
                 "starting_at": "2018-08-08T01:00:00Z",
                 "estimated_duration": "00:01:00",
                 "invite_token": None,
+                "instructor_token": None,
                 "recordings": [],
             },
             content,
@@ -216,6 +219,7 @@ class ClassroomRetrieveAPITest(TestCase):
 
         content = json.loads(response.content)
         invite_token = content.pop("invite_token")
+        instructor_token = content.pop("instructor_token")
         self.assertDictEqual(
             {
                 "id": str(classroom.id),
@@ -236,6 +240,7 @@ class ClassroomRetrieveAPITest(TestCase):
                 "estimated_duration": None,
                 "recordings": [],
                 # invite_token is tested below
+                # instructor_token is tested below
             },
             content,
         )
@@ -246,6 +251,13 @@ class ClassroomRetrieveAPITest(TestCase):
         self.assertEqual(
             decoded_invite_token.payload["permissions"],
             {"can_update": False, "can_access_dashboard": False},
+        )
+
+        decoded_instructor_token = ResourceAccessToken(instructor_token)
+        self.assertEqual(decoded_instructor_token.payload["roles"], [INSTRUCTOR])
+        self.assertEqual(
+            decoded_instructor_token.payload["permissions"],
+            {"can_update": True, "can_access_dashboard": True},
         )
 
     @mock.patch.object(serializers, "get_meeting_infos")
@@ -290,6 +302,7 @@ class ClassroomRetrieveAPITest(TestCase):
 
         content = json.loads(response.content)
         invite_token = content.pop("invite_token")
+        instructor_token = content.pop("instructor_token")
         self.assertDictEqual(
             {
                 "id": str(classroom.id),
@@ -310,6 +323,7 @@ class ClassroomRetrieveAPITest(TestCase):
                 "estimated_duration": None,
                 "recordings": [],
                 # invite_token is tested below
+                # instructor_token is tested below
             },
             content,
         )
@@ -320,6 +334,16 @@ class ClassroomRetrieveAPITest(TestCase):
         self.assertEqual(
             decoded_invite_token.payload["permissions"],
             {"can_update": False, "can_access_dashboard": False},
+        )
+
+        decoded_instructor_token = ResourceAccessToken(instructor_token)
+        self.assertEqual(
+            decoded_instructor_token.payload["resource_id"], str(classroom.id)
+        )
+        self.assertEqual(decoded_instructor_token.payload["roles"], [INSTRUCTOR])
+        self.assertEqual(
+            decoded_instructor_token.payload["permissions"],
+            {"can_update": True, "can_access_dashboard": True},
         )
 
     @mock.patch.object(serializers, "get_meeting_infos")
@@ -344,6 +368,7 @@ class ClassroomRetrieveAPITest(TestCase):
 
         content = json.loads(response.content)
         invite_token = content.pop("invite_token")
+        instructor_token = content.pop("instructor_token")
         self.assertDictEqual(
             {
                 "id": str(classroom.id),
@@ -364,6 +389,7 @@ class ClassroomRetrieveAPITest(TestCase):
                 "estimated_duration": None,
                 "recordings": [],
                 # invite_token is tested below
+                # instructor_token is tested below
             },
             content,
         )
@@ -374,6 +400,16 @@ class ClassroomRetrieveAPITest(TestCase):
         self.assertEqual(
             decoded_invite_token.payload["permissions"],
             {"can_update": False, "can_access_dashboard": False},
+        )
+
+        decoded_instructor_token = ResourceAccessToken(instructor_token)
+        self.assertEqual(
+            decoded_instructor_token.payload["resource_id"], str(classroom.id)
+        )
+        self.assertEqual(decoded_instructor_token.payload["roles"], [INSTRUCTOR])
+        self.assertEqual(
+            decoded_instructor_token.payload["permissions"],
+            {"can_update": True, "can_access_dashboard": True},
         )
 
         response = self.client.get(
@@ -413,6 +449,7 @@ class ClassroomRetrieveAPITest(TestCase):
 
         content = json.loads(response.content)
         invite_token = content.pop("invite_token")
+        instructor_token = content.pop("instructor_token")
         self.assertDictEqual(
             {
                 "id": str(classroom.id),
@@ -448,6 +485,7 @@ class ClassroomRetrieveAPITest(TestCase):
                     },
                 ],
                 # invite_token is tested below
+                # instructor_token is tested below
             },
             content,
         )
@@ -458,4 +496,14 @@ class ClassroomRetrieveAPITest(TestCase):
         self.assertEqual(
             decoded_invite_token.payload["permissions"],
             {"can_update": False, "can_access_dashboard": False},
+        )
+
+        decoded_instructor_token = ResourceAccessToken(instructor_token)
+        self.assertEqual(
+            decoded_instructor_token.payload["resource_id"], str(classroom.id)
+        )
+        self.assertEqual(decoded_instructor_token.payload["roles"], [INSTRUCTOR])
+        self.assertEqual(
+            decoded_instructor_token.payload["permissions"],
+            {"can_update": True, "can_access_dashboard": True},
         )

--- a/src/backend/marsha/bbb/tests/api/classroom/test_update.py
+++ b/src/backend/marsha/bbb/tests/api/classroom/test_update.py
@@ -16,7 +16,7 @@ from marsha.core.factories import (
     PlaylistAccessFactory,
     PlaylistFactory,
 )
-from marsha.core.models import ADMINISTRATOR, NONE
+from marsha.core.models import ADMINISTRATOR, INSTRUCTOR, NONE
 from marsha.core.simple_jwt.factories import (
     InstructorOrAdminLtiTokenFactory,
     StudentLtiTokenFactory,
@@ -153,6 +153,7 @@ class ClassroomUpdateAPITest(TestCase):
 
         content = json.loads(response.content)
         invite_token = content.pop("invite_token")
+        instructor_token = content.pop("instructor_token")
         self.assertDictEqual(
             {
                 "id": str(classroom.id),
@@ -176,6 +177,7 @@ class ClassroomUpdateAPITest(TestCase):
                 "estimated_duration": "00:01:00",
                 "recordings": [],
                 # invite_token is tested below
+                # instructor_token is tested below
             },
             content,
         )
@@ -187,6 +189,17 @@ class ClassroomUpdateAPITest(TestCase):
         self.assertEqual(
             decoded_invite_token.payload["permissions"],
             {"can_update": False, "can_access_dashboard": False},
+        )
+
+        # don't verify here, because of time travel (tested elsewhere)
+        decoded_instructor_token = ResourceAccessToken(instructor_token, verify=False)
+        self.assertEqual(
+            decoded_instructor_token.payload["resource_id"], str(classroom.id)
+        )
+        self.assertEqual(decoded_instructor_token.payload["roles"], [INSTRUCTOR])
+        self.assertEqual(
+            decoded_instructor_token.payload["permissions"],
+            {"can_update": True, "can_access_dashboard": True},
         )
 
         classroom.refresh_from_db()
@@ -277,6 +290,7 @@ class ClassroomUpdateAPITest(TestCase):
 
         content = json.loads(response.content)
         invite_token = content.pop("invite_token")
+        instructor_token = content.pop("instructor_token")
         self.assertDictEqual(
             {
                 "id": str(classroom.id),
@@ -297,6 +311,7 @@ class ClassroomUpdateAPITest(TestCase):
                 "estimated_duration": "00:01:00",
                 "recordings": [],
                 # invite_token is tested below
+                # instructor_token is tested below
             },
             content,
         )
@@ -308,6 +323,16 @@ class ClassroomUpdateAPITest(TestCase):
         self.assertEqual(
             decoded_invite_token.payload["permissions"],
             {"can_update": False, "can_access_dashboard": False},
+        )
+
+        decoded_instructor_token = ResourceAccessToken(instructor_token, verify=False)
+        self.assertEqual(
+            decoded_instructor_token.payload["resource_id"], str(classroom.id)
+        )
+        self.assertEqual(decoded_instructor_token.payload["roles"], [INSTRUCTOR])
+        self.assertEqual(
+            decoded_instructor_token.payload["permissions"],
+            {"can_update": True, "can_access_dashboard": True},
         )
 
         classroom.refresh_from_db()

--- a/src/backend/marsha/bbb/tests/test_views_lti.py
+++ b/src/backend/marsha/bbb/tests/test_views_lti.py
@@ -20,14 +20,14 @@ from marsha.core.factories import (
     UserFactory,
 )
 from marsha.core.lti import LTI
-from marsha.core.models import ADMINISTRATOR, NONE
+from marsha.core.models import ADMINISTRATOR, INSTRUCTOR, NONE
 from marsha.core.simple_jwt.tokens import ResourceAccessToken
 from marsha.core.tests.testing_utils import reload_urlconf
 from marsha.core.tests.views.test_lti_base import BaseLTIViewForPortabilityTestCase
 
 
 # We don't enforce arguments classroomation in tests
-# pylint: disable=unused-argument
+# pylint: disable=unused-argument,too-many-locals
 
 
 @override_settings(BBB_API_ENDPOINT="https://10.7.7.1/bigbluebutton/api")
@@ -277,6 +277,7 @@ class ClassroomLTIViewTestCase(TestCase):
 
         resource_data = context.get("resource")
         invite_token = resource_data.pop("invite_token")
+        instructor_token = resource_data.pop("instructor_token")
         self.assertEqual(
             {
                 "id": str(classroom.id),
@@ -297,6 +298,7 @@ class ClassroomLTIViewTestCase(TestCase):
                 "estimated_duration": None,
                 "recordings": [],
                 # "invite_token" is tested separately
+                # "instructor_token" is tested separately
             },
             resource_data,
         )
@@ -306,6 +308,16 @@ class ClassroomLTIViewTestCase(TestCase):
         self.assertEqual(
             decoded_invite_token.payload["permissions"],
             {"can_update": False, "can_access_dashboard": False},
+        )
+
+        decoded_instructor_token = ResourceAccessToken(instructor_token)
+        self.assertEqual(
+            decoded_instructor_token.payload["resource_id"], str(classroom.id)
+        )
+        self.assertEqual(decoded_instructor_token.payload["roles"], [INSTRUCTOR])
+        self.assertEqual(
+            decoded_instructor_token.payload["permissions"],
+            {"can_update": True, "can_access_dashboard": True},
         )
 
         self.assertEqual(context.get("modelName"), "classrooms")
@@ -624,6 +636,7 @@ class MeetingLTIViewTestCase(TestCase):
 
         resource_data = context.get("resource")
         invite_token = resource_data.pop("invite_token")
+        instructor_token = resource_data.pop("instructor_token")
         self.assertEqual(
             {
                 "id": str(classroom.id),
@@ -644,6 +657,7 @@ class MeetingLTIViewTestCase(TestCase):
                 "estimated_duration": None,
                 "recordings": [],
                 # "invite_token" is tested separately
+                # "instructor_token" is tested separately
             },
             resource_data,
         )
@@ -653,6 +667,16 @@ class MeetingLTIViewTestCase(TestCase):
         self.assertEqual(
             decoded_invite_token.payload["permissions"],
             {"can_update": False, "can_access_dashboard": False},
+        )
+
+        decoded_instructor_token = ResourceAccessToken(instructor_token)
+        self.assertEqual(
+            decoded_instructor_token.payload["resource_id"], str(classroom.id)
+        )
+        self.assertEqual(decoded_instructor_token.payload["roles"], [INSTRUCTOR])
+        self.assertEqual(
+            decoded_instructor_token.payload["permissions"],
+            {"can_update": True, "can_access_dashboard": True},
         )
 
         self.assertEqual(context.get("modelName"), "classrooms")

--- a/src/backend/marsha/bbb/utils/tokens.py
+++ b/src/backend/marsha/bbb/utils/tokens.py
@@ -4,16 +4,23 @@ from datetime import timedelta
 from django.conf import settings
 from django.utils import timezone
 
+from marsha.core.models import NONE
 from marsha.core.simple_jwt.tokens import ResourceAccessToken
 
 
-def create_classroom_stable_invite_jwt(classroom):
+def create_classroom_stable_invite_jwt(classroom, role=NONE, permissions=None):
     """Create a resource JWT to be used in classroom invite links.
 
     Parameters
     ----------
     classroom : Type[models.Classroom]
         The classroom for which we want to create a JWT.
+
+    role : str
+        The role to use in the JWT. If not set, the no role is used.
+
+    permissions : dict
+        The permissions to use in the JWT. If not set, no permissions are used.
 
     Returns
     -------
@@ -24,6 +31,8 @@ def create_classroom_stable_invite_jwt(classroom):
     resource_jwt = ResourceAccessToken.for_resource_id(
         resource_id=str(classroom.id),
         session_id=f"{classroom.id}-invite",
+        roles=[role],
+        permissions=permissions or {},
     )
 
     # Set a fixed JWT ID

--- a/src/backend/marsha/e2e/test_lti_bbb.py
+++ b/src/backend/marsha/e2e/test_lti_bbb.py
@@ -360,7 +360,7 @@ def test_lti_bbb_create_enabled(page: Page, live_server: LiveServer, settings):
 
     expect(page.get_by_text("LTI link for this classroom:")).to_be_visible()
     invite_link_button = page.get_by_role(
-        "button", name="Invite someone with this link:"
+        "button", name="Invite a viewer with this link:"
     )
     invite_link_button.click()
     expect(page.get_by_text("Url copied in clipboard !")).to_be_visible()

--- a/src/backend/marsha/e2e/test_site.py
+++ b/src/backend/marsha/e2e/test_site.py
@@ -157,7 +157,7 @@ def test_site_classroom_invite_link(context: BrowserContext, live_server: LiveSe
 
     expect(page.get_by_text("LTI link for this classroom:")).to_be_visible()
     invite_link_button = page.get_by_role(
-        "button", name="Invite someone with this link:"
+        "button", name="Invite a viewer with this link:"
     )
     invite_link_button.click()
     expect(page.get_by_text("Url copied in clipboard !")).to_be_visible()

--- a/src/backend/marsha/e2e/test_site.py
+++ b/src/backend/marsha/e2e/test_site.py
@@ -186,6 +186,103 @@ def test_site_classroom_invite_link(context: BrowserContext, live_server: LiveSe
     BBB_API_ENDPOINT="https://10.7.7.1/bigbluebutton/api",
     BBB_API_SECRET="SuperSecret",
 )
+def test_site_classroom_moderator_link(
+    context: BrowserContext, live_server: LiveServer
+):
+    """Test site moderator link."""
+
+    # Backend requests mocking
+    responses.add(
+        responses.GET,
+        "https://10.7.7.1/bigbluebutton/api/create",
+        body="""<response>
+            <returncode>SUCCESS</returncode>
+            <meetingID>12345</meetingID>
+            <internalMeetingID>232a8ab5dbfde4d33a2bd9d5bbc08bd74d04e163-1628693645640</internalMeetingID>
+            <parentMeetingID>bbb-none</parentMeetingID>
+            <attendeePW>9#R1kuUl3R</attendeePW>
+            <moderatorPW>0$C7Aaz0o</moderatorPW>
+            <createTime>1628693645640</createTime>
+            <voiceBridge>83267</voiceBridge>
+            <dialNumber>613-555-1234</dialNumber>
+            <createDate>Wed Aug 11 14:54:05 UTC 2021</createDate>
+            <hasUserJoined>false</hasUserJoined>
+            <duration>0</duration>
+            <hasBeenForciblyEnded>false</hasBeenForciblyEnded>
+            <messageKey></messageKey>
+            <message></message>
+        </response>
+        """,
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        "https://10.7.7.1/bigbluebutton/api/getMeetingInfo",
+        body="""<response>
+            <returncode>FAILED</returncode>
+            <messageKey>notFound</messageKey>
+            <message>We could not find a meeting with that meeting ID</message>
+        </response>
+        """,
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        "https://10.7.7.1/bigbluebutton/api/join",
+        body="""
+        <response>
+            <returncode>SUCCESS</returncode>
+            <messageKey>successfullyJoined</messageKey>
+            <message>You have joined successfully.</message>
+            <meeting_id>74f4b5fefa00d05889a9095d1c81c51f704a74c0-1632323106549</meeting_id>
+            <user_id>w_cmlgpuqzkqez</user_id>
+            <auth_token>pcwfqes0ugkb</auth_token>
+            <session_token>4vtuguoqsolsqkqi</session_token>
+            <guestStatus>ALLOW</guestStatus>
+            <url>https://10.7.7.1/html5client/join?sessionToken=4vtuguoqsolsqkqi</url>
+        </response>
+        """,
+        status=200,
+    )
+    page = context.pages[0]
+    expect(page.get_by_role("menuitem", name="Dashboard")).to_be_visible()
+    expect(page.get_by_role("menuitem", name="My Playlists")).to_be_visible()
+    expect(page.get_by_role("menuitem", name="My Contents")).to_be_visible()
+    page.get_by_text("Classroom test").click()
+
+    expect(page.get_by_text("LTI link for this classroom:")).to_be_visible()
+    moderator_link_button = page.get_by_role(
+        "button", name="Invite a moderator with this link:"
+    )
+    moderator_link_button.click()
+    expect(page.get_by_text("Url copied in clipboard !")).to_be_visible()
+
+    moderator_page = page.context.new_page()
+    # tries to get the clipboard content, if it fails, it uses the data-clipboard-text
+    # attribute of the button
+    # see https://github.com/microsoft/playwright/issues/8114
+    try:
+        context.grant_permissions(["clipboard-read", "clipboard-write"])
+        moderator_link = page.evaluate("navigator.clipboard.readText()")
+    except Error:
+        moderator_link = moderator_link_button.get_attribute("data-clipboard-text")
+    moderator_page.goto(moderator_link)
+    expect(
+        moderator_page.get_by_text("Launch the classroom now in BBB")
+    ).to_be_visible()
+
+
+@pytest.mark.usefixtures("user_logged_in")
+@responses.activate
+@pytest.mark.django_db()
+@override_settings(
+    DEBUG=True,
+    FRONT_UPLOAD_POLL_INTERVAL="1",
+    STORAGE_BACKEND="marsha.core.storage.dummy",
+    X_FRAME_OPTIONS="",
+    BBB_API_ENDPOINT="https://10.7.7.1/bigbluebutton/api",
+    BBB_API_SECRET="SuperSecret",
+)
 def test_playlist_update(context: BrowserContext, live_server: LiveServer):
     """Test playlist update."""
     responses.add(

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/ClassRoomRouter.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/ClassRoomRouter.spec.tsx
@@ -10,10 +10,9 @@ jest.mock('./Read/ClassRooms', () => ({
 
 jest.mock('./Update/ClassRoomUpdate', () => ({
   __esModule: true,
-  default: ({ isInvited }: { isInvited: boolean }) => (
+  default: () => (
     <div>
       <p>My ClassRoomUpdate</p>
-      {isInvited && <p>Invited</p>}
     </div>
   ),
 }));
@@ -73,7 +72,6 @@ describe('<ClassRoomRouter/>', () => {
       },
     });
     expect(screen.getByText('My ClassRoomUpdate')).toBeInTheDocument();
-    expect(screen.getByText('Invited')).toBeInTheDocument();
   });
 
   test('render invite classroom without inviteId', () => {

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/ClassRoomRouter.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/ClassRoomRouter.tsx
@@ -20,11 +20,8 @@ const ClassRoomRouter = () => {
           <ClassRoomCreate />
           <ClassRooms />
         </Route>
-        <Route path={classroomInvitePath} exact>
-          <ClassRoomUpdate isInvited={true} />
-        </Route>
-        <Route path={classroomUpdatePath} exact>
-          <ClassRoomUpdate isInvited={false} />
+        <Route path={[classroomInvitePath, classroomUpdatePath]} exact>
+          <ClassRoomUpdate />
         </Route>
         <Route>
           <ClassRoomCreate />

--- a/src/frontend/packages/lib_classroom/src/components/ClassroomWidgetProvider/widgets/Invite/index.spec.tsx
+++ b/src/frontend/packages/lib_classroom/src/components/ClassroomWidgetProvider/widgets/Invite/index.spec.tsx
@@ -40,6 +40,7 @@ describe('<Invite />', () => {
       id: '1',
       started: false,
       invite_token: '1',
+      instructor_token: '2',
     });
 
     render(
@@ -59,6 +60,9 @@ describe('<Invite />', () => {
     ).toBeInTheDocument();
     expect(
       screen.getByText('https://localhost/my-contents/classroom/1/invite/1'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('https://localhost/my-contents/classroom/1/invite/2'),
     ).toBeInTheDocument();
     expect(
       screen.getByText('https://localhost/lti/classrooms/1'),

--- a/src/frontend/packages/lib_classroom/src/components/ClassroomWidgetProvider/widgets/Invite/index.tsx
+++ b/src/frontend/packages/lib_classroom/src/components/ClassroomWidgetProvider/widgets/Invite/index.tsx
@@ -9,7 +9,7 @@ const messages = defineMessages({
   title: {
     defaultMessage: 'Invite',
     description: 'A title for the widget.',
-    id: 'component.ClassroomForm.invite',
+    id: 'component.ClassroomWidgetProvider.Invite.invite',
   },
   info: {
     defaultMessage: `This widget provides several links depending on what you want to do:
@@ -18,7 +18,7 @@ const messages = defineMessages({
     course activity.
     `,
     description: 'Helptext for the widget.',
-    id: 'component.ClassroomForm.info',
+    id: 'component.ClassroomWidgetProvider.Invite.info',
   },
 });
 
@@ -34,6 +34,7 @@ export const Invite = () => {
     >
       <DashboardCopyClipboard
         inviteToken={classroom.invite_token}
+        instructorToken={classroom.instructor_token}
         classroomId={classroom.id}
       />
     </FoldableItem>

--- a/src/frontend/packages/lib_classroom/src/components/DashboardClassroomInfos/index.spec.tsx
+++ b/src/frontend/packages/lib_classroom/src/components/DashboardClassroomInfos/index.spec.tsx
@@ -30,7 +30,7 @@ describe('<DashboardClassroomInfos />', () => {
     ).toBeInTheDocument();
     expect(screen.getByText(classroomInfos.listenerCount)).toBeInTheDocument();
     expect(
-      screen.queryByText('Invite someone with this link:'),
+      screen.queryByText('Invite a viewer with this link:'),
     ).not.toBeInTheDocument();
     expect(
       screen.getByText('LTI link for this classroom:'),
@@ -44,7 +44,7 @@ describe('<DashboardClassroomInfos />', () => {
     render(<DashboardClassroomInfos inviteToken="my-token" classroomId="1" />);
 
     expect(
-      screen.getByText('Invite someone with this link:'),
+      screen.getByText('Invite a viewer with this link:'),
     ).toBeInTheDocument();
     expect(screen.getByText(/invite\/my-token/i)).toBeInTheDocument();
   });

--- a/src/frontend/packages/lib_classroom/src/components/DashboardCopyClipboard/index.tsx
+++ b/src/frontend/packages/lib_classroom/src/components/DashboardCopyClipboard/index.tsx
@@ -6,41 +6,51 @@ import { toast } from 'react-hot-toast';
 import { defineMessages, useIntl } from 'react-intl';
 
 const messages = defineMessages({
-  shareLinkLabel: {
-    defaultMessage: 'Invite someone with this link:',
+  shareViewerLinkLabel: {
+    defaultMessage: 'Invite a viewer with this link:',
     description: 'Label input shareable link with student.',
-    id: 'component.DashboardClassroomInstructor.shareLinkLabel',
+    id: 'component.DashboardCopyClipboard.shareLinkLabel',
+  },
+  shareModeratorLinkLabel: {
+    defaultMessage: 'Invite a moderator with this link:',
+    description: 'Label input shareable link with instructor.',
+    id: 'component.DashboardCopyClipboard.shareModeratorLinkLabel',
   },
   toastCopiedClipboardSuccess: {
     defaultMessage: 'Url copied in clipboard !',
     description: 'Toast message when link copied to clipboard.',
-    id: 'component.DashboardClassroomInstructor.toastCopiedClipboardSuccess',
+    id: 'component.DashboardCopyClipboard.toastCopiedClipboardSuccess',
   },
   ltiLinkLabel: {
     defaultMessage: 'LTI link for this classroom:',
     description: 'Label for LTI classroom link.',
-    id: 'component.DashboardCopyLtiUrl.ltiLinkLabel',
+    id: 'component.DashboardCopyClipboard.ltiLinkLabel',
   },
   ltiLinkCopiedSuccess: {
     defaultMessage: 'Url copied in clipboard !',
     description: 'Toast message when link copied to clipboard.',
-    id: 'component.DashboardCopyLtiUrl.ltiLinkCopiedSuccess',
+    id: 'component.DashboardCopyClipboard.ltiLinkCopiedSuccess',
   },
 });
 
 interface DashboardCopyClipboardProps {
   inviteToken?: Nullable<string>;
+  instructorToken?: Nullable<string>;
   classroomId: string;
 }
 
 const DashboardCopyClipboard = ({
   inviteToken,
+  instructorToken,
   classroomId,
 }: DashboardCopyClipboardProps) => {
   const intl = useIntl();
 
   const inviteLink = inviteToken
     ? `${window.location.origin}/my-contents/classroom/${classroomId}/invite/${inviteToken}`
+    : '';
+  const instructorLink = instructorToken
+    ? `${window.location.origin}/my-contents/classroom/${classroomId}/invite/${instructorToken}`
     : '';
   const ltiLink = `${window.location.origin}/lti/classrooms/${classroomId}`;
 
@@ -50,7 +60,25 @@ const DashboardCopyClipboard = ({
         <CopyClipboard
           copyId={`inviteLink-${classroomId}`}
           text={inviteLink}
-          title={intl.formatMessage(messages.shareLinkLabel)}
+          title={intl.formatMessage(messages.shareViewerLinkLabel)}
+          withLabel={true}
+          onSuccess={() => {
+            toast(intl.formatMessage(messages.toastCopiedClipboardSuccess), {
+              icon: '📋',
+            });
+          }}
+          onError={(event) => {
+            toast.error(event.text, {
+              position: 'bottom-center',
+            });
+          }}
+        />
+      )}
+      {instructorToken && (
+        <CopyClipboard
+          copyId={`instructorLink-${classroomId}`}
+          text={instructorLink}
+          title={intl.formatMessage(messages.shareModeratorLinkLabel)}
           withLabel={true}
           onSuccess={() => {
             toast(intl.formatMessage(messages.toastCopiedClipboardSuccess), {

--- a/src/frontend/packages/lib_classroom/src/utils/tests/factories.ts
+++ b/src/frontend/packages/lib_classroom/src/utils/tests/factories.ts
@@ -27,6 +27,7 @@ export const classroomMockFactory = <T extends Partial<Classroom>>(
     starting_at: null,
     estimated_duration: null,
     invite_token: null,
+    instructor_token: null,
     recordings: [],
     ...classroom,
   };

--- a/src/frontend/packages/lib_components/src/types/apps/classroom/models.ts
+++ b/src/frontend/packages/lib_components/src/types/apps/classroom/models.ts
@@ -15,6 +15,7 @@ export interface Classroom extends Resource {
   starting_at: Nullable<string>;
   estimated_duration: Nullable<string>;
   invite_token: Nullable<string>;
+  instructor_token: Nullable<string>;
   recordings: ClassroomRecording[];
 }
 

--- a/src/frontend/packages/lib_components/src/utils/createContext.tsx
+++ b/src/frontend/packages/lib_components/src/utils/createContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState } from 'react';
+import React, { createContext, useContext, useEffect, useState } from 'react';
 
 type StoreContextType<TStore> = [
   TStore,
@@ -35,6 +35,11 @@ export function createStore<TStore>(
     value,
   }: ProviderProps<TStore>) => {
     const storeState = useState<TStore>(value);
+    const [, setStore] = storeState;
+
+    useEffect(() => {
+      setStore(value);
+    }, [setStore, value]);
 
     return (
       <StoreContext.Provider value={storeState}>


### PR DESCRIPTION
## Purpose

Give moderator classroom invite link to users.

Fixes #2159

## Proposal

- [x] Generate a token for classroom instructor, and send it through the API
- [x] Build and display a moderator classroom invite link
- [x] Using this link,  display the dashboard to unauthenticated users 

