### PR TITLE
✨(website) add disabled button create ressource form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Make video dashboard visible by default, and collapsed when using the
   Moodle atto plugin
 - Update live_session api to use mixin to prevent url crafting 
+- standalone website:
+    - put the creating ressource form submit button disabled when the 
+    form is invalid (#2175)
 
 ### Fixed
 

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Create/ClassRoomCreateForm.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Create/ClassRoomCreateForm.spec.tsx
@@ -60,9 +60,13 @@ describe('<ClassRoomCreateForm />', () => {
 
     const button = screen.getByRole('button', { name: /Add Classroom/i });
 
+    expect(button).toBeDisabled();
+
     fireEvent.change(screen.getByRole('textbox', { name: /title/i }), {
       target: { value: 'my title' },
     });
+
+    expect(button).toBeDisabled();
 
     userEvent.click(
       await screen.findByRole('button', {

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Create/ClassRoomCreateForm.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Create/ClassRoomCreateForm.tsx
@@ -144,6 +144,7 @@ const ClassroomCreateForm = () => {
           label={intl.formatMessage(messages.submitLabel)}
           onClickCancel={() => history.push(classroomPath)}
           isSubmitting={isCreating}
+          isDisabled={!classroom.title || !classroom.playlist}
         />
       </Form>
     </Fragment>

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/Create/LiveCreateForm.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/Create/LiveCreateForm.spec.tsx
@@ -61,9 +61,15 @@ describe('<LiveCreateForm />', () => {
 
     deferredPlaylists.resolve(playlistsResponse);
 
+    const button = screen.getByRole('button', { name: /Add Webinar/i });
+
+    expect(button).toBeDisabled();
+
     fireEvent.change(screen.getByRole('textbox', { name: /title/i }), {
       target: { value: 'my title' },
     });
+
+    expect(button).toBeDisabled();
 
     userEvent.click(
       await screen.findByRole('button', {
@@ -81,11 +87,7 @@ describe('<LiveCreateForm />', () => {
       }),
     ).toBeInTheDocument();
 
-    await waitFor(() =>
-      expect(
-        screen.getByRole('button', { name: /Add Webinar/i }),
-      ).not.toBeDisabled(),
-    );
+    expect(button).not.toBeDisabled();
   });
 
   test('fields are posted correctly', async () => {

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/Create/LiveCreateForm.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/Create/LiveCreateForm.tsx
@@ -150,6 +150,7 @@ const LiveCreateForm = () => {
             history.push(livePath);
           }}
           isSubmitting={isCreating || isUpdatingToLive}
+          isDisabled={!live.title || !live.playlist}
         />
       </Form>
     </Fragment>

--- a/src/frontend/apps/standalone_site/src/features/Playlist/components/PlaylistForm.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Playlist/components/PlaylistForm.spec.tsx
@@ -60,11 +60,13 @@ describe('<PlaylistForm />', () => {
     expect(screen.getByLabelText('Organization*required')).toBeInTheDocument();
     expect(screen.getByLabelText('Name*required')).toBeInTheDocument();
 
-    expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+    const submitButton = screen.getByRole('button', { name: 'Save' });
+    expect(submitButton).toBeInTheDocument();
+    expect(submitButton).toBeDisabled();
     expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
   });
 
-  it('selects the first oranization if any', async () => {
+  it('selects the first organization if any', async () => {
     fetchMock.mock('/api/organizations/?limit=20&offset=0', {
       count: 2,
       results: [
@@ -144,6 +146,8 @@ describe('<PlaylistForm />', () => {
     expect(fetchMock.calls()[0][0]).toEqual(
       '/api/organizations/?limit=20&offset=0',
     );
+
+    expect(screen.queryByRole('button', { name: 'Save' })).not.toBeDisabled();
   });
 
   it('loads organizations until it find the initial one', async () => {

--- a/src/frontend/apps/standalone_site/src/features/Playlist/components/PlaylistForm.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Playlist/components/PlaylistForm.tsx
@@ -299,6 +299,7 @@ export const PlaylistForm = ({
               : undefined
           }
           isSubmitting={isSubmitting}
+          isDisabled={!formValues.name || !formValues.organizationId}
         />
         {actions}
       </Form>


### PR DESCRIPTION
## Purpose

Feature Request https://github.com/openfun/marsha/issues/2154

Before this commit, the button to create a classroom or a webinar was always enabled and click on it would show an error message if the form was not valid.
Now, the button is disabled until the form is valid.

## Proposal

[Marsha - Button disabled.webm](https://user-images.githubusercontent.com/25994652/230105508-3e55b468-f97b-415a-bd27-2eecdcd1e1f6.webm)


