### PR TITLE
[site] Creating a resource fail when no playlist exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,15 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- standalone website:
-  - filter contents by playlist (#2176)
-  - add playlist contents on playlist page (#2182)
+- Standalone website:
+  - Filter contents by playlist (#2176)
+  - Add playlist contents on playlist page (#2182)
 - Add a command to sync media channel states and video states
 - pages model api for standalone footer TOS or some legal notices
 
 ### Changed
 
-- standalone website:
+- Standalone website:
   - Improve architecture Contents feature (#2183)
 - Move edition icon on title input at the begining of the input
 - Increase description textarea min height
@@ -28,11 +28,16 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - start date under the title on the BBB dashboard
 
+### Fixed
+
+- Standalone website:
+  - Correctly display creation form when there is no playlist
+
 ## [4.0.0-beta.20] - 2023-04-20
 
 ### Fixed
 
-- downgrade python social auth to version 4.3.0 (#2197)
+- Downgrade python social auth to version 4.3.0 (#2197)
 
 ## [4.0.0-beta.19] - 2023-04-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Standalone website:
   - Filter contents by playlist (#2176)
   - Add playlist contents on playlist page (#2182)
+  - Add a button to create a playlist from any resource creation form
 - Add a command to sync media channel states and video states
 - pages model api for standalone footer TOS or some legal notices
 

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Create/ClassRoomCreateForm.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Create/ClassRoomCreateForm.spec.tsx
@@ -8,7 +8,7 @@ import { Router } from 'react-router-dom';
 import ClassRoomCreateForm from './ClassRoomCreateForm';
 
 const playlistsResponse = {
-  count: 1,
+  count: 2,
   next: null,
   previous: null,
   results: [
@@ -226,5 +226,27 @@ describe('<ClassRoomCreateForm />', () => {
     ).toBeInTheDocument();
 
     expect(consoleError).toHaveBeenCalled();
+  });
+
+  it('renders correctly the form when there is no existing plyalist', () => {
+    render(<ClassRoomCreateForm />);
+
+    deferred.resolve({
+      count: 0,
+      next: null,
+      previous: null,
+      results: [],
+    });
+
+    expect(screen.getByRole('textbox', { name: /title/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole('textbox', { name: /playlist/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('textbox', { name: /description/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Add classroom/i }),
+    ).toBeInTheDocument();
   });
 });

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Create/ClassRoomCreateForm.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Create/ClassRoomCreateForm.tsx
@@ -85,7 +85,7 @@ const ClassroomCreateForm = () => {
   };
 
   useEffect(() => {
-    if (!playlistResponse?.results) {
+    if (!playlistResponse?.results || !playlistResponse?.count) {
       return;
     }
 
@@ -93,7 +93,7 @@ const ClassroomCreateForm = () => {
       ...value,
       playlist: playlistResponse.results[0].id,
     }));
-  }, [playlistResponse?.results]);
+  }, [playlistResponse?.results, playlistResponse?.count]);
 
   return (
     <Fragment>

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/Create/LiveCreateForm.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/Create/LiveCreateForm.spec.tsx
@@ -8,7 +8,7 @@ import { Router } from 'react-router-dom';
 import LiveCreateForm from './LiveCreateForm';
 
 const playlistsResponse = {
-  count: 1,
+  count: 2,
   next: null,
   previous: null,
   results: [
@@ -46,6 +46,30 @@ describe('<LiveCreateForm />', () => {
     expect(
       await screen.findByRole('button', {
         name: 'Choose the playlist.; Selected: some-playlist-id',
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('textbox', { name: /description/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Add Webinar/i }),
+    ).toBeInTheDocument();
+  });
+
+  test('renders LiveCreateForm with no existing playlist', async () => {
+    render(<LiveCreateForm />);
+
+    deferredPlaylists.resolve({
+      count: 0,
+      next: null,
+      previous: null,
+      results: [],
+    });
+
+    expect(screen.getByRole('textbox', { name: /title/i })).toBeInTheDocument();
+    expect(
+      await screen.findByRole('button', {
+        name: 'Choose the playlist.',
       }),
     ).toBeInTheDocument();
     expect(

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/Create/LiveCreateForm.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/Create/LiveCreateForm.tsx
@@ -81,7 +81,7 @@ const LiveCreateForm = () => {
   });
 
   useEffect(() => {
-    if (!playlistResponse?.results) {
+    if (!playlistResponse?.results || !playlistResponse?.count) {
       return;
     }
 
@@ -89,7 +89,7 @@ const LiveCreateForm = () => {
       ...value,
       playlist: playlistResponse.results[0].id,
     }));
-  }, [playlistResponse?.results]);
+  }, [playlistResponse?.results, playlistResponse?.count]);
 
   return (
     <Fragment>

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Video/components/Create/VideoCreateForm.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Video/components/Create/VideoCreateForm.spec.tsx
@@ -13,7 +13,7 @@ import { Router } from 'react-router-dom';
 import VideoCreateForm from './VideoCreateForm';
 
 const playlistsResponse = {
-  count: 1,
+  count: 2,
   next: null,
   previous: null,
   results: [
@@ -100,6 +100,39 @@ describe('<VideoCreateForm />', () => {
     expect(
       await screen.findByRole('button', {
         name: 'Choose the playlist.; Selected: some-playlist-id',
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('textbox', { name: /description/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Add a video or drag & drop it'),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole('button', {
+        name: 'Select the license under which you want to publish your video; Selected: CC_BY',
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Add Video/i }),
+    ).toBeInTheDocument();
+  });
+
+  test('renders VideoCreateForm without existing playlist', async () => {
+    render(<VideoCreateForm />);
+
+    deferredPlaylists.resolve({
+      count: 0,
+      next: null,
+      previous: null,
+      results: [],
+    });
+    deferredVideos.resolve(videosResponse);
+
+    expect(screen.getByRole('textbox', { name: /title/i })).toBeInTheDocument();
+    expect(
+      await screen.findByRole('button', {
+        name: 'Choose the playlist.',
       }),
     ).toBeInTheDocument();
     expect(

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Video/components/Create/VideoCreateForm.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Video/components/Create/VideoCreateForm.tsx
@@ -92,7 +92,7 @@ const VideoCreateForm = () => {
   });
 
   useEffect(() => {
-    if (!playlistResponse?.results) {
+    if (!playlistResponse?.results || !playlistResponse?.count) {
       return;
     }
 
@@ -100,7 +100,7 @@ const VideoCreateForm = () => {
       ...value,
       playlist: playlistResponse.results[0].id,
     }));
-  }, [playlistResponse?.results]);
+  }, [playlistResponse?.results, playlistResponse?.count]);
 
   useEffect(() => {
     if (

--- a/src/frontend/apps/standalone_site/src/features/Playlist/hooks/useSelectPlaylist.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Playlist/hooks/useSelectPlaylist.tsx
@@ -1,14 +1,18 @@
 import {
+  Box,
+  Button,
   Select,
   FormField,
   FormFieldExtendedProps,
   SelectExtendedProps,
 } from 'grommet';
-import { Playlist } from 'lib-components';
+import { Playlist, PlusSVG } from 'lib-components';
 import { useState, useEffect, useMemo } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
+import { Link } from 'react-router-dom';
 
 import { ITEM_PER_PAGE } from 'conf/global';
+import { routes } from 'routes';
 
 import { PlaylistOrderType, usePlaylists } from '../api/usePlaylists';
 
@@ -16,7 +20,13 @@ const messages = defineMessages({
   selectPlaylistLabel: {
     defaultMessage: 'Choose the playlist.',
     description: 'Label select playlist.',
-    id: 'features.Contents.features.Video.VideoCreateForm.selectPlaylistLabel',
+    id: 'features.Playlist.hooks.useSelectPlaylist.selectPlaylistLabel',
+  },
+  createPlaylist: {
+    defaultMessage: 'Create a new playlist',
+    description:
+      'a11y label added to the button redirecting to the playlist creation form',
+    id: 'features.Playlist.hooks.useSelectPlaylist.createPlaylist',
   },
 });
 
@@ -58,34 +68,50 @@ const useSelectPlaylist = ({
 
   const selectPlaylist = useMemo(
     () => (
-      <FormField
-        label={intl.formatMessage(messages.selectPlaylistLabel)}
-        htmlFor="select-playlist-id"
-        name="playlist"
-        required
-        {...formFieldProps}
-      >
-        <Select
-          id="select-playlist-id"
+      <Box direction="row-responsive" pad={{ bottom: 'small' }} gap="small">
+        <FormField
+          label={intl.formatMessage(messages.selectPlaylistLabel)}
+          htmlFor="select-playlist-id"
           name="playlist"
-          size="medium"
-          aria-label={intl.formatMessage(messages.selectPlaylistLabel)}
-          options={playlists}
-          labelKey="title"
-          valueKey={{ key: 'id', reduce: true }}
-          onMore={() => {
-            if (!playlistResponse) {
-              return;
-            }
-
-            if (playlists.length < playlistResponse.count) {
-              setCurrentPlaylistPage((currentPage) => currentPage + 1);
-            }
+          margin="none"
+          required
+          style={{
+            flex: 1,
           }}
-          dropHeight="medium"
-          {...selectProps}
-        />
-      </FormField>
+          {...formFieldProps}
+        >
+          <Select
+            id="select-playlist-id"
+            name="playlist"
+            size="medium"
+            aria-label={intl.formatMessage(messages.selectPlaylistLabel)}
+            options={playlists}
+            labelKey="title"
+            valueKey={{ key: 'id', reduce: true }}
+            onMore={() => {
+              if (!playlistResponse) {
+                return;
+              }
+
+              if (playlists.length < playlistResponse.count) {
+                setCurrentPlaylistPage((currentPage) => currentPage + 1);
+              }
+            }}
+            margin="none"
+            dropHeight="medium"
+            {...selectProps}
+          />
+        </FormField>
+        <Link to={routes.PLAYLIST.subRoutes.CREATE.path}>
+          <Button
+            a11yTitle={intl.formatMessage(messages.createPlaylist)}
+            icon={<PlusSVG iconColor="#055fd2" height="35px" width="35px" />}
+            style={{
+              border: 'transparent',
+            }}
+          />
+        </Link>
+      </Box>
     ),
     [formFieldProps, intl, playlistResponse, playlists, selectProps],
   );


### PR DESCRIPTION
## Purpose

When we want to create a new resource but there is no existing playlist,
the form display was failing because we tried to set the first available
playlist but there is no available.
Also we added a button to create a playlist on the resource creation form.

## Proposal

- [x] Correctly display creation form when there is no playlist
- [x] Add a button to create a playlist from a resource creation form 

Fixes #2207
