### PR TITLE
⬇️(back) downgrade python social auth to version 4.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- downgrade python social auth to version 4.3.0 (#2197)
+
 ## [4.0.0-beta.19] - 2023-04-19
 
 ### Added

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -59,8 +59,8 @@ install_requires =
     sentry-sdk==1.19.1
     requests==2.28.2
     scout-apm==2.26.1
-    social-auth-app-django==5.2.0
-    social-auth-core[saml]==4.4.1
+    social-auth-app-django==5.0.0
+    social-auth-core[saml]==4.3.0
     social-edu-federation==2.1.1
     urllib3==1.26.15
     uvicorn[standard]==0.21.1


### PR DESCRIPTION
## Purpose

Release 4.4 of python social auth upgrades the lxml packages and seemd to be not compatible with our code.
The issue we have is similar to this issue:
https://github.com/SAML-Toolkits/python3-saml/issues/292 In a first time we decided to downgrade python social auth to a known working version.

## Proposal

- [x] downgrade python social auth to version 4.3.0

