### PR TITLE
⚡️(frontend) improve transition to classroom dashboard.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Standalone website:
   - Integrate footer (#2205)
   - Display an error when renater auth fails(#2240)
+  - 404 page (#2244)
 - Configure SOCIAL_AUTH_LOGIN_ERROR_URL setting
 - Convert classroom recording to vod
 - Add a middleware to deal with social auth exception

--- a/src/frontend/apps/standalone_site/craco.config.js
+++ b/src/frontend/apps/standalone_site/craco.config.js
@@ -35,6 +35,7 @@ module.exports = {
         ...appModuleNameMapper['website'],
         'react-markdown': '<rootDir>/src/__mock__/react-markdown.tsx',
       },
+      setupFilesAfterEnv: ['<rootDir>/testSetup.js'],
     },
   },
 };

--- a/src/frontend/apps/standalone_site/src/components/Text/Text404.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/components/Text/Text404.spec.tsx
@@ -1,0 +1,14 @@
+import { screen } from '@testing-library/react';
+import { render } from 'lib-tests';
+
+import Text404 from './Text404';
+
+describe('<Text404 />', () => {
+  test('renders Text404', () => {
+    render(<Text404 />);
+
+    expect(
+      screen.getByText(/Sorry, this page does not exist./i),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/frontend/apps/standalone_site/src/components/Text/Text404.tsx
+++ b/src/frontend/apps/standalone_site/src/components/Text/Text404.tsx
@@ -1,0 +1,29 @@
+import { Heading } from 'grommet';
+import { defineMessages, useIntl } from 'react-intl';
+
+const messages = defineMessages({
+  page404: {
+    defaultMessage: 'Sorry, this page does not exist.',
+    description: 'Website page 404',
+    id: 'components.Text.Text404',
+  },
+});
+
+const Text404 = () => {
+  const intl = useIntl();
+
+  return (
+    <Heading
+      level={3}
+      style={{
+        padding: '0.3rem 1rem',
+        maxWidth: '100%',
+      }}
+      alignSelf="center"
+    >
+      {intl.formatMessage(messages.page404)}
+    </Heading>
+  );
+};
+
+export default Text404;

--- a/src/frontend/apps/standalone_site/src/components/Text/index.ts
+++ b/src/frontend/apps/standalone_site/src/components/Text/index.ts
@@ -1,0 +1,1 @@
+export { default as Text404 } from './Text404';

--- a/src/frontend/apps/standalone_site/src/features/Authentication/hooks/useAuthenticator.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Authentication/hooks/useAuthenticator.spec.tsx
@@ -22,7 +22,6 @@ const whoAmIResponse200 = {
 describe('<useAuthenticator />', () => {
   beforeEach(() => {
     localStorage.removeItem('jwt-storage');
-
     useJwt.getState().resetJwt();
     useCurrentUser.setState({
       currentUser: null,
@@ -57,11 +56,16 @@ describe('<useAuthenticator />', () => {
 
     await waitFor(() => expect(result.current.isAuthenticated).toBeTruthy());
     expect(result.current.isLoading).toBeFalsy();
+    expect(useCurrentUser.getState().currentUser).toEqual(whoAmIResponse200);
+    expect(useJwt.getState().internalDecodedJwt).toEqual(
+      'some-internalDecodedJwt',
+    );
   });
 
   it('checks an AnonymousUser', async () => {
     useJwt.setState({
       jwt: 'some-jwt',
+      internalDecodedJwt: 'some-internalDecodedJwt 1234' as any,
     });
     fetchMock.get('/api/users/whoami/', 401);
 
@@ -75,6 +79,10 @@ describe('<useAuthenticator />', () => {
 
     expect(result.current.isLoading).toBeTruthy();
     await waitFor(() => expect(useJwt.getState().jwt).toBeUndefined());
+    await waitFor(() =>
+      expect(useJwt.getState().internalDecodedJwt).toBeUndefined(),
+    );
+    expect(result.current.isLoading).toBeFalsy();
   });
 
   it('checks successfully the authentication with the token parameter', async () => {
@@ -94,6 +102,9 @@ describe('<useAuthenticator />', () => {
     });
 
     await waitFor(() => expect(result.current.isAuthenticated).toBeTruthy());
+    expect(useJwt.getState().internalDecodedJwt).toEqual(
+      'some-internalDecodedJwt',
+    );
   });
 
   it('checks unsuccessfully the authentication with the token parameter', async () => {

--- a/src/frontend/apps/standalone_site/src/features/Authentication/hooks/useAuthenticator.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Authentication/hooks/useAuthenticator.tsx
@@ -24,7 +24,7 @@ export const useAuthenticator = () => {
     currentUser: state.currentUser,
     setCurrentUser: state.setCurrentUser,
   }));
-  const { jwt, setJwt, setRefreshJwt, resetJwt } = useJwt();
+  const { jwt, setJwt, setRefreshJwt, resetJwt, setDecodedJwt } = useJwt();
 
   const [isAuthenticated, setIsAuthenticated] = useState(
     currentUser !== AnonymousUser.ANONYMOUS && !!currentUser,
@@ -89,12 +89,21 @@ export const useAuthenticator = () => {
         return;
       }
 
+      setDecodedJwt(jwt);
       setCurrentUser(_currentUser);
       setIsAuthenticated(true);
       setIsLoading(false);
     };
     fetchUserData();
-  }, [currentUser, jwt, resetJwt, setCurrentUser, history, inviteId]);
+  }, [
+    currentUser,
+    jwt,
+    resetJwt,
+    setCurrentUser,
+    setDecodedJwt,
+    history,
+    inviteId,
+  ]);
 
   return {
     isAuthenticated,

--- a/src/frontend/apps/standalone_site/src/features/Contents/components/ContentsRouter/ContentsRouter.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/components/ContentsRouter/ContentsRouter.spec.tsx
@@ -49,4 +49,14 @@ describe('<ContentsRouter/>', () => {
     expect(screen.getByText('My VideoRouter')).toBeInTheDocument();
     expect(screen.getByText('My LiveRouter')).toBeInTheDocument();
   });
+
+  test('render bad route', () => {
+    render(<ContentsRouter />, {
+      routerOptions: { history: ['/my-contents/bad-road'] },
+    });
+
+    expect(
+      screen.getByText(/Sorry, this page does not exist./i),
+    ).toBeInTheDocument();
+  });
 });

--- a/src/frontend/apps/standalone_site/src/features/Contents/components/ContentsRouter/ContentsRouter.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/components/ContentsRouter/ContentsRouter.tsx
@@ -1,5 +1,6 @@
 import { Route, Switch } from 'react-router-dom';
 
+import { Text404 } from 'components/Text';
 import { Contents } from 'features/Contents';
 import { routes } from 'routes';
 
@@ -10,12 +11,21 @@ const ContentsRouter = () => {
     featureRoutes: state.featureRoutes,
   }));
 
+  const videoPath = routes.CONTENTS.subRoutes.VIDEO.path;
+  const classroomPath = routes.CONTENTS.subRoutes.CLASSROOM.path;
+  const webinarPath = routes.CONTENTS.subRoutes.LIVE.path;
+
   return (
     <Switch>
       <Route path={routes.CONTENTS.path} exact>
         <Contents />
       </Route>
-      <Route>{featureRoutes}</Route>
+      <Route path={[videoPath, classroomPath, webinarPath]}>
+        {featureRoutes}
+      </Route>
+      <Route>
+        <Text404 />
+      </Route>
     </Switch>
   );
 };

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Update/ClassRoomUpdate.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Update/ClassRoomUpdate.spec.tsx
@@ -52,8 +52,6 @@ jest.mock('lib-classroom', () => ({
   ),
 }));
 
-const mockGetDecodedJwt = jest.fn();
-
 describe('<ClassRoomUpdate />', () => {
   beforeEach(() => {
     mockUseParams.mockReturnValue({
@@ -61,7 +59,7 @@ describe('<ClassRoomUpdate />', () => {
     });
     useJwt.setState({
       jwt: 'some token',
-      getDecodedJwt: mockGetDecodedJwt,
+      internalDecodedJwt: ltiPublicTokenMockFactory(),
     });
   });
 
@@ -73,7 +71,6 @@ describe('<ClassRoomUpdate />', () => {
     mockUseParams.mockReturnValue({
       classroomId: '',
     });
-    mockGetDecodedJwt.mockReturnValue(ltiPublicTokenMockFactory());
 
     render(<ClassRoomUpdate />);
 
@@ -83,8 +80,6 @@ describe('<ClassRoomUpdate />', () => {
   });
 
   test('render small screen', () => {
-    mockGetDecodedJwt.mockReturnValue(ltiPublicTokenMockFactory());
-
     render(
       <ResponsiveContext.Provider value="small">
         <ClassRoomUpdate />
@@ -102,8 +97,6 @@ describe('<ClassRoomUpdate />', () => {
   });
 
   test('ressource if viewer invited', () => {
-    mockGetDecodedJwt.mockReturnValue(ltiPublicTokenMockFactory());
-
     render(<ClassRoomUpdate />);
 
     expect(screen.getByText(/My DashboardClassroom/i)).toBeInTheDocument();
@@ -112,12 +105,13 @@ describe('<ClassRoomUpdate />', () => {
   });
 
   test('ressource if moderator invited', () => {
-    mockGetDecodedJwt.mockReturnValue(
-      ltiPublicTokenMockFactory(
+    useJwt.setState({
+      jwt: 'some token',
+      internalDecodedJwt: ltiPublicTokenMockFactory(
         {},
         { can_access_dashboard: true, can_update: true },
       ),
-    );
+    });
 
     render(<ClassRoomUpdate />);
 

--- a/src/frontend/apps/standalone_site/src/features/Profile/components/ProfileRouter.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Profile/components/ProfileRouter.spec.tsx
@@ -1,0 +1,45 @@
+import { screen } from '@testing-library/react';
+import { render } from 'lib-tests';
+
+import { ProfileRouter } from './ProfileRouter';
+
+jest.mock('./ProfilePage', () => ({
+  ProfilePage: () => <div>My ProfilePage</div>,
+}));
+
+jest.mock('./SettingsProfilePage', () => ({
+  SettingsProfilePage: () => <div>My SettingsProfilePage</div>,
+}));
+
+describe('<ProfileRouter/>', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('render route /my-profile', () => {
+    render(<ProfileRouter />, {
+      routerOptions: {
+        history: ['/my-profile'],
+      },
+    });
+    expect(screen.getByText(/My ProfilePage/i)).toBeInTheDocument();
+  });
+
+  test('render route /my-profile/settings', () => {
+    render(<ProfileRouter />, {
+      routerOptions: { history: ['/my-profile/settings'] },
+    });
+
+    expect(screen.getByText(/My SettingsProfilePage/i)).toBeInTheDocument();
+  });
+
+  test('render bad route', () => {
+    render(<ProfileRouter />, {
+      routerOptions: { history: ['/my-profile/bad-road'] },
+    });
+
+    expect(
+      screen.getByText(/Sorry, this page does not exist./i),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/frontend/apps/standalone_site/src/features/Profile/components/ProfileRouter.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Profile/components/ProfileRouter.tsx
@@ -1,7 +1,6 @@
-import { Suspense } from 'react';
 import { Route, Switch } from 'react-router-dom';
 
-import { ContentSpinner } from 'components/Spinner';
+import { Text404 } from 'components/Text';
 import { routes } from 'routes';
 
 import { ProfilePage } from './ProfilePage';
@@ -11,15 +10,15 @@ export const ProfileRouter = () => {
   return (
     <Switch>
       <Route path={routes.PROFILE.path} exact>
-        <Suspense fallback={<ContentSpinner />}>
-          <ProfilePage />
-        </Suspense>
+        <ProfilePage />
       </Route>
 
       <Route path={routes.PROFILE.subRoutes.PROFILE_SETTINGS.path}>
-        <Suspense fallback={<ContentSpinner />}>
-          <SettingsProfilePage />
-        </Suspense>
+        <SettingsProfilePage />
+      </Route>
+
+      <Route>
+        <Text404 />
       </Route>
     </Switch>
   );

--- a/src/frontend/apps/standalone_site/src/routes/AppRoutes.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/routes/AppRoutes.spec.tsx
@@ -184,5 +184,16 @@ describe('<AppRoutes />', () => {
       ).toBeInTheDocument();
       expect(screen.getByText('My Footer')).toBeInTheDocument();
     });
+
+    test('render 404', async () => {
+      render(<AppRoutes />, {
+        routerOptions: {
+          history: ['/my-404'],
+        },
+      });
+      expect(
+        await screen.findByText(/Sorry, this page does not exist./i),
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/src/frontend/apps/standalone_site/src/routes/AppRoutes.tsx
+++ b/src/frontend/apps/standalone_site/src/routes/AppRoutes.tsx
@@ -6,6 +6,7 @@ import { Route, Switch, useHistory, useLocation } from 'react-router-dom';
 
 import { MainLayout } from 'components/Layout';
 import { ContentSpinner } from 'components/Spinner';
+import { Text404 } from 'components/Text';
 import { useAuthenticator } from 'features/Authentication';
 import { Footer } from 'features/Footer';
 import { Header, HeaderLight, HeaderLightLink } from 'features/Header';
@@ -164,6 +165,10 @@ const AuthenticatedRoutes = () => {
               <Suspense fallback={<ContentSpinner />}>
                 <PagesApi />
               </Suspense>
+            </Route>
+
+            <Route>
+              <Text404 />
             </Route>
           </Switch>
         </MainLayout>

--- a/src/frontend/apps/standalone_site/testSetup.js
+++ b/src/frontend/apps/standalone_site/testSetup.js
@@ -1,0 +1,1 @@
+global.use_jwt_persistence = true;

--- a/src/frontend/apps/standalone_site/testSetup.js
+++ b/src/frontend/apps/standalone_site/testSetup.js
@@ -1,1 +1,9 @@
 global.use_jwt_persistence = true;
+const { useJwt } = require('lib-components');
+
+useJwt.setState({
+  setDecodedJwt: () =>
+    useJwt.setState({
+      internalDecodedJwt: 'some-internalDecodedJwt',
+    }),
+});

--- a/src/frontend/packages/lib_classroom/src/components/DashboardClassroom/index.tsx
+++ b/src/frontend/packages/lib_classroom/src/components/DashboardClassroom/index.tsx
@@ -1,10 +1,10 @@
 import { Box } from 'grommet';
 import {
   AnonymousUser,
-  Loader,
   useCurrentResourceContext,
   useCurrentUser,
   Classroom,
+  Spinner,
 } from 'lib-components';
 import React, {
   useState,
@@ -144,9 +144,7 @@ const DashboardClassroom = ({ classroomId }: DashboardClassroomProps) => {
     case 'idle':
     case 'loading':
     default:
-      content = (
-        <Loader aria-label={intl.formatMessage(messages.loadingClassroom)} />
-      );
+      content = <Spinner />;
       break;
 
     case 'error':
@@ -213,7 +211,7 @@ const DashboardClassroom = ({ classroomId }: DashboardClassroomProps) => {
 
   return (
     <Box align="center">
-      <Suspense fallback={<Loader />}>{content}</Suspense>
+      <Suspense fallback={<Spinner />}>{content}</Suspense>
     </Box>
   );
 };

--- a/src/frontend/packages/lib_classroom/src/components/DashboardClassroomInstructor/index.tsx
+++ b/src/frontend/packages/lib_classroom/src/components/DashboardClassroomInstructor/index.tsx
@@ -1,6 +1,6 @@
 import { Box, Button, Grid } from 'grommet';
 import { Breakpoints, Nullable } from 'lib-common';
-import { Loader, Classroom, useResponsive } from 'lib-components';
+import { Classroom, useResponsive, Spinner } from 'lib-components';
 import React, { lazy, Suspense } from 'react';
 import { toast } from 'react-hot-toast';
 import { defineMessages, useIntl } from 'react-intl';
@@ -78,7 +78,7 @@ const DashboardClassroomInstructor = ({
 
   if (!classroom.started) {
     return (
-      <Suspense fallback={<Loader />}>
+      <Suspense fallback={<Spinner />}>
         <DashboardClassroomForm classroom={classroom} />
       </Suspense>
     );
@@ -148,7 +148,7 @@ const DashboardClassroomInstructor = ({
   }
 
   return (
-    <Suspense fallback={<Loader />}>
+    <Suspense fallback={<Spinner />}>
       <DashboardClassroomLayout left={left} right={right} />
     </Suspense>
   );

--- a/src/frontend/packages/lib_components/src/hooks/stores/useJwt/index.spec.tsx
+++ b/src/frontend/packages/lib_components/src/hooks/stores/useJwt/index.spec.tsx
@@ -16,7 +16,14 @@ const TestJwtComponent = ({
 };
 
 describe('useJwt', () => {
-  beforeEach(() => {});
+  beforeEach(() => {
+    useJwt.setState({
+      setDecodedJwt: () =>
+        useJwt.setState({
+          internalDecodedJwt: 'some-internalDecodedJwt' as any,
+        }),
+    });
+  });
 
   afterEach(() => {
     act(() => {

--- a/src/frontend/packages/lib_components/src/hooks/stores/useJwt/index.ts
+++ b/src/frontend/packages/lib_components/src/hooks/stores/useJwt/index.ts
@@ -62,6 +62,7 @@ export const persistentStore = create<JwtStoreInterface>((set, get) => ({
   },
   setJwt: (jwt) => {
     jwt ? localStorage.setItem(JWT_KEY, jwt) : localStorage.removeItem(JWT_KEY);
+    get().setDecodedJwt(jwt);
     set((state) => ({ ...state, jwt }));
   },
   getRefreshJwt() {


### PR DESCRIPTION
## Purpose

When we displayed the dashboard classroom, we had some screens flickering
because the permissions were updating. Now we update the
permissions during the jwt init / checking, like that permissions are
set before the dashboard classroom is displayed.

## Proposal

Description...

- [x] update permission when jwt is setting or checking
- [x] change classroom loader (background didn't look good)
- [x] add 404 text if routes not found
- [x] add jest setup file to standalone

![Marsha - 404](https://github.com/openfun/marsha/assets/25994652/47825a08-cbb9-4ed0-8280-19b6aff28794)


