### PR TITLE
🔧(back) configure SOCIAL_AUTH_LOGIN_ERROR_URL setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - lti code to copy to clipboard in dashboard VOD and webinar (#2227)
 - Standalone website:
   - Integrate footer (#2205)
+- Configure SOCIAL_AUTH_LOGIN_ERROR_URL setting
 
 ### Changed
 

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -617,6 +617,8 @@ class Base(Configuration):
         ),
     }
 
+    SOCIAL_AUTH_LOGIN_ERROR_URL = values.Value("/login?error=social-auth")
+
     # SOCIAL_AUTH_SAML_FER_SP_ENTITY_ID should be a URL that includes a domain name you own
     SOCIAL_AUTH_SAML_FER_SP_ENTITY_ID = values.Value()
     # SOCIAL_AUTH_SAML_FER_SP_PUBLIC_CERT X.509 certificate for the key pair that


### PR DESCRIPTION
## Purpose

We are using the SocialAuthExceptionMiddleware but without using the LOGIN_ERROR_URL setting. Without this setting, the user is not redirected to an error page having error info. We want to congiure it in our settings so we declare the setting SOCIAL_AUTH_LOGIN_ERROR_URL

## Proposal

- [x] configure SOCIAL_AUTH_LOGIN_ERROR_URL setting

