### PR TITLE
🐛(frontend) increase classroom debounce time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - display title / description when a classroom is not scheduled and not started
 - correctly fetch transcript content in TranscriptReader
 - remove unused 'initiate-live' permissions
+- increase debounce time in classroom description widget
 
 ## [4.0.0-beta.18] - 2023-03-06
 

--- a/src/frontend/packages/lib_classroom/src/components/ClassroomWidgetProvider/widgets/Description/index.tsx
+++ b/src/frontend/packages/lib_classroom/src/components/ClassroomWidgetProvider/widgets/Description/index.tsx
@@ -8,6 +8,8 @@ import { defineMessages, useIntl } from 'react-intl';
 import { useUpdateClassroom } from '@lib-classroom/data/queries';
 import { useCurrentClassroom } from '@lib-classroom/hooks/useCurrentClassroom';
 
+const DEBOUNCE_TIME_MS = 1500;
+
 const messages = defineMessages({
   title: {
     defaultMessage: 'Description',
@@ -65,7 +67,7 @@ export const Description = () => {
       if (JSON.stringify(updatedClassroom) !== '{}') {
         updateClassroomMutation.mutate(updatedClassroom);
       }
-    }),
+    }, DEBOUNCE_TIME_MS),
   ).current;
 
   const handleChange = (updatedClassroomAttribute: Partial<Classroom>) => {


### PR DESCRIPTION
See Issue :
[when updating the desciption of a classroom, the debounce time was set too low to type without an unwanted update.
](https://github.com/openfun/marsha/issues/2181)

## Purpose

Increase the debounce time
