### PR TITLE
✨(back) add a middleware to deal with social auth exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   - Display an error when renater auth fails(#2240)
 - Configure SOCIAL_AUTH_LOGIN_ERROR_URL setting
 - Convert classroom recording to vod
+- Add a middleware to deal with social auth exception
 
 ### Changed
 

--- a/src/backend/marsha/account/middleware.py
+++ b/src/backend/marsha/account/middleware.py
@@ -1,0 +1,61 @@
+"""Account middleware dealing with social auth exception."""
+from urllib.parse import quote
+
+from django.conf import settings
+from django.shortcuts import redirect
+
+from sentry_sdk import capture_exception
+from social_core.exceptions import SocialAuthBaseException
+
+
+class SocialAuthExceptionMiddleware:
+    """Middleware that handles Social Auth AuthExceptions by providing the user
+    with a message and redirecting to some next location.
+
+    By default, is captured in sentry and they are
+    redirected to the location specified in the SOCIAL_AUTH_LOGIN_ERROR_URL
+    setting.
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        return self.get_response(request)
+
+    def process_exception(self, request, exception):
+        """Process the exception if it's a social_core exceptions.
+        Redirect the user to SOCIAL_AUTH_LOGIN_ERROR_URL if defined and
+        capture the exception in sentry"""
+        strategy = getattr(request, "social_strategy", None)
+        if strategy is None or self.raise_exception(request):
+            return None
+
+        if isinstance(exception, SocialAuthBaseException):
+            backend = getattr(request, "backend", None)
+            backend_name = getattr(backend, "name", "unknown-backend")
+
+            url = self.get_redirect_uri(request)
+
+            if url:
+                message = str(exception)
+                url += (
+                    "?" in url and "&" or "?"
+                ) + f"message={quote(message)}&backend={backend_name}"
+                capture_exception(exception)
+                return redirect(url)
+
+        return None
+
+    def raise_exception(self, request):
+        """Determine if the exception should be raised or not."""
+        strategy = getattr(request, "social_strategy", None)
+        if strategy is not None:
+            return strategy.setting("RAISE_EXCEPTIONS", settings.DEBUG)
+
+        return True
+
+    def get_redirect_uri(self, request):
+        """Get the redirected url."""
+        strategy = getattr(request, "social_strategy", None)
+        return strategy.setting("LOGIN_ERROR_URL")

--- a/src/backend/marsha/account/tests/test_middleware.py
+++ b/src/backend/marsha/account/tests/test_middleware.py
@@ -1,0 +1,50 @@
+"""Test SocialAuthExceptionMiddleware."""
+from unittest import mock
+
+from django.conf import settings
+from django.http import HttpResponseRedirect
+from django.test import TestCase, override_settings
+from django.urls import reverse
+
+from social_core.exceptions import AuthFailed
+
+
+@override_settings(
+    AUTHENTICATION_BACKENDS=["marsha.account.tests.utils.MockedAuthFailedFERSAMLAuth"]
+)
+class TestMiddleware(TestCase):
+    """Test SocialAuthExceptionMiddleware."""
+
+    def setUp(self):
+        """Define complete url."""
+        self.complete_url = reverse(
+            "account:social:complete", kwargs={"backend": "saml_fer"}
+        )
+        self.complete_url += "?RelayState=marsha-local-idp"
+
+    @override_settings()
+    def test_exception(self):
+        """Without SOCIAL_AUTH_LOGIN_ERROR_URL the exception should bubble."""
+        del settings.SOCIAL_AUTH_LOGIN_ERROR_URL
+        with self.assertRaises(AuthFailed), mock.patch(
+            "marsha.account.middleware.capture_exception"
+        ) as sentry_capture_exception:
+            self.assertFalse(sentry_capture_exception.called)
+            self.client.post(self.complete_url, {"SAMLResponse": "dummy-response"})
+
+    @override_settings(SOCIAL_AUTH_LOGIN_ERROR_URL="/")
+    def test_return_url(self):
+        """When SOCIAL_AUTH_LOGIN_ERROR_URL is defined, should be redirected to it
+        with message and backend query string."""
+        with mock.patch(
+            "marsha.account.middleware.capture_exception"
+        ) as sentry_capture_exception:
+            response = self.client.post(
+                self.complete_url, {"SAMLResponse": "dummy-response"}
+            )
+            self.assertTrue(sentry_capture_exception.called)
+        self.assertTrue(isinstance(response, HttpResponseRedirect))
+        self.assertEqual(
+            response.url,
+            "/?message=Authentication%20failed%3A%20SAML%20login%20failed&backend=saml_fer",
+        )

--- a/src/backend/marsha/account/tests/test_social_pipeline_organization.py
+++ b/src/backend/marsha/account/tests/test_social_pipeline_organization.py
@@ -3,12 +3,10 @@
 from django.test import TestCase
 
 from social_django.utils import load_strategy
-from social_edu_federation.backends.saml_fer import FERSAMLAuth
-from social_edu_federation.testing.certificates import get_dev_certificate
 
 from marsha.account.models import IdpOrganizationAssociation
 from marsha.account.social_pipeline.organization import create_organization_from_saml
-from marsha.account.tests.utils import override_saml_fer_settings
+from marsha.account.tests.utils import MockedFERSAMLAuth, override_saml_fer_settings
 from marsha.core.factories import OrganizationFactory, UserFactory
 from marsha.core.models import (
     INSTRUCTOR,
@@ -17,38 +15,6 @@ from marsha.core.models import (
     Organization,
     OrganizationAccess,
 )
-
-
-class MockedFERSAMLAuth(FERSAMLAuth):
-    """Mocking the base SAML backend to ease testing."""
-
-    def __init__(
-        self,
-        *args,
-        idp_name="marsha-local-idp",
-        entity_id="http://marcha.local/idp/",
-        organization_display_name="Marsha organization",
-        **kwargs
-    ):
-        super().__init__(*args, **kwargs)
-        self.idp_name = idp_name
-        self.entity_id = entity_id
-        self.organization_display_name = organization_display_name
-
-    def get_idp(self, idp_name):
-        """Always return our simple Identity Provider configuration."""
-        return self.edu_fed_saml_idp_class.create_from_config_dict(
-            name=self.idp_name,
-            entityId=self.entity_id,
-            singleSignOnService={"url": "http://marcha.local/idp/sso/"},  # unused
-            singleLogoutService={"url": "http://marcha.local/idp/slo/"},  # unused
-            x509cert=get_dev_certificate(),  # unused
-            edu_fed_data={
-                "display_name": "Marsha local IdP",  # unused
-                "organization_name": "Marsha organization name",  # unused
-                "organization_display_name": self.organization_display_name,
-            },
-        )
 
 
 @override_saml_fer_settings()

--- a/src/backend/marsha/account/tests/utils.py
+++ b/src/backend/marsha/account/tests/utils.py
@@ -1,7 +1,50 @@
 """Defines testing settings for the SAML FER authentication."""
 from django.test import override_settings
 
+from social_core.exceptions import AuthFailed
+from social_edu_federation.backends.saml_fer import FERSAMLAuth
+from social_edu_federation.testing.certificates import get_dev_certificate
 from social_edu_federation.testing.settings import saml_fer_settings
+
+
+class MockedFERSAMLAuth(FERSAMLAuth):
+    """Mocking the base SAML backend to ease testing."""
+
+    def __init__(
+        self,
+        *args,
+        idp_name="marsha-local-idp",
+        entity_id="http://marcha.local/idp/",
+        organization_display_name="Marsha organization",
+        **kwargs
+    ):
+        super().__init__(*args, **kwargs)
+        self.idp_name = idp_name
+        self.entity_id = entity_id
+        self.organization_display_name = organization_display_name
+
+    def get_idp(self, idp_name):
+        """Always return our simple Identity Provider configuration."""
+        return self.edu_fed_saml_idp_class.create_from_config_dict(
+            name=self.idp_name,
+            entityId=self.entity_id,
+            singleSignOnService={"url": "http://marcha.local/idp/sso/"},  # unused
+            singleLogoutService={"url": "http://marcha.local/idp/slo/"},  # unused
+            x509cert=get_dev_certificate(),  # unused
+            edu_fed_data={
+                "display_name": "Marsha local IdP",  # unused
+                "organization_name": "Marsha organization name",  # unused
+                "organization_display_name": self.organization_display_name,
+            },
+        )
+
+
+class MockedAuthFailedFERSAMLAuth(MockedFERSAMLAuth):
+    """Mocking the base SAML backend with auth complete failure."""
+
+    def auth_complete(self, *args, **kwargs):
+        """Raise an AuthFailed exception to ease failure test."""
+        raise AuthFailed(self, "SAML login failed")
 
 
 class override_saml_fer_settings(override_settings):  # pylint: disable=invalid-name

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -150,7 +150,7 @@ class Base(Configuration):
         "django.middleware.clickjacking.XFrameOptionsMiddleware",
         "dockerflow.django.middleware.DockerflowMiddleware",
         "waffle.middleware.WaffleMiddleware",
-        "social_django.middleware.SocialAuthExceptionMiddleware",
+        "marsha.account.middleware.SocialAuthExceptionMiddleware",
     ]
 
     ROOT_URLCONF = "marsha.urls"


### PR DESCRIPTION
## Purpose

The middleware provided by django social auth to redirect the user to an error page when an authentification failure exception is raised does not match our need and we can't customize it like we want. We want to redirect the user to an error page, display the error message and we don't want to lose the exception. For this, the exception is captured by sentry, then the user is redirected and the message is added in the query string.

## Proposal

- [x] Add a middleware to deal with social auth exception
