### PR TITLE
🐛(frontend) add missing classroom invitation link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - correctly fetch transcript content in TranscriptReader
 - remove unused 'initiate-live' permissions
 - increase debounce time in classroom description widget
+- add an invitation link for moderators in a launched classroom if available
 
 ## [4.0.0-beta.18] - 2023-03-06
 

--- a/src/frontend/packages/lib_classroom/src/components/DashboardClassroomInfos/index.spec.tsx
+++ b/src/frontend/packages/lib_classroom/src/components/DashboardClassroomInfos/index.spec.tsx
@@ -16,6 +16,7 @@ describe('<DashboardClassroomInfos />', () => {
     render(
       <DashboardClassroomInfos
         inviteToken={null}
+        instructorToken={null}
         infos={classroomInfos}
         classroomId="1"
       />,
@@ -41,10 +42,31 @@ describe('<DashboardClassroomInfos />', () => {
   });
 
   it('displays invite link', () => {
-    render(<DashboardClassroomInfos inviteToken="my-token" classroomId="1" />);
+    render(
+      <DashboardClassroomInfos
+        inviteToken="my-token"
+        instructorToken={null}
+        classroomId="1"
+      />,
+    );
 
     expect(
       screen.getByText('Invite a viewer with this link:'),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/invite\/my-token/i)).toBeInTheDocument();
+  });
+
+  it('displays moderator link', () => {
+    render(
+      <DashboardClassroomInfos
+        inviteToken={null}
+        instructorToken="my-token"
+        classroomId="1"
+      />,
+    );
+
+    expect(
+      screen.getByText('Invite a moderator with this link:'),
     ).toBeInTheDocument();
     expect(screen.getByText(/invite\/my-token/i)).toBeInTheDocument();
   });

--- a/src/frontend/packages/lib_classroom/src/components/DashboardClassroomInfos/index.tsx
+++ b/src/frontend/packages/lib_classroom/src/components/DashboardClassroomInfos/index.tsx
@@ -47,6 +47,7 @@ const DashboardClassroomInfosItem = ({
 
 interface DashboardClassroomInfosProps {
   inviteToken: Nullable<string>;
+  instructorToken: Nullable<string>;
   infos?: ClassroomInfos;
   classroomId: string;
 }
@@ -54,6 +55,7 @@ interface DashboardClassroomInfosProps {
 const DashboardClassroomInfos = ({
   infos,
   inviteToken,
+  instructorToken,
   classroomId,
 }: DashboardClassroomInfosProps) => {
   return (
@@ -87,6 +89,7 @@ const DashboardClassroomInfos = ({
       <Box margin={{ top: 'large' }}>
         <DashboardCopyClipboard
           inviteToken={inviteToken}
+          instructorToken={instructorToken}
           classroomId={classroomId}
         />
       </Box>

--- a/src/frontend/packages/lib_classroom/src/components/DashboardClassroomInstructor/index.tsx
+++ b/src/frontend/packages/lib_classroom/src/components/DashboardClassroomInstructor/index.tsx
@@ -96,6 +96,7 @@ const DashboardClassroomInstructor = ({
         <DashboardClassroomInfos
           infos={classroom.infos}
           inviteToken={classroom.invite_token}
+          instructorToken={classroom.instructor_token}
           classroomId={classroom.id}
         />
       </React.Fragment>
@@ -115,6 +116,7 @@ const DashboardClassroomInstructor = ({
         <DashboardClassroomInfos
           infos={classroom.infos}
           inviteToken={classroom.invite_token}
+          instructorToken={classroom.instructor_token}
           classroomId={classroom.id}
         />
       </Box>


### PR DESCRIPTION
The invitation link for moderators was not accessible once a classroom was launched. This PR adds the missing link in the component.

See https://github.com/openfun/marsha/issues/2180

## Proposal

Add the missing link if available

