### PR TITLE
Bulk delete resources (videos, webinars and classrooms)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Add checkbox of recording consent (#2259)
 - Setting for instructor classroom invitation link expiration
 - Add a downloadable ICS file to scheduled student classrooms
+- frontend bulk delete for videos, webinars and classrooms
 
 ### Fixed
 

--- a/src/backend/marsha/bbb/api.py
+++ b/src/backend/marsha/bbb/api.py
@@ -100,19 +100,22 @@ class ClassroomViewSet(
                     )
                 )
             ]
-        elif self.action in ["destroy"]:
+        elif self.action in ["destroy", "bulk_destroy"]:
             # Not available in LTI
             # For standalone site, only playlist admin or organization admin can access
             permission_classes = [
-                core_permissions.IsObjectPlaylistAdminOrInstructor
-                | core_permissions.IsObjectPlaylistOrganizationAdmin
+                core_permissions.UserIsAuthenticated
+                & (
+                    core_permissions.IsObjectPlaylistAdminOrInstructor
+                    | core_permissions.IsObjectPlaylistOrganizationAdmin
+                )
             ]
         elif self.action in ["retrieve", "service_join"]:
             permission_classes = [
                 core_permissions.IsTokenResourceRouteObject
                 | IsClassroomPlaylistOrOrganizationAdmin
             ]
-        elif self.action in ["list", "bulk_destroy"]:
+        elif self.action in ["list"]:
             permission_classes = [core_permissions.UserIsAuthenticated]
         else:
             permission_classes = self.permission_classes

--- a/src/backend/marsha/core/api/video.py
+++ b/src/backend/marsha/core/api/video.py
@@ -138,7 +138,7 @@ class VideoViewSet(
                 | permissions.IsObjectPlaylistAdminOrInstructor
                 | permissions.IsObjectPlaylistOrganizationAdmin
             ]
-        elif self.action in ["list", "metadata", "bulk_destroy"]:
+        elif self.action in ["list", "metadata"]:
             # Anyone authenticated can list videos (results are filtered in action)
             # or access metadata
             permission_classes = [permissions.UserOrResourceIsAuthenticated]
@@ -153,12 +153,15 @@ class VideoViewSet(
                     & (permissions.IsTokenInstructor | permissions.IsTokenAdmin)
                 )
             ]
-        elif self.action in ["destroy"]:
+        elif self.action in ["destroy", "bulk_destroy"]:
             # Not available in LTI
             # For standalone site, only playlist admin or organization admin can access
             permission_classes = [
-                permissions.IsObjectPlaylistAdminOrInstructor
-                | permissions.IsObjectPlaylistOrganizationAdmin
+                permissions.IsAuthenticated
+                & (
+                    permissions.IsObjectPlaylistAdminOrInstructor
+                    | permissions.IsObjectPlaylistOrganizationAdmin
+                )
             ]
         elif self.action in ["initiate_live"]:
             permission_classes = [

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/ClassRoomRouter.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/ClassRoomRouter.spec.tsx
@@ -33,7 +33,7 @@ describe('<ClassRoomRouter/>', () => {
     jest.resetAllMocks();
   });
 
-  test('render route /my-contents/classroom?playlist=test-playlist-id', () => {
+  it('renders route /my-contents/classroom?playlist=test-playlist-id', () => {
     render(<ClassRoomRouter />, {
       routerOptions: {
         history: ['/my-contents/classroom?playlist=test-playlist-id'],
@@ -45,7 +45,7 @@ describe('<ClassRoomRouter/>', () => {
     ).toBeInTheDocument();
   });
 
-  test('render classroom no match', () => {
+  it('renders classroom no match', () => {
     render(<ClassRoomRouter />, {
       routerOptions: { history: ['/some/bad/route'] },
     });
@@ -53,7 +53,7 @@ describe('<ClassRoomRouter/>', () => {
     expect(screen.queryByText(/My ClassroomsRead/i)).not.toBeInTheDocument();
   });
 
-  test('render create classroom', () => {
+  it('renders create classroom', () => {
     render(<ClassRoomRouter />, {
       routerOptions: { history: ['/my-contents/classroom/create'] },
     });
@@ -61,7 +61,7 @@ describe('<ClassRoomRouter/>', () => {
     expect(screen.getByText(/My ClassroomsRead/i)).toBeInTheDocument();
   });
 
-  test('render update classroom', () => {
+  it('renders update classroom', () => {
     render(<ClassRoomRouter />, {
       routerOptions: { history: ['/my-contents/classroom/123456'] },
     });
@@ -69,7 +69,7 @@ describe('<ClassRoomRouter/>', () => {
     expect(screen.queryByText('Invited')).not.toBeInTheDocument();
   });
 
-  test('render invite classroom', () => {
+  it('renders invite classroom', () => {
     render(<ClassRoomRouter />, {
       routerOptions: {
         history: ['/my-contents/classroom/123456/invite/123456'],
@@ -78,7 +78,7 @@ describe('<ClassRoomRouter/>', () => {
     expect(screen.getByText('My ClassRoomUpdate')).toBeInTheDocument();
   });
 
-  test('render invite classroom without inviteId', () => {
+  it('renders invite classroom without inviteId', () => {
     render(<ClassRoomRouter />, {
       routerOptions: {
         history: ['/my-contents/classroom/123456/invite/'],

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Read/ClassRoomItem.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Read/ClassRoomItem.spec.tsx
@@ -1,8 +1,12 @@
-import { getDefaultNormalizer, screen } from '@testing-library/react';
+import { getDefaultNormalizer, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { classroomMockFactory } from 'lib-classroom';
 import { playlistMockFactory } from 'lib-components';
 import { render } from 'lib-tests';
 import React from 'react';
+import { act } from 'react-dom/test-utils';
+
+import { useSelectFeatures } from 'features/Contents/store/selectionStore';
 
 import ClassRoom from './ClassRoomItem';
 
@@ -19,7 +23,7 @@ const classroom = {
 };
 
 describe('<ClassRoom />', () => {
-  test('renders ClassRoom', () => {
+  it('renders ClassRoom', () => {
     render(<ClassRoom classroom={classroomMockFactory(classroom)} />);
 
     expect(screen.getByText(/Welcome!/i)).toBeInTheDocument();
@@ -34,5 +38,34 @@ describe('<ClassRoom />', () => {
     ).toBeInTheDocument();
     expect(screen.getByText('01:23:00')).toBeInTheDocument();
     expect(screen.getByText('Nouvelle Playlist title')).toBeInTheDocument();
+  });
+
+  it('successfully selects and unselects a classroom', async () => {
+    const classroom = classroomMockFactory({
+      id: '4321',
+      title: 'New classroom title',
+      description: 'New video description',
+      playlist: {
+        ...classroomMockFactory().playlist,
+        title: 'New playlist title',
+      },
+    });
+    render(<ClassRoom classroom={classroom} />);
+
+    act(() =>
+      useSelectFeatures.setState({
+        isSelectionEnabled: true,
+        selectedItems: [],
+      }),
+    );
+
+    const videoCardCheckBox = screen.getByRole('checkbox');
+    expect(videoCardCheckBox).not.toBeChecked();
+
+    const card = screen.getByRole('contentinfo');
+    userEvent.click(card);
+    await waitFor(() => expect(videoCardCheckBox).toBeChecked());
+    userEvent.click(card);
+    await waitFor(() => expect(videoCardCheckBox).not.toBeChecked());
   });
 });

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Read/ClassRoomItem.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Read/ClassRoomItem.tsx
@@ -1,4 +1,4 @@
-import { Text, Box } from 'grommet';
+import { Text, Box, CheckBox } from 'grommet';
 import { FormSchedule, InProgress } from 'grommet-icons';
 import {
   ClassroomLite,
@@ -6,11 +6,12 @@ import {
   ContentCard,
   TextTruncated,
 } from 'lib-components';
-import { Fragment } from 'react';
+import { Fragment, useEffect, useState } from 'react';
 import { useIntl } from 'react-intl';
 
 import { ReactComponent as VueListIcon } from 'assets/svg/iko_vuelistesvg.svg';
 import { ReactComponent as ClassroomsIcon } from 'assets/svg/iko_webinairesvg.svg';
+import { useSelectFeatures } from 'features/Contents/store/selectionStore';
 import { routes } from 'routes';
 import { localDate } from 'utils/date';
 
@@ -18,9 +19,33 @@ const ClassRoom = ({ classroom }: { classroom: ClassroomLite }) => {
   const intl = useIntl();
   const classroomPath = routes.CONTENTS.subRoutes.CLASSROOM.path;
 
+  const { isSelectionEnabled, selectedItems, selectItem } = useSelectFeatures();
+  const [isClassroomSelected, setIsClassroomSelected] = useState<boolean>(
+    () => selectedItems.includes(classroom.id) || false,
+  );
+
+  useEffect(() => {
+    if (!isSelectionEnabled) {
+      setIsClassroomSelected(false);
+    }
+  }, [isSelectionEnabled, setIsClassroomSelected]);
+
   return (
-    <StyledLink to={`${classroomPath}/${classroom.id}`}>
+    <StyledLink
+      to={isSelectionEnabled ? '#' : `${classroomPath}/${classroom.id}`}
+    >
       <ContentCard
+        style={
+          isClassroomSelected
+            ? {
+                boxShadow:
+                  'inset 0px 0px 0px 0px #45a3ff, #81ade6 1px 1px 1px 9px',
+              }
+            : undefined
+        }
+        onClick={() =>
+          selectItem(classroom.id, isClassroomSelected, setIsClassroomSelected)
+        }
         header={
           <Box
             width="100%"
@@ -28,7 +53,19 @@ const ClassRoom = ({ classroom }: { classroom: ClassroomLite }) => {
             align="center"
             justify="center"
             background="radial-gradient(ellipse at center, #8682bc 0%,#6460c3 100%);"
+            style={{ position: 'relative' }}
           >
+            <Box
+              style={{
+                position: 'absolute',
+                top: '21px',
+                left: '21px',
+                background: 'white',
+                borderRadius: '6px',
+              }}
+            >
+              {isSelectionEnabled && <CheckBox checked={isClassroomSelected} />}
+            </Box>
             <ClassroomsIcon width={70} height={70} color="white" />
             <Text
               weight="bold"

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/Create/LiveCreate.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/Create/LiveCreate.spec.tsx
@@ -1,6 +1,11 @@
+import { useJwt } from '@lib-components/hooks';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import fetchMock from 'fetch-mock';
 import { render } from 'lib-tests';
+import { act } from 'react-dom/test-utils';
+
+import { useSelectFeatures } from 'features/Contents/store/selectionStore';
 
 import LiveCreate from './LiveCreate';
 
@@ -10,20 +15,184 @@ jest.mock('./LiveCreateForm', () => ({
 }));
 
 describe('<LiveCreate />', () => {
-  test('renders LiveCreate', () => {
+  beforeEach(() => {
+    useJwt.setState({
+      jwt: 'json web token',
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    fetchMock.restore();
+  });
+
+  it('renders LiveCreate', () => {
     render(<LiveCreate />);
 
-    const button = screen.getByRole('button', { name: /Create Webinar/i });
-    expect(button).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Create Webinar/i }),
+    ).toBeInTheDocument();
     expect(
       screen.queryByRole('heading', { name: /Create Webinar/i }),
     ).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Select' })).toBeInTheDocument();
+  });
 
-    userEvent.click(button);
+  it('shows video creation Modal', () => {
+    render(<LiveCreate />);
+    const createButton = screen.getByRole('button', {
+      name: /Create Webinar/i,
+    });
+    userEvent.click(createButton);
 
     expect(
       screen.getByRole('heading', { name: /Create Webinar/i }),
     ).toBeInTheDocument();
     expect(screen.getByText('My WebinarCreate Form')).toBeInTheDocument();
+  });
+
+  it('switches into selection mode on select button click', () => {
+    render(<LiveCreate />);
+    const selectButton = screen.getByRole('button', { name: 'Select' });
+    userEvent.click(selectButton);
+    expect(
+      screen.queryByRole('button', { name: 'Select' }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Delete 0 webinar' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Delete 0 webinar' }),
+    ).toBeDisabled();
+  });
+
+  it('counts the right amount of selected items (1)', () => {
+    render(<LiveCreate />);
+    act(() =>
+      useSelectFeatures.setState({
+        isSelectionEnabled: true,
+        selectedItems: ['id1'],
+      }),
+    );
+    expect(
+      screen.queryByRole('button', { name: 'Select' }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Delete 1 webinar' }),
+    ).toBeInTheDocument();
+  });
+
+  it('counts the right amount of selected items (3)', () => {
+    render(<LiveCreate />);
+    act(() =>
+      useSelectFeatures.setState({
+        isSelectionEnabled: true,
+        selectedItems: ['id1', 'id2', 'id3'],
+      }),
+    );
+    expect(
+      screen.queryByRole('button', { name: 'Select' }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Delete 3 webinars' }),
+    ).toBeInTheDocument();
+  });
+
+  it('opens the delete confirmation modal', () => {
+    render(<LiveCreate />);
+    act(() =>
+      useSelectFeatures.setState({
+        isSelectionEnabled: true,
+        selectedItems: ['id1', 'id2', 'id3'],
+      }),
+    );
+    const deleteButon = screen.getByRole('button', {
+      name: 'Delete 3 webinars',
+    });
+    userEvent.click(deleteButon);
+
+    expect(screen.getByText('Confirm delete 3 webinars')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Are you sure you want to delete 3 webinars ? This action is irreversible.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('successfully deletes lives', async () => {
+    fetchMock.delete('/api/videos/', {
+      status: 204,
+      body: { ids: ['id1', 'id2'] },
+    });
+
+    render(<LiveCreate />);
+    act(() =>
+      useSelectFeatures.setState({
+        isSelectionEnabled: true,
+        selectedItems: ['id1', 'id2'],
+      }),
+    );
+    const deleteButon = screen.getByRole('button', {
+      name: 'Delete 2 webinars',
+    });
+    userEvent.click(deleteButon);
+
+    const confirmDeleteButton = screen.getByRole('button', {
+      name: 'Confirm delete 2 webinars',
+    });
+    userEvent.click(confirmDeleteButton);
+
+    expect(
+      await screen.findByText('2 webinars successfully deleted'),
+    ).toBeInTheDocument();
+
+    expect(fetchMock.lastCall()![0]).toEqual(`/api/videos/`);
+    expect(fetchMock.lastCall()![1]).toEqual({
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: `{"ids":["id1","id2"]}`,
+      method: 'DELETE',
+    });
+  });
+
+  it('fails to delete lives', async () => {
+    fetchMock.delete('/api/videos/', {
+      status: 400,
+      body: { ids: ['id1', 'id2'] },
+    });
+
+    render(<LiveCreate />);
+    act(() =>
+      useSelectFeatures.setState({
+        isSelectionEnabled: true,
+        selectedItems: ['id1', 'id2'],
+      }),
+    );
+    const deleteButon = screen.getByRole('button', {
+      name: 'Delete 2 webinars',
+    });
+    userEvent.click(deleteButon);
+
+    const confirmDeleteButton = screen.getByRole('button', {
+      name: 'Confirm delete 2 webinars',
+    });
+    userEvent.click(confirmDeleteButton);
+
+    expect(
+      await screen.findByText('Failed to delete 2 webinars'),
+    ).toBeInTheDocument();
+
+    expect(fetchMock.lastCall()![0]).toEqual(`/api/videos/`);
+    expect(fetchMock.lastCall()![1]).toEqual({
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: `{"ids":["id1","id2"]}`,
+      method: 'DELETE',
+    });
   });
 });

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/Create/LiveCreate.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/Create/LiveCreate.tsx
@@ -1,10 +1,14 @@
-import { Button, Heading, Text } from 'grommet';
-import { Modal } from 'lib-components';
-import { Fragment } from 'react';
+import { Box, Button, Heading, Text } from 'grommet';
+import { ButtonLoaderStyle, Modal, ModalButton, report } from 'lib-components';
+import { useDeleteVideos } from 'lib-video';
+import { Fragment, useEffect, useState } from 'react';
+import toast from 'react-hot-toast';
 import { defineMessages, useIntl } from 'react-intl';
 import { Link, Route, Switch, useHistory } from 'react-router-dom';
+import styled from 'styled-components';
 
 import { ContentsHeader } from 'features/Contents';
+import { useSelectFeatures } from 'features/Contents/store/selectionStore';
 import { routes } from 'routes';
 
 import LiveCreateForm from './LiveCreateForm';
@@ -20,7 +24,51 @@ const messages = defineMessages({
     description: 'Text heading create webinar.',
     id: 'features.Contents.features.Webinar.Create.CreateWebinarLabel',
   },
+  SelectButtonLabel: {
+    defaultMessage: 'Select',
+    description: 'Button label to select webinars.',
+    id: 'features.Contents.features.Webinar.Create.SelectButtonLabel',
+  },
+  DeleteButtonLabel: {
+    defaultMessage: `Delete {item_count, plural,  =0 {0 webinar} one {# webinar} other {# webinars}}`,
+    description: 'Button label to delete webinar.',
+    id: 'features.Contents.features.Webinar.Create.DeleteButtonSingularLabel',
+  },
+  CancelSelectionLabel: {
+    defaultMessage: 'Cancel',
+    description: 'Button label to cancel webinar selection.',
+    id: 'features.Contents.features.Webinar.Create.CancelSelectionLabel',
+  },
+  webinarsDeleteModalTitle: {
+    defaultMessage: `Delete {item_count, plural, one {# webinar} other {# webinars}}`,
+    description: 'Title of the webinar delete modal.',
+    id: 'features.Contents.features.Webinar.Create.webinarDeleteModalTitle',
+  },
+  confirmDeleteWebinarsTitle: {
+    defaultMessage: `Confirm delete {item_count, plural,  =0 {0 webinar} one {# webinar} other {# webinars}}`,
+    description: 'Title of the widget used for webinar delete confirmation.',
+    id: 'features.Contents.features.Webinar.Create.confirmDeleteWebinarsTitle',
+  },
+  confirmDeleteWebinarsText: {
+    defaultMessage: `Are you sure you want to delete {item_count, plural, one {# webinar} other {# webinars}} ? This action is irreversible.`,
+    description: 'Text of the widget used for webinar delete confirmation.',
+    id: 'features.Contents.features.Webinar.Create.confirmDeleteWebinarsText',
+  },
+  webinarsDeleteSuccess: {
+    defaultMessage: `{item_count, plural, one {# webinar} other {# webinars}} successfully deleted`,
+    description: 'Text of the webinar delete confirmation toast.',
+    id: 'features.Contents.features.Webinar.Create.webinarsDeleteSuccess',
+  },
+  webinarsDeleteError: {
+    defaultMessage: `Failed to delete {item_count, plural, one {# webinar} other {# webinars}}`,
+    description: 'Text of the webinar delete error toast.',
+    id: 'features.Contents.features.Webinar.Create.webinarsDeleteError',
+  },
 });
+
+const ButtonStyled = styled(Button)`
+  color: white;
+`;
 
 const LiveCreate = () => {
   const intl = useIntl();
@@ -29,6 +77,44 @@ const LiveCreate = () => {
   const liveRoute = routes.CONTENTS.subRoutes.LIVE;
   const livePath = liveRoute.path;
   const liveCreatePath = liveRoute.subRoutes?.CREATE?.path || '';
+  const {
+    isSelectionEnabled,
+    switchSelectEnabled,
+    resetSelection,
+    selectedItems,
+  } = useSelectFeatures();
+
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState<boolean>(false);
+
+  const deleteLives = useDeleteVideos({
+    onSuccess: () => {
+      toast.success(
+        intl.formatMessage(messages.webinarsDeleteSuccess, {
+          item_count: selectedItems.length,
+        }),
+        {
+          position: 'bottom-center',
+        },
+      );
+    },
+    onError: (err: unknown) => {
+      report(err);
+      toast.error(
+        intl.formatMessage(messages.webinarsDeleteError, {
+          item_count: selectedItems.length,
+        }),
+        {
+          position: 'bottom-center',
+        },
+      );
+    },
+  });
+
+  useEffect(() => {
+    if (!isSelectionEnabled) {
+      resetSelection();
+    }
+  }, [isSelectionEnabled, resetSelection]);
 
   return (
     <Fragment>
@@ -36,12 +122,40 @@ const LiveCreate = () => {
         <Text size="large" weight="bold">
           {intl.formatMessage(messages.WebinarTitle)}
         </Text>
-        <Link to={liveCreatePath}>
-          <Button
-            primary
-            label={intl.formatMessage(messages.CreateWebinarLabel)}
-          />
-        </Link>
+        {!isSelectionEnabled && (
+          <Box direction="row" gap="small">
+            <Button
+              secondary
+              label={intl.formatMessage(messages.SelectButtonLabel)}
+              onClick={switchSelectEnabled}
+            />
+
+            <Link to={liveCreatePath}>
+              <Button
+                primary
+                label={intl.formatMessage(messages.CreateWebinarLabel)}
+              />
+            </Link>
+          </Box>
+        )}
+        {isSelectionEnabled && (
+          <Box direction="row" gap="small">
+            <Button
+              secondary
+              label={intl.formatMessage(messages.CancelSelectionLabel)}
+              onClick={switchSelectEnabled}
+            />
+            <ButtonStyled
+              primary
+              color="action-danger"
+              label={intl.formatMessage(messages.DeleteButtonLabel, {
+                item_count: selectedItems.length,
+              })}
+              disabled={selectedItems.length < 1}
+              onClick={() => setIsDeleteModalOpen(true)}
+            />
+          </Box>
+        )}
       </ContentsHeader>
       <Switch>
         <Route path={liveCreatePath} exact>
@@ -63,6 +177,41 @@ const LiveCreate = () => {
           </Modal>
         </Route>
       </Switch>
+      <Modal
+        isOpen={isDeleteModalOpen}
+        onClose={() => {
+          setIsDeleteModalOpen(false);
+        }}
+      >
+        <Heading
+          size="3"
+          alignSelf="center"
+          margin={{ top: '0', bottom: 'small' }}
+        >
+          {intl.formatMessage(messages.webinarsDeleteModalTitle, {
+            item_count: selectedItems.length,
+          })}
+        </Heading>
+        <Text margin={{ top: 'small' }}>
+          {intl.formatMessage(messages.confirmDeleteWebinarsText, {
+            item_count: selectedItems.length,
+          })}
+        </Text>
+        <ModalButton
+          label={intl.formatMessage(messages.confirmDeleteWebinarsTitle, {
+            item_count: selectedItems.length,
+          })}
+          onClickCancel={() => {
+            setIsDeleteModalOpen(false);
+          }}
+          onClickSubmit={() => {
+            deleteLives.mutate({ ids: selectedItems });
+            setIsDeleteModalOpen(false);
+            switchSelectEnabled();
+          }}
+          style={ButtonLoaderStyle.DESTRUCTIVE}
+        />
+      </Modal>
     </Fragment>
   );
 };

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/LiveRouter.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/LiveRouter.spec.tsx
@@ -33,7 +33,7 @@ describe('<LiveRouter/>', () => {
     jest.resetAllMocks();
   });
 
-  test('render route /my-contents/webinars?playlist=test-playlist-id', () => {
+  it('renders route /my-contents/webinars?playlist=test-playlist-id', () => {
     render(<LiveRouter />, {
       routerOptions: {
         history: ['/my-contents/webinars?playlist=test-playlist-id'],
@@ -46,7 +46,7 @@ describe('<LiveRouter/>', () => {
     ).toBeInTheDocument();
   });
 
-  test('render create live', () => {
+  it('renders create live', () => {
     render(<LiveRouter />, {
       routerOptions: { history: ['/my-contents/webinars/create'] },
     });
@@ -54,7 +54,7 @@ describe('<LiveRouter/>', () => {
     expect(screen.getByText(/My Lives Read/i)).toBeInTheDocument();
   });
 
-  test('render live no match', () => {
+  it('renders live no match', () => {
     render(<LiveRouter />, {
       routerOptions: { history: ['/some/bad/route'] },
     });
@@ -63,7 +63,7 @@ describe('<LiveRouter/>', () => {
     expect(screen.queryByText('My Lives Read')).not.toBeInTheDocument();
   });
 
-  test('render update video', () => {
+  it('renders update live', () => {
     render(<LiveRouter />, {
       routerOptions: {
         history: ['/my-contents/webinars/123456/'],

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/Read/Live.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/Read/Live.spec.tsx
@@ -1,11 +1,15 @@
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { thumbnailMockFactory, videoMockFactory } from 'lib-components';
 import { render } from 'lib-tests';
+import { act } from 'react-dom/test-utils';
+
+import { useSelectFeatures } from 'features/Contents/store/selectionStore';
 
 import Live from './Live';
 
 describe('<Live />', () => {
-  test('renders Live', () => {
+  it('renders Live', () => {
     const live = videoMockFactory({
       id: '4321',
       title: 'New webinar title',
@@ -33,7 +37,7 @@ describe('<Live />', () => {
     );
   });
 
-  test('renders thumbnail', () => {
+  it('renders thumbnail', () => {
     const live = videoMockFactory({
       id: '4321',
       title: 'New webinar title',
@@ -59,5 +63,35 @@ describe('<Live />', () => {
     ).toHaveStyle(
       `background: url(https://example.com/240) no-repeat center / cover`,
     );
+  });
+
+  it('successfully selects and unselects a webinar', async () => {
+    const live = videoMockFactory({
+      id: '4321',
+      title: 'New video title',
+      description: 'New video description',
+      is_live: true,
+      playlist: {
+        ...videoMockFactory().playlist,
+        title: 'New playlist title',
+      },
+    });
+    render(<Live live={live} />);
+
+    act(() =>
+      useSelectFeatures.setState({
+        isSelectionEnabled: true,
+        selectedItems: [],
+      }),
+    );
+
+    const liveCardCheckBox = screen.getByRole('checkbox');
+    expect(liveCardCheckBox).not.toBeChecked();
+
+    const card = screen.getByRole('contentinfo');
+    userEvent.click(card);
+    await waitFor(() => expect(liveCardCheckBox).toBeChecked());
+    userEvent.click(card);
+    await waitFor(() => expect(liveCardCheckBox).not.toBeChecked());
   });
 });

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/Read/Live.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/Read/Live.tsx
@@ -1,10 +1,11 @@
-import { Text, Box } from 'grommet';
+import { Text, Box, CheckBox } from 'grommet';
 import { StyledLink, Video, ContentCard } from 'lib-components';
-import { Fragment } from 'react';
+import { Fragment, useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import { ReactComponent as LiveIcon } from 'assets/svg/iko_live.svg';
 import { ReactComponent as VueListIcon } from 'assets/svg/iko_vuelistesvg.svg';
+import { useSelectFeatures } from 'features/Contents/store/selectionStore';
 import { routes } from 'routes';
 
 const TextTruncated = styled(Text)`
@@ -17,10 +18,29 @@ const TextTruncated = styled(Text)`
 const Live = ({ live }: { live: Video }) => {
   const livePath = routes.CONTENTS.subRoutes.LIVE.path;
   const thumbnail = live.thumbnail?.urls?.[240] || live.urls?.thumbnails?.[240];
+  const { isSelectionEnabled, selectedItems, selectItem } = useSelectFeatures();
+  const [isLiveSelected, setIsLiveSelected] = useState<boolean>(
+    () => selectedItems.includes(live.id) || false,
+  );
+
+  useEffect(() => {
+    if (!isSelectionEnabled) {
+      setIsLiveSelected(false);
+    }
+  }, [isSelectionEnabled, setIsLiveSelected]);
 
   return (
-    <StyledLink to={`${livePath}/${live.id}`}>
+    <StyledLink to={isSelectionEnabled ? '#' : `${livePath}/${live.id}`}>
       <ContentCard
+        style={
+          isLiveSelected
+            ? {
+                boxShadow:
+                  'inset 0px 0px 0px 0px #45a3ff, #81ade6 1px 1px 1px 9px',
+              }
+            : undefined
+        }
+        onClick={() => selectItem(live.id, isLiveSelected, setIsLiveSelected)}
         header={
           <Box
             aria-label="thumbnail"
@@ -36,7 +56,19 @@ const Live = ({ live }: { live: Video }) => {
                   : `radial-gradient(ellipse at center, #96b6db 0%,#4c46ab 100%)`
               }
             `}
+            style={{ position: 'relative' }}
           >
+            <Box
+              style={{
+                position: 'absolute',
+                top: '21px',
+                left: '21px',
+                background: 'white',
+                borderRadius: '6px',
+              }}
+            >
+              {isSelectionEnabled && <CheckBox checked={isLiveSelected} />}
+            </Box>
             <LiveIcon width={80} height={80} color="white" />
           </Box>
         }

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Video/components/Create/VideoCreate.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Video/components/Create/VideoCreate.spec.tsx
@@ -1,6 +1,11 @@
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import fetchMock from 'fetch-mock';
+import { useJwt } from 'lib-components';
 import { render } from 'lib-tests';
+import { act } from 'react-dom/test-utils';
+
+import { useSelectFeatures } from 'features/Contents/store/selectionStore';
 
 import VideoCreate from './VideoCreate';
 
@@ -10,20 +15,176 @@ jest.mock('./VideoCreateForm', () => ({
 }));
 
 describe('<VideoCreate />', () => {
-  test('renders VideoCreate', () => {
+  beforeEach(() => {
+    useJwt.setState({
+      jwt: 'json web token',
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    fetchMock.restore();
+  });
+
+  it('renders VideoCreate', () => {
     render(<VideoCreate />);
 
-    const button = screen.getByRole('button', { name: /Create Video/i });
-    expect(button).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Create Video/i }),
+    ).toBeInTheDocument();
     expect(
       screen.queryByRole('heading', { name: /Create Video/i }),
     ).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Select' })).toBeInTheDocument();
+  });
 
-    userEvent.click(button);
+  it('shows video creation Modal', () => {
+    render(<VideoCreate />);
+    const createButton = screen.getByRole('button', { name: /Create Video/i });
+    userEvent.click(createButton);
 
     expect(
       screen.getByRole('heading', { name: /Create Video/i }),
     ).toBeInTheDocument();
     expect(screen.getByText('My VideoCreate Form')).toBeInTheDocument();
+  });
+
+  it('switches into selection mode on select button click', () => {
+    render(<VideoCreate />);
+    const selectButton = screen.getByRole('button', { name: 'Select' });
+    userEvent.click(selectButton);
+    expect(
+      screen.queryByRole('button', { name: 'Select' }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Delete 0 video' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Delete 0 video' }),
+    ).toBeDisabled();
+  });
+
+  it('counts the right amount of selected items (1)', () => {
+    render(<VideoCreate />);
+    act(() =>
+      useSelectFeatures.setState({
+        isSelectionEnabled: true,
+        selectedItems: ['id1'],
+      }),
+    );
+    expect(
+      screen.queryByRole('button', { name: 'Select' }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Delete 1 video' }),
+    ).toBeInTheDocument();
+  });
+
+  it('counts the right amount of selected items (3)', () => {
+    render(<VideoCreate />);
+    act(() =>
+      useSelectFeatures.setState({
+        isSelectionEnabled: true,
+        selectedItems: ['id1', 'id2', 'id3'],
+      }),
+    );
+    expect(
+      screen.queryByRole('button', { name: 'Select' }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Delete 3 videos' }),
+    ).toBeInTheDocument();
+  });
+
+  it('opens the delete confirmation modal', () => {
+    render(<VideoCreate />);
+    act(() =>
+      useSelectFeatures.setState({
+        isSelectionEnabled: true,
+        selectedItems: ['id1', 'id2', 'id3'],
+      }),
+    );
+    const deleteButon = screen.getByRole('button', { name: 'Delete 3 videos' });
+    userEvent.click(deleteButon);
+
+    expect(screen.getByText('Confirm delete 3 videos')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Are you sure you want to delete 3 videos ? This action is irreversible.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('successfully deletes videos', async () => {
+    fetchMock.delete('/api/videos/', {
+      status: 204,
+      body: { ids: ['id1', 'id2'] },
+    });
+
+    render(<VideoCreate />);
+    act(() =>
+      useSelectFeatures.setState({
+        isSelectionEnabled: true,
+        selectedItems: ['id1', 'id2'],
+      }),
+    );
+    const deleteButon = screen.getByRole('button', { name: 'Delete 2 videos' });
+    userEvent.click(deleteButon);
+
+    const confirmDeleteButton = screen.getByRole('button', {
+      name: 'Confirm delete 2 videos',
+    });
+    userEvent.click(confirmDeleteButton);
+
+    expect(
+      await screen.findByText('2 videos successfully deleted'),
+    ).toBeInTheDocument();
+
+    expect(fetchMock.lastCall()![0]).toEqual(`/api/videos/`);
+    expect(fetchMock.lastCall()![1]).toEqual({
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: `{"ids":["id1","id2"]}`,
+      method: 'DELETE',
+    });
+  });
+
+  it('fails to delete videos', async () => {
+    fetchMock.delete('/api/videos/', {
+      status: 400,
+      body: { ids: ['id1', 'id2'] },
+    });
+
+    render(<VideoCreate />);
+    act(() =>
+      useSelectFeatures.setState({
+        isSelectionEnabled: true,
+        selectedItems: ['id1', 'id2'],
+      }),
+    );
+    const deleteButon = screen.getByRole('button', { name: 'Delete 2 videos' });
+    userEvent.click(deleteButon);
+
+    const confirmDeleteButton = screen.getByRole('button', {
+      name: 'Confirm delete 2 videos',
+    });
+    userEvent.click(confirmDeleteButton);
+
+    expect(
+      await screen.findByText('Failed to delete 2 videos'),
+    ).toBeInTheDocument();
+
+    expect(fetchMock.lastCall()![0]).toEqual(`/api/videos/`);
+    expect(fetchMock.lastCall()![1]).toEqual({
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: `{"ids":["id1","id2"]}`,
+      method: 'DELETE',
+    });
   });
 });

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Video/components/Create/VideoCreate.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Video/components/Create/VideoCreate.tsx
@@ -1,10 +1,20 @@
-import { Button, Heading, Text } from 'grommet';
-import { UploadManager, Modal } from 'lib-components';
-import { Fragment } from 'react';
+import { Box, Button, Heading, Text } from 'grommet';
+import {
+  UploadManager,
+  Modal,
+  ModalButton,
+  ButtonLoaderStyle,
+  report,
+} from 'lib-components';
+import { useDeleteVideos } from 'lib-video';
+import { Fragment, useEffect, useState } from 'react';
+import toast from 'react-hot-toast';
 import { defineMessages, useIntl } from 'react-intl';
 import { Link, Route, Switch, useHistory } from 'react-router-dom';
+import styled from 'styled-components';
 
 import { ContentsHeader } from 'features/Contents';
+import { useSelectFeatures } from 'features/Contents/store/selectionStore';
 import { routes } from 'routes';
 
 import VideoCreateForm from './VideoCreateForm';
@@ -20,7 +30,51 @@ const messages = defineMessages({
     description: 'Text heading create video.',
     id: 'features.Contents.features.Video.Create.CreateVideoLabel',
   },
+  SelectButtonLabel: {
+    defaultMessage: 'Select',
+    description: 'Button label to select videos.',
+    id: 'features.Contents.features.Video.Create.SelectButtonLabel',
+  },
+  DeleteButtonLabel: {
+    defaultMessage: `Delete {item_count, plural,  =0 {0 video} one {# video} other {# videos}}`,
+    description: 'Button label to delete single video.',
+    id: 'features.Contents.features.Video.Create.DeleteButtonSingularLabel',
+  },
+  CancelSelectionLabel: {
+    defaultMessage: 'Cancel',
+    description: 'Button label to cancel video selection.',
+    id: 'features.Contents.features.Video.Create.CancelSelectionLabel',
+  },
+  videosDeleteModalTitle: {
+    defaultMessage: `Delete {item_count, plural, one {# video} other {# videos}}`,
+    description: 'Title of the delete video modal.',
+    id: 'features.Contents.features.Video.Create.videoDeleteModalTitle',
+  },
+  confirmDeleteVideosTitle: {
+    defaultMessage: `Confirm delete {item_count, plural, one {# video} other {# videos}}`,
+    description: 'Title of the widget used for delete video confirmation.',
+    id: 'cfeatures.Contents.features.Video.Create.confirmDeleteVideoTitle',
+  },
+  confirmDeleteVideosText: {
+    defaultMessage: `Are you sure you want to delete {item_count, plural, one {# video} other {# videos}} ? This action is irreversible.`,
+    description: 'Text of the widget used for delete video confirmation.',
+    id: 'features.Contents.features.Video.Create.confirmDeleteVideoText',
+  },
+  videosDeleteSuccess: {
+    defaultMessage: `{item_count, plural,  =0 {0 video} one {# video} other {# videos}} successfully deleted`,
+    description: 'Text of the delete video confirmation toast.',
+    id: 'features.Contents.features.Video.Create.videoDeleteSuccess',
+  },
+  videosDeleteError: {
+    defaultMessage: `Failed to delete {item_count, plural,  =0 {0 video} one {# video} other {# videos}}`,
+    description: 'Text of the delete video error toast.',
+    id: 'features.Contents.features.Video.Create.videoDeleteError',
+  },
 });
+
+const ButtonStyled = styled(Button)`
+  color: white;
+`;
 
 const VideoCreate = () => {
   const intl = useIntl();
@@ -29,6 +83,44 @@ const VideoCreate = () => {
   const videoRoute = routes.CONTENTS.subRoutes.VIDEO;
   const videoPath = videoRoute.path;
   const videoCreatePath = videoRoute.subRoutes?.CREATE?.path || '';
+  const {
+    isSelectionEnabled,
+    switchSelectEnabled,
+    resetSelection,
+    selectedItems,
+  } = useSelectFeatures();
+
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState<boolean>(false);
+
+  const deleteVideos = useDeleteVideos({
+    onSuccess: () => {
+      toast.success(
+        intl.formatMessage(messages.videosDeleteSuccess, {
+          item_count: selectedItems.length,
+        }),
+        {
+          position: 'bottom-center',
+        },
+      );
+    },
+    onError: (err: unknown) => {
+      report(err);
+      toast.error(
+        intl.formatMessage(messages.videosDeleteError, {
+          item_count: selectedItems.length,
+        }),
+        {
+          position: 'bottom-center',
+        },
+      );
+    },
+  });
+
+  useEffect(() => {
+    if (!isSelectionEnabled) {
+      resetSelection();
+    }
+  }, [isSelectionEnabled, resetSelection]);
 
   return (
     <Fragment>
@@ -36,12 +128,42 @@ const VideoCreate = () => {
         <Text size="large" weight="bold">
           {intl.formatMessage(messages.VideoTitle)}
         </Text>
-        <Link to={videoCreatePath}>
-          <Button
-            primary
-            label={intl.formatMessage(messages.CreateVideoLabel)}
-          />
-        </Link>
+        {!isSelectionEnabled && (
+          <Box direction="row" gap="small">
+            <Button
+              secondary
+              label={intl.formatMessage(messages.SelectButtonLabel)}
+              onClick={switchSelectEnabled}
+            />
+
+            <Link to={videoCreatePath}>
+              <Button
+                primary
+                label={intl.formatMessage(messages.CreateVideoLabel)}
+                disabled={isSelectionEnabled}
+              />
+            </Link>
+          </Box>
+        )}
+        {isSelectionEnabled && (
+          <Box direction="row" gap="small">
+            <Button
+              secondary
+              label={intl.formatMessage(messages.CancelSelectionLabel)}
+              onClick={switchSelectEnabled}
+            />
+
+            <ButtonStyled
+              primary
+              color="action-danger"
+              label={intl.formatMessage(messages.DeleteButtonLabel, {
+                item_count: selectedItems.length,
+              })}
+              disabled={selectedItems.length < 1}
+              onClick={() => setIsDeleteModalOpen(true)}
+            />
+          </Box>
+        )}
       </ContentsHeader>
       <Switch>
         <Route path={videoCreatePath} exact>
@@ -65,6 +187,41 @@ const VideoCreate = () => {
           </Modal>
         </Route>
       </Switch>
+      <Modal
+        isOpen={isDeleteModalOpen}
+        onClose={() => {
+          setIsDeleteModalOpen(false);
+        }}
+      >
+        <Heading
+          size="3"
+          alignSelf="center"
+          margin={{ top: '0', bottom: 'small' }}
+        >
+          {intl.formatMessage(messages.videosDeleteModalTitle, {
+            item_count: selectedItems.length,
+          })}
+        </Heading>
+        <Text margin={{ top: 'small' }}>
+          {intl.formatMessage(messages.confirmDeleteVideosText, {
+            item_count: selectedItems.length,
+          })}
+        </Text>
+        <ModalButton
+          label={intl.formatMessage(messages.confirmDeleteVideosTitle, {
+            item_count: selectedItems.length,
+          })}
+          onClickCancel={() => {
+            setIsDeleteModalOpen(false);
+          }}
+          onClickSubmit={() => {
+            deleteVideos.mutate({ ids: selectedItems });
+            setIsDeleteModalOpen(false);
+            switchSelectEnabled();
+          }}
+          style={ButtonLoaderStyle.DESTRUCTIVE}
+        />
+      </Modal>
     </Fragment>
   );
 };

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Video/components/Read/Video.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Video/components/Read/Video.spec.tsx
@@ -1,11 +1,15 @@
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { thumbnailMockFactory, videoMockFactory } from 'lib-components';
 import { render } from 'lib-tests';
+import { act } from 'react-dom/test-utils';
+
+import { useSelectFeatures } from 'features/Contents/store/selectionStore';
 
 import Video from './Video';
 
 describe('<Video />', () => {
-  test('renders Video', () => {
+  it('renders Video', () => {
     const video = videoMockFactory({
       id: '4321',
       title: 'New video title',
@@ -33,7 +37,7 @@ describe('<Video />', () => {
     );
   });
 
-  test('renders thumbnail', () => {
+  it('renders thumbnail', () => {
     const video = videoMockFactory({
       id: '4321',
       title: 'New video title',
@@ -59,5 +63,34 @@ describe('<Video />', () => {
     ).toHaveStyle(
       `background: url(https://example.com/240) no-repeat center / cover`,
     );
+  });
+
+  it('successfully selects and unselects a video', async () => {
+    const video = videoMockFactory({
+      id: '4321',
+      title: 'New video title',
+      description: 'New video description',
+      playlist: {
+        ...videoMockFactory().playlist,
+        title: 'New playlist title',
+      },
+    });
+    render(<Video video={video} />);
+
+    act(() =>
+      useSelectFeatures.setState({
+        isSelectionEnabled: true,
+        selectedItems: [],
+      }),
+    );
+
+    const videoCardCheckBox = screen.getByRole('checkbox');
+    expect(videoCardCheckBox).not.toBeChecked();
+
+    const card = screen.getByRole('contentinfo');
+    userEvent.click(card);
+    await waitFor(() => expect(videoCardCheckBox).toBeChecked());
+    userEvent.click(card);
+    await waitFor(() => expect(videoCardCheckBox).not.toBeChecked());
   });
 });

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Video/components/Read/Video.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Video/components/Read/Video.tsx
@@ -1,24 +1,46 @@
-import { Text, Box } from 'grommet';
+import { Text, Box, CheckBox } from 'grommet';
 import {
   ContentCard,
   StyledLink,
   TextTruncated,
   Video as IVideo,
 } from 'lib-components';
-import { Fragment } from 'react';
+import { Fragment, useEffect, useState } from 'react';
 
 import { ReactComponent as VideoIcon } from 'assets/svg/iko_next.svg';
 import { ReactComponent as VueListIcon } from 'assets/svg/iko_vuelistesvg.svg';
+import { useSelectFeatures } from 'features/Contents/store/selectionStore';
 import { routes } from 'routes';
 
 const Video = ({ video }: { video: IVideo }) => {
   const videoPath = routes.CONTENTS.subRoutes.VIDEO.path;
   const thumbnail =
     video.thumbnail?.urls?.[240] || video.urls?.thumbnails?.[240];
+  const { isSelectionEnabled, selectedItems, selectItem } = useSelectFeatures();
+  const [isVideoSelected, setIsVideoSelected] = useState<boolean>(
+    () => selectedItems.includes(video.id) || false,
+  );
+
+  useEffect(() => {
+    if (!isSelectionEnabled) {
+      setIsVideoSelected(false);
+    }
+  }, [isSelectionEnabled, setIsVideoSelected]);
 
   return (
-    <StyledLink to={`${videoPath}/${video.id}`}>
+    <StyledLink to={isSelectionEnabled ? '#' : `${videoPath}/${video.id}`}>
       <ContentCard
+        style={
+          isVideoSelected
+            ? {
+                boxShadow:
+                  'inset 0px 0px 0px 0px #45a3ff, #81ade6 1px 1px 1px 9px',
+              }
+            : undefined
+        }
+        onClick={() =>
+          selectItem(video.id, isVideoSelected, setIsVideoSelected)
+        }
         header={
           <Box
             aria-label="thumbnail"
@@ -34,8 +56,20 @@ const Video = ({ video }: { video: IVideo }) => {
                   : `radial-gradient(ellipse at center, #45a3ff 0%,#2169ff 100%)`
               }
             `}
+            style={{ position: 'relative' }}
           >
-            <VideoIcon width={80} height={80} color="white" />
+            <Box
+              style={{
+                position: 'absolute',
+                top: '21px',
+                left: '21px',
+                background: 'white',
+                borderRadius: '6px',
+              }}
+            >
+              {isSelectionEnabled && <CheckBox checked={isVideoSelected} />}
+            </Box>
+            <VideoIcon width={75} height={75} color="white" />
           </Box>
         }
         footer={

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Video/components/VideoRouter.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Video/components/VideoRouter.spec.tsx
@@ -33,7 +33,7 @@ describe('<VideoRouter/>', () => {
     jest.resetAllMocks();
   });
 
-  test('render route /my-contents/videos?playlist=test-playlist-id', () => {
+  it('renders route /my-contents/videos?playlist=test-playlist-id', () => {
     render(<VideoRouter />, {
       routerOptions: {
         history: ['/my-contents/videos?playlist=test-playlist-id'],
@@ -45,7 +45,7 @@ describe('<VideoRouter/>', () => {
     ).toBeInTheDocument();
   });
 
-  test('render video no match', () => {
+  it('renders video no match', () => {
     render(<VideoRouter />, {
       routerOptions: { history: ['/some/bad/route'] },
     });
@@ -53,7 +53,7 @@ describe('<VideoRouter/>', () => {
     expect(screen.queryByText(/My VideosRead/i)).not.toBeInTheDocument();
   });
 
-  test('render create video', () => {
+  it('renders create video', () => {
     render(<VideoRouter />, {
       routerOptions: { history: ['/my-contents/videos/create'] },
     });
@@ -62,7 +62,7 @@ describe('<VideoRouter/>', () => {
     expect(screen.getByText(/My VideosRead/i)).toBeInTheDocument();
   });
 
-  test('render update video', () => {
+  it('renders update video', () => {
     render(<VideoRouter />, {
       routerOptions: {
         history: ['/my-contents/videos/123456/'],

--- a/src/frontend/apps/standalone_site/src/features/Contents/store/selectionStore.ts
+++ b/src/frontend/apps/standalone_site/src/features/Contents/store/selectionStore.ts
@@ -1,0 +1,49 @@
+import { create } from 'zustand';
+
+interface useSelectFeatures {
+  isSelectionEnabled: boolean;
+  selectedItems: string[];
+  switchSelectEnabled: () => void;
+  setSelectedItems: (selectedItems: string[]) => void;
+  resetSelection: () => void;
+  selectItem: (
+    contentId: string,
+    isSelected: boolean,
+    setIsSelected: (isSelected: boolean) => void,
+  ) => void;
+}
+
+export const useSelectFeatures = create<useSelectFeatures>((set, get) => ({
+  isSelectionEnabled: false,
+  selectedItems: [],
+  switchSelectEnabled: () => {
+    set((state: { isSelectionEnabled: boolean }) => ({
+      isSelectionEnabled: !state.isSelectionEnabled,
+      selectedItems: [],
+    }));
+  },
+  setSelectedItems: (selectedItems: string[]) => {
+    return set(() => ({
+      selectedItems: selectedItems,
+    }));
+  },
+  resetSelection: () => {
+    set({
+      isSelectionEnabled: false,
+      selectedItems: [],
+    });
+  },
+  selectItem: (contentId, isSelected, setIsSelected) => {
+    if (get().isSelectionEnabled) {
+      if (isSelected) {
+        get().setSelectedItems(
+          get().selectedItems.filter((itemId) => itemId !== contentId),
+        );
+        setIsSelected(false);
+      } else {
+        get().setSelectedItems([...get().selectedItems, contentId]);
+        setIsSelected(true);
+      }
+    }
+  },
+}));

--- a/src/frontend/apps/standalone_site/src/routes/AppRoutes.tsx
+++ b/src/frontend/apps/standalone_site/src/routes/AppRoutes.tsx
@@ -47,7 +47,7 @@ const AppRoutes = () => {
       top: 0,
       behavior: 'smooth',
     });
-  }, [location]);
+  }, [location.pathname]);
 
   useEffect(() => {
     document.title = intl.formatMessage(messages.metaTitle);

--- a/src/frontend/packages/lib_classroom/src/data/queries/index.tsx
+++ b/src/frontend/packages/lib_classroom/src/data/queries/index.tsx
@@ -20,6 +20,7 @@ import {
   metadata,
   FetchResponseError,
   deleteOne,
+  bulkDelete,
 } from 'lib-components';
 import {
   useMutation,
@@ -400,4 +401,37 @@ export const useClassroomDocumentMetadata = (
     staleTime: Infinity,
     ...queryConfig,
   });
+};
+
+type UseDeleteClassroomsData = { ids: string[] };
+type UseDeleteClassroomsError = FetchResponseError<UseDeleteClassroomsData>;
+type UseDeleteClassroomsOptions = UseMutationOptions<
+  void,
+  UseDeleteClassroomsError,
+  UseDeleteClassroomsData
+>;
+export const useDeleteClassrooms = (options?: UseDeleteClassroomsOptions) => {
+  const queryClient = useQueryClient();
+  return useMutation<void, UseDeleteClassroomsError, UseDeleteClassroomsData>(
+    (classroomIds) =>
+      bulkDelete({
+        name: 'classrooms',
+        objects: classroomIds,
+      }),
+    {
+      ...options,
+      onSuccess: (data, variables, context) => {
+        queryClient.invalidateQueries('classrooms');
+        if (options?.onSuccess) {
+          options.onSuccess(data, variables, context);
+        }
+      },
+      onError: (error, variables, context) => {
+        queryClient.invalidateQueries('classrooms');
+        if (options?.onError) {
+          options.onError(error, variables, context);
+        }
+      },
+    },
+  );
 };

--- a/src/frontend/packages/lib_common/src/theme.ts
+++ b/src/frontend/packages/lib_common/src/theme.ts
@@ -158,6 +158,9 @@ export const theme: ThemeType = {
   box: {
     extend: 'min-height: initial; min-width: initial;',
   },
+  checkBox: {
+    hover: { border: { color: 'blue-active' } },
+  },
   button: {
     default: {
       background: { color: 'white' },

--- a/src/frontend/packages/lib_components/src/common/queries/bulkDelete.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/queries/bulkDelete.spec.tsx
@@ -1,0 +1,141 @@
+import fetchMock from 'fetch-mock';
+
+import { useJwt } from '@lib-components/hooks/stores/useJwt';
+import { FetchResponseError } from '@lib-components/utils/errors/exception';
+
+import { bulkDelete } from './bulkDelete';
+
+describe('queries/bulkDelete', () => {
+  afterEach(() => fetchMock.restore());
+
+  it('deletes the resources', async () => {
+    useJwt.getState().setJwt('some token');
+
+    fetchMock.mock('/api/model-name/', {
+      status: 204,
+      method: 'DELETE',
+      body: { ids: ['id1', 'id2'] },
+    });
+
+    await bulkDelete({
+      name: 'model-name',
+      objects: { ids: ['id1', 'id2'] },
+    });
+
+    expect(fetchMock.lastCall()?.[0]).toEqual('/api/model-name/');
+    expect(fetchMock.lastCall()?.[1]).toEqual({
+      headers: {
+        Authorization: 'Bearer some token',
+        'Content-Type': 'application/json',
+      },
+      method: 'DELETE',
+      body: '{"ids":["id1","id2"]}',
+    });
+  });
+
+  it('cannot delete the resources without JWT token', async () => {
+    useJwt.getState().resetJwt();
+
+    fetchMock.mock('/api/model-name/', 403, {
+      method: 'DELETE',
+      body: { ids: ['id1', 'id2'] },
+    });
+
+    let thrownError;
+    try {
+      await bulkDelete({
+        name: 'model-name',
+        objects: { ids: ['id1', 'id2'] },
+      });
+    } catch (error) {
+      if (error instanceof FetchResponseError) {
+        thrownError = error.error;
+      }
+    }
+
+    expect(thrownError).toEqual({
+      code: 'exception',
+      status: 403,
+      message: 'Forbidden',
+      response: expect.objectContaining({
+        status: 403,
+      }),
+    });
+
+    expect(fetchMock.lastCall()?.[0]).toEqual('/api/model-name/');
+    expect(fetchMock.lastCall()?.[1]).toEqual({
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      method: 'DELETE',
+      body: '{"ids":["id1","id2"]}',
+    });
+  });
+
+  it('resolves with a failure and handles it when it fails to delete the resource (local)', async () => {
+    useJwt.getState().setJwt('some token');
+
+    fetchMock.mock(
+      '/api/model-name/',
+      Promise.reject(new Error('Failed to perform the request')),
+    );
+
+    await expect(
+      bulkDelete({
+        name: 'model-name',
+        objects: { ids: ['id1', 'id2'] },
+      }),
+    ).rejects.toThrow('Failed to perform the request');
+
+    expect(fetchMock.lastCall()?.[0]).toEqual('/api/model-name/');
+    expect(fetchMock.lastCall()?.[1]).toEqual({
+      headers: {
+        Authorization: 'Bearer some token',
+        'Content-Type': 'application/json',
+      },
+      method: 'DELETE',
+      body: '{"ids":["id1","id2"]}',
+    });
+  });
+
+  it('resolves with a 400 and handles it when it fails to delete the resource (api)', async () => {
+    useJwt.getState().setJwt('some token');
+
+    fetchMock.mock('/api/model-name/', {
+      body: JSON.stringify({ error: 'An error occured!' }),
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    let thrownError;
+    try {
+      await bulkDelete({
+        name: 'model-name',
+        objects: { ids: ['id1', 'id2'] },
+      });
+    } catch (error) {
+      if (error instanceof FetchResponseError) {
+        thrownError = error.error;
+      }
+    }
+
+    expect(thrownError).toEqual({
+      code: 'invalid',
+      message: 'Bad Request',
+      status: 400,
+      response: expect.objectContaining({
+        status: 400,
+      }),
+    });
+
+    expect(fetchMock.lastCall()?.[0]).toEqual('/api/model-name/');
+    expect(fetchMock.lastCall()?.[1]).toEqual({
+      headers: {
+        Authorization: 'Bearer some token',
+        'Content-Type': 'application/json',
+      },
+      method: 'DELETE',
+      body: '{"ids":["id1","id2"]}',
+    });
+  });
+});

--- a/src/frontend/packages/lib_components/src/common/queries/bulkDelete.tsx
+++ b/src/frontend/packages/lib_components/src/common/queries/bulkDelete.tsx
@@ -1,0 +1,24 @@
+import { useJwt } from '@lib-components/hooks/stores/useJwt';
+
+import { fetchResponseHandler } from './fetchResponseHandler';
+import { fetchWrapper } from './fetchWrapper';
+
+export const bulkDelete = async ({
+  name,
+  objects,
+}: {
+  name: string;
+  objects: { ids: string[] };
+}) => {
+  const jwt = useJwt.getState().getJwt();
+  const response = await fetchWrapper(`/api/${name}/`, {
+    headers: {
+      'Content-Type': 'application/json',
+      ...(jwt ? { Authorization: `Bearer ${jwt}` } : {}),
+    },
+    method: 'DELETE',
+    body: JSON.stringify(objects),
+  });
+
+  await fetchResponseHandler(response, { withoutBody: true });
+};

--- a/src/frontend/packages/lib_components/src/common/queries/index.ts
+++ b/src/frontend/packages/lib_components/src/common/queries/index.ts
@@ -7,3 +7,4 @@ export * from './fetchWrapper';
 export * from './fetchResponseHandler';
 export * from './metadata';
 export * from './updateOne';
+export * from './bulkDelete';

--- a/src/frontend/packages/lib_video/src/api/index.ts
+++ b/src/frontend/packages/lib_video/src/api/index.ts
@@ -14,6 +14,7 @@ export * from './stopLive';
 export * from './updateLiveParticipants';
 export * from './updateLiveSession';
 export * from './useCreateVideo';
+export * from './useDeleteVideos';
 export * from './useDeleteSharedLiveMedia';
 export * from './useDeleteThumbnail';
 export * from './useDeleteTimedTextTrack';

--- a/src/frontend/packages/lib_video/src/api/useDeleteVideos/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/api/useDeleteVideos/index.spec.tsx
@@ -1,0 +1,78 @@
+import { WrapperComponent, renderHook } from '@testing-library/react-hooks';
+import fetchMock from 'fetch-mock';
+import { useJwt, videoMockFactory } from 'lib-components';
+import { WrapperReactQuery } from 'lib-tests';
+
+import { useDeleteVideos } from '.';
+
+jest.mock('lib-components', () => ({
+  ...jest.requireActual('lib-components'),
+  report: jest.fn(),
+}));
+
+let Wrapper: WrapperComponent<Element>;
+
+describe('useDeleteVideos', () => {
+  beforeEach(() => {
+    useJwt.getState().setJwt('some token');
+    Wrapper = WrapperReactQuery;
+  });
+
+  afterEach(() => {
+    fetchMock.restore();
+    jest.resetAllMocks();
+  });
+
+  it('deletes multiples resources', async () => {
+    const video1 = videoMockFactory();
+    const video2 = videoMockFactory();
+
+    fetchMock.delete('/api/videos/', {
+      status: 204,
+      body: { ids: [video1.id, video2.id] },
+    });
+    const { result, waitFor } = renderHook(() => useDeleteVideos(), {
+      wrapper: Wrapper,
+    });
+    result.current.mutate({ ids: [video1.id, video2.id] });
+    await waitFor(() => result.current.isSuccess);
+
+    expect(fetchMock.lastCall()![0]).toEqual(`/api/videos/`);
+    expect(fetchMock.lastCall()![1]).toEqual({
+      headers: {
+        Authorization: 'Bearer some token',
+        'Content-Type': 'application/json',
+      },
+      body: `{"ids":["${video1.id}","${video2.id}"]}`,
+      method: 'DELETE',
+    });
+    expect(result.current.data).toEqual(undefined);
+    expect(result.current.status).toEqual('success');
+  });
+
+  it('fails to delete the resources', async () => {
+    const video = videoMockFactory();
+    fetchMock.delete('/api/videos/', {
+      status: 400,
+    });
+
+    const { result, waitFor } = renderHook(() => useDeleteVideos(), {
+      wrapper: Wrapper,
+    });
+    result.current.mutate({ ids: [video.id] });
+
+    await waitFor(() => result.current.isError);
+
+    expect(fetchMock.lastCall()![0]).toEqual(`/api/videos/`);
+    expect(fetchMock.lastCall()![1]).toEqual({
+      headers: {
+        Authorization: 'Bearer some token',
+        'Content-Type': 'application/json',
+      },
+      body: `{"ids":["${video.id}"]}`,
+      method: 'DELETE',
+    });
+    expect(result.current.data).toEqual(undefined);
+    expect(result.current.status).toEqual('error');
+  });
+});

--- a/src/frontend/packages/lib_video/src/api/useDeleteVideos/index.tsx
+++ b/src/frontend/packages/lib_video/src/api/useDeleteVideos/index.tsx
@@ -1,0 +1,35 @@
+import { FetchResponseError, bulkDelete } from 'lib-components';
+import { useMutation, UseMutationOptions, useQueryClient } from 'react-query';
+
+type UseDeleteVideosData = { ids: string[] };
+type UseDeleteVideosError = FetchResponseError<UseDeleteVideosData>;
+type UseDeleteVideosOptions = UseMutationOptions<
+  void,
+  UseDeleteVideosError,
+  UseDeleteVideosData
+>;
+export const useDeleteVideos = (options?: UseDeleteVideosOptions) => {
+  const queryClient = useQueryClient();
+  return useMutation<void, UseDeleteVideosError, UseDeleteVideosData>(
+    (videoIds) =>
+      bulkDelete({
+        name: 'videos',
+        objects: videoIds,
+      }),
+    {
+      ...options,
+      onSuccess: (data, variables, context) => {
+        queryClient.invalidateQueries('videos');
+        if (options?.onSuccess) {
+          options.onSuccess(data, variables, context);
+        }
+      },
+      onError: (error, variables, context) => {
+        queryClient.invalidateQueries('videos');
+        if (options?.onError) {
+          options.onError(error, variables, context);
+        }
+      },
+    },
+  );
+};


### PR DESCRIPTION
## Purpose

Be able to bulk delete resources (videos, webinars and classrooms) from the list page.

## Proposal

Use a store for each resource to keep track of the selected items, and accordingly to its state show the different edition options on the cards and banners.

- [x] Bulk delete Videos
- [x] Bulk delete Webinars
- [x] Bulk delete Classrooms

![Screenshot from 2023-05-23 15-29-22](https://github.com/openfun/marsha/assets/9515777/bf305920-6274-41b8-9302-4ef0f9b870ed)
![Screenshot from 2023-05-23 15-29-29](https://github.com/openfun/marsha/assets/9515777/7d3a3a2f-8812-414c-8417-6a3e438211b3)
![Screenshot from 2023-05-23 15-29-36](https://github.com/openfun/marsha/assets/9515777/7106523a-f7bd-4bd9-9f25-d215f00a11f9)
![Screenshot from 2023-05-23 15-29-42](https://github.com/openfun/marsha/assets/9515777/233181e9-3514-4b8e-9417-2a4d6876ce30)
