### PR TITLE
Delete Resource Widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   - Add playlist contents on playlist page (#2182)
   - Add a button to create a playlist from any resource creation form
   - new widget for video and classroom dashboard that enables resource deletion
+  - Add a button on playlist edition view to delete the playlist
 - Add a command to sync media channel states and video states
 - pages model api for standalone footer TOS or some legal notices
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   - Filter contents by playlist (#2176)
   - Add playlist contents on playlist page (#2182)
   - Add a button to create a playlist from any resource creation form
+  - new widget for video and classroom dashboard that enables resource deletion
 - Add a command to sync media channel states and video states
 - pages model api for standalone footer TOS or some legal notices
 

--- a/src/backend/marsha/bbb/api.py
+++ b/src/backend/marsha/bbb/api.py
@@ -82,7 +82,7 @@ class ClassroomViewSet(
         Default to the actions' self defined permissions if applicable or
         to the ViewSet's default permissions.
         """
-        if self.action in ["create", "destroy"]:
+        if self.action in ["create"]:
             permission_classes = [
                 (
                     core_permissions.HasPlaylistToken
@@ -98,6 +98,13 @@ class ClassroomViewSet(
                         | core_permissions.IsParamsPlaylistAdminThroughOrganization
                     )
                 )
+            ]
+        elif self.action in ["destroy"]:
+            # Not available in LTI
+            # For standalone site, only playlist admin or organization admin can access
+            permission_classes = [
+                core_permissions.IsObjectPlaylistAdminOrInstructor
+                | core_permissions.IsObjectPlaylistOrganizationAdmin
             ]
         elif self.action in ["retrieve", "service_join"]:
             permission_classes = [

--- a/src/backend/marsha/bbb/tests/api/classroom/test_delete.py
+++ b/src/backend/marsha/bbb/tests/api/classroom/test_delete.py
@@ -77,9 +77,7 @@ class ClassroomDeleteAPITest(TestCase):
 
     def test_api_classroom_delete_instructor_with_playlist_token(self):
         """
-        Delete classroom with playlist token.
-
-        Used in the context of a lti select request (deep linking).
+        Delete classroom with playlist token should not be permitted in LTI.
         """
         playlist = PlaylistFactory()
         classroom = ClassroomFactory(playlist=playlist)
@@ -93,8 +91,7 @@ class ClassroomDeleteAPITest(TestCase):
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
-        self.assertEqual(response.status_code, 204)
-        self.assertEqual(Classroom.objects.count(), 0)
+        self.assertEqual(response.status_code, 403)
 
     def test_api_classroom_delete_user_access_token(self):
         """A user with UserAccessToken should not be able to delete a classroom."""

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Video/components/Update/VideoUpdate.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Video/components/Update/VideoUpdate.tsx
@@ -1,8 +1,10 @@
 import {
   AppConfig,
   AppConfigProvider,
+  CurrentResourceContextProvider,
   UploadHandlers,
   UploadManager,
+  ResourceContext,
 } from 'lib-components';
 import { useVideo, DashboardVideoWrapper, useSetVideoState } from 'lib-video';
 import { defineMessages, useIntl } from 'react-intl';
@@ -62,6 +64,16 @@ const VideoDashboard = ({ videoId }: { videoId: string }) => {
 
   useSetVideoState(currentVideo);
 
+  const resourceContext: ResourceContext = {
+    resource_id: videoId,
+    roles: [],
+    permissions: {
+      can_access_dashboard: true,
+      can_update: true,
+    },
+    isFromWebsite: true,
+  };
+
   return (
     <ManageAPIState
       isError={isError}
@@ -76,10 +88,12 @@ const VideoDashboard = ({ videoId }: { videoId: string }) => {
     >
       {currentVideo && (
         <AppConfigProvider value={appConfig}>
-          <UploadManager>
-            <UploadHandlers />
-            <DashboardVideoWrapper video={currentVideo} />
-          </UploadManager>
+          <CurrentResourceContextProvider value={resourceContext}>
+            <UploadManager>
+              <UploadHandlers />
+              <DashboardVideoWrapper video={currentVideo} />
+            </UploadManager>
+          </CurrentResourceContextProvider>
         </AppConfigProvider>
       )}
     </ManageAPIState>

--- a/src/frontend/apps/standalone_site/src/features/Playlist/api/useDeletePlaylist/index.ts
+++ b/src/frontend/apps/standalone_site/src/features/Playlist/api/useDeletePlaylist/index.ts
@@ -1,0 +1,40 @@
+import { Maybe } from 'lib-common';
+import { deleteOne, FetchResponseError, Playlist } from 'lib-components';
+import { useMutation, UseMutationOptions, useQueryClient } from 'react-query';
+
+type UseDeletePlaylistData = string;
+type UseDeletePlaylistError = FetchResponseError<UseDeletePlaylistData>;
+type UseDeletePlaylistOptions = UseMutationOptions<
+  Maybe<Playlist>,
+  UseDeletePlaylistError,
+  UseDeletePlaylistData
+>;
+export const useDeletePlaylist = (options?: UseDeletePlaylistOptions) => {
+  const queryClient = useQueryClient();
+  return useMutation<
+    Maybe<Playlist>,
+    UseDeletePlaylistError,
+    UseDeletePlaylistData
+  >(
+    (playlistId) =>
+      deleteOne({
+        name: 'playlists',
+        id: playlistId,
+      }),
+    {
+      ...options,
+      onSuccess: (data, variables, context) => {
+        queryClient.invalidateQueries('playlists');
+        if (options?.onSuccess) {
+          options.onSuccess(data, variables, context);
+        }
+      },
+      onError: (error, variables, context) => {
+        queryClient.invalidateQueries('playlists');
+        if (options?.onError) {
+          options.onError(error, variables, context);
+        }
+      },
+    },
+  );
+};

--- a/src/frontend/apps/standalone_site/src/features/Playlist/features/UpdatePlaylist/components/UpdatePlaylistPage.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Playlist/features/UpdatePlaylist/components/UpdatePlaylistPage.spec.tsx
@@ -123,6 +123,10 @@ describe('<UpdatePlaylistPage />', () => {
         screen.getByRole('button', { name: 'Open Drop; Selected: id orga' }),
       ).not.toBeDisabled(),
     );
+
+    expect(
+      screen.getByRole('button', { name: 'Delete playlist' }),
+    ).toBeInTheDocument();
   });
 
   it('checks the contents render by playlist', async () => {

--- a/src/frontend/apps/standalone_site/src/features/Playlist/features/UpdatePlaylist/components/UpdatePlaylistPage.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Playlist/features/UpdatePlaylist/components/UpdatePlaylistPage.tsx
@@ -97,6 +97,7 @@ export const UpdatePlaylistPage = () => {
             }}
             submitTitle={intl.formatMessage(messages.saveButtonTitle)}
             isSubmitting={isSubmitting}
+            playlistId={playlistId}
           />
         </Box>
       </WhiteCard>

--- a/src/frontend/packages/lib_classroom/src/components/ClassroomWidgetProvider/index.spec.tsx
+++ b/src/frontend/packages/lib_classroom/src/components/ClassroomWidgetProvider/index.spec.tsx
@@ -1,7 +1,7 @@
 import { screen } from '@testing-library/react';
 import faker from 'faker';
 import fetchMock from 'fetch-mock';
-import { useJwt } from 'lib-components';
+import { useCurrentResourceContext, useJwt } from 'lib-components';
 import { render } from 'lib-tests';
 import { DateTime } from 'luxon';
 import React from 'react';
@@ -16,7 +16,13 @@ jest.mock('lib-components', () => ({
   useAppConfig: () => ({
     static: { img: { liveBackground: 'some_url' } },
   }),
+  useCurrentResourceContext: jest.fn(),
 }));
+
+const mockedUseCurrentResourceContext =
+  useCurrentResourceContext as jest.MockedFunction<
+    typeof useCurrentResourceContext
+  >;
 
 const currentDate = DateTime.fromISO('2022-01-13T12:00');
 
@@ -28,6 +34,14 @@ describe('<ClassroomWidgetProvider />', () => {
   afterEach(() => fetchMock.restore());
 
   it('renders widgets', () => {
+    mockedUseCurrentResourceContext.mockReturnValue([
+      {
+        permissions: {
+          can_access_dashboard: true,
+          can_update: true,
+        },
+      },
+    ] as any);
     const classroomId = faker.datatype.uuid();
     const mockedClassroom = classroomMockFactory({
       id: classroomId,

--- a/src/frontend/packages/lib_classroom/src/components/ClassroomWidgetProvider/index.tsx
+++ b/src/frontend/packages/lib_classroom/src/components/ClassroomWidgetProvider/index.tsx
@@ -7,6 +7,7 @@ import {
 } from 'lib-components';
 import React from 'react';
 
+import { DeleteClassroom } from './widgets/DeleteClassroom';
 import { Description } from './widgets/Description';
 import { Invite } from './widgets/Invite';
 import { Recordings } from './widgets/Recordings';
@@ -21,6 +22,7 @@ enum WidgetType {
   INVITE = 'INVITE',
   SUPPORT_SHARING = 'SUPPORT_SHARING',
   RECORDINGS = 'RECORDINGS',
+  DELETE_CLASSROOM = 'DELETE_CLASSROOM',
 }
 
 const widgetLoader: { [key in WidgetType]: WidgetProps } = {
@@ -48,6 +50,10 @@ const widgetLoader: { [key in WidgetType]: WidgetProps } = {
     component: <ToolsAndApplications />,
     size: WidgetSize.DEFAULT,
   },
+  [WidgetType.DELETE_CLASSROOM]: {
+    component: <DeleteClassroom />,
+    size: WidgetSize.DEFAULT,
+  },
 };
 
 const classroomWidgets: WidgetType[] = [
@@ -57,6 +63,7 @@ const classroomWidgets: WidgetType[] = [
   WidgetType.SCHEDULING,
   WidgetType.SUPPORT_SHARING,
   WidgetType.RECORDINGS,
+  WidgetType.DELETE_CLASSROOM,
 ];
 
 export const ClassroomWidgetProvider = () => {

--- a/src/frontend/packages/lib_classroom/src/components/ClassroomWidgetProvider/widgets/DeleteClassroom/index.spec.tsx
+++ b/src/frontend/packages/lib_classroom/src/components/ClassroomWidgetProvider/widgets/DeleteClassroom/index.spec.tsx
@@ -1,0 +1,195 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import fetchMock from 'fetch-mock';
+import {
+  InfoWidgetModalProvider,
+  useCurrentResourceContext,
+  useJwt,
+} from 'lib-components';
+import { render } from 'lib-tests';
+import React from 'react';
+
+import { classroomMockFactory } from '@lib-classroom/utils';
+import { wrapInClassroom } from '@lib-classroom/utils/wrapInClassroom';
+
+import { DeleteClassroom } from '.';
+
+jest.mock('lib-components', () => ({
+  ...jest.requireActual('lib-components'),
+  report: jest.fn(),
+  useCurrentResourceContext: jest.fn(),
+}));
+
+const mockedUseCurrentResourceContext =
+  useCurrentResourceContext as jest.MockedFunction<
+    typeof useCurrentResourceContext
+  >;
+
+describe('<DeleteClassroom />', () => {
+  beforeEach(() => {
+    useJwt.setState({
+      jwt: 'json web token',
+    });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('does not render the component on LTI', () => {
+    mockedUseCurrentResourceContext.mockReturnValue([
+      {
+        isFromWebsite: false,
+        permissions: {
+          can_access_dashboard: true,
+          can_update: true,
+        },
+      },
+    ] as any);
+    const mockedClassroom = classroomMockFactory();
+    render(
+      wrapInClassroom(
+        <InfoWidgetModalProvider value={null}>
+          <DeleteClassroom />
+        </InfoWidgetModalProvider>,
+        mockedClassroom,
+      ),
+    );
+
+    expect(screen.queryByText('DANGER ZONE')).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Delete classroom' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders the component on standalone site', () => {
+    mockedUseCurrentResourceContext.mockReturnValue([
+      {
+        isFromWebsite: true,
+        permissions: {
+          can_access_dashboard: true,
+          can_update: true,
+        },
+      },
+    ] as any);
+    const mockedClassroom = classroomMockFactory();
+    render(
+      wrapInClassroom(
+        <InfoWidgetModalProvider value={null}>
+          <DeleteClassroom />
+        </InfoWidgetModalProvider>,
+        mockedClassroom,
+      ),
+    );
+
+    expect(screen.getByText('DANGER ZONE')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Delete classroom' }),
+    ).toBeInTheDocument();
+  });
+
+  it('successfully opens the confirmation modal', () => {
+    mockedUseCurrentResourceContext.mockReturnValue([
+      {
+        isFromWebsite: true,
+        permissions: {
+          can_access_dashboard: true,
+          can_update: true,
+        },
+      },
+    ] as any);
+    const mockedClassroom = classroomMockFactory();
+    render(
+      wrapInClassroom(
+        <InfoWidgetModalProvider value={null}>
+          <DeleteClassroom />
+        </InfoWidgetModalProvider>,
+        mockedClassroom,
+      ),
+    );
+
+    const deleteButton = screen.getByRole('button', {
+      name: 'Delete classroom',
+    });
+    userEvent.click(deleteButton);
+    expect(
+      screen.getByText(
+        'Are you sure you want to delete this classroom ? This action is irreversible.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('successfully deletes the classroom', async () => {
+    mockedUseCurrentResourceContext.mockReturnValue([
+      {
+        isFromWebsite: true,
+        permissions: {
+          can_access_dashboard: true,
+          can_update: true,
+        },
+      },
+    ] as any);
+    const mockedClassroom = classroomMockFactory();
+    fetchMock.delete(`/api/classrooms/${mockedClassroom.id}/`, 204);
+    render(
+      wrapInClassroom(
+        <InfoWidgetModalProvider value={null}>
+          <DeleteClassroom />
+        </InfoWidgetModalProvider>,
+        mockedClassroom,
+      ),
+    );
+
+    const deleteButton = screen.getByRole('button', {
+      name: 'Delete classroom',
+    });
+    userEvent.click(deleteButton);
+
+    const confirmDeleteButton = screen.getByRole('button', {
+      name: 'Confirm',
+    });
+    userEvent.click(confirmDeleteButton);
+
+    const successMessage = await screen.findByText(
+      'Classroom successfully deleted',
+    );
+    expect(successMessage).toBeInTheDocument();
+  });
+
+  it('fails to delete the classroom', async () => {
+    mockedUseCurrentResourceContext.mockReturnValue([
+      {
+        isFromWebsite: true,
+        permissions: {
+          can_access_dashboard: true,
+          can_update: true,
+        },
+      },
+    ] as any);
+    const mockedClassroom = classroomMockFactory();
+    fetchMock.delete(`/api/classrooms/${mockedClassroom.id}/`, 403);
+    render(
+      wrapInClassroom(
+        <InfoWidgetModalProvider value={null}>
+          <DeleteClassroom />
+        </InfoWidgetModalProvider>,
+        mockedClassroom,
+      ),
+    );
+
+    const deleteButton = screen.getByRole('button', {
+      name: 'Delete classroom',
+    });
+    userEvent.click(deleteButton);
+
+    const confirmDeleteButton = screen.getByRole('button', {
+      name: 'Confirm',
+    });
+    userEvent.click(confirmDeleteButton);
+
+    const errorMessage = await screen.findByText(
+      'Failed to delete the classroom',
+    );
+    expect(errorMessage).toBeInTheDocument();
+  });
+});

--- a/src/frontend/packages/lib_classroom/src/components/ClassroomWidgetProvider/widgets/DeleteClassroom/index.tsx
+++ b/src/frontend/packages/lib_classroom/src/components/ClassroomWidgetProvider/widgets/DeleteClassroom/index.tsx
@@ -1,0 +1,124 @@
+import { Button } from 'grommet';
+import {
+  ConfirmationModal,
+  FoldableItem,
+  report,
+  useCurrentResourceContext,
+} from 'lib-components';
+import { useState } from 'react';
+import toast from 'react-hot-toast';
+import { defineMessages, useIntl } from 'react-intl';
+import { useHistory } from 'react-router-dom';
+import styled from 'styled-components';
+
+import { useDeleteClassroom } from '@lib-classroom/data/queries';
+import { useCurrentClassroom } from '@lib-classroom/hooks/useCurrentClassroom';
+
+const messages = defineMessages({
+  info: {
+    defaultMessage:
+      'DANGER ZONE : This widget allows you to delete the classroom permanently.',
+    description: 'Info of the widget used for deleting the classroom.',
+    id: 'components.DeleteClassroom.info',
+  },
+  title: {
+    defaultMessage: 'DANGER ZONE',
+    description: 'Title of the widget used for deleting the classroom.',
+    id: 'components.DeleteClassroom.title',
+  },
+  confirmDeleteTitle: {
+    defaultMessage: 'Confirm delete classroom',
+    description: 'Title of the widget used for confirmation.',
+    id: 'components.DeleteClassroomConfirm.title',
+  },
+  confirmDeleteText: {
+    defaultMessage:
+      'Are you sure you want to delete this classroom ? This action is irreversible.',
+    description: 'Text of the widget used for confirmation.',
+    id: 'components.DeleteClassroomConfirm.text',
+  },
+  deleteButtonText: {
+    defaultMessage: 'Delete classroom',
+    description: 'Text of the delete button.',
+    id: 'components.DeleteClassroomButton.text',
+  },
+  classroomDeleteSuccess: {
+    defaultMessage: 'Classroom successfully deleted',
+    description: 'Text of the delete confirmation toast.',
+    id: 'components.deleteClassroomSuccess.text',
+  },
+  classroomDeleteError: {
+    defaultMessage: 'Failed to delete the classroom',
+    description: 'ext of the delete error toast..',
+    id: 'components.classroomDeleteError.text',
+  },
+});
+
+const StyledAnchorButton = styled(Button)`
+  height: 50px;
+  font-family: 'Roboto-Medium';
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+export const DeleteClassroom = () => {
+  const intl = useIntl();
+  const [context] = useCurrentResourceContext();
+  const history = useHistory();
+  const [showDeleteConfirmationModal, setShowDeleteConfirmationModal] =
+    useState(false);
+  const classroom = useCurrentClassroom();
+  const deleteClassroom = useDeleteClassroom({
+    onSuccess: () => {
+      toast.success(intl.formatMessage(messages.classroomDeleteSuccess), {
+        position: 'bottom-center',
+      });
+      setShowDeleteConfirmationModal(false);
+      history.goBack();
+    },
+    onError: (err: unknown) => {
+      report(err);
+      toast.error(intl.formatMessage(messages.classroomDeleteError), {
+        position: 'bottom-center',
+      });
+    },
+  });
+
+  if (!context.isFromWebsite) {
+    return null;
+  }
+
+  return (
+    <FoldableItem
+      infoText={intl.formatMessage(messages.info)}
+      initialOpenValue
+      title={intl.formatMessage(messages.title)}
+    >
+      {showDeleteConfirmationModal && (
+        <ConfirmationModal
+          text={intl.formatMessage(messages.confirmDeleteText)}
+          title={intl.formatMessage(messages.confirmDeleteTitle)}
+          onModalCloseOrCancel={() => setShowDeleteConfirmationModal(false)}
+          onModalConfirm={() => {
+            deleteClassroom.mutate(classroom.id);
+          }}
+          color="action-danger"
+        />
+      )}
+      <StyledAnchorButton
+        a11yTitle={intl.formatMessage(messages.deleteButtonText)}
+        download
+        disabled={!context.permissions.can_update}
+        fill="horizontal"
+        label={intl.formatMessage(messages.deleteButtonText)}
+        target="_blank"
+        rel="noopener noreferrer"
+        primary
+        title={intl.formatMessage(messages.deleteButtonText)}
+        onClick={() => setShowDeleteConfirmationModal(true)}
+        color="action-danger"
+      />
+    </FoldableItem>
+  );
+};

--- a/src/frontend/packages/lib_classroom/src/components/DashboardClassroomForm/index.spec.tsx
+++ b/src/frontend/packages/lib_classroom/src/components/DashboardClassroomForm/index.spec.tsx
@@ -1,6 +1,7 @@
 import { screen } from '@testing-library/react';
 import fetchMock from 'fetch-mock';
 import { ResponsiveContext } from 'grommet';
+import { useCurrentResourceContext } from 'lib-components';
 import { render } from 'lib-tests';
 import { Settings } from 'luxon';
 import React from 'react';
@@ -17,7 +18,13 @@ jest.mock('lib-components', () => ({
       id: '1',
     },
   }),
+  useCurrentResourceContext: jest.fn(),
 }));
+
+const mockedUseCurrentResourceContext =
+  useCurrentResourceContext as jest.MockedFunction<
+    typeof useCurrentResourceContext
+  >;
 
 Settings.defaultLocale = 'en';
 Settings.defaultZone = 'Europe/Paris';
@@ -35,6 +42,14 @@ describe('<DashboardClassroomForm />', () => {
   });
 
   it('creates and renders a classroom form', () => {
+    mockedUseCurrentResourceContext.mockReturnValue([
+      {
+        permissions: {
+          can_access_dashboard: true,
+          can_update: true,
+        },
+      },
+    ] as any);
     const classroom = classroomMockFactory({ id: '1', started: false });
     render(
       <ResponsiveContext.Provider value="large">
@@ -48,6 +63,14 @@ describe('<DashboardClassroomForm />', () => {
   });
 
   it('selects the configuration tab by default', () => {
+    mockedUseCurrentResourceContext.mockReturnValue([
+      {
+        permissions: {
+          can_access_dashboard: true,
+          can_update: true,
+        },
+      },
+    ] as any);
     const classroom = classroomMockFactory({ id: '1', started: false });
     render(
       <ResponsiveContext.Provider value="large">

--- a/src/frontend/packages/lib_classroom/src/data/queries/index.spec.tsx
+++ b/src/frontend/packages/lib_classroom/src/data/queries/index.spec.tsx
@@ -18,6 +18,7 @@ import {
   useJoinClassroomAction,
   useClassroomDocuments,
   useUpdateClassroomDocument,
+  useDeleteClassroom,
 } from '.';
 
 jest.mock('lib-components', () => ({
@@ -203,6 +204,57 @@ describe('queries', () => {
           playlist: classroom.playlist.id,
           title: classroom.title,
         }),
+      });
+      expect(result.current.data).toEqual(undefined);
+      expect(result.current.status).toEqual('error');
+    });
+  });
+
+  describe('useDeleteClassroom', () => {
+    it('deletes the resource', async () => {
+      const classroom = classroomMockFactory();
+      fetchMock.delete(`/api/classrooms/${classroom.id}/`, 204);
+
+      const { result, waitFor } = renderHook(() => useDeleteClassroom(), {
+        wrapper: Wrapper,
+      });
+      result.current.mutate(classroom.id);
+      await waitFor(() => result.current.isSuccess);
+
+      expect(fetchMock.lastCall()![0]).toEqual(
+        `/api/classrooms/${classroom.id}/`,
+      );
+      expect(fetchMock.lastCall()![1]).toEqual({
+        headers: {
+          Authorization: 'Bearer some token',
+          'Content-Type': 'application/json',
+        },
+        method: 'DELETE',
+      });
+      expect(result.current.data).toEqual(undefined);
+      expect(result.current.status).toEqual('success');
+    });
+
+    it('fails to delete the resource', async () => {
+      const classroom = classroomMockFactory();
+      fetchMock.delete(`/api/classrooms/${classroom.id}/`, 400);
+
+      const { result, waitFor } = renderHook(() => useDeleteClassroom(), {
+        wrapper: Wrapper,
+      });
+      result.current.mutate(classroom.id);
+
+      await waitFor(() => result.current.isError);
+
+      expect(fetchMock.lastCall()![0]).toEqual(
+        `/api/classrooms/${classroom.id}/`,
+      );
+      expect(fetchMock.lastCall()![1]).toEqual({
+        headers: {
+          Authorization: 'Bearer some token',
+          'Content-Type': 'application/json',
+        },
+        method: 'DELETE',
       });
       expect(result.current.data).toEqual(undefined);
       expect(result.current.status).toEqual('error');

--- a/src/frontend/packages/lib_classroom/src/data/queries/index.tsx
+++ b/src/frontend/packages/lib_classroom/src/data/queries/index.tsx
@@ -156,6 +156,43 @@ export const useUpdateClassroom = (
   );
 };
 
+type UseDeleteClassroomData = string;
+type UseDeleteClassroomError = FetchResponseError<UseDeleteClassroomData>;
+type UseDeleteClassroomOptions = UseMutationOptions<
+  Maybe<Classroom>,
+  UseDeleteClassroomError,
+  UseDeleteClassroomData
+>;
+export const useDeleteClassroom = (options?: UseDeleteClassroomOptions) => {
+  const queryClient = useQueryClient();
+  return useMutation<
+    Maybe<Classroom>,
+    UseDeleteClassroomError,
+    UseDeleteClassroomData
+  >(
+    (classroomId) =>
+      deleteOne({
+        name: 'classrooms',
+        id: classroomId,
+      }),
+    {
+      ...options,
+      onSuccess: (data, variables, context) => {
+        queryClient.invalidateQueries('classrooms');
+        if (options?.onSuccess) {
+          options.onSuccess(data, variables, context);
+        }
+      },
+      onError: (error, variables, context) => {
+        queryClient.invalidateQueries('classrooms');
+        if (options?.onError) {
+          options.onError(error, variables, context);
+        }
+      },
+    },
+  );
+};
+
 type ClassroomDocumentsResponse = APIList<ClassroomDocument>;
 type UseClassroomDocumentParams = Record<string, never>;
 export const useClassroomDocuments = (

--- a/src/frontend/packages/lib_common/src/theme.ts
+++ b/src/frontend/packages/lib_common/src/theme.ts
@@ -49,6 +49,7 @@ const colorsGeneric = {
   'red-hover': '#e22d2d',
   'red-off': '#ec8080',
   'shadow-1': '#dcebf4',
+  'action-danger': 'red-hover',
   'status-critical': 'accent-2',
   'status-disabled': '#cccccc',
   'status-error': 'accent-2',

--- a/src/frontend/packages/lib_components/src/common/ConfirmationModal/index.tsx
+++ b/src/frontend/packages/lib_components/src/common/ConfirmationModal/index.tsx
@@ -34,6 +34,7 @@ interface ConfirmationModalProps {
   title: string;
   onModalCloseOrCancel: () => void;
   onModalConfirm: () => void;
+  color?: string;
 }
 
 export const ConfirmationModal = ({
@@ -41,6 +42,7 @@ export const ConfirmationModal = ({
   title,
   onModalCloseOrCancel,
   onModalConfirm,
+  color,
 }: ConfirmationModalProps) => {
   const intl = useIntl();
   const { isMobile } = useResponsive();
@@ -84,6 +86,7 @@ export const ConfirmationModal = ({
               primary
               label={intl.formatMessage(messages.confirmButtonLabel)}
               onClick={onModalConfirm}
+              color={color || 'blue-active'}
             />
             <Button
               secondary

--- a/src/frontend/packages/lib_video/src/api/useDeleteVideo/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/api/useDeleteVideo/index.spec.tsx
@@ -1,0 +1,81 @@
+import { WrapperComponent, renderHook } from '@testing-library/react-hooks';
+import fetchMock from 'fetch-mock';
+import { useJwt, videoMockFactory } from 'lib-components';
+import { QueryClient, QueryClientProvider } from 'react-query';
+
+import { useDeleteVideo } from '.';
+
+jest.mock('lib-components', () => ({
+  ...jest.requireActual('lib-components'),
+  report: jest.fn(),
+}));
+
+let Wrapper: WrapperComponent<Element>;
+
+describe('useDeleteVideo', () => {
+  beforeEach(() => {
+    useJwt.getState().setJwt('some token');
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
+
+    Wrapper = ({ children }: Element) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  });
+
+  afterEach(() => {
+    fetchMock.restore();
+    jest.resetAllMocks();
+  });
+
+  it('deletes the resource', async () => {
+    const video = videoMockFactory();
+    fetchMock.delete(`/api/videos/${video.id}/`, 204);
+
+    const { result, waitFor } = renderHook(() => useDeleteVideo(), {
+      wrapper: Wrapper,
+    });
+    result.current.mutate(video.id);
+    await waitFor(() => result.current.isSuccess);
+
+    expect(fetchMock.lastCall()![0]).toEqual(`/api/videos/${video.id}/`);
+    expect(fetchMock.lastCall()![1]).toEqual({
+      headers: {
+        Authorization: 'Bearer some token',
+        'Content-Type': 'application/json',
+      },
+      method: 'DELETE',
+    });
+    expect(result.current.data).toEqual(undefined);
+    expect(result.current.status).toEqual('success');
+  });
+
+  it('fails to delete the resource', async () => {
+    const video = videoMockFactory();
+    fetchMock.delete(`/api/videos/${video.id}/`, 400);
+
+    const { result, waitFor } = renderHook(() => useDeleteVideo(), {
+      wrapper: Wrapper,
+    });
+    result.current.mutate(video.id);
+
+    await waitFor(() => result.current.isError);
+
+    expect(fetchMock.lastCall()![0]).toEqual(`/api/videos/${video.id}/`);
+    expect(fetchMock.lastCall()![1]).toEqual({
+      headers: {
+        Authorization: 'Bearer some token',
+        'Content-Type': 'application/json',
+      },
+      method: 'DELETE',
+    });
+    expect(result.current.data).toEqual(undefined);
+    expect(result.current.status).toEqual('error');
+  });
+});

--- a/src/frontend/packages/lib_video/src/api/useDeleteVideo/index.ts
+++ b/src/frontend/packages/lib_video/src/api/useDeleteVideo/index.ts
@@ -1,0 +1,36 @@
+import { Maybe } from 'lib-common';
+import { deleteOne, FetchResponseError, Video } from 'lib-components';
+import { useMutation, UseMutationOptions, useQueryClient } from 'react-query';
+
+type UseDeleteVideoData = string;
+type UseDeleteVideoError = FetchResponseError<UseDeleteVideoData>;
+type UseDeleteVideoOptions = UseMutationOptions<
+  Maybe<Video>,
+  UseDeleteVideoError,
+  UseDeleteVideoData
+>;
+export const useDeleteVideo = (options?: UseDeleteVideoOptions) => {
+  const queryClient = useQueryClient();
+  return useMutation<Maybe<Video>, UseDeleteVideoError, UseDeleteVideoData>(
+    (videoId) =>
+      deleteOne({
+        name: 'videos',
+        id: videoId,
+      }),
+    {
+      ...options,
+      onSuccess: (data, variables, context) => {
+        queryClient.invalidateQueries('videos');
+        if (options?.onSuccess) {
+          options.onSuccess(data, variables, context);
+        }
+      },
+      onError: (error, variables, context) => {
+        queryClient.invalidateQueries('videos');
+        if (options?.onError) {
+          options.onError(error, variables, context);
+        }
+      },
+    },
+  );
+};

--- a/src/frontend/packages/lib_video/src/components/common/DashboardControlPane/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/DashboardControlPane/index.spec.tsx
@@ -1,6 +1,11 @@
 import { screen } from '@testing-library/react';
 import { ResponsiveContext } from 'grommet';
-import { useJwt, videoMockFactory, liveState } from 'lib-components';
+import {
+  useJwt,
+  videoMockFactory,
+  liveState,
+  useCurrentResourceContext,
+} from 'lib-components';
 import { render } from 'lib-tests';
 import React from 'react';
 
@@ -17,7 +22,13 @@ jest.mock('lib-components', () => ({
       },
     },
   }),
+  useCurrentResourceContext: jest.fn(),
 }));
+
+const mockedUseCurrentResourceContext =
+  useCurrentResourceContext as jest.MockedFunction<
+    typeof useCurrentResourceContext
+  >;
 
 describe('<DashboardControlPane />', () => {
   beforeEach(() => {
@@ -27,6 +38,14 @@ describe('<DashboardControlPane />', () => {
   });
 
   it('renders configuration and attendance tabs', () => {
+    mockedUseCurrentResourceContext.mockReturnValue([
+      {
+        permissions: {
+          can_access_dashboard: true,
+          can_update: true,
+        },
+      },
+    ] as any);
     const mockVideo = videoMockFactory({
       id: '5cffe85a-1829-4000-a6ca-a45d4647dc0d',
       live_state: liveState.RUNNING,

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/index.spec.tsx
@@ -14,6 +14,7 @@ import {
   uploadState,
   useTimedTextTrack,
   liveState,
+  useCurrentResourceContext,
 } from 'lib-components';
 import { render } from 'lib-tests';
 import { DateTime } from 'luxon';
@@ -28,8 +29,13 @@ jest.mock('lib-components', () => ({
   useAppConfig: () => ({
     static: { img: { liveBackground: 'some_url' } },
   }),
+  useCurrentResourceContext: jest.fn(),
 }));
 
+const mockedUseCurrentResourceContext =
+  useCurrentResourceContext as jest.MockedFunction<
+    typeof useCurrentResourceContext
+  >;
 const currentDate = DateTime.fromISO('2022-01-13T12:00');
 
 const languageChoices = [
@@ -66,6 +72,14 @@ describe('<VideoWidgetProvider />', () => {
   afterEach(() => fetchMock.restore());
 
   it('renders widgets for live teacher', async () => {
+    mockedUseCurrentResourceContext.mockReturnValue([
+      {
+        permissions: {
+          can_access_dashboard: true,
+          can_update: true,
+        },
+      },
+    ] as any);
     const videoId = faker.datatype.uuid();
     const mockedThumbnail = thumbnailMockFactory({
       video: videoId,
@@ -183,6 +197,14 @@ describe('<VideoWidgetProvider />', () => {
   });
 
   it('renders widget for vod teacher', () => {
+    mockedUseCurrentResourceContext.mockReturnValue([
+      {
+        permissions: {
+          can_access_dashboard: true,
+          can_update: true,
+        },
+      },
+    ] as any);
     const videoId = faker.datatype.uuid();
     const mockedThumbnail = thumbnailMockFactory({
       video: videoId,
@@ -242,6 +264,14 @@ describe('<VideoWidgetProvider />', () => {
   });
 
   it('renders widget for vod student', () => {
+    mockedUseCurrentResourceContext.mockReturnValue([
+      {
+        permissions: {
+          can_access_dashboard: true,
+          can_update: true,
+        },
+      },
+    ] as any);
     const videoId = faker.datatype.uuid();
     useTimedTextTrack.getState().addResource({
       active_stamp: 234243242353,

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/index.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/index.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 import { DeleteSharedLiveMediaModalProvider } from '@lib-video/hooks/useDeleteSharedLiveMediaModal';
 import { DeleteTimedTextTrackUploadModalProvider } from '@lib-video/hooks/useDeleteTimedTextTrackUploadModal';
 
+import { DeleteVideo } from './widgets/DeleteVideo';
 import { DescriptionWidget } from './widgets/DescriptionWidget';
 import { DownloadVideo } from './widgets/DownloadVideo';
 import { LicenseManager } from './widgets/LicenseManager';
@@ -49,6 +50,7 @@ enum WidgetType {
   SHARED_MEDIA_VOD_TEACHER = 'SHARED_MEDIA_VOD_TEACHER',
   SHARED_MEDIA_VOD_PUBLIC = 'SHARED_MEDIA_VOD_PUBLIC',
   TRANSCRIPTS = 'TRANSCRIPTS',
+  DELETE_VIDEO = 'DELETE_VIDEO',
 }
 
 const widgetLoader: { [key in WidgetType]: WidgetProps } = {
@@ -140,6 +142,10 @@ const widgetLoader: { [key in WidgetType]: WidgetProps } = {
     component: <LicenseManager key="license_manager" />,
     size: WidgetSize.DEFAULT,
   },
+  [WidgetType.DELETE_VIDEO]: {
+    component: <DeleteVideo key="delete_video" />,
+    size: WidgetSize.DEFAULT,
+  },
 };
 
 const teacherLiveWidgets: WidgetType[] = [
@@ -151,6 +157,7 @@ const teacherLiveWidgets: WidgetType[] = [
   WidgetType.LIVE_PAIRING,
   WidgetType.LIVE_JOIN_MODE,
   WidgetType.SHARED_MEDIA_LIVE_TEACHER,
+  WidgetType.DELETE_VIDEO,
 ];
 const teacherVodWidgets: WidgetType[] = [
   WidgetType.DESCRIPTION,
@@ -164,6 +171,7 @@ const teacherVodWidgets: WidgetType[] = [
   WidgetType.UPLOAD_CLOSED_CAPTATIONS,
   WidgetType.SHARED_MEDIA_VOD_TEACHER,
   WidgetType.TOOLS_AND_APPLICATIONS,
+  WidgetType.DELETE_VIDEO,
 ];
 const publicLiveWidgets: WidgetType[] = [];
 const publicVodWidgets: WidgetType[] = [

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/DeleteVideo/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/DeleteVideo/index.spec.tsx
@@ -1,0 +1,187 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import fetchMock from 'fetch-mock';
+import {
+  InfoWidgetModalProvider,
+  useCurrentResourceContext,
+  useJwt,
+  videoMockFactory,
+} from 'lib-components';
+import { render } from 'lib-tests';
+import React from 'react';
+
+import { wrapInVideo } from '@lib-video/utils/wrapInVideo';
+
+import { DeleteVideo } from '.';
+
+jest.mock('lib-components', () => ({
+  ...jest.requireActual('lib-components'),
+  report: jest.fn(),
+  useCurrentResourceContext: jest.fn(),
+}));
+
+const mockedUseCurrentResourceContext =
+  useCurrentResourceContext as jest.MockedFunction<
+    typeof useCurrentResourceContext
+  >;
+
+describe('<DeleteVideo />', () => {
+  beforeEach(() => {
+    useJwt.setState({
+      jwt: 'json web token',
+    });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('does not render the component on LTI', () => {
+    mockedUseCurrentResourceContext.mockReturnValue([
+      {
+        isFromWebsite: false,
+        permissions: {
+          can_access_dashboard: true,
+          can_update: true,
+        },
+      },
+    ] as any);
+    const mockedVideo = videoMockFactory();
+    render(
+      wrapInVideo(
+        <InfoWidgetModalProvider value={null}>
+          <DeleteVideo />
+        </InfoWidgetModalProvider>,
+        mockedVideo,
+      ),
+    );
+
+    expect(screen.queryByText('DANGER ZONE')).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Delete' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders the component on standalone site', () => {
+    mockedUseCurrentResourceContext.mockReturnValue([
+      {
+        isFromWebsite: true,
+        permissions: {
+          can_access_dashboard: true,
+          can_update: true,
+        },
+      },
+    ] as any);
+    const mockedVideo = videoMockFactory();
+    render(
+      wrapInVideo(
+        <InfoWidgetModalProvider value={null}>
+          <DeleteVideo />
+        </InfoWidgetModalProvider>,
+        mockedVideo,
+      ),
+    );
+
+    expect(screen.getByText('DANGER ZONE')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+  });
+
+  it('successfully opens the confirmation modal', () => {
+    mockedUseCurrentResourceContext.mockReturnValue([
+      {
+        isFromWebsite: true,
+        permissions: {
+          can_access_dashboard: true,
+          can_update: true,
+        },
+      },
+    ] as any);
+    const mockedVideo = videoMockFactory();
+    render(
+      wrapInVideo(
+        <InfoWidgetModalProvider value={null}>
+          <DeleteVideo />
+        </InfoWidgetModalProvider>,
+        mockedVideo,
+      ),
+    );
+
+    const deleteButton = screen.getByRole('button', { name: 'Delete' });
+    userEvent.click(deleteButton);
+    expect(
+      screen.getByText(
+        'Are you sure you want to delete this resource ? This action is irreversible.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('successfully deletes the video', async () => {
+    mockedUseCurrentResourceContext.mockReturnValue([
+      {
+        isFromWebsite: true,
+        permissions: {
+          can_access_dashboard: true,
+          can_update: true,
+        },
+      },
+    ] as any);
+    const mockedVideo = videoMockFactory();
+    fetchMock.delete(`/api/videos/${mockedVideo.id}/`, 204);
+    render(
+      wrapInVideo(
+        <InfoWidgetModalProvider value={null}>
+          <DeleteVideo />
+        </InfoWidgetModalProvider>,
+        mockedVideo,
+      ),
+    );
+
+    const deleteButton = screen.getByRole('button', { name: 'Delete' });
+    userEvent.click(deleteButton);
+
+    const confirmDeleteButton = screen.getByRole('button', {
+      name: 'Confirm',
+    });
+    userEvent.click(confirmDeleteButton);
+
+    const successMessage = await screen.findByText(
+      'Resource successfully deleted',
+    );
+    expect(successMessage).toBeInTheDocument();
+  });
+
+  it('fails to delete the video', async () => {
+    mockedUseCurrentResourceContext.mockReturnValue([
+      {
+        isFromWebsite: true,
+        permissions: {
+          can_access_dashboard: true,
+          can_update: true,
+        },
+      },
+    ] as any);
+    const mockedVideo = videoMockFactory();
+    fetchMock.delete(`/api/videos/${mockedVideo.id}/`, 403);
+    render(
+      wrapInVideo(
+        <InfoWidgetModalProvider value={null}>
+          <DeleteVideo />
+        </InfoWidgetModalProvider>,
+        mockedVideo,
+      ),
+    );
+
+    const deleteButton = screen.getByRole('button', { name: 'Delete' });
+    userEvent.click(deleteButton);
+
+    const confirmDeleteButton = screen.getByRole('button', {
+      name: 'Confirm',
+    });
+    userEvent.click(confirmDeleteButton);
+
+    const errorMessage = await screen.findByText(
+      'Failed to delete the resource',
+    );
+    expect(errorMessage).toBeInTheDocument();
+  });
+});

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/DeleteVideo/index.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/DeleteVideo/index.tsx
@@ -1,0 +1,124 @@
+import { Button } from 'grommet';
+import {
+  ConfirmationModal,
+  FoldableItem,
+  report,
+  useCurrentResourceContext,
+} from 'lib-components';
+import { useState } from 'react';
+import toast from 'react-hot-toast';
+import { defineMessages, useIntl } from 'react-intl';
+import { useHistory } from 'react-router-dom';
+import styled from 'styled-components';
+
+import { useDeleteVideo } from '@lib-video/api/useDeleteVideo';
+import { useCurrentVideo } from '@lib-video/hooks';
+
+const messages = defineMessages({
+  info: {
+    defaultMessage:
+      'DANGER ZONE : This widget allows you to delete the resource permanently.',
+    description: 'Info of the widget used for deleting the video.',
+    id: 'components.DeleteVideo.info',
+  },
+  title: {
+    defaultMessage: 'DANGER ZONE',
+    description: 'Title of the widget used for deleting the video.',
+    id: 'components.DeleteVideo.title',
+  },
+  confirmDeleteTitle: {
+    defaultMessage: 'Confirm delete',
+    description: 'Title of the widget used for confirmation.',
+    id: 'components.DeleteVideoConfirm.title',
+  },
+  confirmDeleteText: {
+    defaultMessage:
+      'Are you sure you want to delete this resource ? This action is irreversible.',
+    description: 'Text of the widget used for confirmation.',
+    id: 'components.DeleteVideoConfirm.text',
+  },
+  deleteButtonText: {
+    defaultMessage: 'Delete',
+    description: 'Text of the delete button.',
+    id: 'components.DeleteVideoButton.text',
+  },
+  videoDeleteSuccess: {
+    defaultMessage: 'Resource successfully deleted',
+    description: 'Text of the delete confirmation toast.',
+    id: 'components.deleteVideoSuccess.text',
+  },
+  videoDeleteError: {
+    defaultMessage: 'Failed to delete the resource',
+    description: 'ext of the delete error toast..',
+    id: 'components.videoDeleteError.text',
+  },
+});
+
+const StyledAnchorButton = styled(Button)`
+  height: 50px;
+  font-family: 'Roboto-Medium';
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+export const DeleteVideo = () => {
+  const intl = useIntl();
+  const [context] = useCurrentResourceContext();
+  const history = useHistory();
+  const [showDeleteConfirmationModal, setShowDeleteConfirmationModal] =
+    useState(false);
+  const video = useCurrentVideo();
+  const deleteVideo = useDeleteVideo({
+    onSuccess: () => {
+      toast.success(intl.formatMessage(messages.videoDeleteSuccess), {
+        position: 'bottom-center',
+      });
+      setShowDeleteConfirmationModal(false);
+      history.goBack();
+    },
+    onError: (err: unknown) => {
+      report(err);
+      toast.error(intl.formatMessage(messages.videoDeleteError), {
+        position: 'bottom-center',
+      });
+    },
+  });
+
+  if (!context.isFromWebsite) {
+    return null;
+  }
+
+  return (
+    <FoldableItem
+      infoText={intl.formatMessage(messages.info)}
+      initialOpenValue
+      title={intl.formatMessage(messages.title)}
+    >
+      {showDeleteConfirmationModal && (
+        <ConfirmationModal
+          text={intl.formatMessage(messages.confirmDeleteText)}
+          title={intl.formatMessage(messages.confirmDeleteTitle)}
+          onModalCloseOrCancel={() => setShowDeleteConfirmationModal(false)}
+          onModalConfirm={() => {
+            deleteVideo.mutate(video.id);
+          }}
+          color="action-danger"
+        />
+      )}
+      <StyledAnchorButton
+        a11yTitle={intl.formatMessage(messages.deleteButtonText)}
+        download
+        disabled={!context.permissions.can_update}
+        fill="horizontal"
+        label={intl.formatMessage(messages.deleteButtonText)}
+        target="_blank"
+        rel="noopener noreferrer"
+        primary
+        title={intl.formatMessage(messages.deleteButtonText)}
+        onClick={() => setShowDeleteConfirmationModal(true)}
+        color="action-danger"
+      />
+    </FoldableItem>
+  );
+};


### PR DESCRIPTION
## Purpose

Add a new widget in standalone site to delete videos,  classrooms and playlists.

## Proposal

After adding a context provider for Video edition in otder to know if the resource is shown on site or LTI, plug the API to the right endpoints and create the components for resource deletion.

- [x] Plug the API to the backend DELETE endpoint 
- [x] Write and add the new frontend widgets to the website

