### PR TITLE
🏗️(website) add featureFactory to integrate contents feature 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+  - Improve architecture Contents feature (#2183)
+
 ## [4.0.0-beta.20] - 2023-04-20
 
 ### Fixed

--- a/src/frontend/apps/standalone_site/src/features/Contents/components/Contents/Contents.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/components/Contents/Contents.spec.tsx
@@ -1,23 +1,30 @@
 import { screen } from '@testing-library/react';
 import { render } from 'lib-tests';
 
+import { useContentFeatures } from '../../store/contentsStore';
+
 import Contents from './Contents';
 
-jest.mock('features/Contents', () => ({
-  ClassRooms: () => <div>Classrooms Component</div>,
-  Videos: () => <div>Videos Component</div>,
-  Lives: () => <div>Webinars Component</div>,
-}));
+const ClassRoomContents = () => <div>Classrooms Component</div>;
+const LiveContents = () => <div>Videos Component</div>;
+const VideoContents = () => <div>Webinars Component</div>;
+useContentFeatures.setState(
+  {
+    featureSamples: [
+      <ClassRoomContents key="classRoomContents" />,
+      <LiveContents key="liveContents" />,
+      <VideoContents key="videoContents" />,
+    ],
+  },
+  true,
+);
 
 describe('<Contents />', () => {
   test('renders Contents', () => {
     render(<Contents />);
-    expect(screen.getByText(/My Classrooms/)).toBeInTheDocument();
-    expect(screen.getByText(/My Videos/)).toBeInTheDocument();
-    expect(screen.getByText(/My Webinars/)).toBeInTheDocument();
+
     expect(screen.getByText(/Classrooms Component/i)).toBeInTheDocument();
     expect(screen.getByText(/Webinars Component/i)).toBeInTheDocument();
     expect(screen.getByText(/Videos Component/i)).toBeInTheDocument();
-    expect(screen.getAllByText(/See Everything/i)).toHaveLength(3);
   });
 });

--- a/src/frontend/apps/standalone_site/src/features/Contents/components/Contents/Contents.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/components/Contents/Contents.tsx
@@ -1,80 +1,13 @@
-import { Box, Text } from 'grommet';
-import { StyledLink } from 'lib-components';
-import { defineMessages, useIntl } from 'react-intl';
-import styled from 'styled-components';
+import { Box } from 'grommet';
 
-import { ClassRooms, Videos, Lives } from 'features/Contents';
-import { routes } from 'routes';
-
-const messages = defineMessages({
-  MyWebinars: {
-    defaultMessage: 'My Webinars',
-    description: 'My contents page, my webinars title',
-    id: 'features.Contents.Contents.MyWebinars',
-  },
-  MyVideos: {
-    defaultMessage: 'My Videos',
-    description: 'My contents page, my videos title',
-    id: 'features.Contents.Contents.MyVideos',
-  },
-  MyClassrooms: {
-    defaultMessage: 'My Classrooms',
-    description: 'My contents page, my classrooms title',
-    id: 'features.Contents.Contents.MyClassrooms',
-  },
-  SeeEverything: {
-    defaultMessage: 'See Everything',
-    description: 'Label to see all the cards',
-    id: 'features.Contents.Contents.SeeEverything',
-  },
-});
-
-const BoxText = styled(Box)`
-  color: #002c84;
-`;
+import { useContentFeatures } from '../../store/contentsStore';
 
 const Contents = () => {
-  const intl = useIntl();
+  const { featureSamples } = useContentFeatures((state) => ({
+    featureSamples: state.featureSamples,
+  }));
 
-  return (
-    <Box margin={{ top: 'medium' }}>
-      <Box margin={{ top: 'medium' }}>
-        <BoxText direction="row" justify="between" margin={{ bottom: 'small' }}>
-          <Text weight="bolder">{intl.formatMessage(messages.MyWebinars)}</Text>
-          <Text weight="bolder">
-            <StyledLink to={`${routes.CONTENTS.subRoutes.LIVE.path}`}>
-              › {intl.formatMessage(messages.SeeEverything)}
-            </StyledLink>
-          </Text>
-        </BoxText>
-        <Lives withPagination={false} limit={4} />
-      </Box>
-      <Box margin={{ top: 'medium' }}>
-        <BoxText direction="row" justify="between" margin={{ bottom: 'small' }}>
-          <Text weight="bolder">{intl.formatMessage(messages.MyVideos)}</Text>
-          <Text weight="bolder">
-            <StyledLink to={`${routes.CONTENTS.subRoutes.VIDEO.path}`}>
-              › {intl.formatMessage(messages.SeeEverything)}
-            </StyledLink>
-          </Text>
-        </BoxText>
-        <Videos withPagination={false} limit={4} />
-      </Box>
-      <Box margin={{ top: 'medium' }}>
-        <BoxText direction="row" justify="between" margin={{ bottom: 'small' }}>
-          <Text weight="bolder">
-            {intl.formatMessage(messages.MyClassrooms)}
-          </Text>
-          <Text weight="bolder">
-            <StyledLink to={`${routes.CONTENTS.subRoutes.CLASSROOM.path}`}>
-              › {intl.formatMessage(messages.SeeEverything)}
-            </StyledLink>
-          </Text>
-        </BoxText>
-        <ClassRooms withPagination={false} limit={4} />
-      </Box>
-    </Box>
-  );
+  return <Box margin={{ top: 'medium' }}>{featureSamples}</Box>;
 };
 
 export default Contents;

--- a/src/frontend/apps/standalone_site/src/features/Contents/components/ContentsRouter/ContentsRouter.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/components/ContentsRouter/ContentsRouter.spec.tsx
@@ -1,18 +1,27 @@
 import { screen } from '@testing-library/react';
 import { render } from 'lib-tests';
 
+import { useContentFeatures } from '../../store/contentsStore';
+
 import ContentsRouter from './ContentsRouter';
 
-jest.mock('../Contents/Contents', () => ({
-  __esModule: true,
-  default: () => <div>My Contents</div>,
+jest.mock('features/Contents', () => ({
+  Contents: () => <div>My Contents</div>,
 }));
 
-jest.mock('features/Contents', () => ({
-  ClassRoomRouter: () => <div>My ClassRoomRouter</div>,
-  VideoRouter: () => <div>My VideoRouter</div>,
-  LiveRouter: () => <div>My LiveRouter</div>,
-}));
+const ClassroomRouter = () => <div>My ClassRoomRouter</div>;
+const VideoRouter = () => <div>My VideoRouter</div>;
+const LiveRouter = () => <div>My LiveRouter</div>;
+useContentFeatures.setState(
+  {
+    featureRoutes: [
+      <ClassroomRouter key="classroomRouter" />,
+      <VideoRouter key="videoRouter" />,
+      <LiveRouter key="liveRouter" />,
+    ],
+  },
+  true,
+);
 
 describe('<ContentsRouter/>', () => {
   afterEach(() => {
@@ -23,27 +32,21 @@ describe('<ContentsRouter/>', () => {
     render(<ContentsRouter />, {
       routerOptions: { history: ['/my-contents'] },
     });
+
     expect(screen.getByText('My Contents')).toBeInTheDocument();
+    expect(screen.queryByText('My ClassRoomRouter')).not.toBeInTheDocument();
+    expect(screen.queryByText('My VideoRouter')).not.toBeInTheDocument();
+    expect(screen.queryByText('My LiveRouter')).not.toBeInTheDocument();
   });
 
-  test('render route /my-contents/classroom', () => {
+  test('render from useContentFeatures', () => {
     render(<ContentsRouter />, {
       routerOptions: { history: ['/my-contents/classroom'] },
     });
+
+    expect(screen.queryByText('My Contents')).not.toBeInTheDocument();
     expect(screen.getByText('My ClassRoomRouter')).toBeInTheDocument();
-  });
-
-  test('render route /my-contents/videos', () => {
-    render(<ContentsRouter />, {
-      routerOptions: { history: ['/my-contents/videos'] },
-    });
     expect(screen.getByText('My VideoRouter')).toBeInTheDocument();
-  });
-
-  test('render route /my-contents/webinars', () => {
-    render(<ContentsRouter />, {
-      routerOptions: { history: ['/my-contents/webinars'] },
-    });
     expect(screen.getByText('My LiveRouter')).toBeInTheDocument();
   });
 });

--- a/src/frontend/apps/standalone_site/src/features/Contents/components/ContentsRouter/ContentsRouter.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/components/ContentsRouter/ContentsRouter.tsx
@@ -1,25 +1,21 @@
 import { Route, Switch } from 'react-router-dom';
 
-import { ClassRoomRouter, VideoRouter, LiveRouter } from 'features/Contents';
+import { Contents } from 'features/Contents';
 import { routes } from 'routes';
 
-import Contents from '../Contents/Contents';
+import { useContentFeatures } from '../../store/contentsStore';
 
 const ContentsRouter = () => {
+  const { featureRoutes } = useContentFeatures((state) => ({
+    featureRoutes: state.featureRoutes,
+  }));
+
   return (
     <Switch>
       <Route path={routes.CONTENTS.path} exact>
         <Contents />
       </Route>
-      <Route path={routes.CONTENTS.subRoutes.CLASSROOM.path}>
-        <ClassRoomRouter />
-      </Route>
-      <Route path={routes.CONTENTS.subRoutes.VIDEO.path}>
-        <VideoRouter />
-      </Route>
-      <Route path={routes.CONTENTS.subRoutes.LIVE.path}>
-        <LiveRouter />
-      </Route>
+      <Route>{featureRoutes}</Route>
     </Switch>
   );
 };

--- a/src/frontend/apps/standalone_site/src/features/Contents/components/ContentsShuffle/ContentsShuffle.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/components/ContentsShuffle/ContentsShuffle.spec.tsx
@@ -1,11 +1,17 @@
 import { screen } from '@testing-library/react';
 import { render } from 'lib-tests';
 
+import { useContentFeatures } from '../../store/contentsStore';
+
 import ContentsShuffle from './ContentsShuffle';
 
-jest.mock('features/Contents', () => ({
-  ClassRooms: () => <div>Part of my classrooms</div>,
-}));
+const ClassRoomContents = () => <div>Part of my classrooms</div>;
+useContentFeatures.setState(
+  {
+    featureShuffles: [<ClassRoomContents key="classRoomContents" />],
+  },
+  true,
+);
 
 describe('<ContentsShuffle />', () => {
   test('renders ContentsShuffle', () => {

--- a/src/frontend/apps/standalone_site/src/features/Contents/components/ContentsShuffle/ContentsShuffle.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/components/ContentsShuffle/ContentsShuffle.tsx
@@ -1,7 +1,13 @@
-import { ClassRooms } from 'features/Contents';
+import { Fragment } from 'react';
+
+import { useContentFeatures } from '../../store/contentsStore';
 
 const ContentsShuffle = () => {
-  return <ClassRooms withPagination={false} limit={5} />;
+  const { featureShuffles } = useContentFeatures((state) => ({
+    featureShuffles: state.featureShuffles,
+  }));
+
+  return <Fragment>{featureShuffles}</Fragment>;
 };
 
 export default ContentsShuffle;

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/ClassRoomRouter.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/ClassRoomRouter.spec.tsx
@@ -38,9 +38,9 @@ describe('<ClassRoomRouter/>', () => {
       routerOptions: { history: ['/some/bad/route'] },
     });
     expect(
-      screen.getByRole('button', { name: 'Create Classroom' }),
-    ).toBeInTheDocument();
-    expect(screen.getByText(/My ClassroomsRead/i)).toBeInTheDocument();
+      screen.queryByRole('button', { name: 'Create Classroom' }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/My ClassroomsRead/i)).not.toBeInTheDocument();
   });
 
   test('render create classroom', async () => {

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/ClassRoomRouter.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/ClassRoomRouter.tsx
@@ -14,21 +14,23 @@ const ClassRoomRouter = () => {
   const classroomInvitePath = classroomRoute.subRoutes?.INVITE?.path || '';
 
   return (
-    <Box pad="medium">
-      <Switch>
-        <Route path={classroomCreatePath} exact>
-          <ClassRoomCreate />
-          <ClassRooms />
-        </Route>
-        <Route path={[classroomInvitePath, classroomUpdatePath]} exact>
-          <ClassRoomUpdate />
-        </Route>
-        <Route>
-          <ClassRoomCreate />
-          <ClassRooms />
-        </Route>
-      </Switch>
-    </Box>
+    <Route path={classroomRoute.path}>
+      <Box pad="medium">
+        <Switch>
+          <Route path={classroomCreatePath} exact>
+            <ClassRoomCreate />
+            <ClassRooms />
+          </Route>
+          <Route path={[classroomInvitePath, classroomUpdatePath]} exact>
+            <ClassRoomUpdate />
+          </Route>
+          <Route>
+            <ClassRoomCreate />
+            <ClassRooms />
+          </Route>
+        </Switch>
+      </Box>
+    </Route>
   );
 };
 

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Read/ClassRoomContents.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Read/ClassRoomContents.spec.tsx
@@ -1,0 +1,18 @@
+import { screen } from '@testing-library/react';
+import { render } from 'lib-tests';
+
+import ClassRoomContents from './ClassRoomContents';
+
+jest.mock('./ClassRooms', () => ({
+  __esModule: true,
+  default: () => <div>Classrooms Component</div>,
+}));
+
+describe('<ClassRoomContents />', () => {
+  test('renders ClassRoomContents', () => {
+    render(<ClassRoomContents />);
+    expect(screen.getByText(/My Classrooms/)).toBeInTheDocument();
+    expect(screen.getByText(/Classrooms Component/i)).toBeInTheDocument();
+    expect(screen.getByText(/See Everything/i)).toBeInTheDocument();
+  });
+});

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Read/ClassRoomContents.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Read/ClassRoomContents.tsx
@@ -1,0 +1,45 @@
+import { Box, Text } from 'grommet';
+import { StyledLink } from 'lib-components';
+import { defineMessages, useIntl } from 'react-intl';
+import styled from 'styled-components';
+
+import { routes } from 'routes';
+
+import ClassRooms from './ClassRooms';
+
+const messages = defineMessages({
+  MyClassrooms: {
+    defaultMessage: 'My Classrooms',
+    description: 'My contents page, my classrooms title',
+    id: 'features.Contents.features.ClassRoomContents.MyClassrooms',
+  },
+  SeeEverything: {
+    defaultMessage: 'See Everything',
+    description: 'Label to see all the cards',
+    id: 'features.Contents.features.ClassRoomContents.SeeEverything',
+  },
+});
+
+const BoxText = styled(Box)`
+  color: #002c84;
+`;
+
+const ClassRoomContents = () => {
+  const intl = useIntl();
+
+  return (
+    <Box margin={{ top: 'medium' }}>
+      <BoxText direction="row" justify="between" margin={{ bottom: 'small' }}>
+        <Text weight="bolder">{intl.formatMessage(messages.MyClassrooms)}</Text>
+        <Text weight="bolder">
+          <StyledLink to={`${routes.CONTENTS.subRoutes.CLASSROOM.path}`}>
+            › {intl.formatMessage(messages.SeeEverything)}
+          </StyledLink>
+        </Text>
+      </BoxText>
+      <ClassRooms withPagination={false} limit={4} />
+    </Box>
+  );
+};
+
+export default ClassRoomContents;

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Read/ClassRoomShuffle.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Read/ClassRoomShuffle.spec.tsx
@@ -1,0 +1,16 @@
+import { screen } from '@testing-library/react';
+import { render } from 'lib-tests';
+
+import ClassRoomShuffle from './ClassRoomShuffle';
+
+jest.mock('./ClassRooms', () => ({
+  __esModule: true,
+  default: () => <div>Part of my classrooms</div>,
+}));
+
+describe('<ClassRoomShuffle />', () => {
+  test('renders ClassRoomShuffle', () => {
+    render(<ClassRoomShuffle />);
+    expect(screen.getByText(/Part of my classrooms/i)).toBeInTheDocument();
+  });
+});

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Read/ClassRoomShuffle.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Read/ClassRoomShuffle.tsx
@@ -1,0 +1,7 @@
+import ClassRooms from './ClassRooms';
+
+const ClassRoomShuffle = () => {
+  return <ClassRooms withPagination={false} limit={5} />;
+};
+
+export default ClassRoomShuffle;

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/index.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/index.tsx
@@ -1,2 +1,3 @@
 export { default as ClassRoomRouter } from './components/ClassRoomRouter';
+export { default as ClassRoomContents } from './components/Read/ClassRoomContents';
 export { default as ClassRooms } from './components/Read/ClassRooms';

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/index.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/index.tsx
@@ -1,3 +1,3 @@
 export { default as ClassRoomRouter } from './components/ClassRoomRouter';
 export { default as ClassRoomContents } from './components/Read/ClassRoomContents';
-export { default as ClassRooms } from './components/Read/ClassRooms';
+export { default as ClassRoomShuffle } from './components/Read/ClassRoomShuffle';

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/LiveRouter.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/LiveRouter.spec.tsx
@@ -43,8 +43,8 @@ describe('<LiveRouter/>', () => {
     });
 
     expect(
-      screen.getByRole('button', { name: 'Create Webinar' }),
-    ).toBeInTheDocument();
-    expect(screen.getByText('My Lives Read')).toBeInTheDocument();
+      screen.queryByRole('button', { name: 'Create Webinar' }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText('My Lives Read')).not.toBeInTheDocument();
   });
 });

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/LiveRouter.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/LiveRouter.tsx
@@ -13,21 +13,23 @@ const LiveRouter = () => {
   const liveUpdatePath = liveRoute.subRoutes?.UPDATE?.path || '';
 
   return (
-    <Box pad="medium">
-      <Switch>
-        <Route path={liveCreatePath} exact>
-          <LiveCreate />
-          <Lives />
-        </Route>
-        <Route path={liveUpdatePath} exact>
-          <LiveUpdate />
-        </Route>
-        <Route>
-          <LiveCreate />
-          <Lives />
-        </Route>
-      </Switch>
-    </Box>
+    <Route path={liveRoute.path}>
+      <Box pad="medium">
+        <Switch>
+          <Route path={liveCreatePath} exact>
+            <LiveCreate />
+            <Lives />
+          </Route>
+          <Route path={liveUpdatePath} exact>
+            <LiveUpdate />
+          </Route>
+          <Route>
+            <LiveCreate />
+            <Lives />
+          </Route>
+        </Switch>
+      </Box>
+    </Route>
   );
 };
 

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/Read/LiveContents.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/Read/LiveContents.spec.tsx
@@ -1,0 +1,18 @@
+import { screen } from '@testing-library/react';
+import { render } from 'lib-tests';
+
+import LiveContents from './LiveContents';
+
+jest.mock('./Lives', () => ({
+  __esModule: true,
+  default: () => <div>Webinars Component</div>,
+}));
+
+describe('<LiveContents />', () => {
+  test('renders LiveContents', () => {
+    render(<LiveContents />);
+    expect(screen.getByText(/My Webinars/)).toBeInTheDocument();
+    expect(screen.getByText(/Webinars Component/i)).toBeInTheDocument();
+    expect(screen.getByText(/See Everything/i)).toBeInTheDocument();
+  });
+});

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/Read/LiveContents.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/Read/LiveContents.tsx
@@ -1,0 +1,45 @@
+import { Box, Text } from 'grommet';
+import { StyledLink } from 'lib-components';
+import { defineMessages, useIntl } from 'react-intl';
+import styled from 'styled-components';
+
+import { routes } from 'routes';
+
+import Lives from './Lives';
+
+const messages = defineMessages({
+  MyWebinars: {
+    defaultMessage: 'My Webinars',
+    description: 'My contents page, my webinars title',
+    id: 'features.Contents.features.LiveContents.MyWebinars',
+  },
+  SeeEverything: {
+    defaultMessage: 'See Everything',
+    description: 'Label to see all the cards',
+    id: 'features.Contents.features.LiveContents.SeeEverything',
+  },
+});
+
+const BoxText = styled(Box)`
+  color: #002c84;
+`;
+
+const LiveContents = () => {
+  const intl = useIntl();
+
+  return (
+    <Box margin={{ top: 'medium' }}>
+      <BoxText direction="row" justify="between" margin={{ bottom: 'small' }}>
+        <Text weight="bolder">{intl.formatMessage(messages.MyWebinars)}</Text>
+        <Text weight="bolder">
+          <StyledLink to={`${routes.CONTENTS.subRoutes.LIVE.path}`}>
+            › {intl.formatMessage(messages.SeeEverything)}
+          </StyledLink>
+        </Text>
+      </BoxText>
+      <Lives withPagination={false} limit={4} />
+    </Box>
+  );
+};
+
+export default LiveContents;

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Live/index.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Live/index.tsx
@@ -1,2 +1,2 @@
 export { default as LiveRouter } from './components/LiveRouter';
-export { default as Lives } from './components/Read/Lives';
+export { default as LiveContents } from './components/Read/LiveContents';

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Video/components/Read/VideoContents.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Video/components/Read/VideoContents.spec.tsx
@@ -1,0 +1,18 @@
+import { screen } from '@testing-library/react';
+import { render } from 'lib-tests';
+
+import VideoContents from './VideoContents';
+
+jest.mock('./Videos', () => ({
+  __esModule: true,
+  default: () => <div>Videos Component</div>,
+}));
+
+describe('<VideoContents />', () => {
+  test('renders VideoContents', () => {
+    render(<VideoContents />);
+    expect(screen.getByText(/My Videos/)).toBeInTheDocument();
+    expect(screen.getByText(/Videos Component/i)).toBeInTheDocument();
+    expect(screen.getByText(/See Everything/i)).toBeInTheDocument();
+  });
+});

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Video/components/Read/VideoContents.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Video/components/Read/VideoContents.tsx
@@ -1,0 +1,45 @@
+import { Box, Text } from 'grommet';
+import { StyledLink } from 'lib-components';
+import { defineMessages, useIntl } from 'react-intl';
+import styled from 'styled-components';
+
+import { routes } from 'routes';
+
+import Videos from './Videos';
+
+const messages = defineMessages({
+  MyVideos: {
+    defaultMessage: 'My Videos',
+    description: 'My contents page, my videos title',
+    id: 'features.Contents.features.VideoContents.MyVideos',
+  },
+  SeeEverything: {
+    defaultMessage: 'See Everything',
+    description: 'Label to see all the cards',
+    id: 'features.Contents.features.VideoContents.SeeEverything',
+  },
+});
+
+const BoxText = styled(Box)`
+  color: #002c84;
+`;
+
+const VideoContents = () => {
+  const intl = useIntl();
+
+  return (
+    <Box margin={{ top: 'medium' }}>
+      <BoxText direction="row" justify="between" margin={{ bottom: 'small' }}>
+        <Text weight="bolder">{intl.formatMessage(messages.MyVideos)}</Text>
+        <Text weight="bolder">
+          <StyledLink to={`${routes.CONTENTS.subRoutes.VIDEO.path}`}>
+            › {intl.formatMessage(messages.SeeEverything)}
+          </StyledLink>
+        </Text>
+      </BoxText>
+      <Videos withPagination={false} limit={4} />
+    </Box>
+  );
+};
+
+export default VideoContents;

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Video/components/VideoRouter.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Video/components/VideoRouter.spec.tsx
@@ -37,9 +37,9 @@ describe('<VideoRouter/>', () => {
       routerOptions: { history: ['/some/bad/route'] },
     });
     expect(
-      screen.getByRole('button', { name: 'Create Video' }),
-    ).toBeInTheDocument();
-    expect(screen.getByText(/My VideosRead/i)).toBeInTheDocument();
+      screen.queryByRole('button', { name: 'Create Video' }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/My VideosRead/i)).not.toBeInTheDocument();
   });
 
   test('render create video', async () => {

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Video/components/VideoRouter.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Video/components/VideoRouter.tsx
@@ -13,21 +13,23 @@ const VideoRouter = () => {
   const videoUpdatePath = videoRoute.subRoutes?.UPDATE?.path || '';
 
   return (
-    <Box pad="medium">
-      <Switch>
-        <Route path={videoCreatePath} exact>
-          <VideoCreate />
-          <Videos />
-        </Route>
-        <Route path={videoUpdatePath} exact>
-          <VideoUpdate />
-        </Route>
-        <Route>
-          <VideoCreate />
-          <Videos />
-        </Route>
-      </Switch>
-    </Box>
+    <Route path={videoRoute.path}>
+      <Box pad="medium">
+        <Switch>
+          <Route path={videoCreatePath} exact>
+            <VideoCreate />
+            <Videos />
+          </Route>
+          <Route path={videoUpdatePath} exact>
+            <VideoUpdate />
+          </Route>
+          <Route>
+            <VideoCreate />
+            <Videos />
+          </Route>
+        </Switch>
+      </Box>
+    </Route>
   );
 };
 

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Video/index.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Video/index.tsx
@@ -1,2 +1,2 @@
 export { default as VideoRouter } from './components/VideoRouter';
-export { default as Videos } from './components/Read/Videos';
+export { default as VideoContents } from './components/Read/VideoContents';

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/featureFactory.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/featureFactory.tsx
@@ -1,0 +1,13 @@
+import { useContentFeatures } from '../store/contentsStore';
+
+import { ClassRoomRouter } from './ClassRoom';
+import { LiveRouter } from './Live';
+import { VideoRouter } from './Video';
+
+useContentFeatures.setState({
+  featureRoutes: [
+    <VideoRouter key="videoRouter" />,
+    <ClassRoomRouter key="classRoomRouter" />,
+    <LiveRouter key="liveRouter" />,
+  ],
+});

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/featureFactory.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/featureFactory.tsx
@@ -1,13 +1,18 @@
 import { useContentFeatures } from '../store/contentsStore';
 
-import { ClassRoomRouter } from './ClassRoom';
-import { LiveRouter } from './Live';
-import { VideoRouter } from './Video';
+import { ClassRoomRouter, ClassRoomContents } from './ClassRoom';
+import { LiveRouter, LiveContents } from './Live';
+import { VideoRouter, VideoContents } from './Video';
 
 useContentFeatures.setState({
   featureRoutes: [
     <VideoRouter key="videoRouter" />,
     <ClassRoomRouter key="classRoomRouter" />,
     <LiveRouter key="liveRouter" />,
+  ],
+  featureSamples: [
+    <ClassRoomContents key="classRoomContents" />,
+    <LiveContents key="liveContents" />,
+    <VideoContents key="videoContents" />,
   ],
 });

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/featureFactory.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/featureFactory.tsx
@@ -1,6 +1,10 @@
 import { useContentFeatures } from '../store/contentsStore';
 
-import { ClassRoomRouter, ClassRoomContents } from './ClassRoom';
+import {
+  ClassRoomRouter,
+  ClassRoomContents,
+  ClassRoomShuffle,
+} from './ClassRoom';
 import { LiveRouter, LiveContents } from './Live';
 import { VideoRouter, VideoContents } from './Video';
 
@@ -15,4 +19,5 @@ useContentFeatures.setState({
     <LiveContents key="liveContents" />,
     <VideoContents key="videoContents" />,
   ],
+  featureShuffles: [<ClassRoomShuffle key="classRoomShuffle" />],
 });

--- a/src/frontend/apps/standalone_site/src/features/Contents/index.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/index.tsx
@@ -3,7 +3,6 @@ export { default as ContentsShuffle } from './components/ContentsShuffle/Content
 export { default as ContentsRouter } from './components/ContentsRouter/ContentsRouter';
 export { default as ContentsWrapper } from './components/ContentsWrapper/ContentsWrapper';
 export { default as ManageAPIState } from './components/ManageAPIState/ManageAPIState';
-export { ClassRooms } from './features/ClassRoom/';
 export { default as useContentPerPage } from './hooks/useContentPerPage';
 
 import './features/featureFactory';

--- a/src/frontend/apps/standalone_site/src/features/Contents/index.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/index.tsx
@@ -1,8 +1,11 @@
-export { default as useContentPerPage } from './hooks/useContentPerPage';
-export { default as ContentsWrapper } from './components/ContentsWrapper/ContentsWrapper';
-export { default as ContentsRouter } from './components/ContentsRouter/ContentsRouter';
+export { default as Contents } from './components/Contents/Contents';
 export { default as ContentsShuffle } from './components/ContentsShuffle/ContentsShuffle';
+export { default as ContentsRouter } from './components/ContentsRouter/ContentsRouter';
+export { default as ContentsWrapper } from './components/ContentsWrapper/ContentsWrapper';
 export { default as ManageAPIState } from './components/ManageAPIState/ManageAPIState';
-export { ClassRoomRouter, ClassRooms } from './features/ClassRoom/';
-export { LiveRouter, Lives } from './features/Live/';
-export { VideoRouter, Videos } from './features/Video/';
+export { ClassRooms } from './features/ClassRoom/';
+export { Lives } from './features/Live/';
+export { Videos } from './features/Video/';
+export { default as useContentPerPage } from './hooks/useContentPerPage';
+
+import './features/featureFactory';

--- a/src/frontend/apps/standalone_site/src/features/Contents/index.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/index.tsx
@@ -4,8 +4,6 @@ export { default as ContentsRouter } from './components/ContentsRouter/ContentsR
 export { default as ContentsWrapper } from './components/ContentsWrapper/ContentsWrapper';
 export { default as ManageAPIState } from './components/ManageAPIState/ManageAPIState';
 export { ClassRooms } from './features/ClassRoom/';
-export { Lives } from './features/Live/';
-export { Videos } from './features/Video/';
 export { default as useContentPerPage } from './hooks/useContentPerPage';
 
 import './features/featureFactory';

--- a/src/frontend/apps/standalone_site/src/features/Contents/store/contentsStore.ts
+++ b/src/frontend/apps/standalone_site/src/features/Contents/store/contentsStore.ts
@@ -4,9 +4,11 @@ import { create } from 'zustand';
 interface UseContentFeatures {
   featureRoutes: ReactNode[];
   featureSamples: ReactNode[];
+  featureShuffles: ReactNode[];
 }
 
 export const useContentFeatures = create<UseContentFeatures>(() => ({
   featureRoutes: [],
   featureSamples: [],
+  featureShuffles: [],
 }));

--- a/src/frontend/apps/standalone_site/src/features/Contents/store/contentsStore.ts
+++ b/src/frontend/apps/standalone_site/src/features/Contents/store/contentsStore.ts
@@ -1,0 +1,10 @@
+import { ReactNode } from 'react';
+import { create } from 'zustand';
+
+interface UseContentFeatures {
+  featureRoutes: ReactNode[];
+}
+
+export const useContentFeatures = create<UseContentFeatures>(() => ({
+  featureRoutes: [],
+}));

--- a/src/frontend/apps/standalone_site/src/features/Contents/store/contentsStore.ts
+++ b/src/frontend/apps/standalone_site/src/features/Contents/store/contentsStore.ts
@@ -3,8 +3,10 @@ import { create } from 'zustand';
 
 interface UseContentFeatures {
   featureRoutes: ReactNode[];
+  featureSamples: ReactNode[];
 }
 
 export const useContentFeatures = create<UseContentFeatures>(() => ({
   featureRoutes: [],
+  featureSamples: [],
 }));

--- a/src/frontend/apps/standalone_site/src/features/Profile/components/ProfilePage.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Profile/components/ProfilePage.spec.tsx
@@ -13,7 +13,7 @@ const mockedUseCurrentUser = useCurrentUser as jest.MockedFunction<
 >;
 
 jest.mock('features/Contents', () => ({
-  ClassRooms: () => <span>classrooms</span>,
+  Contents: () => <span>classrooms</span>,
 }));
 
 describe('<ProfilePage />', () => {

--- a/src/frontend/apps/standalone_site/src/features/Profile/components/ProfilePage.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Profile/components/ProfilePage.tsx
@@ -1,36 +1,15 @@
 import { Box, Heading, Text } from 'grommet';
 import { Nullable } from 'lib-common';
-import {
-  AnonymousUser,
-  StyledLink,
-  useCurrentUser,
-  useResponsive,
-} from 'lib-components';
+import { AnonymousUser, useCurrentUser, useResponsive } from 'lib-components';
 import { defineMessages, useIntl } from 'react-intl';
-import styled from 'styled-components';
 
-import { ClassRooms } from 'features/Contents';
-import { routes } from 'routes';
-
-const BoxText = styled(Box)`
-  color: #002c84;
-`;
+import { Contents } from 'features/Contents';
 
 const messages = defineMessages({
   header: {
     defaultMessage: 'My profile',
     description: "Profile page's title.",
     id: 'feature.Profile.ProfilePage.header',
-  },
-  MyClassrooms: {
-    defaultMessage: 'My Classrooms',
-    description: 'HomePage title',
-    id: 'features.Contents.Contents.MyClassrooms',
-  },
-  SeeEverything: {
-    defaultMessage: 'See Everything',
-    description: 'Label to see all the cards',
-    id: 'features.Contents.Contents.SeeEverything',
   },
 });
 
@@ -93,21 +72,7 @@ export const ProfilePage = () => {
           </Box>
         </Box>
       </Box>
-
-      <Box margin={{ top: 'medium' }}>
-        <BoxText direction="row" justify="between" margin={{ bottom: 'small' }}>
-          <Text weight="bolder">
-            {intl.formatMessage(messages.MyClassrooms)}
-          </Text>
-          <Text weight="bolder">
-            <StyledLink to={`${routes.CONTENTS.subRoutes.CLASSROOM.path}`}>
-              › {intl.formatMessage(messages.SeeEverything)}
-            </StyledLink>
-          </Text>
-        </BoxText>
-
-        <ClassRooms />
-      </Box>
+      <Contents />
     </Box>
   );
 };


### PR DESCRIPTION
## Purpose

Refacto `Content` to be feature agnostic, to avoid potential circular dependencies.
This commit adds a featureFactory that load the contents features in a content store.

## Proposal

- [x] Create `contentsStore`
- [x] Create `featureFactory` and load our feature in `contentsStore`
- [x] Remove children features references from `Contents`, `ContentsRouter`, `ContentsShuffle`
- [x] Tests

