### PR TITLE
🐛(site) remove creation playlist in content filter

### DIFF
--- a/src/frontend/apps/standalone_site/src/features/Contents/components/ContentsFilter/ContentsFilter.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/components/ContentsFilter/ContentsFilter.spec.tsx
@@ -39,6 +39,10 @@ describe('<ContentsFilter />', () => {
 
     deferredPlaylists.resolve(playlistsResponse);
 
+    expect(
+      screen.queryByRole('button', { name: 'Create a new playlist' }),
+    ).not.toBeInTheDocument();
+
     screen
       .getByRole('button', {
         name: /Filter/i,
@@ -77,6 +81,10 @@ describe('<ContentsFilter />', () => {
     );
 
     deferredPlaylists.resolve(playlistsResponse);
+
+    expect(
+      screen.queryByRole('button', { name: 'Create a new playlist' }),
+    ).not.toBeInTheDocument();
 
     expect(screen.getByText('2')).toBeInTheDocument();
 

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Create/ClassRoomCreateForm.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Create/ClassRoomCreateForm.spec.tsx
@@ -46,6 +46,9 @@ describe('<ClassRoomCreateForm />', () => {
       screen.getByRole('textbox', { name: /playlist/i }),
     ).toBeInTheDocument();
     expect(
+      screen.getByRole('button', { name: 'Create a new playlist' }),
+    ).toBeInTheDocument();
+    expect(
       screen.getByRole('textbox', { name: /description/i }),
     ).toBeInTheDocument();
     expect(
@@ -57,6 +60,10 @@ describe('<ClassRoomCreateForm />', () => {
     render(<ClassRoomCreateForm />);
 
     deferred.resolve(playlistsResponse);
+
+    expect(
+      screen.getByRole('button', { name: 'Create a new playlist' }),
+    ).toBeInTheDocument();
 
     const button = screen.getByRole('button', { name: /Add Classroom/i });
 
@@ -101,6 +108,10 @@ describe('<ClassRoomCreateForm />', () => {
     );
 
     deferred.resolve(playlistsResponse);
+
+    expect(
+      screen.getByRole('button', { name: 'Create a new playlist' }),
+    ).toBeInTheDocument();
 
     fireEvent.change(screen.getByRole('textbox', { name: /title/i }), {
       target: { value: 'my title' },
@@ -152,6 +163,10 @@ describe('<ClassRoomCreateForm />', () => {
 
     deferred.resolve(playlistsResponse);
 
+    expect(
+      screen.getByRole('button', { name: 'Create a new playlist' }),
+    ).toBeInTheDocument();
+
     fireEvent.change(screen.getByRole('textbox', { name: /title/i }), {
       target: { value: 'my title' },
     });
@@ -194,6 +209,10 @@ describe('<ClassRoomCreateForm />', () => {
     render(<ClassRoomCreateForm />);
 
     deferred.resolve(playlistsResponse);
+
+    expect(
+      screen.getByRole('button', { name: 'Create a new playlist' }),
+    ).toBeInTheDocument();
 
     fireEvent.change(screen.getByRole('textbox', { name: /title/i }), {
       target: { value: 'my title' },
@@ -241,6 +260,9 @@ describe('<ClassRoomCreateForm />', () => {
     expect(screen.getByRole('textbox', { name: /title/i })).toBeInTheDocument();
     expect(
       screen.getByRole('textbox', { name: /playlist/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Create a new playlist' }),
     ).toBeInTheDocument();
     expect(
       screen.getByRole('textbox', { name: /description/i }),

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Create/ClassRoomCreateForm.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Create/ClassRoomCreateForm.tsx
@@ -64,8 +64,9 @@ const ClassroomCreateForm = () => {
   const intl = useIntl();
   const history = useHistory();
   const classroomPath = routes.CONTENTS.subRoutes.CLASSROOM.path;
-  const { errorPlaylist, selectPlaylist, playlistResponse } =
-    useSelectPlaylist();
+  const { errorPlaylist, selectPlaylist, playlistResponse } = useSelectPlaylist(
+    { withPlaylistCreation: true },
+  );
   const {
     mutate: createClassroom,
     error: errorClassroom,

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/Create/LiveCreateForm.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/Create/LiveCreateForm.spec.tsx
@@ -49,6 +49,9 @@ describe('<LiveCreateForm />', () => {
       }),
     ).toBeInTheDocument();
     expect(
+      screen.getByRole('button', { name: 'Create a new playlist' }),
+    ).toBeInTheDocument();
+    expect(
       screen.getByRole('textbox', { name: /description/i }),
     ).toBeInTheDocument();
     expect(
@@ -73,6 +76,9 @@ describe('<LiveCreateForm />', () => {
       }),
     ).toBeInTheDocument();
     expect(
+      screen.getByRole('button', { name: 'Create a new playlist' }),
+    ).toBeInTheDocument();
+    expect(
       screen.getByRole('textbox', { name: /description/i }),
     ).toBeInTheDocument();
     expect(
@@ -84,6 +90,10 @@ describe('<LiveCreateForm />', () => {
     render(<LiveCreateForm />);
 
     deferredPlaylists.resolve(playlistsResponse);
+
+    expect(
+      screen.getByRole('button', { name: 'Create a new playlist' }),
+    ).toBeInTheDocument();
 
     const button = screen.getByRole('button', { name: /Add Webinar/i });
 
@@ -140,6 +150,10 @@ describe('<LiveCreateForm />', () => {
     );
 
     deferredPlaylists.resolve(playlistsResponse);
+
+    expect(
+      screen.getByRole('button', { name: 'Create a new playlist' }),
+    ).toBeInTheDocument();
 
     fireEvent.change(screen.getByRole('textbox', { name: /title/i }), {
       target: { value: 'my title' },

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/Create/LiveCreateForm.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/Create/LiveCreateForm.tsx
@@ -59,8 +59,9 @@ const LiveCreateForm = () => {
     title: '',
     live_type: LiveModeType.JITSI,
   });
-  const { errorPlaylist, selectPlaylist, playlistResponse } =
-    useSelectPlaylist();
+  const { errorPlaylist, selectPlaylist, playlistResponse } = useSelectPlaylist(
+    { withPlaylistCreation: true },
+  );
   const {
     mutate: createLive,
     error: errorVideo,

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Video/components/Create/VideoCreateForm.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Video/components/Create/VideoCreateForm.spec.tsx
@@ -103,6 +103,9 @@ describe('<VideoCreateForm />', () => {
       }),
     ).toBeInTheDocument();
     expect(
+      screen.getByRole('button', { name: 'Create a new playlist' }),
+    ).toBeInTheDocument();
+    expect(
       screen.getByRole('textbox', { name: /description/i }),
     ).toBeInTheDocument();
     expect(
@@ -136,6 +139,9 @@ describe('<VideoCreateForm />', () => {
       }),
     ).toBeInTheDocument();
     expect(
+      screen.getByRole('button', { name: 'Create a new playlist' }),
+    ).toBeInTheDocument();
+    expect(
       screen.getByRole('textbox', { name: /description/i }),
     ).toBeInTheDocument();
     expect(
@@ -156,6 +162,10 @@ describe('<VideoCreateForm />', () => {
 
     deferredPlaylists.resolve(playlistsResponse);
     deferredVideos.resolve(videosResponse);
+
+    expect(
+      screen.getByRole('button', { name: 'Create a new playlist' }),
+    ).toBeInTheDocument();
 
     fireEvent.change(screen.getByRole('textbox', { name: /title/i }), {
       target: { value: 'my title' },
@@ -220,6 +230,10 @@ describe('<VideoCreateForm />', () => {
 
     deferredPlaylists.resolve(playlistsResponse);
     deferredVideos.resolve(videosResponse);
+
+    expect(
+      screen.getByRole('button', { name: 'Create a new playlist' }),
+    ).toBeInTheDocument();
 
     fireEvent.change(screen.getByRole('textbox', { name: /title/i }), {
       target: { value: 'my title' },
@@ -296,6 +310,10 @@ describe('<VideoCreateForm />', () => {
     deferredPlaylists.resolve(playlistsResponse);
     deferredVideos.resolve(videosResponse);
 
+    expect(
+      screen.getByRole('button', { name: 'Create a new playlist' }),
+    ).toBeInTheDocument();
+
     fireEvent.change(screen.getByRole('textbox', { name: /title/i }), {
       target: { value: 'my title' },
     });
@@ -350,6 +368,10 @@ describe('<VideoCreateForm />', () => {
 
     deferredPlaylists.resolve(500);
     deferredVideos.resolve(videosResponse);
+
+    expect(
+      screen.getByRole('button', { name: 'Create a new playlist' }),
+    ).toBeInTheDocument();
 
     expect(
       await screen.findByText(

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Video/components/Create/VideoCreateForm.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Video/components/Create/VideoCreateForm.tsx
@@ -72,8 +72,9 @@ const VideoCreateForm = () => {
   });
   const [newVideo, setNewVideo] = useState<Video>();
   const [isUploading, setIsUploading] = useState(false);
-  const { errorPlaylist, selectPlaylist, playlistResponse } =
-    useSelectPlaylist();
+  const { errorPlaylist, selectPlaylist, playlistResponse } = useSelectPlaylist(
+    { withPlaylistCreation: true },
+  );
   const {
     mutate: createVideo,
     error: errorVideo,

--- a/src/frontend/apps/standalone_site/src/features/Playlist/hooks/useSelectPlaylist.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Playlist/hooks/useSelectPlaylist.spec.tsx
@@ -69,6 +69,64 @@ describe('<useSelectPlaylist />', () => {
     );
 
     expect(
+      screen.queryByRole('button', { name: 'Create a new playlist' }),
+    ).not.toBeInTheDocument();
+
+    userEvent.click(
+      await screen.findByRole('button', {
+        name: 'Choose the playlist.',
+      }),
+    );
+
+    userEvent.click(
+      await screen.findByRole('option', { name: 'an other title' }),
+    );
+
+    expect(
+      await screen.findByRole('button', {
+        name: 'Choose the playlist.; Selected: an-other-playlist',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  test('renders useSelectPlaylist success with new playlist creation button', async () => {
+    fetchMock.get(
+      '/api/playlists/?limit=20&offset=0&ordering=-created_on&can_edit=true',
+      playlistsResponse,
+    );
+
+    const useSelectPlaylistSuccess = new Deferred();
+    const { result, waitForNextUpdate } = renderHook(
+      () =>
+        useSelectPlaylist({
+          withPlaylistCreation: true,
+        }),
+      {
+        wrapper: Wrapper,
+      },
+    );
+
+    await waitForNextUpdate();
+
+    useSelectPlaylistSuccess.resolve(result.current.playlistResponse);
+    expect(result.current.errorPlaylist).toBeNull();
+    expect(await useSelectPlaylistSuccess.promise).toEqual({
+      count: 1,
+      next: null,
+      previous: null,
+      results: [
+        { id: 'some-playlist-id', title: 'some playlist title' },
+        { id: 'an-other-playlist', title: 'an other title' },
+      ],
+    });
+
+    render(
+      <Form onSubmitError={() => ({})} onSubmit={() => {}}>
+        {result.current.selectPlaylist}
+      </Form>,
+    );
+
+    expect(
       screen.getByRole('button', { name: 'Create a new playlist' }),
     ).toBeInTheDocument();
 
@@ -97,7 +155,10 @@ describe('<useSelectPlaylist />', () => {
 
     const useSelectPlaylistSuccess = new Deferred();
     const { result, waitForNextUpdate } = renderHook(
-      () => useSelectPlaylist(),
+      () =>
+        useSelectPlaylist({
+          withPlaylistCreation: true,
+        }),
       {
         wrapper: Wrapper,
       },

--- a/src/frontend/apps/standalone_site/src/features/Playlist/hooks/useSelectPlaylist.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Playlist/hooks/useSelectPlaylist.tsx
@@ -33,11 +33,13 @@ const messages = defineMessages({
 interface UseSelectPlaylistOptions {
   formFieldProps?: Partial<FormFieldExtendedProps>;
   selectProps?: Partial<SelectExtendedProps>;
+  withPlaylistCreation?: boolean;
 }
 
 const useSelectPlaylist = ({
   formFieldProps,
   selectProps,
+  withPlaylistCreation,
 }: UseSelectPlaylistOptions = {}) => {
   const intl = useIntl();
   const [currentPlaylistPage, setCurrentPlaylistPage] = useState(0);
@@ -68,16 +70,24 @@ const useSelectPlaylist = ({
 
   const selectPlaylist = useMemo(
     () => (
-      <Box direction="row-responsive" pad={{ bottom: 'small' }} gap="small">
+      <Box
+        direction="row-responsive"
+        pad={withPlaylistCreation ? { bottom: 'small' } : {}}
+        gap="small"
+      >
         <FormField
           label={intl.formatMessage(messages.selectPlaylistLabel)}
           htmlFor="select-playlist-id"
           name="playlist"
           margin="none"
           required
-          style={{
-            flex: 1,
-          }}
+          style={
+            withPlaylistCreation
+              ? {
+                  flex: 1,
+                }
+              : {}
+          }
           {...formFieldProps}
         >
           <Select
@@ -102,18 +112,27 @@ const useSelectPlaylist = ({
             {...selectProps}
           />
         </FormField>
-        <Link to={routes.PLAYLIST.subRoutes.CREATE.path}>
-          <Button
-            a11yTitle={intl.formatMessage(messages.createPlaylist)}
-            icon={<PlusSVG iconColor="#055fd2" height="35px" width="35px" />}
-            style={{
-              border: 'transparent',
-            }}
-          />
-        </Link>
+        {withPlaylistCreation && (
+          <Link to={routes.PLAYLIST.subRoutes.CREATE.path}>
+            <Button
+              a11yTitle={intl.formatMessage(messages.createPlaylist)}
+              icon={<PlusSVG iconColor="#055fd2" height="35px" width="35px" />}
+              style={{
+                border: 'transparent',
+              }}
+            />
+          </Link>
+        )}
       </Box>
     ),
-    [formFieldProps, intl, playlistResponse, playlists, selectProps],
+    [
+      formFieldProps,
+      intl,
+      playlistResponse,
+      playlists,
+      selectProps,
+      withPlaylistCreation,
+    ],
   );
 
   return {


### PR DESCRIPTION
## Purpose

We added a button allowing to create a new playlist in the useSelectPlaylist hook. But we didn't notice it was also present in the content filter. To solve this issue we added a new parameter to the hook to choose to display the button or not.

## Proposal

- [x] remove creation playlist in content filter
