### PR TITLE
🐛(front) extract DashboardContent from VODTeacherDashboard

### DIFF
--- a/src/frontend/packages/lib_video/src/components/vod/Teacher/Dashboard.tsx
+++ b/src/frontend/packages/lib_video/src/components/vod/Teacher/Dashboard.tsx
@@ -37,6 +37,37 @@ const StyledLiveVideoInformationBarWrapper = styled(Box)`
   flex-wrap: wrap;
 `;
 
+interface DashboardContentProps {
+  video: Video;
+}
+
+const DashboardContent = ({ video }: DashboardContentProps) => (
+  <React.Fragment>
+    <StyledLiveVideoInformationBarWrapper
+      align="center"
+      background="white"
+      direction="row-responsive"
+      height="80px"
+      justify="between"
+      margin="small"
+      pad={{
+        vertical: 'small',
+        horizontal: 'medium',
+      }}
+      round="xsmall"
+    >
+      <TeacherVideoInfoBar flex startDate={video.starting_at} />
+    </StyledLiveVideoInformationBarWrapper>
+
+    <DashboardControlPane
+      isLive={false}
+      tabs={
+        video.live_state === null ? [PaneTabs.STATS] : [PaneTabs.ATTENDANCE]
+      }
+    />
+  </React.Fragment>
+);
+
 interface DashboardProps {
   video: Video;
   socketUrl: string;
@@ -50,33 +81,6 @@ export const Dashboard = ({ video, socketUrl }: DashboardProps) => {
     state.getTimedTextTracks(),
   );
   const thumbnail = useThumbnail((state) => state.getThumbnail());
-
-  const DashboardContent = () => (
-    <React.Fragment>
-      <StyledLiveVideoInformationBarWrapper
-        align="center"
-        background="white"
-        direction="row-responsive"
-        height="80px"
-        justify="between"
-        margin="small"
-        pad={{
-          vertical: 'small',
-          horizontal: 'medium',
-        }}
-        round="xsmall"
-      >
-        <TeacherVideoInfoBar flex startDate={video.starting_at} />
-      </StyledLiveVideoInformationBarWrapper>
-
-      <DashboardControlPane
-        isLive={false}
-        tabs={
-          video.live_state === null ? [PaneTabs.STATS] : [PaneTabs.ATTENDANCE]
-        }
-      />
-    </React.Fragment>
-  );
 
   return (
     <CurrentVideoProvider value={video}>
@@ -109,11 +113,11 @@ export const Dashboard = ({ video, socketUrl }: DashboardProps) => {
                   videoTitle: video.title,
                 })}
               >
-                <DashboardContent />
+                <DashboardContent video={video} />
               </FoldableItem>
             </InfoWidgetModalProvider>
           ) : (
-            <DashboardContent />
+            <DashboardContent video={video} />
           )}
         </Box>
       </VideoWebSocketInitializer>


### PR DESCRIPTION
## Purpose

In the VODTeacherDashboard component, the DashboardContent component was declare in the component itself. For every new render, the component is redeclare and the complete dashboard is rerender leading to scroll issue, the video is fully reload etc. Extracting it but keeping it in the same file and not exporting it resolve the issue.

## Proposal

- [x] extract DashboardContent from VODTeacherDashboard
