### PR TITLE
✨(backend) Use more RESTful URLs for video related objects (thumbnails, timed_text_track, shared_live_media)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - thumbnail not reset correctly on the video player (#2137)
 - display title / description when a classroom is not scheduled and not started
 - correctly fetch transcript content in TranscriptReader
+- remove unused 'initiate-live' permissions
 
 ## [4.0.0-beta.18] - 2023-03-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - improve the dropdown languages positionning in the dashboard (#2138)
 - Make video dashboard visible by default, and collapsed when using the
   Moodle atto plugin
+- Update live_session api to use mixin to prevent url crafting 
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - add routes related URL:
   - thumbnails
   - timed_text_track
+  - shared_live_media
 - Add classroom widgets :
   - InfoBar
   - Description

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   - Document
   - Markdown
 - Allow delete playlist
+- add routes related URL:
+  - thumbnails
 - Add classroom widgets :
   - InfoBar
   - Description

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Allow delete playlist
 - add routes related URL:
   - thumbnails
+  - timed_text_track
 - Add classroom widgets :
   - InfoBar
   - Description

--- a/src/backend/marsha/core/api/thumbnail.py
+++ b/src/backend/marsha/core/api/thumbnail.py
@@ -14,7 +14,12 @@ from .. import defaults, permissions, serializers
 from ..models import Thumbnail
 from ..utils.s3_utils import create_presigned_post
 from ..utils.time_utils import to_timestamp
-from .base import APIViewMixin, ObjectPkMixin, ObjectRelatedMixin
+from .base import (
+    APIViewMixin,
+    ObjectPkMixin,
+    ObjectRelatedMixin,
+    ObjectVideoRelatedMixin,
+)
 
 
 class ThumbnailFilter(django_filters.FilterSet):
@@ -31,6 +36,7 @@ class ThumbnailViewSet(
     APIViewMixin,
     ObjectPkMixin,
     ObjectRelatedMixin,
+    ObjectVideoRelatedMixin,
     mixins.CreateModelMixin,
     mixins.DestroyModelMixin,
     mixins.RetrieveModelMixin,
@@ -78,30 +84,18 @@ class ThumbnailViewSet(
             raise NotImplementedError(f"Action '{self.action}' is not implemented.")
         return [permission() for permission in permission_classes]
 
-    def _get_list_queryset(self):
-        """Build the queryset used on the list action."""
+    def get_queryset(self):
+        """Redefine the queryset to use based on the current action."""
         queryset = super().get_queryset()
-
-        if self.request.resource:  # aka we are authenticated through LTI
-            queryset = queryset.filter(video__id=self.request.resource.id)
-
-        # Otherwise, we are authenticated through a user JWT.
-        # Filtering is currently not necessary as permissions enforce
-        # a "video" parameter to be present in the request.
-        # See `IsParamsVideoAdminThrough*` permissions.
+        if self.action in ["list"]:
+            video_id = self.get_related_video_id()
+            return queryset.filter(video__id=video_id)
 
         return queryset
 
-    def get_queryset(self):
-        """Redefine the queryset to use based on the current action."""
-        if self.action in ["list"]:
-            return self._get_list_queryset()
-
-        return super().get_queryset()
-
     @action(methods=["post"], detail=True, url_path="initiate-upload")
     # pylint: disable=unused-argument
-    def initiate_upload(self, request, pk=None):
+    def initiate_upload(self, request, pk=None, video_id=None):
         """Get an upload policy for a thumbnail.
 
         Calling the endpoint resets the upload state to `pending` and returns an upload policy to

--- a/src/backend/marsha/core/api/timed_text_track.py
+++ b/src/backend/marsha/core/api/timed_text_track.py
@@ -13,7 +13,12 @@ from ..metadata import TimedTextMetadata
 from ..models import TimedTextTrack
 from ..utils.s3_utils import create_presigned_post
 from ..utils.time_utils import to_timestamp
-from .base import APIViewMixin, ObjectPkMixin, ObjectRelatedMixin
+from .base import (
+    APIViewMixin,
+    ObjectPkMixin,
+    ObjectRelatedMixin,
+    ObjectVideoRelatedMixin,
+)
 
 
 class TimedTextTrackFilter(django_filters.FilterSet):
@@ -27,7 +32,11 @@ class TimedTextTrackFilter(django_filters.FilterSet):
 
 
 class TimedTextTrackViewSet(
-    APIViewMixin, ObjectPkMixin, ObjectRelatedMixin, viewsets.ModelViewSet
+    APIViewMixin,
+    ObjectPkMixin,
+    ObjectRelatedMixin,
+    ObjectVideoRelatedMixin,
+    viewsets.ModelViewSet,
 ):
     """Viewset for the API of the TimedTextTrack object."""
 
@@ -77,30 +86,18 @@ class TimedTextTrackViewSet(
             raise NotImplementedError(f"Action '{self.action}' is not implemented.")
         return [permission() for permission in permission_classes]
 
-    def _get_list_queryset(self):
-        """Build the queryset used on the list action."""
+    def get_queryset(self):
+        """Redefine the queryset to use based on the current action."""
         queryset = super().get_queryset()
-
-        if self.request.resource:  # aka we are authenticated through LTI
-            queryset = queryset.filter(video__id=self.request.resource.id)
-
-        # Otherwise, we are authenticated through a user JWT.
-        # Filtering is currently not necessary as permissions enforce
-        # a "video" parameter to be present in the request.
-        # See `IsParamsVideoAdminThrough*` permissions.
+        if self.action in ["list"]:
+            video_id = self.get_related_video_id()
+            return queryset.filter(video__id=video_id)
 
         return queryset
 
-    def get_queryset(self):
-        """Redefine the queryset to use based on the current action."""
-        if self.action in ["list"]:
-            return self._get_list_queryset()
-
-        return super().get_queryset()
-
     @action(methods=["post"], detail=True, url_path="initiate-upload")
     # pylint: disable=unused-argument
-    def initiate_upload(self, request, pk=None):
+    def initiate_upload(self, request, pk=None, video_id=None):
         """Get an upload policy for a timed text track.
 
         Calling the endpoint resets the upload state to `pending` and returns an upload policy to

--- a/src/backend/marsha/core/api/video.py
+++ b/src/backend/marsha/core/api/video.py
@@ -343,11 +343,6 @@ class VideoViewSet(APIViewMixin, ObjectPkMixin, viewsets.ModelViewSet):
         methods=["post"],
         detail=True,
         url_path="initiate-live",
-        permission_classes=[
-            permissions.IsTokenResourceRouteObject & permissions.IsTokenInstructor
-            | permissions.IsTokenResourceRouteObject & permissions.IsTokenAdmin
-            | permissions.HasPlaylistToken
-        ],
     )
     # pylint: disable=unused-argument
     def initiate_live(self, request, pk=None):

--- a/src/backend/marsha/core/permissions.py
+++ b/src/backend/marsha/core/permissions.py
@@ -418,66 +418,6 @@ class IsParamsVideoAdminThroughOrganization(permissions.BasePermission):
         ).exists()
 
 
-class BaseHasVideoRoleThroughOrganization(permissions.BasePermission):
-    """
-    Base permission to allow access according to the role of the user on the video's organization.
-    """
-
-    role_filter = {}
-
-    def _get_video_id(self, request, view):
-        """Get the video id."""
-        return view.kwargs.get("video_id")
-
-    def has_permission(self, request, view):
-        """
-        Allow the request if user has a specific role on the video's playlist's organization.
-        """
-        video_id = self._get_video_id(request, view)
-        if video_id is None:  # backward compatibility
-            return False
-        return models.OrganizationAccess.objects.filter(
-            **self.role_filter,
-            organization__playlists__videos__id=video_id,
-            user_id=request.user.id,
-        ).exists()
-
-
-class HasVideoAdminThroughOrganization(
-    HasAdminRoleMixIn, BaseHasVideoRoleThroughOrganization
-):
-    """
-    Allow access to user with admin role on the video's playlist's organization.
-    """
-
-
-class HasVideoRoleThroughPlaylist(BaseHasVideoRoleThroughOrganization):
-    """
-    Base permission to allow access according to the role of the user on the video's playlist.
-    """
-
-    def has_permission(self, request, view):
-        """
-        Allow the request if user has a specific role on the video's playlist.
-        """
-        video_id = self._get_video_id(request, view)
-        if video_id is None:  # backward compatibility
-            return False
-        return models.PlaylistAccess.objects.filter(
-            **self.role_filter,
-            playlist__videos__id=video_id,
-            user_id=request.user.id,
-        ).exists()
-
-
-class HasVideoAdminOrInstructorThroughPlaylist(
-    HasAdminOrInstructorRoleMixIn, HasVideoRoleThroughPlaylist
-):
-    """
-    Allow access to user with admin and instructor role on the video's playlist.
-    """
-
-
 class BaseIsParamsVideoRoleThroughPlaylist(permissions.BasePermission):
     """
     Permission to allow a request to proceed only if the user provides the ID for an existing

--- a/src/backend/marsha/core/permissions.py
+++ b/src/backend/marsha/core/permissions.py
@@ -410,7 +410,7 @@ class IsParamsVideoAdminThroughOrganization(permissions.BasePermission):
         the current logged in user is one of the administrators of the organization to which
         this video's playlist belongs.
         """
-        video_id = request.data.get("video") or request.query_params.get("video")
+        video_id = view.get_related_video_id()
         return models.OrganizationAccess.objects.filter(
             role=ADMINISTRATOR,
             organization__playlists__videos__id=video_id,
@@ -492,7 +492,7 @@ class BaseIsParamsVideoRoleThroughPlaylist(permissions.BasePermission):
         the current logged in user has a specific role of the playlist to which
         this video belongs.
         """
-        video_id = request.data.get("video") or request.query_params.get("video")
+        video_id = view.get_related_video_id()
         return models.PlaylistAccess.objects.filter(
             **self.role_filter,
             playlist__videos__id=video_id,

--- a/src/backend/marsha/core/serializers/shared_live_media.py
+++ b/src/backend/marsha/core/serializers/shared_live_media.py
@@ -69,17 +69,7 @@ class SharedLiveMediaSerializer(
             The "validated_data" dictionary is returned after modification.
 
         """
-        resource = self.context["request"].resource
-
-        # Set the video field from the payload if there is one and the user is identified
-        # as a proper user object through access rights
-        if self.initial_data.get("video") and not resource:
-            validated_data["video_id"] = self.initial_data.get("video")
-
-        # If the request regards a resource, force the video ID on the shared live media
-        if not validated_data.get("video_id") and resource:
-            validated_data["video_id"] = resource.id
-
+        validated_data["video_id"] = self.context["video_id"]
         return super().create(validated_data)
 
     def get_filename(self, obj):

--- a/src/backend/marsha/core/serializers/thumbnail.py
+++ b/src/backend/marsha/core/serializers/thumbnail.py
@@ -63,19 +63,10 @@ class ThumbnailSerializer(serializers.ModelSerializer):
             The "validated_data" dictionary is returned after modification.
 
         """
-        resource = self.context["request"].resource
-
-        # Set the video field from the payload if there is one and the user is identified
-        # as a proper user object through access rights
-        if self.initial_data.get("video") and not resource:
-            validated_data["video_id"] = self.initial_data.get("video")
+        validated_data["video_id"] = self.context["video_id"]
 
         if "size" not in self.initial_data:
             raise serializers.ValidationError({"size": ["File size is required"]})
-
-        # If the request regards a resource, force the video ID on the timed text track
-        if not validated_data.get("video_id") and resource:
-            validated_data["video_id"] = resource.id
 
         try:
             return super().create(validated_data)

--- a/src/backend/marsha/core/serializers/timed_text_track.py
+++ b/src/backend/marsha/core/serializers/timed_text_track.py
@@ -70,19 +70,10 @@ class TimedTextTrackSerializer(serializers.ModelSerializer):
             The "validated_data" dictionary is returned after modification.
 
         """
-        resource = self.context["request"].resource
-
-        # Set the video field from the payload if there is one and the user is identified
-        # as a proper user object through access rights
-        if self.initial_data.get("video") and not resource:
-            validated_data["video_id"] = self.initial_data.get("video")
+        validated_data["video_id"] = self.context["video_id"]
 
         if "size" not in self.initial_data:
             raise serializers.ValidationError({"size": ["File size is required"]})
-
-        # If the request regards a resource, force the video ID on the timed text track
-        if not validated_data.get("video_id") and resource:
-            validated_data["video_id"] = resource.id
 
         return super().create(validated_data)
 

--- a/src/backend/marsha/core/tests/api/live_sessions/test_create.py
+++ b/src/backend/marsha/core/tests/api/live_sessions/test_create.py
@@ -1146,7 +1146,7 @@ class LiveSessionCreateApiTest(LiveSessionApiTestCase):
         anonymous_id = uuid.uuid4()
         # With the same email but other video, livesession is possible
         response = self.client.post(
-            self._post_url(video),
+            self._post_url(video2),
             {
                 "anonymous_id": anonymous_id,
                 "email": "chantal@test-fun-mooc.fr",
@@ -1215,7 +1215,7 @@ class LiveSessionCreateApiTest(LiveSessionApiTestCase):
         )
         # With the same email but other video, livesession is possible
         response = self.client.post(
-            self._post_url(video),
+            self._post_url(video2),
             {"email": "chantal@test-fun-mooc.fr", "should_send_reminders": False},
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             content_type="application/json",
@@ -1301,20 +1301,6 @@ class LiveSessionCreateApiTest(LiveSessionApiTestCase):
         self.checkRegistrationEmailSent(
             "salome@test-fun-mooc.fr", video, "Token", created_livesession
         )
-
-    def test_api_livesession_create_with_unknown_video(self):
-        """Token with wrong resource_id should render a 404."""
-        video = VideoFactory()
-
-        # token with no user information
-        jwt_token = ResourceAccessTokenFactory()
-        response = self.client.post(
-            self._post_url(video),
-            {"email": "salome@test-fun-mooc.fr", "should_send_reminders": True},
-            content_type="application/json",
-            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
-        )
-        self.assertEqual(response.status_code, 404)
 
     def test_list_livesession_role_student_email_wrong_token_email(
         self,
@@ -1545,3 +1531,17 @@ class LiveSessionCreateApiOldTest(LiveSessionCreateApiTest):
     def assert_user_can_create(self, user, video):
         """Defuse original assertion for old URLs"""
         self.assert_user_cannot_create(user, video)
+
+    def test_api_livesession_create_with_unknown_video(self):
+        """Token with wrong resource_id should render a 404."""
+        video = VideoFactory()
+
+        # token with no user information
+        jwt_token = ResourceAccessTokenFactory()
+        response = self.client.post(
+            self._post_url(video),
+            {"email": "salome@test-fun-mooc.fr", "should_send_reminders": True},
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+        self.assertEqual(response.status_code, 404)

--- a/src/backend/marsha/core/tests/api/live_sessions/test_list_attendances.py
+++ b/src/backend/marsha/core/tests/api/live_sessions/test_list_attendances.py
@@ -958,7 +958,7 @@ class LiveSessionListAttendancesApiTest(LiveSessionApiTestCase):
         # nothing is already cached
         with self.assertNumQueries(3):
             response = self.client.get(
-                self._get_url(video),
+                self._get_url(video2),
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
 

--- a/src/backend/marsha/core/tests/api/live_sessions/test_push_attendance.py
+++ b/src/backend/marsha/core/tests/api/live_sessions/test_push_attendance.py
@@ -199,29 +199,6 @@ class LiveSessionPushAttendanceApiTest(LiveSessionApiTestCase):
             response.json(), {"live_attendance": ["This field is required."]}
         )
 
-    def test_api_livesession_post_attendance_token_lti_video_not_existing(
-        self,
-    ):
-        """Pushing an attendance on a not existing video should fail."""
-        video = VideoFactory()
-        jwt_token = LTIResourceAccessTokenFactory(
-            context_id=str(video.playlist.lti_id),
-            consumer_site=str(video.playlist.consumer_site.id),
-            user__email=None,
-        )
-        response = self.client.post(
-            self._post_url(video),
-            {
-                "live_attendance": {
-                    to_timestamp(timezone.now()): {"sound": "ON", "tabs": "OFF"}
-                }
-            },
-            content_type="application/json",
-            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
-        )
-
-        self.assertEqual(response.status_code, 404)
-
     def test_api_livesession_post_attendance_token_lti_consumer_site_not_existing(
         self,
     ):
@@ -892,3 +869,26 @@ class LiveSessionPushAttendanceApiOldTest(LiveSessionPushAttendanceApiTest):
     def assert_user_can_push_attendance(self, user, video):
         """Defuse original assertion for old URLs"""
         self.assert_user_cannot_push_attendance(user, video)
+
+    def test_api_livesession_post_attendance_token_lti_video_not_existing(
+        self,
+    ):
+        """Pushing an attendance on a non existing video should fail."""
+        video = VideoFactory()
+        jwt_token = LTIResourceAccessTokenFactory(
+            context_id=str(video.playlist.lti_id),
+            consumer_site=str(video.playlist.consumer_site.id),
+            user__email=None,
+        )
+        response = self.client.post(
+            self._post_url(video),
+            {
+                "live_attendance": {
+                    to_timestamp(timezone.now()): {"sound": "ON", "tabs": "OFF"}
+                }
+            },
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+
+        self.assertEqual(response.status_code, 404)

--- a/src/backend/marsha/core/tests/api/live_sessions/test_retrieve.py
+++ b/src/backend/marsha/core/tests/api/live_sessions/test_retrieve.py
@@ -41,6 +41,14 @@ class LiveSessionRetrieveApiTest(LiveSessionApiTestCase):
         cls.organization = OrganizationFactory()
         cls.live = WebinarVideoFactory(playlist__organization=cls.organization)
 
+    def assert_response_resource_not_accessible(self, response):
+        """Assert response resource not the same as video_id"""
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json(),
+            {"detail": "Resource from token does not match given parameters."},
+        )
+
     def assert_user_cannot_read(self, user, video):
         """Assert a user cannot retrieve with a GET request."""
         livesession = LiveSessionFactory(
@@ -747,7 +755,7 @@ class LiveSessionRetrieveApiTest(LiveSessionApiTestCase):
             self._get_url(livesession.video, livesession),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
-        self.assertEqual(response.status_code, 403)
+        self.assert_response_resource_not_accessible(response)
 
     def test_api_livesession_read_token_lti_wrong_video_token(self):
         """Request with wrong video in token and LTI token."""
@@ -763,7 +771,7 @@ class LiveSessionRetrieveApiTest(LiveSessionApiTestCase):
             self._get_url(livesession.video, livesession),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
-        self.assertEqual(response.status_code, 403)
+        self.assert_response_resource_not_accessible(response)
 
     def test_api_livesession_read_token_public_other_video_context_none_role(self):
         """Public token can't read another video than the one in the token."""
@@ -777,7 +785,7 @@ class LiveSessionRetrieveApiTest(LiveSessionApiTestCase):
             self._get_url(livesession.video, livesession),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
-        self.assertEqual(response.status_code, 403)
+        self.assert_response_resource_not_accessible(response)
 
     def test_api_livesession_read_token_lti_other_video_context_none_role(self):
         """LTI token can't read another video than the one in the token."""
@@ -796,7 +804,7 @@ class LiveSessionRetrieveApiTest(LiveSessionApiTestCase):
             self._get_url(livesession.video, livesession),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
-        self.assertEqual(response.status_code, 403)
+        self.assert_response_resource_not_accessible(response)
 
     def test_api_livesession_read_detail_unknown_video(self):
         """Token with wrong resource_id should render a 404."""
@@ -810,7 +818,7 @@ class LiveSessionRetrieveApiTest(LiveSessionApiTestCase):
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
-        self.assertEqual(response.status_code, 403)
+        self.assert_response_resource_not_accessible(response)
 
 
 # Old routes to remove
@@ -824,3 +832,7 @@ class LiveSessionRetrieveApiOldTest(LiveSessionRetrieveApiTest):
     def assert_user_can_read(self, user, video):
         """Defuse original assertion for old URLs"""
         self.assert_user_cannot_read(user, video)
+
+    def assert_response_resource_not_accessible(self, response):
+        """Assert response resource not accessible"""
+        self.assertEqual(response.status_code, 403)

--- a/src/backend/marsha/core/tests/api/live_sessions/test_update.py
+++ b/src/backend/marsha/core/tests/api/live_sessions/test_update.py
@@ -43,6 +43,14 @@ class LiveSessionUpdateApiTest(LiveSessionApiTestCase):
         cls.organization = OrganizationFactory()
         cls.live = WebinarVideoFactory(playlist__organization=cls.organization)
 
+    def assert_response_resource_not_accessible(self, response):
+        """Assert response resource not the same as video_id"""
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json(),
+            {"detail": "Resource from token does not match given parameters."},
+        )
+
     def assert_user_cannot_patch(self, user, video):
         """Assert a user cannot update livesession with a PATCH request."""
         livesession = LiveSessionFactory(
@@ -669,7 +677,7 @@ class LiveSessionUpdateApiTest(LiveSessionApiTestCase):
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
-        self.assertEqual(response.status_code, 403)
+        self.assert_response_resource_not_accessible(response)
 
     def test_api_live_session_admin_using_existing_email(self):
         """An instructor trying to update an anonymous live_session using an email
@@ -906,3 +914,7 @@ class LiveSessionUpdateApiOldTest(LiveSessionUpdateApiTest):
     def assert_user_can_patch(self, user, video):
         """Defuse original assertion for old URLs"""
         self.assert_user_cannot_patch(user, video)
+
+    def assert_response_resource_not_accessible(self, response):
+        """Assert response resource not accessible"""
+        self.assertEqual(response.status_code, 403)

--- a/src/backend/marsha/core/tests/api/shared_live_media/test_create.py
+++ b/src/backend/marsha/core/tests/api/shared_live_media/test_create.py
@@ -23,11 +23,16 @@ from marsha.core.simple_jwt.factories import (
 class SharedLiveMediaCreateAPITest(TestCase):
     """Test the create API of the shared live media object."""
 
+    def _post_url(self, video):
+        """Return the url to use in tests."""
+        return f"/api/videos/{video.pk}/sharedlivemedias/"
+
     maxDiff = None
 
     def test_api_shared_live_media_create_anonymous(self):
         """An anonymous user can't create a shared live media."""
-        response = self.client.post("/api/sharedlivemedias/")
+        video = VideoFactory()
+        response = self.client.post(self._post_url(video))
         self.assertEqual(response.status_code, 401)
         self.assertFalse(SharedLiveMedia.objects.exists())
 
@@ -38,7 +43,7 @@ class SharedLiveMediaCreateAPITest(TestCase):
         jwt_token = InstructorOrAdminLtiTokenFactory(resource=video)
 
         response = self.client.post(
-            "/api/sharedlivemedias/",
+            self._post_url(video),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             content_type="application/json",
         )
@@ -71,7 +76,7 @@ class SharedLiveMediaCreateAPITest(TestCase):
         )
 
         response = self.client.post(
-            "/api/sharedlivemedias/",
+            self._post_url(video),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
@@ -84,7 +89,7 @@ class SharedLiveMediaCreateAPITest(TestCase):
         jwt_token = StudentLtiTokenFactory(resource=video)
 
         response = self.client.post(
-            "/api/sharedlivemedias/",
+            self._post_url(video),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
@@ -93,9 +98,10 @@ class SharedLiveMediaCreateAPITest(TestCase):
 
     def test_api_shared_live_media_create_staff_or_user(self):
         """Users authenticated via a session shouldn't be able to create new shared live medias."""
+        video = VideoFactory()
         for user in [UserFactory(), UserFactory(is_staff=True)]:
             self.client.login(username=user.username, password="test")
-            response = self.client.post("/api/sharedlivemedias/")
+            response = self.client.post(self._post_url(video))
             self.assertEqual(response.status_code, 401)
             self.assertFalse(SharedLiveMedia.objects.exists())
 
@@ -111,7 +117,7 @@ class SharedLiveMediaCreateAPITest(TestCase):
         jwt_token = UserAccessTokenFactory()
 
         response = self.client.post(
-            "/api/sharedlivemedias/",
+            self._post_url(video),
             {"video": str(video.id)},
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             content_type="application/json",
@@ -136,7 +142,7 @@ class SharedLiveMediaCreateAPITest(TestCase):
         jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.post(
-            "/api/sharedlivemedias/",
+            self._post_url(video),
             {"video": str(video.id)},
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             content_type="application/json",
@@ -176,7 +182,7 @@ class SharedLiveMediaCreateAPITest(TestCase):
         jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.post(
-            "/api/sharedlivemedias/",
+            self._post_url(video),
             {"video": str(video.id)},
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             content_type="application/json",
@@ -218,7 +224,7 @@ class SharedLiveMediaCreateAPITest(TestCase):
         jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.post(
-            "/api/sharedlivemedias/",
+            self._post_url(video),
             {"video": str(video.id)},
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
@@ -245,7 +251,7 @@ class SharedLiveMediaCreateAPITest(TestCase):
         jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.post(
-            "/api/sharedlivemedias/",
+            self._post_url(video),
             {"video": str(video.id)},
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             content_type="application/json",
@@ -270,3 +276,11 @@ class SharedLiveMediaCreateAPITest(TestCase):
                 "video": str(video.id),
             },
         )
+
+
+class SharedLiveMediaCreateAPIOldTest(SharedLiveMediaCreateAPITest):
+    """Test the create API of the shared live media object."""
+
+    def _post_url(self, video):
+        """Return the url to use in tests."""
+        return "/api/sharedlivemedias/"

--- a/src/backend/marsha/core/tests/api/shared_live_media/test_delete.py
+++ b/src/backend/marsha/core/tests/api/shared_live_media/test_delete.py
@@ -25,6 +25,10 @@ from marsha.core.simple_jwt.factories import (
 class SharedLiveMediaDeleteAPITest(TestCase):
     """Test the delete API of the shared live media object."""
 
+    def _delete_url(self, video, shared_live_media):
+        """Return the url to use in tests."""
+        return f"/api/videos/{video.pk}/sharedlivemedias/{shared_live_media.pk}/"
+
     maxDiff = None
 
     def test_api_shared_live_media_delete_anonymous(self):
@@ -32,7 +36,7 @@ class SharedLiveMediaDeleteAPITest(TestCase):
         shared_live_media = SharedLiveMediaFactory()
 
         response = self.client.delete(
-            f"/api/sharedlivemedias/{shared_live_media.id}/",
+            self._delete_url(shared_live_media.video, shared_live_media),
         )
 
         self.assertEqual(response.status_code, 401)
@@ -44,7 +48,7 @@ class SharedLiveMediaDeleteAPITest(TestCase):
         jwt_token = StudentLtiTokenFactory(resource=shared_live_media.video)
 
         response = self.client.delete(
-            f"/api/sharedlivemedias/{shared_live_media.id}/",
+            self._delete_url(shared_live_media.video, shared_live_media),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
@@ -64,7 +68,7 @@ class SharedLiveMediaDeleteAPITest(TestCase):
             "marsha.websocket.utils.channel_layers_utils.dispatch_video_to_groups"
         ) as mock_dispatch_video_to_groups:
             response = self.client.delete(
-                f"/api/sharedlivemedias/{shared_live_media.id}/",
+                self._delete_url(shared_live_media.video, shared_live_media),
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
             mock_dispatch_video_to_groups.assert_called_once_with(video)
@@ -78,7 +82,7 @@ class SharedLiveMediaDeleteAPITest(TestCase):
         for user in [UserFactory(), UserFactory(is_staff=True)]:
             self.client.login(username=user.username, password="test")
             response = self.client.delete(
-                f"/api/sharedlivemedias/{shared_live_media.id}/",
+                self._delete_url(shared_live_media.video, shared_live_media),
                 content_type="application/json",
             )
             self.assertEqual(response.status_code, 401)
@@ -95,7 +99,7 @@ class SharedLiveMediaDeleteAPITest(TestCase):
         jwt_token = UserAccessTokenFactory()
 
         response = self.client.delete(
-            f"/api/sharedlivemedias/{shared_live_media.id}/",
+            self._delete_url(shared_live_media.video, shared_live_media),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
@@ -123,7 +127,7 @@ class SharedLiveMediaDeleteAPITest(TestCase):
             "marsha.websocket.utils.channel_layers_utils.dispatch_video_to_groups"
         ) as mock_dispatch_video_to_groups:
             response = self.client.delete(
-                f"/api/sharedlivemedias/{shared_live_media.id}/",
+                self._delete_url(shared_live_media.video, shared_live_media),
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
             mock_dispatch_video_to_groups.assert_called_once_with(video)
@@ -159,7 +163,7 @@ class SharedLiveMediaDeleteAPITest(TestCase):
             "marsha.websocket.utils.channel_layers_utils.dispatch_video_to_groups"
         ) as mock_dispatch_video_to_groups:
             response = self.client.delete(
-                f"/api/sharedlivemedias/{shared_live_media.id}/",
+                self._delete_url(shared_live_media.video, shared_live_media),
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
             mock_dispatch_video_to_groups.assert_called_once_with(video)
@@ -185,7 +189,7 @@ class SharedLiveMediaDeleteAPITest(TestCase):
         jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.delete(
-            f"/api/sharedlivemedias/{shared_live_media.id}/",
+            self._delete_url(shared_live_media.video, shared_live_media),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
@@ -222,7 +226,7 @@ class SharedLiveMediaDeleteAPITest(TestCase):
             "marsha.websocket.utils.channel_layers_utils.dispatch_video_to_groups"
         ) as mock_dispatch_video_to_groups:
             response = self.client.delete(
-                f"/api/sharedlivemedias/{shared_live_media.id}/",
+                self._delete_url(shared_live_media.video, shared_live_media),
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
             mock_dispatch_video_to_groups.assert_called_once_with(video)
@@ -251,7 +255,7 @@ class SharedLiveMediaDeleteAPITest(TestCase):
             "marsha.websocket.utils.channel_layers_utils.dispatch_video_to_groups"
         ) as mock_dispatch_video_to_groups:
             response = self.client.delete(
-                f"/api/sharedlivemedias/{shared_live_media.id}/",
+                self._delete_url(shared_live_media.video, shared_live_media),
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
             mock_dispatch_video_to_groups.assert_called_once_with(video)
@@ -261,3 +265,11 @@ class SharedLiveMediaDeleteAPITest(TestCase):
         video.refresh_from_db()
         self.assertIsNone(video.active_shared_live_media)
         self.assertIsNone(video.active_shared_live_media_page)
+
+
+class SharedLiveMediaDeleteAPIOldTest(SharedLiveMediaDeleteAPITest):
+    """Test the delete API of the shared live media object."""
+
+    def _delete_url(self, video, shared_live_media):
+        """Return the url to use in tests."""
+        return f"/api/sharedlivemedias/{shared_live_media.id}/"

--- a/src/backend/marsha/core/tests/api/shared_live_media/test_initiate_upload.py
+++ b/src/backend/marsha/core/tests/api/shared_live_media/test_initiate_upload.py
@@ -28,6 +28,10 @@ from marsha.core.simple_jwt.factories import (
 class SharedLiveMediaInitiateUploadAPITest(TestCase):
     """Test the initiate-upload API of the shared live media object."""
 
+    def _post_url(self, video, shared_live_media):
+        """Return the url to use in tests."""
+        return f"/api/videos/{video.id}/sharedlivemedias/{shared_live_media.id}/initiate-upload/"
+
     maxDiff = None
 
     def test_api_shared_live_media_initiate_upload_anonymous(self):
@@ -36,7 +40,7 @@ class SharedLiveMediaInitiateUploadAPITest(TestCase):
         shared_live_media = SharedLiveMediaFactory()
 
         response = self.client.post(
-            f"/api/sharedlivemedias/{shared_live_media.id}/initiate-upload/",
+            self._post_url(shared_live_media.video, shared_live_media),
             {
                 "filename": "python extensions.pdf",
                 "mimetype": "application/pdf",
@@ -55,7 +59,7 @@ class SharedLiveMediaInitiateUploadAPITest(TestCase):
         jwt_token = StudentLtiTokenFactory(resource=shared_live_media.video)
 
         response = self.client.post(
-            f"/api/sharedlivemedias/{shared_live_media.id}/initiate-upload/",
+            self._post_url(shared_live_media.video, shared_live_media),
             {
                 "filename": "python extensions.pdf",
                 "mimetype": "application/pdf",
@@ -83,7 +87,7 @@ class SharedLiveMediaInitiateUploadAPITest(TestCase):
         ) as mock_dt:
             mock_dt.utcnow = mock.Mock(return_value=now)
             response = self.client.post(
-                f"/api/sharedlivemedias/{shared_live_media.id}/initiate-upload/",
+                self._post_url(shared_live_media.video, shared_live_media),
                 {
                     "filename": "python extensions.pdf",
                     "mimetype": "application/pdf",
@@ -145,7 +149,7 @@ class SharedLiveMediaInitiateUploadAPITest(TestCase):
         ) as mock_dt:
             mock_dt.utcnow = mock.Mock(return_value=now)
             response = self.client.post(
-                f"/api/sharedlivemedias/{shared_live_media.id}/initiate-upload/",
+                self._post_url(shared_live_media.video, shared_live_media),
                 {
                     "filename": "python extensions",
                     "mimetype": "application/pdf",
@@ -207,7 +211,7 @@ class SharedLiveMediaInitiateUploadAPITest(TestCase):
         ) as mock_dt:
             mock_dt.utcnow = mock.Mock(return_value=now)
             response = self.client.post(
-                f"/api/sharedlivemedias/{shared_live_media.id}/initiate-upload/",
+                self._post_url(shared_live_media.video, shared_live_media),
                 {"filename": "python extensions", "mimetype": "", "size": 10},
                 content_type="application/json",
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
@@ -236,7 +240,7 @@ class SharedLiveMediaInitiateUploadAPITest(TestCase):
         ) as mock_dt:
             mock_dt.utcnow = mock.Mock(return_value=now)
             response = self.client.post(
-                f"/api/sharedlivemedias/{shared_live_media.id}/initiate-upload/",
+                self._post_url(shared_live_media.video, shared_live_media),
                 {
                     "filename": "python extensions",
                     "mimetype": "application/wrong-type",
@@ -262,7 +266,7 @@ class SharedLiveMediaInitiateUploadAPITest(TestCase):
         for user in [UserFactory(), UserFactory(is_staff=True)]:
             self.client.login(username=user.username, password="test")
             response = self.client.post(
-                f"/api/sharedlivemedias/{shared_live_media.id}/initiate-upload/",
+                self._post_url(shared_live_media.video, shared_live_media),
                 {
                     "filename": "python extensions.pdf",
                     "mimetype": "application/pdf",
@@ -284,7 +288,7 @@ class SharedLiveMediaInitiateUploadAPITest(TestCase):
         jwt_token = UserAccessTokenFactory()
 
         response = self.client.post(
-            f"/api/sharedlivemedias/{shared_live_media.id}/initiate-upload/",
+            self._post_url(shared_live_media.video, shared_live_media),
             {
                 "filename": "python extensions.pdf",
                 "mimetype": "application/pdf",
@@ -327,7 +331,7 @@ class SharedLiveMediaInitiateUploadAPITest(TestCase):
         ) as mock_dt:
             mock_dt.utcnow = mock.Mock(return_value=now)
             response = self.client.post(
-                f"/api/sharedlivemedias/{shared_live_media.id}/initiate-upload/",
+                self._post_url(shared_live_media.video, shared_live_media),
                 {
                     "filename": "python extensions.pdf",
                     "mimetype": "application/pdf",
@@ -403,7 +407,7 @@ class SharedLiveMediaInitiateUploadAPITest(TestCase):
         ) as mock_dt:
             mock_dt.utcnow = mock.Mock(return_value=now)
             response = self.client.post(
-                f"/api/sharedlivemedias/{shared_live_media.id}/initiate-upload/",
+                self._post_url(shared_live_media.video, shared_live_media),
                 {
                     "filename": "python extensions.pdf",
                     "mimetype": "application/pdf",
@@ -470,7 +474,7 @@ class SharedLiveMediaInitiateUploadAPITest(TestCase):
         jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.post(
-            f"/api/sharedlivemedias/{shared_live_media.id}/initiate-upload/",
+            self._post_url(shared_live_media.video, shared_live_media),
             {
                 "filename": "python extensions.pdf",
                 "mimetype": "application/pdf",
@@ -517,7 +521,7 @@ class SharedLiveMediaInitiateUploadAPITest(TestCase):
         ) as mock_dt:
             mock_dt.utcnow = mock.Mock(return_value=now)
             response = self.client.post(
-                f"/api/sharedlivemedias/{shared_live_media.id}/initiate-upload/",
+                self._post_url(shared_live_media.video, shared_live_media),
                 {
                     "filename": "python extensions.pdf",
                     "mimetype": "application/pdf",
@@ -562,3 +566,11 @@ class SharedLiveMediaInitiateUploadAPITest(TestCase):
 
         shared_live_media.refresh_from_db()
         self.assertEqual(shared_live_media.upload_state, defaults.PENDING)
+
+
+class SharedLiveMediaInitiateUploadAPIOldTest(SharedLiveMediaInitiateUploadAPITest):
+    """Test the update API of the shared live media object."""
+
+    def _post_url(self, video, shared_live_media):
+        """Return the url to use in tests."""
+        return f"/api/sharedlivemedias/{shared_live_media.id}/initiate-upload/"

--- a/src/backend/marsha/core/tests/api/shared_live_media/test_retrieve.py
+++ b/src/backend/marsha/core/tests/api/shared_live_media/test_retrieve.py
@@ -30,13 +30,19 @@ from marsha.core.tests.testing_utils import RSA_KEY_MOCK
 class SharedLiveMediaRetrieveAPITest(TestCase):
     """Test the retrieve API of the shared live media object."""
 
+    def _get_url(self, video, shared_live_media):
+        """Return the url to use in tests."""
+        return f"/api/videos/{video.pk}/sharedlivemedias/{shared_live_media.pk}/"
+
     maxDiff = None
 
     def test_api_shared_live_media_read_detail_anonymous(self):
         """An anonymous user can not read a shared live media detail"""
         shared_live_media = SharedLiveMediaFactory()
 
-        response = self.client.get(f"/api/sharedlivemedias/{shared_live_media.pk}/")
+        response = self.client.get(
+            self._get_url(shared_live_media.video, shared_live_media)
+        )
 
         self.assertEqual(response.status_code, 401)
 
@@ -51,7 +57,7 @@ class SharedLiveMediaRetrieveAPITest(TestCase):
         jwt_token = StudentLtiTokenFactory(resource=shared_live_media.video)
 
         response = self.client.get(
-            f"/api/sharedlivemedias/{shared_live_media.pk}/",
+            self._get_url(shared_live_media.video, shared_live_media),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
@@ -89,7 +95,7 @@ class SharedLiveMediaRetrieveAPITest(TestCase):
         jwt_token = StudentLtiTokenFactory(resource=shared_live_media.video)
 
         response = self.client.get(
-            f"/api/sharedlivemedias/{shared_live_media.pk}/",
+            self._get_url(shared_live_media.video, shared_live_media),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
@@ -156,7 +162,7 @@ class SharedLiveMediaRetrieveAPITest(TestCase):
             "builtins.open", new_callable=mock.mock_open, read_data=RSA_KEY_MOCK
         ):
             response = self.client.get(
-                f"/api/sharedlivemedias/{shared_live_media.pk}/",
+                self._get_url(shared_live_media.video, shared_live_media),
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
 
@@ -246,7 +252,7 @@ class SharedLiveMediaRetrieveAPITest(TestCase):
             "builtins.open", new_callable=mock.mock_open, read_data=RSA_KEY_MOCK
         ):
             response = self.client.get(
-                f"/api/sharedlivemedias/{shared_live_media.pk}/",
+                self._get_url(shared_live_media.video, shared_live_media),
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
 
@@ -314,7 +320,7 @@ class SharedLiveMediaRetrieveAPITest(TestCase):
         )
 
         response = self.client.get(
-            f"/api/sharedlivemedias/{shared_live_media.pk}/",
+            self._get_url(shared_live_media.video, shared_live_media),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
@@ -355,7 +361,7 @@ class SharedLiveMediaRetrieveAPITest(TestCase):
         )
 
         response = self.client.get(
-            f"/api/sharedlivemedias/{shared_live_media.pk}/",
+            self._get_url(shared_live_media.video, shared_live_media),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
@@ -425,7 +431,7 @@ class SharedLiveMediaRetrieveAPITest(TestCase):
             "builtins.open", new_callable=mock.mock_open, read_data=RSA_KEY_MOCK
         ):
             response = self.client.get(
-                f"/api/sharedlivemedias/{shared_live_media.pk}/",
+                self._get_url(shared_live_media.video, shared_live_media),
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
 
@@ -496,7 +502,7 @@ class SharedLiveMediaRetrieveAPITest(TestCase):
         )
 
         response = self.client.get(
-            f"/api/sharedlivemedias/{shared_live_media.pk}/",
+            self._get_url(shared_live_media.video, shared_live_media),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
@@ -521,7 +527,7 @@ class SharedLiveMediaRetrieveAPITest(TestCase):
         jwt_token = UserAccessTokenFactory()
 
         response = self.client.get(
-            f"/api/sharedlivemedias/{shared_live_media.id}/",
+            self._get_url(shared_live_media.video, shared_live_media),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
@@ -544,7 +550,7 @@ class SharedLiveMediaRetrieveAPITest(TestCase):
         jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
-            f"/api/sharedlivemedias/{shared_live_media.id}/",
+            self._get_url(shared_live_media.video, shared_live_media),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
@@ -582,7 +588,7 @@ class SharedLiveMediaRetrieveAPITest(TestCase):
         jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
-            f"/api/sharedlivemedias/{shared_live_media.id}/",
+            self._get_url(shared_live_media.video, shared_live_media),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
@@ -622,7 +628,7 @@ class SharedLiveMediaRetrieveAPITest(TestCase):
         jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
-            f"/api/sharedlivemedias/{shared_live_media.id}/",
+            self._get_url(shared_live_media.video, shared_live_media),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
@@ -648,7 +654,7 @@ class SharedLiveMediaRetrieveAPITest(TestCase):
         jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
-            f"/api/sharedlivemedias/{shared_live_media.id}/",
+            self._get_url(shared_live_media.video, shared_live_media),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
         self.assertEqual(response.status_code, 200)
@@ -669,3 +675,11 @@ class SharedLiveMediaRetrieveAPITest(TestCase):
                 "video": str(video.id),
             },
         )
+
+
+class SharedLiveMediaRetrieveAPIOldTest(SharedLiveMediaRetrieveAPITest):
+    """Test the retrieve API of the shared live media object."""
+
+    def _get_url(self, video, shared_live_media):
+        """Return the url to use in tests."""
+        return f"/api/sharedlivemedias/{shared_live_media.id}/"

--- a/src/backend/marsha/core/tests/api/shared_live_media/test_update.py
+++ b/src/backend/marsha/core/tests/api/shared_live_media/test_update.py
@@ -25,6 +25,10 @@ from marsha.core.simple_jwt.factories import (
 class SharedLiveMediaUpdateAPITest(TestCase):
     """Test the update API of the shared live media object."""
 
+    def _update_url(self, video, shared_live_media):
+        """Return the url to use in tests."""
+        return f"/api/videos/{video.pk}/sharedlivemedias/{shared_live_media.pk}/"
+
     maxDiff = None
 
     def test_api_shared_live_media_update_anonymous(self):
@@ -32,7 +36,7 @@ class SharedLiveMediaUpdateAPITest(TestCase):
         shared_live_media = SharedLiveMediaFactory()
 
         response = self.client.put(
-            f"/api/sharedlivemedias/{shared_live_media.id}/",
+            self._update_url(shared_live_media.video, shared_live_media),
             {"title": "you shall not pass!"},
             content_type="application/json",
         )
@@ -46,7 +50,7 @@ class SharedLiveMediaUpdateAPITest(TestCase):
         jwt_token = StudentLtiTokenFactory(resource=shared_live_media.video)
 
         response = self.client.put(
-            f"/api/sharedlivemedias/{shared_live_media.id}/",
+            self._update_url(shared_live_media.video, shared_live_media),
             {"title": "you shall not pass!"},
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             content_type="application/json",
@@ -64,7 +68,7 @@ class SharedLiveMediaUpdateAPITest(TestCase):
             "marsha.websocket.utils.channel_layers_utils.dispatch_shared_live_media"
         ) as mock_dispatch_shared_live_media:
             response = self.client.put(
-                f"/api/sharedlivemedias/{shared_live_media.id}/",
+                self._update_url(shared_live_media.video, shared_live_media),
                 {"title": "Give me the red pill"},
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
                 content_type="application/json",
@@ -96,7 +100,7 @@ class SharedLiveMediaUpdateAPITest(TestCase):
         for user in [UserFactory(), UserFactory(is_staff=True)]:
             self.client.login(username=user.username, password="test")
             response = self.client.put(
-                f"/api/sharedlivemedias/{shared_live_media.id}/",
+                self._update_url(shared_live_media.video, shared_live_media),
                 {"title": "you shall not pass!"},
                 content_type="application/json",
             )
@@ -114,7 +118,7 @@ class SharedLiveMediaUpdateAPITest(TestCase):
         jwt_token = UserAccessTokenFactory()
 
         response = self.client.put(
-            f"/api/sharedlivemedias/{shared_live_media.id}/",
+            self._update_url(shared_live_media.video, shared_live_media),
             {"title": "you shall not pass!"},
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             content_type="application/json",
@@ -148,7 +152,7 @@ class SharedLiveMediaUpdateAPITest(TestCase):
             "marsha.websocket.utils.channel_layers_utils.dispatch_shared_live_media"
         ) as mock_dispatch_shared_live_media:
             response = self.client.put(
-                f"/api/sharedlivemedias/{shared_live_media.id}/",
+                self._update_url(shared_live_media.video, shared_live_media),
                 {"title": "give me the red pill!"},
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
                 content_type="application/json",
@@ -198,7 +202,7 @@ class SharedLiveMediaUpdateAPITest(TestCase):
             "marsha.websocket.utils.channel_layers_utils.dispatch_shared_live_media"
         ) as mock_dispatch_shared_live_media:
             response = self.client.put(
-                f"/api/sharedlivemedias/{shared_live_media.id}/",
+                self._update_url(shared_live_media.video, shared_live_media),
                 {"title": "give me the red pill!"},
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
                 content_type="application/json",
@@ -241,7 +245,7 @@ class SharedLiveMediaUpdateAPITest(TestCase):
         jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.put(
-            f"/api/sharedlivemedias/{shared_live_media.id}/",
+            self._update_url(shared_live_media.video, shared_live_media),
             {"title": "you shall not pass!"},
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             content_type="application/json",
@@ -278,7 +282,7 @@ class SharedLiveMediaUpdateAPITest(TestCase):
             "marsha.websocket.utils.channel_layers_utils.dispatch_shared_live_media"
         ) as mock_dispatch_shared_live_media:
             response = self.client.put(
-                f"/api/sharedlivemedias/{shared_live_media.id}/",
+                self._update_url(shared_live_media.video, shared_live_media),
                 {"title": "give me the red pill!"},
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
                 content_type="application/json",
@@ -302,3 +306,11 @@ class SharedLiveMediaUpdateAPITest(TestCase):
                 "video": str(video.id),
             },
         )
+
+
+class SharedLiveMediaUpdateAPIOldTest(SharedLiveMediaUpdateAPITest):
+    """Test the update API of the shared live media object."""
+
+    def _update_url(self, video, shared_live_media):
+        """Return the url to use in tests."""
+        return f"/api/sharedlivemedias/{shared_live_media.id}/"

--- a/src/backend/marsha/core/tests/api/thumbnails/test_create.py
+++ b/src/backend/marsha/core/tests/api/thumbnails/test_create.py
@@ -25,6 +25,10 @@ class ThumbnailCreateApiTest(TestCase):
 
     maxDiff = None
 
+    def _post_url(self, video):
+        """Return the url to use to create a thumbnail."""
+        return f"/api/videos/{video.pk}/thumbnails/"
+
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
@@ -39,7 +43,7 @@ class ThumbnailCreateApiTest(TestCase):
         jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.post(
-            "/api/thumbnails/",
+            self._post_url(video),
             {"video": str(video.pk), "size": 10},
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
@@ -51,7 +55,7 @@ class ThumbnailCreateApiTest(TestCase):
         jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.post(
-            "/api/thumbnails/",
+            self._post_url(video),
             {"video": str(video.pk), "size": 10},
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
@@ -74,7 +78,7 @@ class ThumbnailCreateApiTest(TestCase):
 
     def test_api_thumbnail_create_anonymous(self):
         """Anonymous users should not be able to create a thumbnail."""
-        response = self.client.post("/api/thumbnails/")
+        response = self.client.post(self._post_url(self.some_video))
         self.assertEqual(response.status_code, 401)
 
     def test_api_thumbnail_create_by_random_user(self):
@@ -170,7 +174,9 @@ class ThumbnailCreateApiTest(TestCase):
         jwt_token = InstructorOrAdminLtiTokenFactory(resource=video)
 
         response = self.client.post(
-            "/api/thumbnails/", {"size": 10}, HTTP_AUTHORIZATION=f"Bearer {jwt_token}"
+            self._post_url(video),
+            {"size": 10},
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
         self.assertEqual(response.status_code, 201)
@@ -196,7 +202,9 @@ class ThumbnailCreateApiTest(TestCase):
         jwt_token = InstructorOrAdminLtiTokenFactory(resource=video)
 
         response = self.client.post(
-            "/api/thumbnails/", {"size": 100}, HTTP_AUTHORIZATION=f"Bearer {jwt_token}"
+            self._post_url(video),
+            {"size": 100},
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
@@ -210,7 +218,7 @@ class ThumbnailCreateApiTest(TestCase):
         jwt_token = InstructorOrAdminLtiTokenFactory(resource=video)
 
         response = self.client.post(
-            "/api/thumbnails/", HTTP_AUTHORIZATION=f"Bearer {jwt_token}"
+            self._post_url(video), HTTP_AUTHORIZATION=f"Bearer {jwt_token}"
         )
         self.assertEqual(response.status_code, 400)
 
@@ -227,7 +235,9 @@ class ThumbnailCreateApiTest(TestCase):
         jwt_token = InstructorOrAdminLtiTokenFactory(resource=video)
 
         response = self.client.post(
-            "/api/thumbnails/", {"size": 10}, HTTP_AUTHORIZATION=f"Bearer {jwt_token}"
+            self._post_url(video),
+            {"size": 10},
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
         self.assertEqual(response.status_code, 400)
@@ -251,3 +261,11 @@ class ThumbnailCreateApiTest(TestCase):
         )
 
         self.assertEqual(response.status_code, 403)
+
+
+class ThumbnailCreateApiOldTest(ThumbnailCreateApiTest):
+    """Test the create API of the thumbnail object."""
+
+    def _post_url(self, video):
+        """Return the url to use to create a thumbnail."""
+        return "/api/thumbnails/"

--- a/src/backend/marsha/core/tests/api/thumbnails/test_delete.py
+++ b/src/backend/marsha/core/tests/api/thumbnails/test_delete.py
@@ -24,6 +24,10 @@ class ThumbnailDeleteApiTest(TestCase):
 
     maxDiff = None
 
+    def _delete_url(self, video, thumbnail):
+        """Return the url to use to delete a thumbnail."""
+        return f"/api/videos/{video.pk}/thumbnails/{thumbnail.id}/"
+
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
@@ -39,7 +43,7 @@ class ThumbnailDeleteApiTest(TestCase):
         jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.delete(
-            f"/api/thumbnails/{thumbnail.pk}/",
+            self._delete_url(thumbnail.video, thumbnail),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
@@ -52,7 +56,7 @@ class ThumbnailDeleteApiTest(TestCase):
         jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.delete(
-            f"/api/thumbnails/{thumbnail.pk}/",
+            self._delete_url(thumbnail.video, thumbnail),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
         self.assertEqual(response.status_code, 204)
@@ -65,7 +69,7 @@ class ThumbnailDeleteApiTest(TestCase):
         video = VideoFactory()
         thumbnail = ThumbnailFactory(video=video)
 
-        response = self.client.delete(f"/api/thumbnails/{thumbnail.id}/")
+        response = self.client.delete(self._delete_url(video, thumbnail))
         self.assertEqual(response.status_code, 401)
 
     def test_api_thumbnail_delete_by_random_user(self):
@@ -154,7 +158,7 @@ class ThumbnailDeleteApiTest(TestCase):
         jwt_token = StudentLtiTokenFactory(resource=video)
 
         response = self.client.delete(
-            f"/api/thumbnails/{thumbnail.id}/",
+            self._delete_url(video, thumbnail),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
         self.assertEqual(response.status_code, 403)
@@ -166,7 +170,7 @@ class ThumbnailDeleteApiTest(TestCase):
         self.assertEqual(Thumbnail.objects.count(), 1)
 
         response = self.client.delete(
-            f"/api/thumbnails/{self.some_thumbnail.pk}/",
+            self._delete_url(self.some_video, self.some_thumbnail),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
         self.assertEqual(response.status_code, 204)
@@ -198,7 +202,7 @@ class ThumbnailDeleteApiTest(TestCase):
         )
 
         response = self.client.delete(
-            f"/api/thumbnails/{thumbnail.id}/",
+            self._delete_url(thumbnail.video, thumbnail),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
@@ -213,7 +217,15 @@ class ThumbnailDeleteApiTest(TestCase):
         jwt_token = InstructorOrAdminLtiTokenFactory(resource=video_token)
 
         response = self.client.delete(
-            f"/api/thumbnails/{thumbnail.id}/",
+            self._delete_url(video_other, thumbnail),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
         self.assertEqual(response.status_code, 403)
+
+
+class ThumbnailDeleteApiOldTest(ThumbnailDeleteApiTest):
+    """Test the delete API of the thumbnail object."""
+
+    def _delete_url(self, video, thumbnail):
+        """Return the url to use to delete a thumbnail."""
+        return f"/api/thumbnails/{thumbnail.id}/"

--- a/src/backend/marsha/core/tests/api/thumbnails/test_initiate_upload.py
+++ b/src/backend/marsha/core/tests/api/thumbnails/test_initiate_upload.py
@@ -18,11 +18,14 @@ class ThumbnailInitiateUploadApiTest(TestCase):
 
     maxDiff = None
 
+    def _post_url(self, video, thumbnail):
+        return f"/api/videos/{video.pk}/thumbnails/{thumbnail.id}/initiate-upload/"
+
     def test_api_thumbnail_initiate_upload_anonymous(self):
         """Anonymous users are not allowed to initiate an upload."""
         thumbnail = ThumbnailFactory()
 
-        response = self.client.post(f"/api/thumbnails/{thumbnail.id}/initiate-upload/")
+        response = self.client.post(self._post_url(thumbnail.video, thumbnail))
         self.assertEqual(response.status_code, 401)
 
     def test_api_thumbnail_initiate_upload_student(self):
@@ -31,7 +34,7 @@ class ThumbnailInitiateUploadApiTest(TestCase):
         jwt_token = StudentLtiTokenFactory(resource=thumbnail.video)
 
         response = self.client.post(
-            f"/api/thumbnails/{thumbnail.id}/initiate-upload/",
+            self._post_url(thumbnail.video, thumbnail),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
         self.assertEqual(response.status_code, 403)
@@ -54,7 +57,7 @@ class ThumbnailInitiateUploadApiTest(TestCase):
         ) as mock_dt:
             mock_dt.utcnow = mock.Mock(return_value=now)
             response = self.client.post(
-                f"/api/thumbnails/{thumbnail.id}/initiate-upload/",
+                self._post_url(thumbnail.video, thumbnail),
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
         self.assertEqual(response.status_code, 200)
@@ -103,7 +106,7 @@ class ThumbnailInitiateUploadApiTest(TestCase):
         )
 
         response = self.client.post(
-            f"/api/thumbnails/{thumbnail.id}/initiate-upload/",
+            self._post_url(thumbnail.video, thumbnail),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
@@ -124,7 +127,7 @@ class ThumbnailInitiateUploadApiTest(TestCase):
         ) as mock_dt:
             mock_dt.utcnow = mock.Mock(return_value=now)
             response = self.client.post(
-                f"/api/thumbnails/{thumbnail.id}/initiate-upload/",
+                self._post_url(thumbnail.video, thumbnail),
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
                 data={
                     "filename": "foo",
@@ -137,3 +140,10 @@ class ThumbnailInitiateUploadApiTest(TestCase):
             response.json(),
             {"size": ["File too large, max size allowed is 10 Bytes"]},
         )
+
+
+class ThumbnailInitiateUploadApiOldTest(ThumbnailInitiateUploadApiTest):
+    """Test the initiate-upload API of the thumbnail object."""
+
+    def _post_url(self, video, thumbnail):
+        return f"/api/thumbnails/{thumbnail.id}/initiate-upload/"

--- a/src/backend/marsha/core/tests/api/thumbnails/test_options.py
+++ b/src/backend/marsha/core/tests/api/thumbnails/test_options.py
@@ -16,13 +16,23 @@ class ThumbnailOptionsApiTest(TestCase):
 
     maxDiff = None
 
+    def _options_url(self, video):
+        """Return the url to use options a thumbnail."""
+        return f"/api/videos/{video.id}/thumbnails/"
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.video = VideoFactory()
+
     def assert_user_can_query_options(self, user):
         """Assert the user can query the thumbnail options' endpoint."""
 
         jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.options(
-            "/api/thumbnails/", HTTP_AUTHORIZATION=f"Bearer {jwt_token}"
+            self._options_url(self.video), HTTP_AUTHORIZATION=f"Bearer {jwt_token}"
         )
 
         self.assertEqual(response.status_code, 200)
@@ -32,7 +42,7 @@ class ThumbnailOptionsApiTest(TestCase):
         """
         Unauthenticated user cannot query the thumbnail options' endpoint.
         """
-        response = self.client.options("/api/thumbnails/")
+        response = self.client.options(self._options_url(self.video))
 
         self.assertEqual(response.status_code, 401)
 
@@ -54,7 +64,7 @@ class ThumbnailOptionsApiTest(TestCase):
         jwt_token = InstructorOrAdminLtiTokenFactory(resource=video)
 
         response = self.client.options(
-            "/api/thumbnails/", HTTP_AUTHORIZATION=f"Bearer {jwt_token}"
+            self._options_url(video), HTTP_AUTHORIZATION=f"Bearer {jwt_token}"
         )
 
         self.assertEqual(response.status_code, 200)
@@ -69,8 +79,16 @@ class ThumbnailOptionsApiTest(TestCase):
         jwt_token = StudentLtiTokenFactory(resource=video)
 
         response = self.client.options(
-            "/api/thumbnails/", HTTP_AUTHORIZATION=f"Bearer {jwt_token}"
+            self._options_url(video), HTTP_AUTHORIZATION=f"Bearer {jwt_token}"
         )
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["upload_max_size_bytes"], 10)
+
+
+class ThumbnailOptionsApiOldTest(ThumbnailOptionsApiTest):
+    """Test the options API of the thumbnail object."""
+
+    def _options_url(self, video):
+        """Return the url to use to create a live session."""
+        return "/api/thumbnails/"

--- a/src/backend/marsha/core/tests/api/thumbnails/test_retrieve.py
+++ b/src/backend/marsha/core/tests/api/thumbnails/test_retrieve.py
@@ -27,6 +27,10 @@ class ThumbnailRetrieveApiTest(TestCase):
 
     maxDiff = None
 
+    def _get_url(self, video, thumbnail):
+        """Return the url to use to get a video thumbnail."""
+        return f"/api/videos/{video.pk}/thumbnails/{thumbnail.id}/"
+
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
@@ -42,7 +46,7 @@ class ThumbnailRetrieveApiTest(TestCase):
         jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
-            f"/api/thumbnails/{thumbnail.pk}/",
+            self._get_url(thumbnail.video, thumbnail),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
@@ -53,7 +57,7 @@ class ThumbnailRetrieveApiTest(TestCase):
         jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
-            f"/api/thumbnails/{thumbnail.id}/",
+            self._get_url(thumbnail.video, thumbnail),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
@@ -75,7 +79,7 @@ class ThumbnailRetrieveApiTest(TestCase):
         """Anonymous users should not be allowed to retrieve a thumbnail."""
         video = VideoFactory()
         thumbnail = ThumbnailFactory(video=video)
-        response = self.client.get(f"/api/thumbnails/{thumbnail.id}/")
+        response = self.client.get(self._get_url(video, thumbnail))
         self.assertEqual(response.status_code, 401)
         content = json.loads(response.content)
         self.assertEqual(
@@ -172,7 +176,7 @@ class ThumbnailRetrieveApiTest(TestCase):
         jwt_token = StudentLtiTokenFactory(resource=video)
 
         response = self.client.get(
-            f"/api/thumbnails/{thumbnail.id}/",
+            self._get_url(video, thumbnail),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
@@ -188,7 +192,7 @@ class ThumbnailRetrieveApiTest(TestCase):
         )
 
         response = self.client.get(
-            f"/api/thumbnails/{thumbnail.id}/",
+            self._get_url(thumbnail.video, thumbnail),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
@@ -205,7 +209,7 @@ class ThumbnailRetrieveApiTest(TestCase):
         jwt_token = InstructorOrAdminLtiTokenFactory(resource=video)
 
         response = self.client.get(
-            f"/api/thumbnails/{thumbnail.id}/",
+            self._get_url(thumbnail.video, thumbnail),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
@@ -234,7 +238,7 @@ class ThumbnailRetrieveApiTest(TestCase):
         )
 
         response = self.client.get(
-            f"/api/thumbnails/{thumbnail.id}/",
+            self._get_url(thumbnail.video, thumbnail),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
@@ -254,7 +258,7 @@ class ThumbnailRetrieveApiTest(TestCase):
         )
 
         response = self.client.get(
-            f"/api/thumbnails/{thumbnail.id}/",
+            self._get_url(video, thumbnail),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
@@ -289,7 +293,7 @@ class ThumbnailRetrieveApiTest(TestCase):
         jwt_token = InstructorOrAdminLtiTokenFactory(resource=video)
 
         response = self.client.get(
-            f"/api/thumbnails/{thumbnail.id}/",
+            self._get_url(video, thumbnail),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
@@ -318,3 +322,11 @@ class ThumbnailRetrieveApiTest(TestCase):
                 "video": str(video.id),
             },
         )
+
+
+class ThumbnailRetrieveApiOldTest(ThumbnailRetrieveApiTest):
+    """Test the retrieve API of the thumbnail object."""
+
+    def _get_url(self, video, thumbnail):
+        """Return the url to use to create a live session."""
+        return f"/api/thumbnails/{thumbnail.id}/"

--- a/src/backend/marsha/core/tests/api/timed_text_tracks/test_create.py
+++ b/src/backend/marsha/core/tests/api/timed_text_tracks/test_create.py
@@ -17,9 +17,14 @@ class TimedTextTrackCreateAPITest(TestCase):
 
     maxDiff = None
 
+    def _post_url(self, video):
+        """Return the url to use to create a timed text track."""
+        return f"/api/videos/{video.pk}/timedtexttracks/"
+
     def test_api_timed_text_track_create_anonymous(self):
         """Anonymous users should not be able to create a new timed text track."""
-        response = self.client.post("/api/timedtexttracks/")
+        video = VideoFactory(id="f8c30d0d-2bb4-440d-9e8d-f4b231511f1f")
+        response = self.client.post(self._post_url(video))
         self.assertEqual(response.status_code, 401)
         self.assertFalse(TimedTextTrack.objects.exists())
 
@@ -30,11 +35,10 @@ class TimedTextTrackCreateAPITest(TestCase):
 
         data = {"language": "fr", "size": 10}
         response = self.client.post(
-            "/api/timedtexttracks/",
+            self._post_url(video),
             data,
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
-
         self.assertEqual(response.status_code, 201)
         self.assertEqual(TimedTextTrack.objects.count(), 1)
         content = json.loads(response.content)
@@ -60,7 +64,7 @@ class TimedTextTrackCreateAPITest(TestCase):
 
         data = {"language": "fr"}
         response = self.client.post(
-            "/api/timedtexttracks/",
+            self._post_url(video),
             data,
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
@@ -80,7 +84,7 @@ class TimedTextTrackCreateAPITest(TestCase):
 
         data = {"language": "fr", "video": str(video.pk), "size": 100}
         response = self.client.post(
-            "/api/timedtexttracks/",
+            self._post_url(video),
             data,
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
@@ -102,15 +106,17 @@ class TimedTextTrackCreateAPITest(TestCase):
         )
 
         response = self.client.post(
-            "/api/timedtexttracks/", HTTP_AUTHORIZATION=f"Bearer {jwt_token}"
+            self._post_url(timed_text_track.video),
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
         self.assertEqual(response.status_code, 403)
 
     def test_api_timed_text_track_create_staff_or_user(self):
         """Users authenticated via a session shouldn't be able to create new timed text tracks."""
+        video = VideoFactory()
         for user in [UserFactory(), UserFactory(is_staff=True)]:
             self.client.login(username=user.username, password="test")
-            response = self.client.post("/api/timedtexttracks/")
+            response = self.client.post(self._post_url(video))
             self.assertEqual(response.status_code, 401)
             self.assertFalse(TimedTextTrack.objects.exists())
 
@@ -126,7 +132,7 @@ class TimedTextTrackCreateAPITest(TestCase):
         jwt_token = UserAccessTokenFactory()
 
         response = self.client.post(
-            "/api/timedtexttracks/",
+            self._post_url(video),
             {"language": "fr", "video": str(video.id), "size": 10},
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
@@ -152,7 +158,7 @@ class TimedTextTrackCreateAPITest(TestCase):
         jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.post(
-            "/api/timedtexttracks/",
+            self._post_url(video),
             {"language": "fr", "video": str(video.id), "size": 10},
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
@@ -192,7 +198,7 @@ class TimedTextTrackCreateAPITest(TestCase):
         jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.post(
-            "/api/timedtexttracks/",
+            self._post_url(video),
             {"language": "fr", "video": str(video.id), "size": 10},
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
@@ -233,7 +239,7 @@ class TimedTextTrackCreateAPITest(TestCase):
         jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.post(
-            "/api/timedtexttracks/",
+            self._post_url(video),
             {"language": "fr", "video": str(video.id), "size": 10},
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
@@ -260,7 +266,7 @@ class TimedTextTrackCreateAPITest(TestCase):
         jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.post(
-            "/api/timedtexttracks/",
+            self._post_url(video),
             data={"language": "fr", "video": str(video.id), "size": 10},
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
@@ -282,3 +288,12 @@ class TimedTextTrackCreateAPITest(TestCase):
                 "video": str(video.id),
             },
         )
+
+
+# Old routes to remove
+class TimedTextTrackCreateAPIOldTest(TimedTextTrackCreateAPITest):
+    """Test the create API of the timed text track object with old URLs."""
+
+    def _post_url(self, video):
+        """Return the url to use to create a timed text track."""
+        return "/api/timedtexttracks/"

--- a/src/backend/marsha/core/tests/api/timed_text_tracks/test_delete.py
+++ b/src/backend/marsha/core/tests/api/timed_text_tracks/test_delete.py
@@ -17,6 +17,10 @@ class TimedTextTrackDeleteAPITest(TestCase):
 
     maxDiff = None
 
+    def _delete_url(self, video, track):
+        """Return the url to delete a timed text track."""
+        return f"/api/videos/{video.pk}/timedtexttracks/{track.id}/"
+
     def test_api_timed_text_track_patch_by_video_organization_admin(self):
         """
         Organization administrator token user patches a timed text track.
@@ -39,7 +43,7 @@ class TimedTextTrackDeleteAPITest(TestCase):
         data = {"language": "en", "size": 10}
 
         response = self.client.patch(
-            f"/api/timedtexttracks/{track.id}/",
+            self._delete_url(video, track),
             json.dumps(data),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             content_type="application/json",
@@ -52,7 +56,9 @@ class TimedTextTrackDeleteAPITest(TestCase):
         """Anonymous users should not be allowed to delete a timed text track."""
         timed_text_track = TimedTextTrackFactory()
 
-        response = self.client.delete(f"/api/timedtexttracks/{timed_text_track.id}/")
+        response = self.client.delete(
+            self._delete_url(timed_text_track.video, timed_text_track)
+        )
 
         self.assertEqual(response.status_code, 401)
         content = json.loads(response.content)
@@ -71,7 +77,7 @@ class TimedTextTrackDeleteAPITest(TestCase):
                 resource=timed_text_track.video
             )
             response = self.client.delete(
-                f"/api/timedtexttracks/{timed_text_track.id}/",
+                self._delete_url(timed_text_track.video, timed_text_track),
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
             self.assertEqual(response.status_code, 204)
@@ -90,7 +96,7 @@ class TimedTextTrackDeleteAPITest(TestCase):
             self.client.login(username=user.username, password="test")
 
             response = self.client.delete(
-                f"/api/timedtexttracks/{timed_text_track.id}/"
+                self._delete_url(timed_text_track.video, timed_text_track),
             )
 
             self.assertEqual(response.status_code, 401)
@@ -110,7 +116,7 @@ class TimedTextTrackDeleteAPITest(TestCase):
         )
 
         response = self.client.delete(
-            f"/api/timedtexttracks/{timed_text_track.id}/",
+            self._delete_url(timed_text_track.video, timed_text_track),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
         self.assertEqual(response.status_code, 403)
@@ -130,7 +136,7 @@ class TimedTextTrackDeleteAPITest(TestCase):
         jwt_token = UserAccessTokenFactory()
 
         response = self.client.delete(
-            f"/api/timedtexttracks/{track.id}/",
+            self._delete_url(video, track),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
@@ -158,7 +164,7 @@ class TimedTextTrackDeleteAPITest(TestCase):
         jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.delete(
-            f"/api/timedtexttracks/{track.id}/",
+            self._delete_url(video, track),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
@@ -186,7 +192,7 @@ class TimedTextTrackDeleteAPITest(TestCase):
         jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.delete(
-            f"/api/timedtexttracks/{track.id}/",
+            self._delete_url(video, track),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
@@ -215,7 +221,7 @@ class TimedTextTrackDeleteAPITest(TestCase):
         jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.delete(
-            f"/api/timedtexttracks/{track.id}/",
+            self._delete_url(video, track),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
@@ -244,9 +250,17 @@ class TimedTextTrackDeleteAPITest(TestCase):
         jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.delete(
-            f"/api/timedtexttracks/{track.id}/",
+            self._delete_url(video, track),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
         self.assertEqual(response.status_code, 204)
         self.assertEqual(TimedTextTrack.objects.count(), 0)
+
+
+class TimedTextTrackDeleteAPIOldTest(TimedTextTrackDeleteAPITest):
+    """Test the delete API of the timed text track object with old URLs."""
+
+    def _delete_url(self, video, track):
+        """Return the url to delete a timed text track."""
+        return f"/api/timedtexttracks/{track.id}/"

--- a/src/backend/marsha/core/tests/api/timed_text_tracks/test_initiate_upload.py
+++ b/src/backend/marsha/core/tests/api/timed_text_tracks/test_initiate_upload.py
@@ -15,17 +15,20 @@ from marsha.core.simple_jwt.factories import (
 )
 
 
-class TimedTextTrackInitiateUIploadAPITest(TestCase):
+class TimedTextTrackInitiateUploadAPITest(TestCase):
     """Test the initiate-upload API of the timed text track object."""
 
     maxDiff = None
+
+    def _post_url(self, video, track):
+        return f"/api/videos/{video.pk}/timedtexttracks/{track.id}/initiate-upload/"
 
     def test_api_timed_text_track_initiate_upload_anonymous_user(self):
         """Anonymous users should not be allowed to initiate an upload."""
         timed_text_track = TimedTextTrackFactory()
 
         response = self.client.post(
-            f"/api/timedtexttracks/{timed_text_track.id}/initiate-upload/"
+            self._post_url(timed_text_track.video, timed_text_track),
         )
 
         self.assertEqual(response.status_code, 401)
@@ -64,7 +67,7 @@ class TimedTextTrackInitiateUIploadAPITest(TestCase):
         ) as mock_dt:
             mock_dt.utcnow = mock.Mock(return_value=now)
             response = self.client.post(
-                f"/api/timedtexttracks/{timed_text_track.id}/initiate-upload/",
+                self._post_url(timed_text_track.video, timed_text_track),
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
                 data={
                     "filename": "foo",
@@ -114,7 +117,7 @@ class TimedTextTrackInitiateUIploadAPITest(TestCase):
 
         # Try initiating an upload for a timed_text_track linked to another video
         response = self.client.post(
-            f"/api/timedtexttracks/{other_ttt_for_other_video.id}/initiate-upload/",
+            self._post_url(other_ttt_for_other_video.video, other_ttt_for_other_video),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
         self.assertEqual(response.status_code, 403)
@@ -133,7 +136,7 @@ class TimedTextTrackInitiateUIploadAPITest(TestCase):
         ]:
             self.client.login(username=user.username, password="test")
             response = self.client.post(
-                f"/api/timedtexttracks/{timed_text_track.id}/initiate-upload/"
+                self._post_url(timed_text_track.video, timed_text_track),
             )
             self.assertEqual(response.status_code, 401)
             content = json.loads(response.content)
@@ -151,7 +154,7 @@ class TimedTextTrackInitiateUIploadAPITest(TestCase):
         )
 
         response = self.client.post(
-            f"/api/timedtexttracks/{timed_text_track.id}/initiate-upload/",
+            self._post_url(timed_text_track.video, timed_text_track),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
         self.assertEqual(response.status_code, 403)
@@ -182,7 +185,7 @@ class TimedTextTrackInitiateUIploadAPITest(TestCase):
         ) as mock_dt:
             mock_dt.utcnow = mock.Mock(return_value=now)
             response = self.client.post(
-                f"/api/timedtexttracks/{track.id}/initiate-upload/",
+                self._post_url(track.video, track),
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
         self.assertEqual(response.status_code, 403)
@@ -221,7 +224,7 @@ class TimedTextTrackInitiateUIploadAPITest(TestCase):
         ) as mock_dt:
             mock_dt.utcnow = mock.Mock(return_value=now)
             response = self.client.post(
-                f"/api/timedtexttracks/{track.id}/initiate-upload/",
+                self._post_url(track.video, track),
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
                 data={
                     "filename": "foo",
@@ -294,7 +297,7 @@ class TimedTextTrackInitiateUIploadAPITest(TestCase):
         ) as mock_dt:
             mock_dt.utcnow = mock.Mock(return_value=now)
             response = self.client.post(
-                f"/api/timedtexttracks/{track.id}/initiate-upload/",
+                self._post_url(track.video, track),
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
                 data={
                     "filename": "foo",
@@ -368,7 +371,7 @@ class TimedTextTrackInitiateUIploadAPITest(TestCase):
         ) as mock_dt:
             mock_dt.utcnow = mock.Mock(return_value=now)
             response = self.client.post(
-                f"/api/timedtexttracks/{track.id}/initiate-upload/",
+                self._post_url(track.video, track),
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
         self.assertEqual(response.status_code, 403)
@@ -408,7 +411,7 @@ class TimedTextTrackInitiateUIploadAPITest(TestCase):
         ) as mock_dt:
             mock_dt.utcnow = mock.Mock(return_value=now)
             response = self.client.post(
-                f"/api/timedtexttracks/{track.id}/initiate-upload/",
+                self._post_url(track.video, track),
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
                 data={
                     "filename": "foo",
@@ -472,7 +475,7 @@ class TimedTextTrackInitiateUIploadAPITest(TestCase):
         ) as mock_dt:
             mock_dt.utcnow = mock.Mock(return_value=now)
             response = self.client.post(
-                f"/api/timedtexttracks/{track.id}/initiate-upload/",
+                self._post_url(track.video, track),
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
                 data={
                     "filename": "foo",
@@ -485,3 +488,10 @@ class TimedTextTrackInitiateUIploadAPITest(TestCase):
             response.json(),
             {"size": ["file too large, max size allowed is 10 Bytes"]},
         )
+
+
+class TimedTextTrackInitiateUploadAPIOldTest(TimedTextTrackInitiateUploadAPITest):
+    """Test the create API of the liveSession object with old URLs."""
+
+    def _post_url(self, video, track):
+        return f"/api/timedtexttracks/{track.id}/initiate-upload/"

--- a/src/backend/marsha/core/tests/api/timed_text_tracks/test_list.py
+++ b/src/backend/marsha/core/tests/api/timed_text_tracks/test_list.py
@@ -16,10 +16,14 @@ class TimedTextTrackListAPITest(TestCase):
 
     maxDiff = None
 
+    def _get_url(self, video):
+        """Return the url to list timed text track."""
+        return f"/api/videos/{video.id}/timedtexttracks/"
+
     def test_api_timed_text_track_read_list_anonymous(self):
         """Anonymous users should not be able to read a list of timed text tracks."""
-        TimedTextTrackFactory()
-        response = self.client.get("/api/timedtexttracks/")
+        track = TimedTextTrackFactory()
+        response = self.client.get(self._get_url(track.video))
         self.assertEqual(response.status_code, 401)
 
     def test_api_timed_text_track_read_list_token_user(self):
@@ -38,7 +42,8 @@ class TimedTextTrackListAPITest(TestCase):
         )
 
         response = self.client.get(
-            "/api/timedtexttracks/", HTTP_AUTHORIZATION=f"Bearer {jwt_token}"
+            self._get_url(timed_text_track_one.video),
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
         self.assertEqual(response.status_code, 200)
         timed_text_track_list = json.loads(response.content)
@@ -78,7 +83,7 @@ class TimedTextTrackListAPITest(TestCase):
         jwt_token = UserAccessTokenFactory()
 
         response = self.client.get(
-            f"/api/timedtexttracks/?video={video.id}",
+            self._get_url(video),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
@@ -107,7 +112,7 @@ class TimedTextTrackListAPITest(TestCase):
         jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
-            f"/api/timedtexttracks/?video={video.id}",
+            self._get_url(video),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
@@ -147,7 +152,7 @@ class TimedTextTrackListAPITest(TestCase):
         jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
-            f"/api/timedtexttracks/?video={video.id}",
+            self._get_url(video),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
@@ -188,7 +193,7 @@ class TimedTextTrackListAPITest(TestCase):
         jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
-            f"/api/timedtexttracks/?video={video.id}",
+            self._get_url(video),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
@@ -218,7 +223,7 @@ class TimedTextTrackListAPITest(TestCase):
         jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
-            f"/api/timedtexttracks/?video={video.id}",
+            self._get_url(video),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
@@ -234,6 +239,16 @@ class TimedTextTrackListAPITest(TestCase):
             str(timed_text_track_two.id)
             in (ttt["id"] for ttt in timed_text_track_list["results"])
         )
+
+
+class TimedTextTrackListAPIOldTest(TimedTextTrackListAPITest):
+    """Test the create API of the timed text track object with old URLs."""
+
+    def _get_url(self, video=None):
+        """Return the url to delete a timed text track."""
+        if video:
+            return f"/api/timedtexttracks/?video={video.id}"
+        return "/api/timedtexttracks/"
 
     def test_api_timed_text_track_read_list_by_admin_without_video_filter(self):
         """
@@ -259,7 +274,7 @@ class TimedTextTrackListAPITest(TestCase):
         jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
-            "/api/timedtexttracks/",
+            self._get_url(),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 

--- a/src/backend/marsha/core/tests/api/timed_text_tracks/test_retrieve.py
+++ b/src/backend/marsha/core/tests/api/timed_text_tracks/test_retrieve.py
@@ -22,10 +22,16 @@ class TimedTextTrackRetrieveAPITest(TestCase):
 
     maxDiff = None
 
+    def _get_url(self, video, track):
+        """Return the url to retrieve a timed text track."""
+        return f"/api/videos/{video.pk}/timedtexttracks/{track.id}/"
+
     def test_api_timed_text_track_read_detail_anonymous(self):
         """Anonymous users should not be allowed to read a timed text track detail."""
         timed_text_track = TimedTextTrackFactory()
-        response = self.client.get(f"/api/timedtexttracks/{timed_text_track.id}/")
+        response = self.client.get(
+            self._get_url(timed_text_track.video, timed_text_track)
+        )
         self.assertEqual(response.status_code, 401)
         content = json.loads(response.content)
         self.assertEqual(
@@ -38,7 +44,7 @@ class TimedTextTrackRetrieveAPITest(TestCase):
         jwt_token = StudentLtiTokenFactory(resource=timed_text_track.video)
         # Get the timed text track using the JWT token
         response = self.client.get(
-            f"/api/timedtexttracks/{timed_text_track.id}/",
+            self._get_url(timed_text_track.video, timed_text_track),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
         self.assertEqual(response.status_code, 403)
@@ -64,7 +70,7 @@ class TimedTextTrackRetrieveAPITest(TestCase):
 
         # Get the timed text track using the JWT token
         response = self.client.get(
-            f"/api/timedtexttracks/{timed_text_track.id}/",
+            self._get_url(timed_text_track.video, timed_text_track),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
         self.assertEqual(response.status_code, 200)
@@ -120,7 +126,7 @@ class TimedTextTrackRetrieveAPITest(TestCase):
 
         # Get the timed text track using the JWT token
         response = self.client.get(
-            f"/api/timedtexttracks/{timed_text_track.id}/",
+            self._get_url(timed_text_track.video, timed_text_track),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
         self.assertEqual(response.status_code, 200)
@@ -176,7 +182,7 @@ class TimedTextTrackRetrieveAPITest(TestCase):
 
         # Get the timed text track using the JWT token
         response = self.client.get(
-            f"/api/timedtexttracks/{timed_text_track.id}/",
+            self._get_url(timed_text_track.video, timed_text_track),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
         self.assertEqual(response.status_code, 200)
@@ -226,7 +232,7 @@ class TimedTextTrackRetrieveAPITest(TestCase):
         )
 
         response = self.client.get(
-            f"/api/timedtexttracks/{timed_text_track.id}/",
+            self._get_url(timed_text_track.video, timed_text_track),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
         self.assertEqual(response.status_code, 403)
@@ -242,7 +248,7 @@ class TimedTextTrackRetrieveAPITest(TestCase):
 
         # Get the timed text track using the JWT token
         response = self.client.get(
-            f"/api/timedtexttracks/{timed_text_track.id}/",
+            self._get_url(timed_text_track.video, timed_text_track),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
         self.assertEqual(response.status_code, 200)
@@ -260,7 +266,7 @@ class TimedTextTrackRetrieveAPITest(TestCase):
 
         # Get the timed_text_track linked to the JWT token
         response = self.client.get(
-            f"/api/timedtexttracks/{timed_text_track.id}/",
+            self._get_url(timed_text_track.video, timed_text_track),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
         self.assertEqual(response.status_code, 200)
@@ -291,7 +297,7 @@ class TimedTextTrackRetrieveAPITest(TestCase):
         now = datetime(2018, 8, 8, tzinfo=timezone.utc)
         with mock.patch.object(timezone, "now", return_value=now):
             response = self.client.get(
-                f"/api/timedtexttracks/{timed_text_track.id}/",
+                self._get_url(timed_text_track.video, timed_text_track),
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
         self.assertEqual(response.status_code, 200)
@@ -330,7 +336,9 @@ class TimedTextTrackRetrieveAPITest(TestCase):
         for user in [UserFactory(), UserFactory(is_staff=True)]:
             self.client.login(username=user.username, password="test")
             timed_text_track = TimedTextTrackFactory()
-            response = self.client.get(f"/api/timedtexttracks/{timed_text_track.id}/")
+            response = self.client.get(
+                self._get_url(timed_text_track.video, timed_text_track)
+            )
             self.assertEqual(response.status_code, 401)
             content = json.loads(response.content)
             self.assertEqual(
@@ -351,7 +359,7 @@ class TimedTextTrackRetrieveAPITest(TestCase):
         jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
-            f"/api/timedtexttracks/{track.id}/",
+            self._get_url(track.video, track),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
@@ -376,7 +384,7 @@ class TimedTextTrackRetrieveAPITest(TestCase):
         jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
-            f"/api/timedtexttracks/{track.id}/",
+            self._get_url(track.video, track),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
@@ -415,7 +423,7 @@ class TimedTextTrackRetrieveAPITest(TestCase):
         jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
-            f"/api/timedtexttracks/{track.id}/",
+            self._get_url(track.video, track),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
@@ -455,7 +463,7 @@ class TimedTextTrackRetrieveAPITest(TestCase):
         jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
-            f"/api/timedtexttracks/{track.id}/",
+            self._get_url(track.video, track),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
@@ -481,7 +489,7 @@ class TimedTextTrackRetrieveAPITest(TestCase):
         jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
-            f"/api/timedtexttracks/{track.id}/",
+            self._get_url(track.video, track),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
@@ -500,3 +508,11 @@ class TimedTextTrackRetrieveAPITest(TestCase):
                 "video": str(video.id),
             },
         )
+
+
+class TimedTextTrackRetrieveAPIOldTest(TimedTextTrackRetrieveAPITest):
+    """Test the retrieve API of the timed text track object with old URLs."""
+
+    def _get_url(self, video, track):
+        """Return the url to retrieve a timed text track."""
+        return f"/api/timedtexttracks/{track.id}/"

--- a/src/backend/marsha/core/tests/api/timed_text_tracks/test_update.py
+++ b/src/backend/marsha/core/tests/api/timed_text_tracks/test_update.py
@@ -16,12 +16,16 @@ class TimedTextTrackUpdateAPITest(TestCase):
 
     maxDiff = None
 
+    def _update_url(self, video, track):
+        """Return the url to use to create a live session."""
+        return f"/api/videos/{video.pk}/timedtexttracks/{track.id}/"
+
     def test_api_timed_text_track_update_detail_anonymous(self):
         """Anonymous users should not be allowed to update a timed_text_track through the API."""
         timed_text_track = TimedTextTrackFactory(language="fr")
         data = {"language": "en", "size": 10}
         response = self.client.put(
-            f"/api/timedtexttracks/{timed_text_track.id}/",
+            self._update_url(timed_text_track.video, timed_text_track),
             json.dumps(data),
             content_type="application/json",
         )
@@ -35,13 +39,13 @@ class TimedTextTrackUpdateAPITest(TestCase):
         jwt_token = InstructorOrAdminLtiTokenFactory(resource=timed_text_track.video)
 
         response = self.client.get(
-            f"/api/timedtexttracks/{timed_text_track.id}/",
+            self._update_url(timed_text_track.video, timed_text_track),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
         data = json.loads(response.content)
         data["language"] = "en"
         response = self.client.put(
-            f"/api/timedtexttracks/{timed_text_track.id}/",
+            self._update_url(timed_text_track.video, timed_text_track),
             json.dumps(data),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             content_type="application/json",
@@ -56,13 +60,13 @@ class TimedTextTrackUpdateAPITest(TestCase):
         jwt_token = InstructorOrAdminLtiTokenFactory(resource=timed_text_track.video)
 
         response = self.client.get(
-            f"/api/timedtexttracks/{timed_text_track.id}/",
+            self._update_url(timed_text_track.video, timed_text_track),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
         data = json.loads(response.content)
         data["mode"] = "ts"
         response = self.client.put(
-            f"/api/timedtexttracks/{timed_text_track.id}/",
+            self._update_url(timed_text_track.video, timed_text_track),
             json.dumps(data),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             content_type="application/json",
@@ -78,7 +82,7 @@ class TimedTextTrackUpdateAPITest(TestCase):
         jwt_token = InstructorOrAdminLtiTokenFactory(resource=timed_text_track.video)
 
         response = self.client.get(
-            f"/api/timedtexttracks/{timed_text_track.id}/",
+            self._update_url(timed_text_track.video, timed_text_track),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
         data = json.loads(response.content)
@@ -86,7 +90,7 @@ class TimedTextTrackUpdateAPITest(TestCase):
         data["active_stamp"] = "1533686400"
 
         response = self.client.put(
-            f"/api/timedtexttracks/{timed_text_track.id}/",
+            self._update_url(timed_text_track.video, timed_text_track),
             json.dumps(data),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             content_type="application/json",
@@ -101,7 +105,7 @@ class TimedTextTrackUpdateAPITest(TestCase):
         jwt_token = InstructorOrAdminLtiTokenFactory(resource=timed_text_track.video)
 
         response = self.client.get(
-            f"/api/timedtexttracks/{timed_text_track.id}/",
+            self._update_url(timed_text_track.video, timed_text_track),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
         data = json.loads(response.content)
@@ -109,7 +113,7 @@ class TimedTextTrackUpdateAPITest(TestCase):
         data["upload_state"] = "ready"
 
         response = self.client.put(
-            f"/api/timedtexttracks/{timed_text_track.id}/",
+            self._update_url(timed_text_track.video, timed_text_track),
             json.dumps(data),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             content_type="application/json",
@@ -128,7 +132,7 @@ class TimedTextTrackUpdateAPITest(TestCase):
         )
 
         response = self.client.put(
-            f"/api/timedtexttracks/{timed_text_track.id}/",
+            self._update_url(timed_text_track.video, timed_text_track),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
         self.assertEqual(response.status_code, 403)
@@ -152,7 +156,7 @@ class TimedTextTrackUpdateAPITest(TestCase):
         data["language"] = "en"
 
         response = self.client.put(
-            f"/api/timedtexttracks/{track.id}/",
+            self._update_url(track.video, track),
             json.dumps(data),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             content_type="application/json",
@@ -187,7 +191,7 @@ class TimedTextTrackUpdateAPITest(TestCase):
         data["language"] = "en"
 
         response = self.client.put(
-            f"/api/timedtexttracks/{track.id}/",
+            self._update_url(video, track),
             json.dumps(data),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             content_type="application/json",
@@ -222,7 +226,7 @@ class TimedTextTrackUpdateAPITest(TestCase):
         data["language"] = "en"
 
         response = self.client.put(
-            f"/api/timedtexttracks/{track.id}/",
+            self._update_url(video, track),
             json.dumps(data),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             content_type="application/json",
@@ -258,7 +262,7 @@ class TimedTextTrackUpdateAPITest(TestCase):
         data["language"] = "en"
 
         response = self.client.put(
-            f"/api/timedtexttracks/{track.id}/",
+            self._update_url(video, track),
             json.dumps(data),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             content_type="application/json",
@@ -287,7 +291,7 @@ class TimedTextTrackUpdateAPITest(TestCase):
         jwt_token = UserAccessTokenFactory(user=user)
 
         response = self.client.get(
-            f"/api/timedtexttracks/{track.id}/",
+            self._update_url(video, track),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
         data = json.loads(response.content)
@@ -316,7 +320,7 @@ class TimedTextTrackUpdateAPITest(TestCase):
         data = {"active_stamp": "1533686400", "upload_state": "ready"}
 
         response = self.client.patch(
-            f"/api/timedtexttracks/{timed_text_track.id}/",
+            self._update_url(timed_text_track.video, timed_text_track),
             json.dumps(data),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             content_type="application/json",
@@ -341,7 +345,7 @@ class TimedTextTrackUpdateAPITest(TestCase):
         data["id"] = "my new id"
 
         response = self.client.put(
-            f"/api/timedtexttracks/{timed_text_track.id}/",
+            self._update_url(timed_text_track.video, timed_text_track),
             json.dumps(data),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             content_type="application/json",
@@ -364,7 +368,7 @@ class TimedTextTrackUpdateAPITest(TestCase):
         data["video"] = str(VideoFactory().id)
 
         response = self.client.put(
-            f"/api/timedtexttracks/{timed_text_track.id}/",
+            self._update_url(timed_text_track.video, timed_text_track),
             json.dumps(data),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             content_type="application/json",
@@ -381,7 +385,7 @@ class TimedTextTrackUpdateAPITest(TestCase):
 
         data = {"language": "fr", "size": 10}
         response = self.client.put(
-            f"/api/timedtexttracks/{timed_text_track_update.id}/",
+            self._update_url(timed_text_track_update.video, timed_text_track_update),
             json.dumps(data),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             content_type="application/json",
@@ -389,3 +393,34 @@ class TimedTextTrackUpdateAPITest(TestCase):
         self.assertEqual(response.status_code, 403)
         timed_text_track_update.refresh_from_db()
         self.assertEqual(timed_text_track_update.language, "en")
+
+
+class TimedTextTrackUpdateAPIOldTest(TimedTextTrackUpdateAPITest):
+    """Test the update API of the liveSession object with old URLs."""
+
+    def _update_url(self, video, track):
+        """Return the url to update a timed text track."""
+        return f"/api/timedtexttracks/{track.id}/"
+
+    def test_api_timed_text_track_update_detail_token_video(self):
+        """Token users trying to update the video of a timed text return an error."""
+        timed_text_track = TimedTextTrackFactory()
+        original_video = timed_text_track.video
+        jwt_token = InstructorOrAdminLtiTokenFactory(resource=timed_text_track.video)
+
+        response = self.client.get(
+            f"/api/timedtexttracks/{timed_text_track.id}/",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+        data = json.loads(response.content)
+        data["video"] = str(VideoFactory().id)
+
+        response = self.client.put(
+            self._update_url(timed_text_track.video, timed_text_track),
+            json.dumps(data),
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 400)
+        timed_text_track.refresh_from_db()
+        self.assertEqual(timed_text_track.video, original_video)

--- a/src/backend/marsha/urls.py
+++ b/src/backend/marsha/urls.py
@@ -60,7 +60,6 @@ router.register(
     TimedTextTrackViewSet,
     basename="timed_text_tracks",
 )
-router.register(models.Thumbnail.RESOURCE_NAME, ThumbnailViewSet, basename="thumbnails")
 router.register("organizations", OrganizationViewSet, basename="organizations")
 router.register("playlists", PlaylistViewSet, basename="playlists")
 router.register(
@@ -85,6 +84,7 @@ router.register(
     LiveSessionViewSet,
     basename="live_sessions",
 )
+router.register(models.Thumbnail.RESOURCE_NAME, ThumbnailViewSet, basename="thumbnails")
 
 # Video related resources (for nested routes)
 video_related_router = DefaultRouter()
@@ -92,6 +92,10 @@ video_related_router.register(
     models.LiveSession.RESOURCE_NAME,
     LiveSessionViewSet,
     basename="live_sessions",
+)
+
+video_related_router.register(
+    models.Thumbnail.RESOURCE_NAME, ThumbnailViewSet, basename="thumbnails"
 )
 
 urlpatterns = [

--- a/src/backend/marsha/urls.py
+++ b/src/backend/marsha/urls.py
@@ -67,17 +67,17 @@ router.register("users", UserViewSet, basename="users")
 router.register(
     "lti-user-associations", LtiUserAssociationViewSet, basename="lti_user_associations"
 )
-router.register(
-    models.SharedLiveMedia.RESOURCE_NAME,
-    SharedLiveMediaViewSet,
-    basename="sharedlivemedias",
-)
 
 # Old routes to remove
 router.register(
     models.LiveSession.RESOURCE_NAME,
     LiveSessionViewSet,
     basename="live_sessions",
+)
+router.register(
+    models.SharedLiveMedia.RESOURCE_NAME,
+    SharedLiveMediaViewSet,
+    basename="sharedlivemedias",
 )
 router.register(
     models.TimedTextTrack.RESOURCE_NAME,
@@ -98,6 +98,12 @@ video_related_router.register(
     models.TimedTextTrack.RESOURCE_NAME,
     TimedTextTrackViewSet,
     basename="timed_text_tracks",
+)
+
+video_related_router.register(
+    models.SharedLiveMedia.RESOURCE_NAME,
+    SharedLiveMediaViewSet,
+    basename="sharedlivemedias",
 )
 
 video_related_router.register(

--- a/src/backend/marsha/urls.py
+++ b/src/backend/marsha/urls.py
@@ -55,11 +55,6 @@ LTI_SELECT_ROUTE_PATTERN = (
 router = DefaultRouter()
 router.register(models.Video.RESOURCE_NAME, VideoViewSet, basename="videos")
 router.register(models.Document.RESOURCE_NAME, DocumentViewSet, basename="documents")
-router.register(
-    models.TimedTextTrack.RESOURCE_NAME,
-    TimedTextTrackViewSet,
-    basename="timed_text_tracks",
-)
 router.register("organizations", OrganizationViewSet, basename="organizations")
 router.register("playlists", PlaylistViewSet, basename="playlists")
 router.register(
@@ -84,6 +79,11 @@ router.register(
     LiveSessionViewSet,
     basename="live_sessions",
 )
+router.register(
+    models.TimedTextTrack.RESOURCE_NAME,
+    TimedTextTrackViewSet,
+    basename="timed_text_tracks",
+)
 router.register(models.Thumbnail.RESOURCE_NAME, ThumbnailViewSet, basename="thumbnails")
 
 # Video related resources (for nested routes)
@@ -92,6 +92,12 @@ video_related_router.register(
     models.LiveSession.RESOURCE_NAME,
     LiveSessionViewSet,
     basename="live_sessions",
+)
+
+video_related_router.register(
+    models.TimedTextTrack.RESOURCE_NAME,
+    TimedTextTrackViewSet,
+    basename="timed_text_tracks",
 )
 
 video_related_router.register(


### PR DESCRIPTION
## Purpose

This use the nested-like route for video related objects also used for the live sessions API.

Example: /api/livesessions/ becomes /api/videos/<video_pk>/livesessions/

See https://github.com/openfun/marsha/issues/2094

## Proposal
 
- [x] thumbnails
- [x] timed_text_track 
- [x] shared_live_media 
- [x] update live_session to use the new mixin
- [x] fix a video typo permissions 

