### PR TITLE
✨(back) add bulk_destroy for video / classroom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- bulk delete for video and classroom
+
 ## [4.0.0] - 2023-05-02
 
 ### Added

--- a/src/backend/marsha/bbb/tests/api/classroom/test_bulk_destroy.py
+++ b/src/backend/marsha/bbb/tests/api/classroom/test_bulk_destroy.py
@@ -1,0 +1,221 @@
+"""Tests for the classroom bulk destroy API."""
+import json
+
+from django.test import TestCase, override_settings
+
+from marsha.bbb.factories import ClassroomFactory
+from marsha.bbb.models import Classroom
+from marsha.core.factories import (
+    OrganizationAccessFactory,
+    PlaylistAccessFactory,
+    PlaylistFactory,
+)
+from marsha.core.models import ADMINISTRATOR
+from marsha.core.simple_jwt.factories import (
+    InstructorOrAdminLtiTokenFactory,
+    PlaylistLtiTokenFactory,
+    StudentLtiTokenFactory,
+    UserAccessTokenFactory,
+)
+
+
+# We don't enforce arguments documentation in tests
+# pylint: disable=unused-argument
+
+
+@override_settings(BBB_API_ENDPOINT="https://10.7.7.1/bigbluebutton/api")
+@override_settings(BBB_API_SECRET="SuperSecret")
+@override_settings(BBB_ENABLED=True)
+class ClassroomBulkDestroyAPITest(TestCase):
+    """Test for the bulk destroy API."""
+
+    maxDiff = None
+
+    def _api_url(self):
+        """Bulk destroy api url."""
+        return "/api/classrooms/"
+
+    def test_api_classroom_bulk_delete_anonymous(self):
+        """An anonymous should not be able to delete a list of classroom."""
+        classroom = ClassroomFactory()
+        response = self.client.delete(self._api_url())
+        self.assertEqual(response.status_code, 401)
+        content = json.loads(response.content)
+        self.assertEqual(
+            content, {"detail": "Authentication credentials were not provided."}
+        )
+        self.assertTrue(Classroom.objects.filter(id=classroom.id).exists())
+
+    def test_api_classroom_bulk_delete_student(self):
+        """A student should not be able to delete a list of classroom."""
+        classroom1 = ClassroomFactory()
+        classroom2 = ClassroomFactory()
+
+        jwt_token = StudentLtiTokenFactory(
+            resource=classroom1,
+            permissions__can_update=True,
+        )
+
+        response = self.client.delete(
+            self._api_url(),
+            {"ids": [str(classroom1.pk), str(classroom2.pk)]},
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 403)
+        content = json.loads(response.content)
+        self.assertEqual(
+            content, {"detail": "You do not have permission to perform this action."}
+        )
+
+    def test_api_classroom_bulk_delete_student_with_playlist_token(self):
+        """LTI Token can't delete a list of classroom."""
+        classroom1 = ClassroomFactory()
+        classroom2 = ClassroomFactory()
+        jwt_token = PlaylistLtiTokenFactory(
+            roles=["student"],
+            permissions__can_update=True,
+        )
+
+        response = self.client.delete(
+            self._api_url(),
+            {"ids": [str(classroom1.pk), str(classroom2.pk)]},
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 403)
+        content = json.loads(response.content)
+        self.assertEqual(
+            content, {"detail": "You do not have permission to perform this action."}
+        )
+
+    def test_api_classroom_bulk_delete_instructor(self):
+        """LTI Token can't delete a list of classroom."""
+        classroom = ClassroomFactory()
+
+        jwt_token = InstructorOrAdminLtiTokenFactory(resource=classroom)
+
+        response = self.client.delete(
+            self._api_url(),
+            {"ids": [str(classroom.pk)]},
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 403)
+        content = json.loads(response.content)
+        self.assertEqual(
+            content, {"detail": "You do not have permission to perform this action."}
+        )
+
+    def test_api_classroom_bulk_delete_instructor_with_playlist_token(self):
+        """LTI Token can't delete a list of classroom."""
+
+        playlist = PlaylistFactory()
+        classroom = ClassroomFactory(playlist=playlist)
+
+        jwt_token = PlaylistLtiTokenFactory(resource=classroom)
+
+        self.assertEqual(Classroom.objects.count(), 1)
+
+        response = self.client.delete(
+            self._api_url(),
+            {"ids": [str(classroom.pk)]},
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(Classroom.objects.count(), 1)
+        content = json.loads(response.content)
+        self.assertEqual(
+            content, {"detail": "You do not have permission to perform this action."}
+        )
+
+    def test_api_classroom_bulk_delete_user_access_token(self):
+        """LTI Token can't delete a list of classroom."""
+        organization_access = OrganizationAccessFactory()
+        classroom1 = ClassroomFactory()
+        classroom2 = ClassroomFactory()
+
+        jwt_token = UserAccessTokenFactory(user=organization_access.user)
+
+        response = self.client.delete(
+            self._api_url(),
+            {"ids": [str(classroom1.pk), str(classroom2.pk)]},
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 403)
+        content = json.loads(response.content)
+        self.assertEqual(
+            content,
+            "You do not have permission to perform this action for objects:"
+            f"['{str(classroom1.id)}', '{str(classroom2.id)}']",
+        )
+
+    def test_api_classroom_bulk_delete_user_access_token_organization_admin(self):
+        """An organization administrator should be able to delete a list of classroom."""
+        organization_access = OrganizationAccessFactory(role=ADMINISTRATOR)
+        playlist = PlaylistFactory(organization=organization_access.organization)
+        classroom1 = ClassroomFactory(playlist=playlist)
+        classroom2 = ClassroomFactory(playlist=playlist)
+
+        jwt_token = UserAccessTokenFactory(user=organization_access.user)
+
+        self.assertEqual(Classroom.objects.count(), 2)
+
+        response = self.client.delete(
+            self._api_url(),
+            {"ids": [str(classroom1.pk), str(classroom2.pk)]},
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 204)
+        self.assertEqual(Classroom.objects.count(), 0)
+
+    def test_api_classroom_bulk_delete_user_access_token_playlist_admin(self):
+        """A playlist administrator should be able to delete a list of classroom."""
+        playlist_access = PlaylistAccessFactory(role=ADMINISTRATOR)
+        classroom1 = ClassroomFactory(playlist=playlist_access.playlist)
+        classroom2 = ClassroomFactory(playlist=playlist_access.playlist)
+        jwt_token = UserAccessTokenFactory(user=playlist_access.user)
+
+        self.assertEqual(Classroom.objects.count(), 2)
+
+        response = self.client.delete(
+            self._api_url(),
+            {"ids": [str(classroom1.pk), str(classroom2.pk)]},
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 204)
+        self.assertEqual(Classroom.objects.count(), 0)
+
+    def test_api_classroom_bulk_delete_user_access_token_playlist_admin_partial_permission(
+        self,
+    ):
+        """
+        A playlist administrator should not be able to delete a list of classroom
+        if one the classroom is not from their playlist.
+        """
+        playlist_access = PlaylistAccessFactory(role=ADMINISTRATOR)
+        classroom1 = ClassroomFactory(playlist=playlist_access.playlist)
+        classroom2 = ClassroomFactory()
+        jwt_token = UserAccessTokenFactory(user=playlist_access.user)
+
+        self.assertEqual(Classroom.objects.count(), 2)
+
+        response = self.client.delete(
+            self._api_url(),
+            {"ids": [str(classroom1.pk), str(classroom2.pk)]},
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(Classroom.objects.count(), 2)
+        content = json.loads(response.content)
+        self.assertEqual(
+            content,
+            "You do not have permission to perform this action for objects:"
+            f"['{str(classroom2.id)}']",
+        )

--- a/src/backend/marsha/bbb/urls.py
+++ b/src/backend/marsha/bbb/urls.py
@@ -2,7 +2,7 @@
 
 from django.urls import include, path
 
-from rest_framework.routers import DefaultRouter
+from marsha.core.routers import MarshaDefaultRouter
 
 from .api import ClassroomDocumentViewSet, ClassroomViewSet
 from .views import ClassroomLTIView
@@ -10,7 +10,9 @@ from .views import ClassroomLTIView
 
 app_name = "classroom"
 
-router = DefaultRouter()
+router = MarshaDefaultRouter()
+
+
 router.register("classrooms", ClassroomViewSet, basename="classrooms")
 router.register(
     "classroomdocuments", ClassroomDocumentViewSet, basename="classroom_documents"

--- a/src/backend/marsha/core/routers.py
+++ b/src/backend/marsha/core/routers.py
@@ -1,0 +1,36 @@
+"""Marsha router implementation."""
+
+from django.core.exceptions import ImproperlyConfigured
+
+from rest_framework.routers import DefaultRouter, Route
+
+
+class MarshaDefaultRouter(DefaultRouter):
+    """
+    This router handles the "DELETE" verb on list routes eg: DELETE on /api/videos/
+    The route then call the action "bulk_destroy" if it is implemented.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        custom_routes = []
+        list_route_found = False
+        for route in self.routes:
+            if route.name == "{basename}-list":
+                custom_routes.append(
+                    Route(
+                        url=route.url,
+                        mapping=route.mapping | {"delete": "bulk_destroy"},
+                        name=route.name,
+                        detail=route.detail,
+                        initkwargs=route.initkwargs,
+                    )
+                )
+                list_route_found = True
+            else:
+                custom_routes.append(route)
+
+        if not list_route_found:
+            raise ImproperlyConfigured("Missing list route in DefaultRouter")
+
+        self.routes = custom_routes

--- a/src/backend/marsha/core/tests/api/video/test_bulk_destroy.py
+++ b/src/backend/marsha/core/tests/api/video/test_bulk_destroy.py
@@ -1,0 +1,254 @@
+"""Tests for the Bulk destroy API of the Marsha project."""
+import json
+
+from django.test import TestCase
+
+from marsha.core import factories, models
+from marsha.core.simple_jwt.factories import (
+    InstructorOrAdminLtiTokenFactory,
+    StudentLtiTokenFactory,
+    UserAccessTokenFactory,
+)
+
+
+class VideoBulkDestroyAPITest(TestCase):
+    """Test the destroy API of the video object."""
+
+    maxDiff = None
+
+    def _api_url(self):
+        """Bulk delete api url."""
+        return "/api/videos/"
+
+    def test_api_video_bulk_delete_detail_anonymous(self):
+        """Anonymous users should not be allowed to delete a list of video."""
+        video1 = factories.VideoFactory()
+        response = self.client.delete(self._api_url())
+        self.assertEqual(response.status_code, 401)
+        content = json.loads(response.content)
+        self.assertEqual(
+            content, {"detail": "Authentication credentials were not provided."}
+        )
+        self.assertTrue(models.Video.objects.filter(id=video1.id).exists())
+
+    def test_api_video_bulk_delete_detail_token_user(self):
+        """A token user associated to a video should not be able to delete it or any other."""
+        video1 = factories.VideoFactory()
+        jwt_token = InstructorOrAdminLtiTokenFactory(resource=video1)
+
+        # Try deleting the video linked to the JWT token and the other one
+        response = self.client.delete(
+            self._api_url(),
+            {"ids": [str(video1.pk)]},
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertTrue(models.Video.objects.filter(id=video1.id).exists())
+
+    def test_api_video_bulk_delete_detail_student(self):
+        """Student users should not be able to delete a video."""
+        video1 = factories.VideoFactory()
+        jwt_token = StudentLtiTokenFactory(resource=video1)
+
+        response = self.client.delete(
+            self._api_url(),
+            {"ids": [str(video1.pk)]},
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 403)
+        content = json.loads(response.content)
+        self.assertEqual(
+            content,
+            "You do not have permission to perform this action for objects:"
+            f"['{str(video1.id)}']",
+        )
+
+    def test_api_video_bulk_delete_for_one_video(self):
+        """
+        Delete a list of video by playlist admin.
+
+        If admin doesn't have the permission on one of them, then
+        the call must fail.
+        """
+        user = factories.UserFactory()
+        playlist = factories.PlaylistFactory()
+        factories.PlaylistAccessFactory(
+            role=models.ADMINISTRATOR, playlist=playlist, user=user
+        )
+        video1 = factories.VideoFactory(playlist=playlist)
+        video2 = factories.VideoFactory()
+        jwt_token = UserAccessTokenFactory(user=user)
+
+        self.assertEqual(models.Video.objects.count(), 2)
+
+        response = self.client.delete(
+            self._api_url(),
+            {"ids": [str(video1.pk), str(video2.pk)]},
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(models.Video.objects.count(), 2)
+        content = json.loads(response.content)
+        self.assertEqual(
+            content,
+            f"You do not have permission to perform this action for objects:['{str(video2.id)}']",
+        )
+
+    def test_api_video_bulk_delete_detail_staff_or_user(self):
+        """Users authenticated via a session should not be able to delete a list of video."""
+        video1 = factories.VideoFactory()
+        video2 = factories.VideoFactory()
+        for user in [factories.UserFactory(), factories.UserFactory(is_staff=True)]:
+            self.client.login(username=user.username, password="test")
+
+            response = self.client.delete(
+                self._api_url(),
+                {"ids": [str(video1.pk), str(video2.pk)]},
+                content_type="application/json",
+            )
+
+            self.assertEqual(response.status_code, 401)
+            content = json.loads(response.content)
+            self.assertEqual(
+                content, {"detail": "Authentication credentials were not provided."}
+            )
+        self.assertTrue(models.Video.objects.filter(id=video1.id).exists())
+        self.assertTrue(models.Video.objects.filter(id=video2.id).exists())
+
+    def test_api_video_bulk_delete_by_playlist_admin(self):
+        """
+        Delete video by playlist admin.
+
+        Users with an administrator role on a playlist should be able to delete videos list.
+        """
+        user = factories.UserFactory()
+        playlist = factories.PlaylistFactory()
+        factories.PlaylistAccessFactory(
+            role=models.ADMINISTRATOR, playlist=playlist, user=user
+        )
+        video1 = factories.VideoFactory(playlist=playlist)
+        video2 = factories.VideoFactory(playlist=playlist)
+        jwt_token = UserAccessTokenFactory(user=user)
+
+        self.assertEqual(models.Video.objects.count(), 2)
+
+        response = self.client.delete(
+            self._api_url(),
+            {"ids": [str(video1.pk), str(video2.pk)]},
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 204)
+        self.assertEqual(models.Video.objects.count(), 0)
+
+    def test_api_video_bulk_delete_by_playlist_instructor(self):
+        """
+        Delete video by playlist instructor.
+
+        Users with an instructor role on a playlist should be able to delete list of video.
+        """
+        user = factories.UserFactory()
+        playlist = factories.PlaylistFactory()
+        factories.PlaylistAccessFactory(
+            role=models.INSTRUCTOR, playlist=playlist, user=user
+        )
+        video1 = factories.VideoFactory(playlist=playlist)
+        video2 = factories.VideoFactory(playlist=playlist)
+        jwt_token = UserAccessTokenFactory(user=user)
+
+        self.assertEqual(models.Video.objects.count(), 2)
+
+        response = self.client.delete(
+            self._api_url(),
+            {"ids": [str(video1.pk), str(video2.pk)]},
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+            content_type="application/json",
+        )
+
+        self.assertEqual(models.Video.objects.count(), 0)
+        self.assertEqual(response.status_code, 204)
+
+    def test_api_video_bulk_delete_by_organization_admin(self):
+        """
+        Delete video by organization admin.
+
+        Users with an administrator role on an organization should be able to
+        delete list of video from playlists linked to that organization.
+        """
+        user = factories.UserFactory()
+        organization = factories.OrganizationFactory()
+        factories.OrganizationAccessFactory(
+            role=models.ADMINISTRATOR, organization=organization, user=user
+        )
+        playlist = factories.PlaylistFactory(organization=organization)
+        video1 = factories.VideoFactory(playlist=playlist)
+        video2 = factories.VideoFactory(playlist=playlist)
+        jwt_token = UserAccessTokenFactory(user=user)
+
+        self.assertEqual(models.Video.objects.count(), 2)
+
+        response = self.client.delete(
+            self._api_url(),
+            {"ids": [str(video1.pk), str(video2.pk)]},
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+            content_type="application/json",
+        )
+
+        self.assertEqual(models.Video.objects.count(), 0)
+        self.assertEqual(response.status_code, 204)
+
+    def test_api_video_bulk_delete_by_organization_instructor(self):
+        """
+        Delete video by organization instructor.
+
+        Users with an instructor role on an organization should not be able to
+        delete list of video from playlists linked to that organization.
+        """
+        user = factories.UserFactory()
+        organization = factories.OrganizationFactory()
+        factories.OrganizationAccessFactory(
+            role=models.INSTRUCTOR, organization=organization, user=user
+        )
+        playlist = factories.PlaylistFactory(organization=organization)
+        video1 = factories.VideoFactory(playlist=playlist)
+        video2 = factories.VideoFactory(playlist=playlist)
+        jwt_token = UserAccessTokenFactory(user=user)
+
+        self.assertEqual(models.Video.objects.count(), 2)
+
+        response = self.client.delete(
+            self._api_url(),
+            {"ids": [str(video1.pk), str(video2.pk)]},
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+            content_type="application/json",
+        )
+
+        self.assertEqual(models.Video.objects.count(), 2)
+        self.assertEqual(response.status_code, 403)
+
+    def test_api_video_instructor_bulk_delete_video_in_read_only(self):
+        """
+        An instructor with read_only set to true
+        should not be able to delete the list of video.
+        """
+        video1 = factories.VideoFactory()
+        video2 = factories.VideoFactory()
+        jwt_token = InstructorOrAdminLtiTokenFactory(
+            resource=video1,
+            permissions__can_update=False,
+        )
+
+        response = self.client.delete(
+            self._api_url(),
+            {"ids": [str(video1.pk), str(video2.pk)]},
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 403)

--- a/src/backend/marsha/core/tests/api/video/test_destroy.py
+++ b/src/backend/marsha/core/tests/api/video/test_destroy.py
@@ -189,37 +189,3 @@ class VideoDestroyAPITest(TestCase):
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
         self.assertEqual(response.status_code, 403)
-
-    def test_api_video_delete_list_anonymous(self):
-        """Anonymous users should not be able to delete a list of videos."""
-        video = factories.VideoFactory()
-
-        response = self.client.delete("/api/videos/")
-
-        self.assertEqual(response.status_code, 405)
-        self.assertTrue(models.Video.objects.filter(id=video.id).exists())
-
-    def test_api_video_delete_list_token_user(self):
-        """A token user associated to a video should not be able to delete a list of videos."""
-        video = factories.VideoFactory()
-        jwt_token = InstructorOrAdminLtiTokenFactory(
-            resource=video,
-            permissions__can_update=False,
-        )
-
-        response = self.client.delete(
-            "/api/videos/", HTTP_AUTHORIZATION=f"Bearer {jwt_token}"
-        )
-        self.assertEqual(response.status_code, 405)
-        self.assertTrue(models.Video.objects.filter(id=video.id).exists())
-
-    def test_api_video_delete_list_staff_or_user(self):
-        """Users authenticated via a session should not be able to delete a list of videos."""
-        video = factories.VideoFactory()
-        for user in [factories.UserFactory(), factories.UserFactory(is_staff=True)]:
-            self.client.login(username=user.username, password="test")
-
-            response = self.client.delete("/api/videos/")
-
-            self.assertEqual(response.status_code, 405)
-        self.assertTrue(models.Video.objects.filter(id=video.id).exists())

--- a/src/backend/marsha/core/tests/test_router.py
+++ b/src/backend/marsha/core/tests/test_router.py
@@ -1,0 +1,53 @@
+"""Test marsha router."""
+from django.core.cache import cache
+from django.test import TestCase, override_settings
+
+from rest_framework.routers import DynamicRoute, Route
+
+from marsha.core.routers import MarshaDefaultRouter
+from marsha.core.tests.testing_utils import reload_urlconf
+
+
+@override_settings(DEBUG=False)
+class MarshBaseRouteTestCase(TestCase):
+    """
+    Test case for marsha rooter routes.
+    """
+
+    def setUp(self):
+        """Pre-flight resets"""
+        super().setUp()
+
+        # Reset the cache to always reach the site route.
+        cache.clear()
+
+        # Force URLs reload to take DEBUG into account
+        reload_urlconf()
+
+    def test_list_route_mapping(self):
+        """The "list" route must handle the "DELETE" REST verb."""
+        router = MarshaDefaultRouter()
+        # first route is the "list" route
+        list_route = router.routes[0]
+        # seconde route is for dynamically generated list routes with  @action(detail=False).
+        dynamic_list_route = router.routes[1]
+
+        # list_route must handle delete verb
+        self.assertTrue(isinstance(list_route, Route))
+        self.assertEqual(list_route.url, r"^{prefix}{trailing_slash}$")
+        self.assertEqual(
+            list_route.mapping,
+            {"get": "list", "post": "create", "delete": "bulk_destroy"},
+        )
+        self.assertEqual(list_route.name, "{basename}-list")
+        self.assertFalse(list_route.detail)
+        self.assertEqual(list_route.initkwargs, {"suffix": "List"})
+
+        # dynamic_list_route should not be impacted
+        self.assertTrue(isinstance(dynamic_list_route, DynamicRoute))
+        self.assertEqual(
+            dynamic_list_route.url, r"^{prefix}/{url_path}{trailing_slash}$"
+        )
+        self.assertEqual(dynamic_list_route.name, "{basename}-{url_name}")
+        self.assertFalse(dynamic_list_route.detail)
+        self.assertEqual(dynamic_list_route.initkwargs, {})

--- a/src/backend/marsha/urls.py
+++ b/src/backend/marsha/urls.py
@@ -30,6 +30,7 @@ from marsha.core.api import (
     update_state,
 )
 from marsha.core.api.lti_user_association import LtiUserAssociationViewSet
+from marsha.core.routers import MarshaDefaultRouter
 from marsha.core.urls.converters import XAPIResourceKindConverter
 from marsha.core.utils.lti_select_utils import get_lti_select_resources
 from marsha.core.views import (
@@ -52,7 +53,7 @@ LTI_SELECT_ROUTE_PATTERN = (
     rf"lti/select/((?P<resource_kind>{'|'.join(get_lti_select_resources().keys())})/)?$"
 )
 
-router = DefaultRouter()
+router = MarshaDefaultRouter()
 router.register(models.Video.RESOURCE_NAME, VideoViewSet, basename="videos")
 router.register(models.Document.RESOURCE_NAME, DocumentViewSet, basename="documents")
 router.register("organizations", OrganizationViewSet, basename="organizations")


### PR DESCRIPTION
## Purpose

We currently can't delete several object in one request

## Proposal

We want to do this by creating a mixin providing a "bulk_destroy" action. This action takes ids from the body,
verify if user has permission on all of them then delete. Like "list" actions with their corresponding "retrieve" actions, "bulk_destroy" queryset filters must match "delete" action permissions. (one action can't destroy more or less than the other).
The MarshaDefaultRouter handles DELETE verb on list object URL. (eg: /api/videos/).
