### PR TITLE
⬆️(tray) use batch/v1 api in cronjob_pipeline manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - bulk delete for video and classroom
 
+### Changed
+
+- use batch/v1 api in cronjob_pipeline manifest
+
 ### Fixed
 
 - Wrong usage of reduce index in xapiVideo mergeSegments

--- a/src/tray/templates/services/app/cronjob_pipeline.yml.j2
+++ b/src/tray/templates/services/app/cronjob_pipeline.yml.j2
@@ -1,10 +1,10 @@
 {% if marsha_cronjobs | length > 0 %}
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJobList
 items:
 {% for cronjob in marsha_cronjobs %}
 {% if cronjob.enabled | bool %}
-  - apiVersion: batch/v1beta1
+  - apiVersion: batch/v1
     kind: CronJob
     metadata:
       labels:


### PR DESCRIPTION
## Purpose

The bach/v1beta1 API is deprecated since kubernets 1.21 and is removed in version 1.25. We can upgrade the manifests to use it now.

## Proposal

- [x] use batch/v1 api in cronjob_pipeline manifest

