### PR TITLE
⬇️(back) downgrade django to version 4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,8 +61,6 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - standalone website:
   - put the creating ressource form submit button disabled when the
     form is invalid (#2175)
-- `DJANGO_STATICFILES_STORAGE` environment variable is replaced by
-  `DJANGO_STORAGES_STATICFILES_BACKEND`
 
 ### Fixed
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -32,8 +32,6 @@ You also have to remove the `DJANGO_CLOUDFRONT_ACCESS_KEY_ID` environment variab
 $ /bin/terraform output cloudfront_publick_key_id
 ```
 
-`DJANGO_STATICFILES_STORAGE` environment variable is not used anymore. You have to replace it by `DJANGO_STORAGES_STATICFILES_BACKEND`.
-
 ## 3.0.0 to 3.1.0
 
 ### After deploying

--- a/docs/env.md
+++ b/docs/env.md
@@ -221,10 +221,10 @@ name of the bucket created by the relevant AWS deployment.
   - `"preprod-marsha-static"` in preprod;
   - `"production-marsha-static"` in production.
 
-### DJANGO_STORAGES_STATICFILES_BACKEND
+### DJANGO_STATICFILES_STORAGE
 
 The static files storage backend that Django should use to serve static files. For more
-information, see [documentation](https://docs.djangoproject.com/en/4.2/ref/contrib/staticfiles/#storages).
+information, see [documentation](https://docs.djangoproject.com/en/2.1/ref/contrib/staticfiles/#storages).
 
 - Type: string
 - Required: No

--- a/renovate.json
+++ b/renovate.json
@@ -32,6 +32,16 @@
       ]
     },
     {
+      "groupName": "allowed django versions",
+      "matchManagers": [
+        "setup-cfg"
+      ],
+      "matchPackageNames": [
+        "django"
+      ],
+      "allowedVersions": "<4.2"
+    },
+    {
       "groupName": "allowed django channels version",
       "matchManagers": [
         "setup-cfg"

--- a/src/backend/marsha/core/tests/test_statics.py
+++ b/src/backend/marsha/core/tests/test_statics.py
@@ -85,11 +85,7 @@ class TestMarshaCompressedManifestStaticFilesStorage(TestCase):
     """Test suite for Marsha's collectstatic command."""
 
     @override_settings(
-        STORAGES={
-            "staticfiles": {
-                "BACKEND": "marsha.core.static.MarshaCompressedManifestStaticFilesStorage",
-            }
-        }
+        STATICFILES_STORAGE="marsha.core.static.MarshaCompressedManifestStaticFilesStorage",
     )
     def test_collectstatic_marsha(self):
         """Files are excluded correctly"""
@@ -107,11 +103,7 @@ class TestMarshaCompressedManifestStaticFilesStorage(TestCase):
             self.assertFalse(os.path.exists(path), f"{path} exists")
 
     @override_settings(
-        STORAGES={
-            "staticfiles": {
-                "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
-            }
-        }
+        STATICFILES_STORAGE="whitenoise.storage.CompressedManifestStaticFilesStorage",
     )
     def test_collectstatic_whitenoise(self):
         """All files are included

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -815,14 +815,9 @@ class Build(Base):
     AWS_MEDIAPACKAGE_HARVEST_JOB_ARN = values.Value("")
     BBB_API_SECRET = values.Value("")
     SECRET_KEY = values.Value("DummyKey")
-    STORAGES = {
-        "staticfiles": {
-            "BACKEND": values.Value(
-                "marsha.core.static.MarshaCompressedManifestStaticFilesStorage",
-                environ_name="STORAGES_STATICFILES_BACKEND",
-            )
-        }
-    }
+    STATICFILES_STORAGE = values.Value(
+        "marsha.core.static.MarshaCompressedManifestStaticFilesStorage"
+    )
 
     STATIC_POSTPROCESS_IGNORE_REGEX = values.Value(
         r"^js\/build\/.*[0-9]*\..*\.js(\.map)?$"
@@ -937,14 +932,9 @@ class Production(Base):
 
     ALLOWED_HOSTS = values.ListValue(None)
 
-    STORAGES = {
-        "staticfiles": {
-            "BACKEND": values.Value(
-                "marsha.core.static.MarshaCompressedManifestStaticFilesStorage",
-                environ_name="STORAGES_STATICFILES_BACKEND",
-            )
-        }
-    }
+    STATICFILES_STORAGE = values.Value(
+        "marsha.core.static.MarshaCompressedManifestStaticFilesStorage"
+    )
     STATIC_POSTPROCESS_IGNORE_REGEX = values.Value(
         r"^js\/build\/.*[0-9]*\..*\.js(\.map)?$"
     )

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -34,7 +34,7 @@ install_requires =
     chardet==5.1.0
     coreapi==2.3.3
     cryptography==40.0.1
-    django==4.2
+    django<4.2
     dj-database-url==1.3.0
     dj-rest-auth==3.0.0
     django-configurations==2.4.1


### PR DESCRIPTION
## Purpose

django_rest_framework is not yet compatible with django 4.2, last renovate PR has upgraded it and tests didn't show this incompatibility. We have to downgrade django to version 4.1 while a new version of DRF is not released.

## Proposal

- [x] downgrade django to version 4.1
