### PR TITLE
🐛(live) fix start_live upload id3 tags error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - correctly fetch transcript content in TranscriptReader
 - remove unused 'initiate-live' permissions
 - increase debounce time in classroom description widget
+- remove id3 tags upload when live channel is not ready
 - add an invitation link for moderators in a launched classroom if available
 
 ## [4.0.0-beta.18] - 2023-03-06

--- a/src/backend/marsha/core/api/video.py
+++ b/src/backend/marsha/core/api/video.py
@@ -470,7 +470,6 @@ class VideoViewSet(APIViewMixin, ObjectPkMixin, viewsets.ModelViewSet):
         channel_layers_utils.dispatch_video_to_groups(video)
 
         serializer = self.get_serializer(video)
-        update_id3_tags(video)
         return Response(serializer.data)
 
     @action(methods=["post"], detail=True, url_path="stop-live")

--- a/src/backend/marsha/core/utils/medialive_utils.py
+++ b/src/backend/marsha/core/utils/medialive_utils.py
@@ -317,6 +317,7 @@ def update_id3_tags(video):
         video.live_info is None
         or video.live_info.get("medialive") is None
         or video.get_medialive_channel() is None
+        or not video.is_live
     ):
         return
 


### PR DESCRIPTION
## Purpose

When we started a live, we got an an error caused by the id3's tags upload on a not ready live channel.

## Proposal

We skip id3 tags upload after starting a live and instead, we upload them when aws use our callback when the live is ready.

