### PR TITLE
fix wrong usage of reduce index in xapiVideo mergeSegments 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - bulk delete for video and classroom
 
+### Fixed
+
+- Wrong usage of reduce index in xapiVideo mergeSegments
+
 ## [4.0.0] - 2023-05-02
 
 ### Added

--- a/src/frontend/packages/lib_components/src/utils/XAPI/VideoXAPIStatement.spec.ts
+++ b/src/frontend/packages/lib_components/src/utils/XAPI/VideoXAPIStatement.spec.ts
@@ -73,6 +73,42 @@ describe('VideoXAPIStatement', () => {
 
       // merge identical segments
       expect(xapiStatement.mergeSegments(['0[.]5', '0[.]5'])).toBe('0[.]5');
+
+      // merge overlapping segments and continue with new segments
+      expect(
+        xapiStatement.mergeSegments([
+          '0[.]3.067',
+          '3.092[.]77.944',
+          '81.245[.]81.245',
+          '86.036[.]86.036',
+          '87.833[.]31.721',
+        ]),
+      ).toBe('0[.]3.067[,]3.092[.]87.833');
+      expect(
+        xapiStatement.mergeSegments([
+          '0[.]1.065',
+          '1.257[.]515.048',
+          '0[.]515.048',
+        ]),
+      ).toBe('0[.]515.048');
+      expect(
+        xapiStatement.mergeSegments([
+          '0[.]14.352',
+          '14.532[.]119.96',
+          '0[.]119.96',
+        ]),
+      ).toBe('0[.]119.96');
+      expect(
+        xapiStatement.mergeSegments([
+          '0[.]1.333',
+          '1.337[.]36.429',
+          '36.585[.]250.757',
+          '250.762[.]277.599',
+          '250.714[.]250.714',
+        ]),
+      ).toBe(
+        '0[.]1.333[,]1.337[.]36.429[,]36.585[.]250.757[,]250.762[.]277.599',
+      );
     });
   });
 

--- a/src/frontend/packages/lib_components/src/utils/XAPI/VideoXAPIStatement.ts
+++ b/src/frontend/packages/lib_components/src/utils/XAPI/VideoXAPIStatement.ts
@@ -1,4 +1,5 @@
 // https://liveaspankaj.gitbooks.io/xapi-video-profile/content/statement_data_model.html
+import * as Sentry from '@sentry/browser';
 import { Nullable } from 'lib-common';
 import { DateTime, Interval } from 'luxon';
 
@@ -444,7 +445,17 @@ export class VideoXAPIStatement implements VideoXAPIStatementInterface {
     const playedSegments =
       this.playedSegments.length === 0 ? [] : this.playedSegments.split('[,]');
     playedSegments.push(`${this.startSegment}[.]${time}`);
-    this.playedSegments = this.mergeSegments(playedSegments);
+    try {
+      this.playedSegments = this.mergeSegments(playedSegments);
+    } catch (err) {
+      Sentry.withScope(function (scope) {
+        scope.setContext('mergedSegments', {
+          playedSegments,
+        });
+        Sentry.captureException(err);
+      });
+    }
+
     this.startSegment = null;
   }
 }

--- a/src/frontend/packages/lib_components/src/utils/XAPI/VideoXAPIStatement.ts
+++ b/src/frontend/packages/lib_components/src/utils/XAPI/VideoXAPIStatement.ts
@@ -81,21 +81,22 @@ export class VideoXAPIStatement implements VideoXAPIStatementInterface {
           return a[0] - b[0];
         })
         // once sorted, merge overlapped segments
-        .reduce((acc: number[][], curr: number[], i: number): number[][] => {
+        .reduce((acc: number[][], curr: number[]): number[][] => {
           acc.push(curr);
-          if (i === 0) {
+          const lastIndex = acc.length - 1;
+          if (lastIndex === 0) {
             return acc;
           }
           // segment starting point included in previous segment
-          if (acc[i][0] <= acc[i - 1][1]) {
+          if (acc[lastIndex][0] <= acc[lastIndex - 1][1]) {
             // segments included in previous segments
-            if (acc[i][1] <= acc[i - 1][1]) {
-              // remove "i"nth segments
-              acc.splice(i, 1);
+            if (acc[lastIndex][1] <= acc[lastIndex - 1][1]) {
+              // remove last segment
+              acc.splice(lastIndex, 1);
             } else {
               // remove overlapping part of the current segment with the previous segment
-              acc[i - 1][1] = acc[i][1];
-              acc.splice(i, 1);
+              acc[lastIndex - 1][1] = acc[lastIndex][1];
+              acc.splice(lastIndex, 1);
             }
           }
           return acc;


### PR DESCRIPTION
## Purpose

There is a bug in the XapiVideoStatement mergeSegments method. Once a
first overlapsed segment merge, the reduce index does not match anymore
the accumulator lenght because we removed existing index in the previous
iteration. To fix that and keep having valide merged segments at the end
we must use the current accumulator length.

## Proposal

- [x] fix wrong usage of reduce index in xapiVideo mergeSegments 
- [x] add context to sentry exception capture in XapiVideoStatement

Fixes #2218 