### PR TITLE
Properly clause websocket connection on video/webinar deletion

### DIFF
--- a/src/backend/marsha/websocket/consumers/video.py
+++ b/src/backend/marsha/websocket/consumers/video.py
@@ -175,8 +175,12 @@ class VideoConsumer(AsyncJsonWebsocketConsumer):
         # Leave room group
         await self.channel_layer.group_discard(self.room_group_name, self.channel_name)
         if not await self._is_admin():
-            live_session = await self.retrieve_live_session()
-            await self.reset_live_session(live_session)
+            try:
+                live_session = await self.retrieve_live_session()
+                await self.reset_live_session(live_session)
+            except ConnectionRefusedError:
+                # No live session found, nothing to do
+                pass
 
     async def video_updated(self, event):
         """Listener for the video_updated event."""

--- a/src/backend/marsha/websocket/tests/test_consumers_video.py
+++ b/src/backend/marsha/websocket/tests/test_consumers_video.py
@@ -655,6 +655,28 @@ class VideoConsumerTest(TransactionTestCase):
 
         await communicator.disconnect()
 
+    async def test_video_delete_channel_layer(self):
+        """Disconnecting from a deleted video should not raise."""
+
+        playlist_access = await self._get_playlist_access(
+            playlist=self.some_video.playlist,
+            role=ADMINISTRATOR,
+        )
+
+        jwt_token = await self._get_user_access_token(user=playlist_access.user)
+
+        communicator = WebsocketCommunicator(
+            base_application,
+            f"ws/video/{self.some_video.id}/?jwt={jwt_token}",
+        )
+
+        connected, _subprotocol = await communicator.connect()
+        self.assertTrue(connected)
+
+        await sync_to_async(self.some_video.delete)()
+
+        await communicator.disconnect()
+
     async def test_thumbnail_update_channel_layer(self):
         """Message received on thumbnail_updated event."""
         thumbnail = await self._get_thumbnail()


### PR DESCRIPTION
## Purpose

When we disconnect fron a websocket, we try to reset matching livesession.
If the video has been deleted, no matching livesession could be found, resulting in an error.

Fixes #2232

## Proposal

If no livesession is found, there is nothing to do to reset it.
A simple try except is added to catch the ConnectionRefusedError we're raising.

