### PR TITLE
✨(live) sync video and medialive states command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - standalone website:
   - filter contents by playlist (#2176)
+- Add a command to sync media channel states and video states
 
 ### Changed
 

--- a/src/backend/marsha/core/management/commands/sync_medialive_video.py
+++ b/src/backend/marsha/core/management/commands/sync_medialive_video.py
@@ -1,0 +1,101 @@
+"""Check every existing medialive channel and check if the related video is still usable."""
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+from marsha.core.defaults import IDLE, RUNNING, STOPPED
+from marsha.core.models import Video
+from marsha.core.utils.medialive_utils import list_medialive_channels, update_id3_tags
+from marsha.core.utils.time_utils import to_timestamp
+
+
+class Command(BaseCommand):
+    """
+    Once a live started, video states becomes indirectly linked to medialive channel state.
+    There is a risk that sometimes, states are not sync for an unknown reason,
+    for example, the api was down when aws was calling our callback to update video states.
+    This can let us with media channel "IDLE", while in our side, the video state is "RUNNING"
+    In this case, the video becomes soft locked, the possible actions for a "RUNNING"
+    video will fail because the medialive channel state is "IDLE"
+    This command iterates on medialive channel and ensure that linked videos are
+    state synced to avoid this kind of soft lock.
+    """
+
+    help = __doc__
+
+    def is_channel_sync_with_video(self, live_state, channel_state):
+        """Check if channel state and video state are sync.
+
+        Medialive channel states are not exactly 1-1 with video states:
+        - Creating
+        - Deleting
+        - Idle -> IDLE
+        - Recovering
+        - Running -> RUNNING
+        - Starting -> STARTING
+        - Stopping -> STOPPING
+        - Updating
+
+        """
+        if channel_state == live_state:
+            # Sync for 1-1 cases
+            return True
+
+        if channel_state in ["creating", "recovering", "updating", "deleting"]:
+            # Video states do not handle these AWS states
+            return True
+
+        if channel_state == IDLE and live_state in [STOPPED, IDLE]:
+            # In this case STOPPED is an idle started live
+            return True
+
+        return False
+
+    def update_video_state(self, live, channel_state):
+        """Update video states depending on the channel states"""
+        now = timezone.now()
+        stamp = to_timestamp(now)
+
+        live_state = live.live_state
+        live_info = live.live_info
+        live.live_state = channel_state
+
+        if channel_state == RUNNING:
+            live_info.update({"started_at": stamp})
+            live_info.pop("stopped_at", None)
+            update_id3_tags(live)
+
+        if channel_state == IDLE and live_state == RUNNING:
+            live.live_state = STOPPED
+            live_info.update({"stopped_at": stamp})
+
+        live.live_info = live_info
+        live.save(update_fields=["live_info", "live_state"])
+
+    def handle(self, *args, **options):
+        """Execute management command."""
+        for medialive_channel in list_medialive_channels():
+            # Don't work with stack not belonging to the current environment
+            if (
+                medialive_channel.get("Tags", {}).get("environment")
+                != settings.AWS_BASE_NAME
+            ):
+                continue
+
+            # the channel name contains the environment, the primary key and the created_at
+            # stamp. Here we want to use the primary key
+            _environment, live_pk, _stamp = medialive_channel["Name"].split("_")
+            live = Video.objects.get(pk=live_pk)
+            self.stdout.write(f"Checking video {live.id}")
+            channel_state = medialive_channel.get("State").casefold()
+
+            # If the live state in not sync with media channel state,
+            # we manually update to avoid soft lock
+            live_state = live.live_state.casefold()
+            if not self.is_channel_sync_with_video(live_state, channel_state):
+                self.stdout.write(
+                    f"""
+                    Video {live.id} not sync: (video) {live_state} != {channel_state} (medialive)
+                    """
+                )
+                self.update_video_state(live, channel_state)

--- a/src/backend/marsha/core/tests/management_commands/test_sync_medialive_video.py
+++ b/src/backend/marsha/core/tests/management_commands/test_sync_medialive_video.py
@@ -1,0 +1,414 @@
+"""Test clean_aws_elemental_stack command."""
+from datetime import datetime, timezone
+from io import StringIO
+from unittest import mock
+import uuid
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from botocore.stub import Stubber
+
+from marsha.core.defaults import IDLE, JITSI, RUNNING, STARTING, STOPPED, STOPPING
+from marsha.core.factories import VideoFactory
+from marsha.core.management.commands import sync_medialive_video
+from marsha.core.utils import medialive_utils, time_utils
+
+
+class TestSyncMedialiveVideoCommandTest(TestCase):
+    """Test sync_medialive_video command."""
+
+    maxDiff = None
+
+    def createLive(self, live_id, state):
+        """Create a live with specified id and state."""
+        return VideoFactory(
+            id=live_id,
+            live_state=state,
+            live_type=JITSI,
+            starting_at=datetime(2022, 11, 4, 13, 25, tzinfo=timezone.utc),
+            title="live two",
+            live_info={
+                "started_at": time_utils.to_timestamp(
+                    datetime(2022, 10, 14, 13, 25, tzinfo=timezone.utc)
+                ),
+                "medialive": {
+                    "channel": {
+                        "arn": "arn:aws:medialive:eu-west-1:xxx:channel:2222222",
+                        "id": "2222222",
+                    },
+                    "input": {
+                        "endpoints": [
+                            f"rtmp://x.x.x.x:1935/{live_id}_1667490961-primary",
+                            f"rtmp://x.x.x.x:1935/{live_id}_1667490961-secondary",
+                        ],
+                        "id": "2222222",
+                    },
+                },
+                "mediapackage": {
+                    "channel": {"id": f"test_{live_id}_1667490961"},
+                    "endpoints": {
+                        "hls": {
+                            "id": f"test_{live_id}_1667490961_hls",
+                            "url": (
+                                "https://xxx.mediapackage.eu-west-1.amazonaws.com/out/v1/xxx/"
+                                f"test_{live_id}_1667490961_hls.m3u8",
+                            ),
+                        }
+                    },
+                },
+            },
+        )
+
+    def test_sync_not_used_state_medialive_on_running_video(self):
+        """Not used medialive states should do nothing."""
+        # running lives.
+        live1_id = uuid.uuid4()
+        live1 = self.createLive(live1_id, RUNNING)
+        live2_id = uuid.uuid4()
+        live2 = self.createLive(live2_id, RUNNING)
+        live3_id = uuid.uuid4()
+        live3 = self.createLive(live3_id, RUNNING)
+        live4_id = uuid.uuid4()
+        live4 = self.createLive(live4_id, RUNNING)
+
+        # Run command
+        out = StringIO()
+        with mock.patch(
+            "django.utils.timezone.now",
+            return_value=datetime(2022, 10, 14, 15, 25, tzinfo=timezone.utc),
+        ), Stubber(
+            medialive_utils.medialive_client
+        ) as mediapackage_client_stubber, mock.patch.object(
+            sync_medialive_video, "list_medialive_channels"
+        ) as list_medialive_channels_mock:
+            mediapackage_client_stubber.add_response(
+                "batch_update_schedule",
+                service_response={},
+            )
+            list_medialive_channels_mock.return_value = [
+                {
+                    "Name": f"test_{live1_id}_1667490961",
+                    "Tags": {"environment": "test"},
+                    "State": "Deleting",
+                },
+                {
+                    "Name": f"test_{live2_id}_1667490961",
+                    "Tags": {"environment": "test"},
+                    "State": "Creating",
+                },
+                {
+                    "Name": f"test_{live3_id}_1667490961",
+                    "Tags": {"environment": "test"},
+                    "State": "Recovering",
+                },
+                {
+                    "Name": f"test_{live4_id}_1667490961",
+                    "Tags": {"environment": "test"},
+                    "State": "Updating",
+                },
+            ]
+
+            call_command("sync_medialive_video", stdout=out)
+
+            self.assertIn(f"Checking video {live1_id}", out.getvalue())
+            self.assertIn(f"Checking video {live2_id}", out.getvalue())
+            self.assertIn(f"Checking video {live3_id}", out.getvalue())
+            self.assertIn(f"Checking video {live4_id}", out.getvalue())
+
+            live1.refresh_from_db()
+            live2.refresh_from_db()
+            live3.refresh_from_db()
+            live4.refresh_from_db()
+
+            self.assertEqual(live1.live_state, RUNNING)
+            self.assertEqual(live2.live_state, RUNNING)
+            self.assertEqual(live3.live_state, RUNNING)
+            self.assertEqual(live4.live_state, RUNNING)
+
+        out.close()
+
+    def test_sync_idle_medialive_on_stopped_video(self):
+        """
+        Video state STOPPED is equivalent to medialive channel state IDLE
+        and should do nothing.
+        """
+        # stopped and idle lives should not change.
+        live1_id = uuid.uuid4()
+        live1 = self.createLive(live1_id, STOPPED)
+        live2_id = uuid.uuid4()
+        live2 = self.createLive(live2_id, IDLE)
+
+        # Run command
+        out = StringIO()
+        with mock.patch(
+            "django.utils.timezone.now",
+            return_value=datetime(2022, 10, 14, 15, 25, tzinfo=timezone.utc),
+        ), Stubber(
+            medialive_utils.medialive_client
+        ) as mediapackage_client_stubber, mock.patch.object(
+            sync_medialive_video, "list_medialive_channels"
+        ) as list_medialive_channels_mock:
+            mediapackage_client_stubber.add_response(
+                "batch_update_schedule",
+                service_response={},
+            )
+            list_medialive_channels_mock.return_value = [
+                {
+                    "Name": f"test_{live1_id}_1667490961",
+                    "Tags": {"environment": "test"},
+                    "State": "Idle",
+                },
+                {
+                    "Name": f"test_{live2_id}_1667490961",
+                    "Tags": {"environment": "test"},
+                    "State": "Idle",
+                },
+            ]
+
+            call_command("sync_medialive_video", stdout=out)
+
+            self.assertIn(f"Checking video {live1_id}", out.getvalue())
+            self.assertIn(f"Checking video {live2_id}", out.getvalue())
+
+            live1.refresh_from_db()
+            live2.refresh_from_db()
+
+            self.assertEqual(live1.live_state, STOPPED)
+            self.assertEqual(live2.live_state, IDLE)
+
+        out.close()
+
+    def test_sync_idle_medialive_on_running_video(self):
+        """Medialive channel is IDLE while video is RUNNING, should update video state."""
+        # Running.
+        live_id = uuid.uuid4()
+        live = self.createLive(live_id, RUNNING)
+
+        # Run command
+        out = StringIO()
+        with mock.patch(
+            "django.utils.timezone.now",
+            return_value=datetime(2022, 10, 14, 15, 25, tzinfo=timezone.utc),
+        ), mock.patch.object(
+            sync_medialive_video, "list_medialive_channels"
+        ) as list_medialive_channels_mock:
+            list_medialive_channels_mock.return_value = [
+                {
+                    "Name": f"test_{live_id}_1667490961",
+                    "Tags": {"environment": "test"},
+                    "State": "IDLE",
+                },
+            ]
+
+            call_command("sync_medialive_video", stdout=out)
+
+            self.assertIn(f"Checking video {live.id}", out.getvalue())
+
+            live.refresh_from_db()
+
+            self.assertEqual(live.live_state, STOPPED)
+            self.assertEqual(
+                live.live_info["started_at"],
+                time_utils.to_timestamp(
+                    datetime(2022, 10, 14, 13, 25, tzinfo=timezone.utc)
+                ),
+            )
+            self.assertEqual(
+                live.live_info["stopped_at"],
+                time_utils.to_timestamp(
+                    datetime(2022, 10, 14, 15, 25, tzinfo=timezone.utc)
+                ),
+            )
+
+        out.close()
+
+    def test_sync_running_medialive_on_starting_video(self):
+        """Medialive channel is RUNNING while video is IDLE, should update video state."""
+
+        # Running.
+        live_id = uuid.uuid4()
+        live = self.createLive(live_id, STARTING)
+
+        # Run command
+        out = StringIO()
+        with mock.patch(
+            "django.utils.timezone.now",
+            return_value=datetime(2022, 10, 14, 15, 25, tzinfo=timezone.utc),
+        ), Stubber(
+            medialive_utils.medialive_client
+        ) as mediapackage_client_stubber, mock.patch.object(
+            sync_medialive_video, "list_medialive_channels"
+        ) as list_medialive_channels_mock:
+            mediapackage_client_stubber.add_response(
+                "batch_update_schedule",
+                service_response={},
+            )
+            list_medialive_channels_mock.return_value = [
+                {
+                    "Name": f"test_{live_id}_1667490961",
+                    "Tags": {"environment": "test"},
+                    "State": "RUNNING",
+                },
+            ]
+
+            call_command("sync_medialive_video", stdout=out)
+
+            self.assertIn(f"Checking video {live.id}", out.getvalue())
+
+            live.refresh_from_db()
+
+            self.assertEqual(live.live_state, RUNNING)
+            self.assertEqual(
+                live.live_info["started_at"],
+                time_utils.to_timestamp(
+                    datetime(2022, 10, 14, 15, 25, tzinfo=timezone.utc)
+                ),
+            )
+
+        out.close()
+
+    def test_sync_starting_medialive_on_idle_video(self):
+        """Medialive channel is RUNNING while video is IDLE, should update video state."""
+
+        # Running.
+        live_id = uuid.uuid4()
+        live = self.createLive(live_id, STOPPED)
+
+        # Run command
+        out = StringIO()
+        with mock.patch(
+            "django.utils.timezone.now",
+            return_value=datetime(2022, 10, 14, 15, 25, tzinfo=timezone.utc),
+        ), Stubber(
+            medialive_utils.medialive_client
+        ) as mediapackage_client_stubber, mock.patch.object(
+            sync_medialive_video, "list_medialive_channels"
+        ) as list_medialive_channels_mock:
+            mediapackage_client_stubber.add_response(
+                "batch_update_schedule",
+                service_response={},
+            )
+            list_medialive_channels_mock.return_value = [
+                {
+                    "Name": f"test_{live_id}_1667490961",
+                    "Tags": {"environment": "test"},
+                    "State": "Starting",
+                },
+            ]
+
+            call_command("sync_medialive_video", stdout=out)
+
+            self.assertIn(f"Checking video {live.id}", out.getvalue())
+
+            live.refresh_from_db()
+
+            self.assertEqual(live.live_state, STARTING)
+
+        out.close()
+
+    def test_sync_stopping_medialive_on_running_video(self):
+        """Medialive channel is STOPPING while video is RUNNING, should update video state."""
+
+        # Running.
+        live_id = uuid.uuid4()
+        live = self.createLive(live_id, RUNNING)
+
+        # Run command
+        out = StringIO()
+        with mock.patch(
+            "django.utils.timezone.now",
+            return_value=datetime(2022, 10, 14, 15, 25, tzinfo=timezone.utc),
+        ), Stubber(
+            medialive_utils.medialive_client
+        ) as mediapackage_client_stubber, mock.patch.object(
+            sync_medialive_video, "list_medialive_channels"
+        ) as list_medialive_channels_mock:
+            mediapackage_client_stubber.add_response(
+                "batch_update_schedule",
+                service_response={},
+            )
+            list_medialive_channels_mock.return_value = [
+                {
+                    "Name": f"test_{live_id}_1667490961",
+                    "Tags": {"environment": "test"},
+                    "State": "Stopping",
+                },
+            ]
+
+            call_command("sync_medialive_video", stdout=out)
+
+            self.assertIn(f"Checking video {live.id}", out.getvalue())
+
+            live.refresh_from_db()
+
+            self.assertEqual(live.live_state, STOPPING)
+
+        out.close()
+
+    def test_already_sync_medialives_and_videos(self):
+        """Medialive channels are sync with video and should not be updated."""
+
+        live1_id = uuid.uuid4()
+        live1 = self.createLive(live1_id, RUNNING)
+        live2_id = uuid.uuid4()
+        live2 = self.createLive(live2_id, IDLE)
+        live3_id = uuid.uuid4()
+        live3 = self.createLive(live3_id, STARTING)
+        live4_id = uuid.uuid4()
+        live4 = self.createLive(live4_id, STOPPING)
+        # Run command
+        out = StringIO()
+        with mock.patch(
+            "django.utils.timezone.now",
+            return_value=datetime(2022, 10, 14, 15, 25, tzinfo=timezone.utc),
+        ), Stubber(
+            medialive_utils.medialive_client
+        ) as mediapackage_client_stubber, mock.patch.object(
+            sync_medialive_video, "list_medialive_channels"
+        ) as list_medialive_channels_mock:
+            mediapackage_client_stubber.add_response(
+                "batch_update_schedule",
+                service_response={},
+            )
+            list_medialive_channels_mock.return_value = [
+                {
+                    "Name": f"test_{live1_id}_1667490961",
+                    "Tags": {"environment": "test"},
+                    "State": "Running",
+                },
+                {
+                    "Name": f"test_{live2_id}_1667490961",
+                    "Tags": {"environment": "test"},
+                    "State": "Idle",
+                },
+                {
+                    "Name": f"test_{live3_id}_1667490961",
+                    "Tags": {"environment": "test"},
+                    "State": "Starting",
+                },
+                {
+                    "Name": f"test_{live4_id}_1667490961",
+                    "Tags": {"environment": "test"},
+                    "State": "Stopping",
+                },
+            ]
+
+            call_command("sync_medialive_video", stdout=out)
+
+            self.assertIn(f"Checking video {live1_id}", out.getvalue())
+            self.assertIn(f"Checking video {live2_id}", out.getvalue())
+            self.assertIn(f"Checking video {live3_id}", out.getvalue())
+            self.assertIn(f"Checking video {live4_id}", out.getvalue())
+
+            live1.refresh_from_db()
+            live2.refresh_from_db()
+            live3.refresh_from_db()
+            live4.refresh_from_db()
+
+            self.assertEqual(live1.live_state, RUNNING)
+            self.assertEqual(live2.live_state, IDLE)
+            self.assertEqual(live3.live_state, STARTING)
+            self.assertEqual(live4.live_state, STOPPING)
+
+        out.close()


### PR DESCRIPTION
## Purpose

#2155 
Once a live started, video states becomes indirectly linked to medialive channel state. Their is a risk that sometimes, states are not sync for an unknown reason, for example, the api was down when aws was calling our callback to update video states. This can let us with media channel "IDLE", while in our side, the video state is "RUNNING".
In this case, the video becomes soft locked, the possible actions for a "RUNNING" video will fail because the medialive channel state is "IDLE".

## Proposal

Create a command that iterates on medialive channels and ensure that linked videos are state synced to avoid this kind of soft lock.

