### PR TITLE
✨(lib-video) lti code to copy to clipboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - bulk delete for video and classroom
 - iframe code to copy to clipboard in dashboard VOD and webinar (#2221)
+- lti code to copy to clipboard in dashboard VOD and webinar (#2227)
 
 ### Changed
 

--- a/src/frontend/packages/lib_components/src/common/WidgetsContainer/InfoModal/index.tsx
+++ b/src/frontend/packages/lib_components/src/common/WidgetsContainer/InfoModal/index.tsx
@@ -93,7 +93,11 @@ export const InfoModal = ({
           <StyledTitleText color="blue-active" size="1.125rem" truncate>
             {title}
           </StyledTitleText>
-          <StyledText color="blue-active" size="0.875rem">
+          <StyledText
+            color="blue-active"
+            size="0.875rem"
+            style={{ whiteSpace: 'pre-line' }}
+          >
             {text}
           </StyledText>
         </Box>

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/VisibilityAndInteraction/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/VisibilityAndInteraction/index.spec.tsx
@@ -55,13 +55,24 @@ describe('<VisibilityAndInteraction />', () => {
     expect(visibilityToggleButton).toBeChecked();
     screen.getByText('Make the video publicly available');
 
-    screen.getByText('https://localhost/videos/'.concat(mockedVideo.id));
-    screen.getByRole('button', {
-      name: 'Public link:',
-    });
-    screen.getByRole('button', {
-      name: 'Iframe integration:',
-    });
+    expect(
+      screen.getByText(`https://localhost/videos/${mockedVideo.id}`),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {
+        name: 'Public link:',
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {
+        name: 'Iframe integration:',
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {
+        name: 'LTI link:',
+      }),
+    ).toBeInTheDocument();
   });
 
   it('clicks on the toggle button to make the video publicly available, and copy the public url in clipboard', async () => {
@@ -92,10 +103,15 @@ describe('<VisibilityAndInteraction />', () => {
       screen.queryByRole('button', {
         name: 'Public link:',
       }),
-    ).toBe(null);
-    expect(
-      screen.queryByText('https://localhost/videos/'.concat(mockedVideo.id)),
     ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(`https://localhost/videos/${mockedVideo.id}`),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {
+        name: 'LTI link:',
+      }),
+    ).toBeInTheDocument();
 
     userEvent.click(visibilityToggleButton);
 
@@ -129,7 +145,41 @@ describe('<VisibilityAndInteraction />', () => {
       name: 'Public link:',
     });
     expect(copyButtonReRendered).not.toBeDisabled();
-    screen.getByText('https://localhost/videos/'.concat(mockedVideo.id));
+    expect(
+      screen.getByText(`https://localhost/videos/${mockedVideo.id}`),
+    ).toBeInTheDocument();
+    expect(document.execCommand).toHaveBeenCalledTimes(0);
+
+    userEvent.click(copyButtonReRendered);
+
+    await waitFor(() => expect(document.execCommand).toHaveBeenCalledTimes(1));
+    expect(document.execCommand).toHaveBeenCalledWith('copy');
+    await screen.findByText('Url copied in clipboard !');
+  });
+
+  it('checks the lti link and copy the code in clipboard', async () => {
+    const mockedVideo = videoMockFactory({
+      is_public: false,
+    });
+
+    render(
+      wrapInVideo(
+        <InfoWidgetModalProvider value={null}>
+          <VisibilityAndInteraction />
+        </InfoWidgetModalProvider>,
+        mockedVideo,
+      ),
+    );
+
+    const copyButtonReRendered = screen.getByRole('button', {
+      name: 'LTI link:',
+    });
+    expect(copyButtonReRendered).not.toBeDisabled();
+
+    expect(
+      screen.getByText(`https://localhost/lti/videos/${mockedVideo.id}`),
+    ).toBeInTheDocument();
+
     expect(document.execCommand).toHaveBeenCalledTimes(0);
 
     userEvent.click(copyButtonReRendered);
@@ -230,7 +280,7 @@ describe('<VisibilityAndInteraction />', () => {
     });
     expect(visibilityToggleButton).toBeChecked();
     expect(
-      screen.getByText('https://localhost/videos/'.concat(mockedVideo.id)),
+      screen.getByText(`https://localhost/videos/${mockedVideo.id}`),
     ).toBeInTheDocument();
     const copyButton = screen.getByRole('button', {
       name: 'Public link:',
@@ -267,7 +317,7 @@ describe('<VisibilityAndInteraction />', () => {
 
     await waitFor(() =>
       expect(
-        screen.queryByText('https://localhost/videos/'.concat(mockedVideo.id)),
+        screen.queryByText(`https://localhost/videos/${mockedVideo.id}`),
       ).not.toBeInTheDocument(),
     );
     expect(

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/VisibilityAndInteraction/index.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/VisibilityAndInteraction/index.tsx
@@ -14,8 +14,10 @@ import { useCurrentVideo } from '@lib-video/hooks/useCurrentVideo';
 
 const messages = defineMessages({
   info: {
-    defaultMessage:
-      'This widget allows you to make the video publicly available.',
+    defaultMessage: `This widget allows you to make the video publicly available and provides several links depending on what you want to do: 
+      - Public link: Invite people to participate to this content as guest without any account. 
+      - IFrame Integration: Code to integrate it without control access.
+      - LTI link: Special link used to add this video in your favorite LMS and have it in a course activity.`,
     description: 'Info of the widget used for setting live features.',
     id: 'components.VisibilityAndInteraction.info',
   },
@@ -43,11 +45,11 @@ const messages = defineMessages({
       'A message informing the user on the action of the copy-in-clipboard button.',
     id: 'components.VisibilityAndInteraction.iFrameCopyButtonTitle',
   },
-  publicLinkCopySuccess: {
+  urlCopySuccess: {
     defaultMessage: 'Url copied in clipboard !',
     description:
       "Message displayed when video's publicly available url is copied in clipboard.",
-    id: 'components.VisibilityAndInteraction.publicLinkCopySuccess',
+    id: 'components.VisibilityAndInteraction.urlCopySuccess',
   },
   iFrameCopySuccess: {
     defaultMessage: 'Code copied in clipboard !',
@@ -64,6 +66,11 @@ const messages = defineMessages({
     defaultMessage: 'Video update has failed !',
     description: 'Message displayed when video update has failed.',
     id: 'component.VisibilityAndInteraction.updateVideoFail',
+  },
+  ltiLinkLabel: {
+    defaultMessage: 'LTI link:',
+    description: 'Label for LTI video link.',
+    id: 'component.VisibilityAndInteraction.ltiLinkLabel',
   },
 });
 
@@ -100,14 +107,12 @@ export const VisibilityAndInteraction = () => {
     });
   };
 
-  const publicVideoUrl = window.location.origin
-    .concat('/videos/')
-    .concat(video.id);
-
+  const publicVideoUrl = `${window.location.origin}/videos/${video.id}`;
   const parametersWebinar = video.is_live
     ? 'microphone *; camera *; midi *; display-capture *; '
     : '';
   const iframeCode = `<iframe src="${publicVideoUrl}" allowfullscreen="true" allow="${parametersWebinar}encrypted-media *; autoplay *; fullscreen *" />`;
+  const ltiLink = `${window.location.origin}/lti/videos/${video.id}`;
 
   return (
     <FoldableItem
@@ -128,7 +133,7 @@ export const VisibilityAndInteraction = () => {
             text={publicVideoUrl}
             title={intl.formatMessage(messages.publicLinkCopyButtonTitle)}
             onSuccess={() => {
-              toast(intl.formatMessage(messages.publicLinkCopySuccess), {
+              toast(intl.formatMessage(messages.urlCopySuccess), {
                 icon: '📋',
                 position: 'bottom-center',
               });
@@ -168,6 +173,24 @@ export const VisibilityAndInteraction = () => {
             />
           </Box>
         </Collapsible>
+        <Box>
+          <CopyClipboard
+            copyId={`ltiLink-${video.id}`}
+            text={ltiLink}
+            title={intl.formatMessage(messages.ltiLinkLabel)}
+            withLabel={true}
+            onSuccess={() => {
+              toast(intl.formatMessage(messages.urlCopySuccess), {
+                icon: '📋',
+              });
+            }}
+            onError={(event) => {
+              toast.error(event.text, {
+                position: 'bottom-center',
+              });
+            }}
+          />
+        </Box>
       </Box>
     </FoldableItem>
   );


### PR DESCRIPTION
## Purpose

Feature request: #2208

When the video is_public is toggle on, after the iframe integration box, we added a box with the lti link beeing easily copy/paste.


[Marsha - LTI link.webm](https://user-images.githubusercontent.com/25994652/237046627-d28b2d16-86cd-4a71-9f10-b163cc314a73.webm)


