### PR TITLE
🐛(frontend) change wording on DeleteVideo modals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - use batch/v1 api in cronjob_pipeline manifest
 - Use jammy for e2e tests
 - Homogenize modal use between standalone_site and LTI
-- Nest frontend api routes of video related objects 
+- Nest frontend api routes of video related objects
   (thumbnails, timed_text_track, shared_live_media...) (#2228)
+- Change wording on modals
 
 ### Fixed
 

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/DeleteVideo/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/DeleteVideo/index.spec.tsx
@@ -180,7 +180,9 @@ describe('<DeleteVideo />', () => {
     });
     userEvent.click(confirmDeleteButton);
 
-    const successMessage = await screen.findByText('Live successfully deleted');
+    const successMessage = await screen.findByText(
+      'Webinar successfully deleted',
+    );
     expect(successMessage).toBeInTheDocument();
   });
 

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/DeleteVideo/index.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/DeleteVideo/index.tsx
@@ -62,7 +62,7 @@ const messages = defineMessages({
     id: 'components.DeleteVideo.videoDeleteSuccess',
   },
   liveDeleteSuccess: {
-    defaultMessage: 'Live successfully deleted',
+    defaultMessage: 'Webinar successfully deleted',
     description: 'Text of the delete confirmation toast.',
     id: 'components.DeleteVideo.liveDeleteSuccess',
   },


### PR DESCRIPTION
use `Webinar` and `VOD` wording for the component to be more explicit


