### PR TITLE
♻️(website) better routes separation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Legale pages not accessible from url (#2266)
 - Remove old svg from the back to the front application (#1485)
 
+### Changed
+
+- Refacto routes contents website (#2253)
+
 ## [4.1.0] - 2023-05-23
 
 ### Added

--- a/src/frontend/apps/standalone_site/src/App.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/App.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import fetchMock from 'fetch-mock';
 import {
   playlistMockFactory,
@@ -8,6 +8,7 @@ import {
 
 import fetchMockAuth from '__mock__/fetchMockAuth.mock';
 import { FrontendConfiguration } from 'components/Sentry';
+import { useContentFeatures } from 'features/Contents/';
 
 import App from './App';
 
@@ -119,5 +120,13 @@ describe('<App />', () => {
     expect(
       await screen.findByText(/some welcome classroom/i),
     ).toBeInTheDocument();
+  });
+
+  test('the content features are correcty loaded', async () => {
+    await waitFor(() => {
+      expect(
+        useContentFeatures.getState().featureRouter.length,
+      ).toBeGreaterThan(0);
+    });
   });
 });

--- a/src/frontend/apps/standalone_site/src/App.tsx
+++ b/src/frontend/apps/standalone_site/src/App.tsx
@@ -10,6 +10,7 @@ import { BrowserRouter } from 'react-router-dom';
 import { SentryLoader } from 'components/Sentry';
 import { ContentSpinner } from 'components/Spinner';
 import { DEFAULT_LANGUAGE } from 'conf/global';
+import { featureContentLoader } from 'features/Contents';
 import { AppRoutes } from 'routes';
 import { getFullThemeExtend } from 'styles/theme.extend';
 import { getCurrentTranslation, getLanguage, getLocaleCode } from 'utils/lang';
@@ -31,6 +32,8 @@ const App = () => {
     const language = getLanguage();
     setLanguage(language);
     setLocalCode(getLocaleCode(language));
+
+    featureContentLoader();
   }, []);
 
   /**

--- a/src/frontend/apps/standalone_site/src/features/Authentication/hooks/useAuthenticator.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Authentication/hooks/useAuthenticator.spec.tsx
@@ -3,6 +3,8 @@ import fetchMock from 'fetch-mock';
 import { useCurrentUser, useJwt } from 'lib-components';
 import { Deferred, wrapperUtils } from 'lib-tests';
 
+import { featureContentLoader } from 'features/Contents';
+
 import { useAuthenticator } from './useAuthenticator';
 
 const consoleError = jest
@@ -140,6 +142,8 @@ describe('<useAuthenticator />', () => {
   });
 
   it('checks classroom invite link', async () => {
+    featureContentLoader();
+
     fetchMock.post('/api/auth/challenge/', {
       access: 'some-access2',
       refresh: 'some-refresh2',

--- a/src/frontend/apps/standalone_site/src/features/Authentication/hooks/useAuthenticator.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Authentication/hooks/useAuthenticator.tsx
@@ -2,7 +2,7 @@ import { AnonymousUser, useCurrentUser, useJwt } from 'lib-components';
 import { useEffect, useState } from 'react';
 import { useHistory, useLocation, useRouteMatch } from 'react-router-dom';
 
-import { routes } from 'routes';
+import { useRoutes } from 'routes/useRoutes';
 
 import { getCurrentUser } from '../api/getUserData';
 import { validateChallenge } from '../api/validateChallenge';
@@ -10,8 +10,9 @@ import { validateChallenge } from '../api/validateChallenge';
 const QUERY_PARAMS_CHALLENGE_TOKEN_NAME = 'token';
 
 export const useAuthenticator = () => {
+  const routes = useRoutes();
   const match = useRouteMatch(
-    routes.CONTENTS.subRoutes.CLASSROOM.subRoutes?.INVITE.path || '',
+    routes.CONTENTS.subRoutes?.CLASSROOM?.subRoutes?.INVITE.path || '',
   ) as { params?: { inviteId?: string } } | null;
   const inviteId = match?.params?.inviteId;
 

--- a/src/frontend/apps/standalone_site/src/features/Authentication/hooks/useAuthenticator.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Authentication/hooks/useAuthenticator.tsx
@@ -11,7 +11,7 @@ const QUERY_PARAMS_CHALLENGE_TOKEN_NAME = 'token';
 
 export const useAuthenticator = () => {
   const match = useRouteMatch(
-    routes.CONTENTS.subRoutes.CLASSROOM.subRoutes?.INVITE?.path || '',
+    routes.CONTENTS.subRoutes.CLASSROOM.subRoutes?.INVITE.path || '',
   ) as { params?: { inviteId?: string } } | null;
   const inviteId = match?.params?.inviteId;
 

--- a/src/frontend/apps/standalone_site/src/features/Contents/components/ContentsRouter/ContentsRouter.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/components/ContentsRouter/ContentsRouter.spec.tsx
@@ -5,8 +5,9 @@ import { useContentFeatures } from '../../store/contentsStore';
 
 import ContentsRouter from './ContentsRouter';
 
-jest.mock('features/Contents', () => ({
-  Contents: () => <div>My Contents</div>,
+jest.mock('../Contents/Contents', () => ({
+  default: () => <div>My Contents</div>,
+  __esModule: true,
 }));
 
 const ClassroomRouter = () => <div>My ClassRoomRouter</div>;
@@ -19,6 +20,17 @@ useContentFeatures.setState(
       <VideoRouter key="videoRouter" />,
       <LiveRouter key="liveRouter" />,
     ],
+    featureRoutes: {
+      CLASSROOM: {
+        path: '/my-contents/classroom',
+      },
+      VIDEO: {
+        path: '/my-contents/videos',
+      },
+      LIVE: {
+        path: '/my-contents/webinars',
+      },
+    },
   },
   true,
 );
@@ -39,13 +51,13 @@ describe('<ContentsRouter/>', () => {
     expect(screen.queryByText('My LiveRouter')).not.toBeInTheDocument();
   });
 
-  test('render from useContentFeatures', () => {
+  test('render from useContentFeatures', async () => {
     render(<ContentsRouter />, {
       routerOptions: { history: ['/my-contents/classroom'] },
     });
 
     expect(screen.queryByText('My Contents')).not.toBeInTheDocument();
-    expect(screen.getByText('My ClassRoomRouter')).toBeInTheDocument();
+    expect(await screen.findByText('My ClassRoomRouter')).toBeInTheDocument();
     expect(screen.getByText('My VideoRouter')).toBeInTheDocument();
     expect(screen.getByText('My LiveRouter')).toBeInTheDocument();
   });

--- a/src/frontend/apps/standalone_site/src/features/Contents/components/ContentsRouter/ContentsRouter.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/components/ContentsRouter/ContentsRouter.spec.tsx
@@ -14,7 +14,7 @@ const VideoRouter = () => <div>My VideoRouter</div>;
 const LiveRouter = () => <div>My LiveRouter</div>;
 useContentFeatures.setState(
   {
-    featureRoutes: [
+    featureRouter: [
       <ClassroomRouter key="classroomRouter" />,
       <VideoRouter key="videoRouter" />,
       <LiveRouter key="liveRouter" />,

--- a/src/frontend/apps/standalone_site/src/features/Contents/components/ContentsRouter/ContentsRouter.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/components/ContentsRouter/ContentsRouter.tsx
@@ -7,8 +7,8 @@ import { routes } from 'routes';
 import { useContentFeatures } from '../../store/contentsStore';
 
 const ContentsRouter = () => {
-  const { featureRoutes } = useContentFeatures((state) => ({
-    featureRoutes: state.featureRoutes,
+  const { featureRouter } = useContentFeatures((state) => ({
+    featureRouter: state.featureRouter,
   }));
 
   const videoPath = routes.CONTENTS.subRoutes.VIDEO.path;
@@ -21,7 +21,7 @@ const ContentsRouter = () => {
         <Contents />
       </Route>
       <Route path={[videoPath, classroomPath, webinarPath]}>
-        {featureRoutes}
+        {featureRouter}
       </Route>
       <Route>
         <Text404 />

--- a/src/frontend/apps/standalone_site/src/features/Contents/components/ContentsRouter/ContentsRouter.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/components/ContentsRouter/ContentsRouter.tsx
@@ -2,8 +2,8 @@ import { Route, Switch } from 'react-router-dom';
 
 import { Text404 } from 'components/Text';
 import { Contents } from 'features/Contents';
-import { routes } from 'routes';
 
+import routes from '../../routes';
 import { useContentFeatures } from '../../store/contentsStore';
 
 const ContentsRouter = () => {

--- a/src/frontend/apps/standalone_site/src/features/Contents/components/ContentsRouter/ContentsRouter.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/components/ContentsRouter/ContentsRouter.tsx
@@ -1,28 +1,27 @@
 import { Route, Switch } from 'react-router-dom';
 
 import { Text404 } from 'components/Text';
-import { Contents } from 'features/Contents';
 
-import routes from '../../routes';
+import useContentRoutes from '../../hooks/useContentRoutes';
 import { useContentFeatures } from '../../store/contentsStore';
+import Contents from '../Contents/Contents';
 
 const ContentsRouter = () => {
   const { featureRouter } = useContentFeatures((state) => ({
     featureRouter: state.featureRouter,
   }));
+  const routes = useContentRoutes();
 
-  const videoPath = routes.CONTENTS.subRoutes.VIDEO.path;
-  const classroomPath = routes.CONTENTS.subRoutes.CLASSROOM.path;
-  const webinarPath = routes.CONTENTS.subRoutes.LIVE.path;
+  const paths = Object.values(routes.CONTENTS.subRoutes).map(
+    (subRoute) => subRoute.path,
+  );
 
   return (
     <Switch>
       <Route path={routes.CONTENTS.path} exact>
         <Contents />
       </Route>
-      <Route path={[videoPath, classroomPath, webinarPath]}>
-        {featureRouter}
-      </Route>
+      <Route path={paths}>{featureRouter}</Route>
       <Route>
         <Text404 />
       </Route>

--- a/src/frontend/apps/standalone_site/src/features/Contents/components/ContentsWrapper/ContentsWrapper.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/components/ContentsWrapper/ContentsWrapper.tsx
@@ -3,12 +3,10 @@ import { APIList, ContentCards } from 'lib-components';
 import { Fragment } from 'react';
 import { UseQueryResult } from 'react-query';
 
-import {
-  useContentPerPage,
-  ContentsFilter,
+import useContentPerPage from '../../hooks/useContentPerPage';
+import ContentsFilter, {
   ContentsFilterProps,
-} from 'features/Contents';
-
+} from '../ContentsFilter/ContentsFilter';
 import ManageAPIState from '../ManageAPIState/ManageAPIState';
 
 interface ContentsWrapperProps<ContentType> extends ContentsFilterProps {

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/ClassRoomRouter.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/ClassRoomRouter.tsx
@@ -1,7 +1,7 @@
 import { Box } from 'grommet';
 import { Route, Switch, useLocation } from 'react-router-dom';
 
-import { routes } from 'routes/routes';
+import routes from '../routes';
 
 import ClassRoomCreate from './Create/ClassRoomCreate';
 import ClassRooms from './Read/ClassRooms';
@@ -12,10 +12,10 @@ const ClassRoomRouter = () => {
   const searchParams = new URLSearchParams(search);
   const playlistId = searchParams.get('playlist') || '';
 
-  const classroomRoute = routes.CONTENTS.subRoutes.CLASSROOM;
-  const classroomCreatePath = classroomRoute.subRoutes?.CREATE?.path || '';
-  const classroomUpdatePath = classroomRoute.subRoutes?.UPDATE?.path || '';
-  const classroomInvitePath = classroomRoute.subRoutes?.INVITE?.path || '';
+  const classroomRoute = routes.CLASSROOM;
+  const classroomCreatePath = classroomRoute.subRoutes.CREATE.path;
+  const classroomUpdatePath = classroomRoute.subRoutes.UPDATE.path;
+  const classroomInvitePath = classroomRoute.subRoutes.INVITE.path;
 
   return (
     <Route path={classroomRoute.path}>

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Create/ClassRoomCreate.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Create/ClassRoomCreate.tsx
@@ -9,7 +9,8 @@ import styled from 'styled-components';
 
 import { ContentsHeader } from 'features/Contents';
 import { useSelectFeatures } from 'features/Contents/store/selectionStore';
-import { routes } from 'routes';
+
+import routes from '../../routes';
 
 import ClassroomCreateForm from './ClassRoomCreateForm';
 
@@ -74,9 +75,9 @@ const ClassRoomCreate = () => {
   const intl = useIntl();
   const history = useHistory();
 
-  const classroomRoute = routes.CONTENTS.subRoutes.CLASSROOM;
+  const classroomRoute = routes.CLASSROOM;
   const classroomPath = classroomRoute.path;
-  const classroomCreatePath = classroomRoute.subRoutes?.CREATE?.path || '';
+  const classroomCreatePath = classroomRoute.subRoutes.CREATE.path;
   const {
     isSelectionEnabled,
     switchSelectEnabled,

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Create/ClassRoomCreateForm.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Create/ClassRoomCreateForm.tsx
@@ -7,7 +7,8 @@ import { defineMessages, useIntl } from 'react-intl';
 import { useHistory } from 'react-router-dom';
 
 import { useSelectPlaylist } from 'features/Playlist';
-import { routes } from 'routes';
+
+import routes from '../../routes';
 
 const messages = defineMessages({
   titleLabel: {
@@ -62,7 +63,7 @@ enum ETypeError {
 const ClassroomCreateForm = () => {
   const intl = useIntl();
   const history = useHistory();
-  const classroomPath = routes.CONTENTS.subRoutes.CLASSROOM.path;
+  const classroomPath = routes.CLASSROOM.path;
   const { errorPlaylist, selectPlaylist, playlistResponse } = useSelectPlaylist(
     { withPlaylistCreation: true },
   );

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Read/ClassRoomItem.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Read/ClassRoomItem.tsx
@@ -12,12 +12,13 @@ import { useIntl } from 'react-intl';
 import { ReactComponent as VueListIcon } from 'assets/svg/iko_vuelistesvg.svg';
 import { ReactComponent as ClassroomsIcon } from 'assets/svg/iko_webinairesvg.svg';
 import { useSelectFeatures } from 'features/Contents/store/selectionStore';
-import { routes } from 'routes';
 import { localDate } from 'utils/date';
+
+import routes from '../../routes';
 
 const ClassRoom = ({ classroom }: { classroom: ClassroomLite }) => {
   const intl = useIntl();
-  const classroomPath = routes.CONTENTS.subRoutes.CLASSROOM.path;
+  const classroomPath = routes.CLASSROOM.path;
 
   const { isSelectionEnabled, selectedItems, selectItem } = useSelectFeatures();
   const [isClassroomSelected, setIsClassroomSelected] = useState<boolean>(

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Read/ClassRooms.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Read/ClassRooms.tsx
@@ -8,7 +8,8 @@ import {
   ContentsWrapper,
   useContentPerPage,
 } from 'features/Contents/';
-import { routes } from 'routes';
+
+import routes from '../../routes';
 
 import ClassRoomItem from './ClassRoomItem';
 
@@ -27,7 +28,7 @@ const messages = defineMessages({
 
 export const classRoomContents = (playlistId?: string) => ({
   title: messages.MyClassrooms,
-  route: routes.CONTENTS.subRoutes.CLASSROOM.path,
+  route: routes.CLASSROOM.path,
   component: (
     <ClassRooms
       withPagination={false}

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/index.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/index.tsx
@@ -1,3 +1,4 @@
 export { default as ClassRoomRouter } from './components/ClassRoomRouter';
 export { classRoomContents } from './components/Read/ClassRooms';
 export { default as ClassRoomShuffle } from './components/Read/ClassRoomShuffle';
+export { default as routesClassRoom } from './routes';

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/routes.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/routes.tsx
@@ -1,0 +1,47 @@
+import { defineMessages, FormattedMessage } from 'react-intl';
+
+import { ReactComponent as ClassroomsIcon } from 'assets/svg/iko_webinairesvg.svg';
+import { LoadSVG } from 'components/Assets';
+import { RouteRequired } from 'routes';
+
+const messages = defineMessages({
+  menuContentsClassroomLabel: {
+    defaultMessage: 'Classrooms',
+    description: 'Label for the Classroom link in the content navigation menu',
+    id: 'Contents.Classroom.routes.menuContentsClassroomsLabel',
+  },
+});
+
+enum ECLASSROOMSubRouteNames {
+  CREATE = 'CREATE',
+  INVITE = 'INVITE',
+  UPDATE = 'UPDATE',
+}
+
+const routes: Record<'CLASSROOM', RouteRequired<ECLASSROOMSubRouteNames>> = {
+  CLASSROOM: {
+    label: <FormattedMessage {...messages.menuContentsClassroomLabel} />,
+    path: `/my-contents/classroom`,
+    menuIcon: (
+      <LoadSVG
+        Icon={ClassroomsIcon}
+        aria-label="svg-menu-my-contents-classroom"
+        title={messages.menuContentsClassroomLabel}
+      />
+    ),
+    subRoutes: {
+      CREATE: {
+        path: `/my-contents/classroom/create`,
+      },
+      UPDATE: {
+        path: `/my-contents/classroom/:classroomId`,
+      },
+      INVITE: {
+        path: `/my-contents/classroom/:classroomId/invite/:inviteId`,
+      },
+    },
+    isNavStrict: true,
+  },
+};
+
+export default routes;

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/Create/LiveCreate.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/Create/LiveCreate.tsx
@@ -9,7 +9,8 @@ import styled from 'styled-components';
 
 import { ContentsHeader } from 'features/Contents';
 import { useSelectFeatures } from 'features/Contents/store/selectionStore';
-import { routes } from 'routes';
+
+import routes from '../../routes';
 
 import LiveCreateForm from './LiveCreateForm';
 
@@ -74,9 +75,9 @@ const LiveCreate = () => {
   const intl = useIntl();
   const history = useHistory();
 
-  const liveRoute = routes.CONTENTS.subRoutes.LIVE;
+  const liveRoute = routes.LIVE;
   const livePath = liveRoute.path;
-  const liveCreatePath = liveRoute.subRoutes?.CREATE?.path || '';
+  const liveCreatePath = liveRoute.subRoutes.CREATE.path;
   const {
     isSelectionEnabled,
     switchSelectEnabled,

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/Create/LiveCreateForm.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/Create/LiveCreateForm.tsx
@@ -15,7 +15,8 @@ import { useQueryClient } from 'react-query';
 import { useHistory } from 'react-router-dom';
 
 import { useSelectPlaylist } from 'features/Playlist';
-import { routes } from 'routes';
+
+import routes from '../../routes';
 
 const messages = defineMessages({
   titleLabel: {
@@ -58,7 +59,7 @@ const LiveCreateForm = () => {
   const history = useHistory();
   const { isDesktop } = useResponsive();
   const [isUpdatingToLive, setIsUpdatingToLive] = useState(false);
-  const livePath = routes.CONTENTS.subRoutes.LIVE.path;
+  const livePath = routes.LIVE.path;
   const [live, setLive] = useState<LiveCreate>({
     playlist: '',
     title: '',

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/LiveRouter.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/LiveRouter.tsx
@@ -1,7 +1,7 @@
 import { Box } from 'grommet';
 import { Route, Switch, useLocation } from 'react-router-dom';
 
-import { routes } from 'routes/routes';
+import routes from '../routes';
 
 import LiveCreate from './Create/LiveCreate';
 import Lives from './Read/Lives';
@@ -12,9 +12,9 @@ const LiveRouter = () => {
   const searchParams = new URLSearchParams(search);
   const playlistId = searchParams.get('playlist') || '';
 
-  const liveRoute = routes.CONTENTS.subRoutes.LIVE;
-  const liveCreatePath = liveRoute.subRoutes?.CREATE?.path || '';
-  const liveUpdatePath = liveRoute.subRoutes?.UPDATE?.path || '';
+  const liveRoute = routes.LIVE;
+  const liveCreatePath = liveRoute.subRoutes.CREATE.path;
+  const liveUpdatePath = liveRoute.subRoutes.UPDATE.path;
 
   return (
     <Route path={liveRoute.path}>

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/Read/Live.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/Read/Live.tsx
@@ -6,7 +6,8 @@ import styled from 'styled-components';
 import { ReactComponent as LiveIcon } from 'assets/svg/iko_live.svg';
 import { ReactComponent as VueListIcon } from 'assets/svg/iko_vuelistesvg.svg';
 import { useSelectFeatures } from 'features/Contents/store/selectionStore';
-import { routes } from 'routes';
+
+import routes from '../../routes';
 
 const TextTruncated = styled(Text)`
   display: -webkit-box;
@@ -16,7 +17,7 @@ const TextTruncated = styled(Text)`
 `;
 
 const Live = ({ live }: { live: Video }) => {
-  const livePath = routes.CONTENTS.subRoutes.LIVE.path;
+  const livePath = routes.LIVE.path;
   const thumbnail = live.thumbnail?.urls?.[240] || live.urls?.thumbnails?.[240];
   const { isSelectionEnabled, selectedItems, selectItem } = useSelectFeatures();
   const [isLiveSelected, setIsLiveSelected] = useState<boolean>(

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/Read/Lives.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/Read/Lives.tsx
@@ -8,7 +8,8 @@ import {
   ContentsWrapper,
   useContentPerPage,
 } from 'features/Contents/';
-import { routes } from 'routes';
+
+import routes from '../../routes';
 
 import Live from './Live';
 
@@ -27,7 +28,7 @@ const messages = defineMessages({
 
 export const liveContents = (playlistId?: string) => ({
   title: messages.MyWebinars,
-  route: routes.CONTENTS.subRoutes.LIVE.path,
+  route: routes.LIVE.path,
   component: (
     <Lives
       withPagination={false}

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Live/index.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Live/index.tsx
@@ -1,2 +1,3 @@
 export { default as LiveRouter } from './components/LiveRouter';
 export { liveContents } from './components/Read/Lives';
+export { default as routesLive } from './routes';

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Live/routes.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Live/routes.tsx
@@ -1,0 +1,43 @@
+import { defineMessages, FormattedMessage } from 'react-intl';
+
+import { ReactComponent as LiveIcon } from 'assets/svg/iko_live.svg';
+import { LoadSVG } from 'components/Assets';
+import { RouteRequired } from 'routes';
+
+const messages = defineMessages({
+  menuContentsLivesLabel: {
+    defaultMessage: 'Webinars',
+    description: 'Label for the webinars link in the content navigation menu',
+    id: 'Contents.Live.routes.menuContentsLivesLabel',
+  },
+});
+
+enum ELIVESubRouteNames {
+  CREATE = 'CREATE',
+  UPDATE = 'UPDATE',
+}
+
+const routes: Record<'LIVE', RouteRequired<ELIVESubRouteNames>> = {
+  LIVE: {
+    label: <FormattedMessage {...messages.menuContentsLivesLabel} />,
+    path: `/my-contents/webinars`,
+    menuIcon: (
+      <LoadSVG
+        Icon={LiveIcon}
+        aria-label="svg-menu-my-contents-live"
+        title={messages.menuContentsLivesLabel}
+      />
+    ),
+    subRoutes: {
+      CREATE: {
+        path: `/my-contents/webinars/create`,
+      },
+      UPDATE: {
+        path: `/my-contents/webinars/:liveId`,
+      },
+    },
+    isNavStrict: true,
+  },
+};
+
+export default routes;

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Video/components/Create/VideoCreate.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Video/components/Create/VideoCreate.tsx
@@ -15,7 +15,8 @@ import styled from 'styled-components';
 
 import { ContentsHeader } from 'features/Contents';
 import { useSelectFeatures } from 'features/Contents/store/selectionStore';
-import { routes } from 'routes';
+
+import routes from '../../routes';
 
 import VideoCreateForm from './VideoCreateForm';
 
@@ -80,9 +81,9 @@ const VideoCreate = () => {
   const intl = useIntl();
   const history = useHistory();
 
-  const videoRoute = routes.CONTENTS.subRoutes.VIDEO;
+  const videoRoute = routes.VIDEO;
   const videoPath = videoRoute.path;
-  const videoCreatePath = videoRoute.subRoutes?.CREATE?.path || '';
+  const videoCreatePath = videoRoute.subRoutes.CREATE.path;
   const {
     isSelectionEnabled,
     switchSelectEnabled,

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Video/components/Create/VideoCreateForm.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Video/components/Create/VideoCreateForm.tsx
@@ -17,7 +17,8 @@ import { defineMessages, useIntl } from 'react-intl';
 import { useHistory } from 'react-router-dom';
 
 import { useSelectPlaylist } from 'features/Playlist';
-import { routes } from 'routes';
+
+import routes from '../../routes';
 
 const messages = defineMessages({
   titleLabel: {
@@ -64,7 +65,7 @@ const VideoCreateForm = () => {
   const intl = useIntl();
   const history = useHistory();
   const { isDesktop } = useResponsive();
-  const videoPath = routes.CONTENTS.subRoutes.VIDEO.path;
+  const videoPath = routes.VIDEO.path;
   const { addUpload, uploadManagerState } = useUploadManager();
   const [video, setVideo] = useState<VideoCreate>({
     playlist: '',

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Video/components/Read/Video.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Video/components/Read/Video.tsx
@@ -10,10 +10,11 @@ import { Fragment, useEffect, useState } from 'react';
 import { ReactComponent as VideoIcon } from 'assets/svg/iko_next.svg';
 import { ReactComponent as VueListIcon } from 'assets/svg/iko_vuelistesvg.svg';
 import { useSelectFeatures } from 'features/Contents/store/selectionStore';
-import { routes } from 'routes';
+
+import routes from '../../routes';
 
 const Video = ({ video }: { video: IVideo }) => {
-  const videoPath = routes.CONTENTS.subRoutes.VIDEO.path;
+  const videoPath = routes.VIDEO.path;
   const thumbnail =
     video.thumbnail?.urls?.[240] || video.urls?.thumbnails?.[240];
   const { isSelectionEnabled, selectedItems, selectItem } = useSelectFeatures();

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Video/components/Read/Videos.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Video/components/Read/Videos.tsx
@@ -8,7 +8,8 @@ import {
   ContentsWrapper,
   useContentPerPage,
 } from 'features/Contents/';
-import { routes } from 'routes';
+
+import routes from '../../routes';
 
 import Video from './Video';
 
@@ -27,7 +28,7 @@ const messages = defineMessages({
 
 export const videoContents = (playlistId?: string) => ({
   title: messages.MyVideos,
-  route: routes.CONTENTS.subRoutes.VIDEO.path,
+  route: routes.VIDEO.path,
   component: (
     <Videos
       withPagination={false}

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Video/components/VideoRouter.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Video/components/VideoRouter.tsx
@@ -1,7 +1,7 @@
 import { Box } from 'grommet';
 import { Route, Switch, useLocation } from 'react-router-dom';
 
-import { routes } from 'routes/routes';
+import routes from '../routes';
 
 import VideoCreate from './Create/VideoCreate';
 import Videos from './Read/Videos';
@@ -12,9 +12,9 @@ const VideoRouter = () => {
   const searchParams = new URLSearchParams(search);
   const playlistId = searchParams.get('playlist') || '';
 
-  const videoRoute = routes.CONTENTS.subRoutes.VIDEO;
-  const videoCreatePath = videoRoute.subRoutes?.CREATE?.path || '';
-  const videoUpdatePath = videoRoute.subRoutes?.UPDATE?.path || '';
+  const videoRoute = routes.VIDEO;
+  const videoCreatePath = videoRoute.subRoutes.CREATE.path;
+  const videoUpdatePath = videoRoute.subRoutes.UPDATE.path;
 
   return (
     <Route path={videoRoute.path}>

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Video/index.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Video/index.tsx
@@ -1,2 +1,3 @@
 export { default as VideoRouter } from './components/VideoRouter';
 export { videoContents } from './components/Read/Videos';
+export { default as routesVideo } from './routes';

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Video/routes.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Video/routes.tsx
@@ -1,0 +1,43 @@
+import { defineMessages, FormattedMessage } from 'react-intl';
+
+import { ReactComponent as VideoIcon } from 'assets/svg/iko_next.svg';
+import { LoadSVG } from 'components/Assets';
+import { RouteRequired } from 'routes';
+
+const messages = defineMessages({
+  menuContentsVideosLabel: {
+    defaultMessage: 'Videos',
+    description: 'Label for the video link in the content navigation menu',
+    id: 'Contents.Video.routes.menuContentsVideosLabel',
+  },
+});
+
+enum EVIDEOSubRouteNames {
+  CREATE = 'CREATE',
+  UPDATE = 'UPDATE',
+}
+
+const routes: Record<'VIDEO', RouteRequired<EVIDEOSubRouteNames>> = {
+  VIDEO: {
+    label: <FormattedMessage {...messages.menuContentsVideosLabel} />,
+    path: `/my-contents/videos`,
+    menuIcon: (
+      <LoadSVG
+        Icon={VideoIcon}
+        aria-label="svg-menu-my-contents-videos"
+        title={messages.menuContentsVideosLabel}
+      />
+    ),
+    subRoutes: {
+      CREATE: {
+        path: `/my-contents/videos/create`,
+      },
+      UPDATE: {
+        path: `/my-contents/videos/:videoId`,
+      },
+    },
+    isNavStrict: true,
+  },
+};
+
+export default routes;

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/featureLoader.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/featureLoader.tsx
@@ -16,7 +16,7 @@ import { liveContents, LiveRouter } from './Live';
 import { videoContents, VideoRouter } from './Video';
 
 useContentFeatures.setState({
-  featureRoutes: [
+  featureRouter: [
     <VideoRouter key="videoRouter" />,
     <ClassRoomRouter key="classRoomRouter" />,
     <LiveRouter key="liveRouter" />,

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/featureLoader.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/featureLoader.tsx
@@ -13,7 +13,7 @@ import {
   ClassRoomRouter,
   ClassRoomShuffle,
 } from './ClassRoom';
-import { liveContents, LiveRouter } from './Live';
+import { liveContents, LiveRouter, routesLive } from './Live';
 import { videoContents, VideoRouter, routesVideo } from './Video';
 
 useContentFeatures.setState({
@@ -22,7 +22,7 @@ useContentFeatures.setState({
     <ClassRoomRouter key="classRoomRouter" />,
     <LiveRouter key="liveRouter" />,
   ],
-  featureRoutes: { ...routesVideo },
+  featureRoutes: { ...routesVideo, ...routesLive },
   featureSamples: (playlistId) => [
     videoContents(playlistId),
     liveContents(playlistId),

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/featureLoader.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/featureLoader.tsx
@@ -1,6 +1,7 @@
 /**
  * Init the contents feature state by loading the necessary children components:
- *  - featureRoutes: Load the routes of the children features (/my-contents/videos, /my-contents/classroom...) @see ContentsRouter
+ *  - featureRouter: Load the router of the children features (/my-contents/videos, /my-contents/classroom...) @see ContentsRouter
+ *  - featureRoutes: Load the routes and the link menu of the children features @see routes
  *  - featureSamples: Load the samples of the children features, used in the contents page and playlist page @see Contents
  *  - featureShuffles: Load the shuffles of the children features, used in the frontend page @see ContentsShuffle
  */
@@ -13,7 +14,7 @@ import {
   ClassRoomShuffle,
 } from './ClassRoom';
 import { liveContents, LiveRouter } from './Live';
-import { videoContents, VideoRouter } from './Video';
+import { videoContents, VideoRouter, routesVideo } from './Video';
 
 useContentFeatures.setState({
   featureRouter: [
@@ -21,6 +22,7 @@ useContentFeatures.setState({
     <ClassRoomRouter key="classRoomRouter" />,
     <LiveRouter key="liveRouter" />,
   ],
+  featureRoutes: { ...routesVideo },
   featureSamples: (playlistId) => [
     videoContents(playlistId),
     liveContents(playlistId),

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/featureLoader.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/featureLoader.tsx
@@ -17,17 +17,21 @@ import {
 import { liveContents, LiveRouter, routesLive } from './Live';
 import { videoContents, VideoRouter, routesVideo } from './Video';
 
-useContentFeatures.setState({
-  featureRouter: [
-    <VideoRouter key="videoRouter" />,
-    <ClassRoomRouter key="classRoomRouter" />,
-    <LiveRouter key="liveRouter" />,
-  ],
-  featureRoutes: { ...routesVideo, ...routesLive, ...routesClassRoom },
-  featureSamples: (playlistId) => [
-    videoContents(playlistId),
-    liveContents(playlistId),
-    classRoomContents(playlistId),
-  ],
-  featureShuffles: [<ClassRoomShuffle key="classRoomShuffle" />],
-});
+const featureLoader = () => {
+  useContentFeatures.setState({
+    featureRouter: [
+      <VideoRouter key="videoRouter" />,
+      <ClassRoomRouter key="classRoomRouter" />,
+      <LiveRouter key="liveRouter" />,
+    ],
+    featureRoutes: { ...routesVideo, ...routesLive, ...routesClassRoom },
+    featureSamples: (playlistId) => [
+      videoContents(playlistId),
+      liveContents(playlistId),
+      classRoomContents(playlistId),
+    ],
+    featureShuffles: [<ClassRoomShuffle key="classRoomShuffle" />],
+  });
+};
+
+export default featureLoader;

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/featureLoader.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/featureLoader.tsx
@@ -12,6 +12,7 @@ import {
   classRoomContents,
   ClassRoomRouter,
   ClassRoomShuffle,
+  routesClassRoom,
 } from './ClassRoom';
 import { liveContents, LiveRouter, routesLive } from './Live';
 import { videoContents, VideoRouter, routesVideo } from './Video';
@@ -22,7 +23,7 @@ useContentFeatures.setState({
     <ClassRoomRouter key="classRoomRouter" />,
     <LiveRouter key="liveRouter" />,
   ],
-  featureRoutes: { ...routesVideo, ...routesLive },
+  featureRoutes: { ...routesVideo, ...routesLive, ...routesClassRoom },
   featureSamples: (playlistId) => [
     videoContents(playlistId),
     liveContents(playlistId),

--- a/src/frontend/apps/standalone_site/src/features/Contents/hooks/useContentRoutes.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/hooks/useContentRoutes.spec.tsx
@@ -1,0 +1,22 @@
+import { renderHook } from '@testing-library/react-hooks';
+
+import { useContentFeatures } from '../store/contentsStore';
+
+import useContentRoutes from './useContentRoutes';
+
+describe('useContentRoutes', () => {
+  it('checks the states are correctly init', () => {
+    useContentFeatures.setState({
+      featureRoutes: {
+        TEST: { label: 'My feature test' },
+      } as any,
+    });
+
+    const { result } = renderHook(() => useContentRoutes());
+
+    expect(result.current.CONTENTS.path).toBe('/my-contents');
+    expect(result.current.CONTENTS.subRoutes.TEST.label).toBe(
+      'My feature test',
+    );
+  });
+});

--- a/src/frontend/apps/standalone_site/src/features/Contents/hooks/useContentRoutes.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/hooks/useContentRoutes.tsx
@@ -7,11 +7,6 @@ import { RouteRequired } from 'routes';
 import { useContentFeatures } from '../store/contentsStore';
 
 const messages = defineMessages({
-  menuContentsLessonsLabel: {
-    defaultMessage: 'Lessons',
-    description: 'Label for the Lessons link in the content navigation menu',
-    id: 'Contents.useContentRoutes.menuContentsLessonsLabel',
-  },
   menuMyContentsLabel: {
     defaultMessage: 'My Contents',
     description: 'Label for the MyContents link in the main navigation menu',
@@ -37,18 +32,6 @@ const useContentRoutes = (): Record<'CONTENTS', RouteRequired> => {
       ),
       subRoutes: {
         ...featureRoutes,
-        // LESSON: {
-        //   label: <FormattedMessage {...messages.menuContentsLessonsLabel} />,
-        //   path: `/my-contents/lessons`,
-        //   menuIcon: (
-        //     <CheckListIcon
-        //       width={30}
-        //       height={30}
-        //       role="img"
-        //       aria-label="svg-menu-my-contents-lessons"
-        //     />
-        //   ),
-        // },
       },
     },
   };

--- a/src/frontend/apps/standalone_site/src/features/Contents/hooks/useContentRoutes.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/hooks/useContentRoutes.tsx
@@ -1,0 +1,57 @@
+import { defineMessages, FormattedMessage } from 'react-intl';
+
+import { ReactComponent as VueListIcon } from 'assets/svg/iko_vuelistesvg.svg';
+import { LoadSVG } from 'components/Assets';
+import { RouteRequired } from 'routes';
+
+import { useContentFeatures } from '../store/contentsStore';
+
+const messages = defineMessages({
+  menuContentsLessonsLabel: {
+    defaultMessage: 'Lessons',
+    description: 'Label for the Lessons link in the content navigation menu',
+    id: 'Contents.useContentRoutes.menuContentsLessonsLabel',
+  },
+  menuMyContentsLabel: {
+    defaultMessage: 'My Contents',
+    description: 'Label for the MyContents link in the main navigation menu',
+    id: 'Contents.useContentRoutes.menuMyContentsLabel',
+  },
+});
+
+const useContentRoutes = (): Record<'CONTENTS', RouteRequired> => {
+  const { featureRoutes } = useContentFeatures((state) => ({
+    featureRoutes: state.featureRoutes,
+  }));
+
+  return {
+    CONTENTS: {
+      label: <FormattedMessage {...messages.menuMyContentsLabel} />,
+      path: `/my-contents`,
+      menuIcon: (
+        <LoadSVG
+          Icon={VueListIcon}
+          aria-label="svg-menu-my-contents"
+          title={messages.menuMyContentsLabel}
+        />
+      ),
+      subRoutes: {
+        ...featureRoutes,
+        // LESSON: {
+        //   label: <FormattedMessage {...messages.menuContentsLessonsLabel} />,
+        //   path: `/my-contents/lessons`,
+        //   menuIcon: (
+        //     <CheckListIcon
+        //       width={30}
+        //       height={30}
+        //       role="img"
+        //       aria-label="svg-menu-my-contents-lessons"
+        //     />
+        //   ),
+        // },
+      },
+    },
+  };
+};
+
+export default useContentRoutes;

--- a/src/frontend/apps/standalone_site/src/features/Contents/index.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/index.tsx
@@ -10,5 +10,7 @@ export { default as ContentsShuffle } from './components/ContentsShuffle/Content
 export { default as ContentsWrapper } from './components/ContentsWrapper/ContentsWrapper';
 export { default as ManageAPIState } from './components/ManageAPIState/ManageAPIState';
 export { default as useContentPerPage } from './hooks/useContentPerPage';
+export { default as useContentRoutes } from './hooks/useContentRoutes';
+export * from './store/contentsStore';
 
 import './features/featureLoader';

--- a/src/frontend/apps/standalone_site/src/features/Contents/index.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/index.tsx
@@ -9,8 +9,7 @@ export { default as ContentsRouter } from './components/ContentsRouter/ContentsR
 export { default as ContentsShuffle } from './components/ContentsShuffle/ContentsShuffle';
 export { default as ContentsWrapper } from './components/ContentsWrapper/ContentsWrapper';
 export { default as ManageAPIState } from './components/ManageAPIState/ManageAPIState';
+export { default as featureContentLoader } from './features/featureLoader';
 export { default as useContentPerPage } from './hooks/useContentPerPage';
 export { default as useContentRoutes } from './hooks/useContentRoutes';
 export * from './store/contentsStore';
-
-import './features/featureLoader';

--- a/src/frontend/apps/standalone_site/src/features/Contents/routes.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/routes.tsx
@@ -1,23 +1,12 @@
 import { defineMessages, FormattedMessage } from 'react-intl';
 
 import { ReactComponent as VueListIcon } from 'assets/svg/iko_vuelistesvg.svg';
-import { ReactComponent as ClassroomsIcon } from 'assets/svg/iko_webinairesvg.svg';
 import { LoadSVG } from 'components/Assets';
 import { RouteRequired } from 'routes';
 
 import { useContentFeatures } from './store/contentsStore';
 
 const messages = defineMessages({
-  menuContentsClassroomLabel: {
-    defaultMessage: 'Classrooms',
-    description: 'Label for the Classroom link in the content navigation menu',
-    id: 'routes.routes.menuContentsClassroomsLabel',
-  },
-  menuContentsClassroomCreateLabel: {
-    defaultMessage: 'Create Classroom',
-    description: 'Label for the Create Classrooms link',
-    id: 'routes.routes.menuContentsClassroomsCreateLabel',
-  },
   menuContentsLessonsLabel: {
     defaultMessage: 'Lessons',
     description: 'Label for the Lessons link in the content navigation menu',
@@ -45,29 +34,6 @@ const routes: Record<'CONTENTS', RouteRequired> = {
     ),
     subRoutes: {
       ...routesContent,
-      CLASSROOM: {
-        label: <FormattedMessage {...messages.menuContentsClassroomLabel} />,
-        path: `/my-contents/classroom`,
-        menuIcon: (
-          <LoadSVG
-            Icon={ClassroomsIcon}
-            aria-label="svg-menu-my-contents-classroom"
-            title={messages.menuContentsClassroomLabel}
-          />
-        ),
-        subRoutes: {
-          CREATE: {
-            path: `/my-contents/classroom/create`,
-          },
-          UPDATE: {
-            path: `/my-contents/classroom/:classroomId`,
-          },
-          INVITE: {
-            path: `/my-contents/classroom/:classroomId/invite/:inviteId`,
-          },
-        },
-        isNavStrict: true,
-      },
       // LESSON: {
       //   label: <FormattedMessage {...messages.menuContentsLessonsLabel} />,
       //   path: `/my-contents/lessons`,

--- a/src/frontend/apps/standalone_site/src/features/Contents/routes.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/routes.tsx
@@ -7,11 +7,6 @@ import { RouteRequired } from 'routes';
 import { useContentFeatures } from './store/contentsStore';
 
 const messages = defineMessages({
-  menuContentsLessonsLabel: {
-    defaultMessage: 'Lessons',
-    description: 'Label for the Lessons link in the content navigation menu',
-    id: 'Contents.routes.menuContentsLessonsLabel',
-  },
   menuMyContentsLabel: {
     defaultMessage: 'My Contents',
     description: 'Label for the MyContents link in the main navigation menu',
@@ -34,18 +29,6 @@ const routes: Record<'CONTENTS', RouteRequired> = {
     ),
     subRoutes: {
       ...routesContent,
-      // LESSON: {
-      //   label: <FormattedMessage {...messages.menuContentsLessonsLabel} />,
-      //   path: `/my-contents/lessons`,
-      //   menuIcon: (
-      //     <CheckListIcon
-      //       width={30}
-      //       height={30}
-      //       role="img"
-      //       aria-label="svg-menu-my-contents-lessons"
-      //     />
-      //   ),
-      // },
     },
   },
 };

--- a/src/frontend/apps/standalone_site/src/features/Contents/routes.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/routes.tsx
@@ -1,0 +1,113 @@
+import { defineMessages, FormattedMessage } from 'react-intl';
+
+import { ReactComponent as LiveIcon } from 'assets/svg/iko_live.svg';
+import { ReactComponent as VueListIcon } from 'assets/svg/iko_vuelistesvg.svg';
+import { ReactComponent as ClassroomsIcon } from 'assets/svg/iko_webinairesvg.svg';
+import { LoadSVG } from 'components/Assets';
+import { RouteRequired } from 'routes';
+
+import { useContentFeatures } from './store/contentsStore';
+
+const messages = defineMessages({
+  menuContentsLivesLabel: {
+    defaultMessage: 'Webinars',
+    description: 'Label for the webinars link in the content navigation menu',
+    id: 'routes.routes.menuContentsLivesLabel',
+  },
+  menuContentsClassroomLabel: {
+    defaultMessage: 'Classrooms',
+    description: 'Label for the Classroom link in the content navigation menu',
+    id: 'routes.routes.menuContentsClassroomsLabel',
+  },
+  menuContentsClassroomCreateLabel: {
+    defaultMessage: 'Create Classroom',
+    description: 'Label for the Create Classrooms link',
+    id: 'routes.routes.menuContentsClassroomsCreateLabel',
+  },
+  menuContentsLessonsLabel: {
+    defaultMessage: 'Lessons',
+    description: 'Label for the Lessons link in the content navigation menu',
+    id: 'Contents.routes.menuContentsLessonsLabel',
+  },
+  menuMyContentsLabel: {
+    defaultMessage: 'My Contents',
+    description: 'Label for the MyContents link in the main navigation menu',
+    id: 'Contents.routes.menuMyContentsLabel',
+  },
+});
+
+const routesContent = useContentFeatures.getState().featureRoutes;
+
+const routes: Record<'CONTENTS', RouteRequired> = {
+  CONTENTS: {
+    label: <FormattedMessage {...messages.menuMyContentsLabel} />,
+    path: `/my-contents`,
+    menuIcon: (
+      <LoadSVG
+        Icon={VueListIcon}
+        aria-label="svg-menu-my-contents"
+        title={messages.menuMyContentsLabel}
+      />
+    ),
+    subRoutes: {
+      ...routesContent,
+      LIVE: {
+        label: <FormattedMessage {...messages.menuContentsLivesLabel} />,
+        path: `/my-contents/webinars`,
+        menuIcon: (
+          <LoadSVG
+            Icon={LiveIcon}
+            aria-label="svg-menu-my-contents-live"
+            title={messages.menuContentsLivesLabel}
+          />
+        ),
+        subRoutes: {
+          CREATE: {
+            path: `/my-contents/webinars/create`,
+          },
+          UPDATE: {
+            path: `/my-contents/webinars/:liveId`,
+          },
+        },
+        isNavStrict: true,
+      },
+      CLASSROOM: {
+        label: <FormattedMessage {...messages.menuContentsClassroomLabel} />,
+        path: `/my-contents/classroom`,
+        menuIcon: (
+          <LoadSVG
+            Icon={ClassroomsIcon}
+            aria-label="svg-menu-my-contents-classroom"
+            title={messages.menuContentsClassroomLabel}
+          />
+        ),
+        subRoutes: {
+          CREATE: {
+            path: `/my-contents/classroom/create`,
+          },
+          UPDATE: {
+            path: `/my-contents/classroom/:classroomId`,
+          },
+          INVITE: {
+            path: `/my-contents/classroom/:classroomId/invite/:inviteId`,
+          },
+        },
+        isNavStrict: true,
+      },
+      // LESSON: {
+      //   label: <FormattedMessage {...messages.menuContentsLessonsLabel} />,
+      //   path: `/my-contents/lessons`,
+      //   menuIcon: (
+      //     <CheckListIcon
+      //       width={30}
+      //       height={30}
+      //       role="img"
+      //       aria-label="svg-menu-my-contents-lessons"
+      //     />
+      //   ),
+      // },
+    },
+  },
+};
+
+export default routes;

--- a/src/frontend/apps/standalone_site/src/features/Contents/routes.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/routes.tsx
@@ -1,6 +1,5 @@
 import { defineMessages, FormattedMessage } from 'react-intl';
 
-import { ReactComponent as LiveIcon } from 'assets/svg/iko_live.svg';
 import { ReactComponent as VueListIcon } from 'assets/svg/iko_vuelistesvg.svg';
 import { ReactComponent as ClassroomsIcon } from 'assets/svg/iko_webinairesvg.svg';
 import { LoadSVG } from 'components/Assets';
@@ -9,11 +8,6 @@ import { RouteRequired } from 'routes';
 import { useContentFeatures } from './store/contentsStore';
 
 const messages = defineMessages({
-  menuContentsLivesLabel: {
-    defaultMessage: 'Webinars',
-    description: 'Label for the webinars link in the content navigation menu',
-    id: 'routes.routes.menuContentsLivesLabel',
-  },
   menuContentsClassroomLabel: {
     defaultMessage: 'Classrooms',
     description: 'Label for the Classroom link in the content navigation menu',
@@ -51,26 +45,6 @@ const routes: Record<'CONTENTS', RouteRequired> = {
     ),
     subRoutes: {
       ...routesContent,
-      LIVE: {
-        label: <FormattedMessage {...messages.menuContentsLivesLabel} />,
-        path: `/my-contents/webinars`,
-        menuIcon: (
-          <LoadSVG
-            Icon={LiveIcon}
-            aria-label="svg-menu-my-contents-live"
-            title={messages.menuContentsLivesLabel}
-          />
-        ),
-        subRoutes: {
-          CREATE: {
-            path: `/my-contents/webinars/create`,
-          },
-          UPDATE: {
-            path: `/my-contents/webinars/:liveId`,
-          },
-        },
-        isNavStrict: true,
-      },
       CLASSROOM: {
         label: <FormattedMessage {...messages.menuContentsClassroomLabel} />,
         path: `/my-contents/classroom`,

--- a/src/frontend/apps/standalone_site/src/features/Contents/store/contentsStore.ts
+++ b/src/frontend/apps/standalone_site/src/features/Contents/store/contentsStore.ts
@@ -2,8 +2,11 @@ import { ReactNode } from 'react';
 import { MessageDescriptor } from 'react-intl';
 import { create } from 'zustand';
 
+import { Route } from 'routes';
+
 interface UseContentFeatures {
   featureRouter: ReactNode[];
+  featureRoutes: Record<string, Route>;
   featureSamples: (playlistId?: string) => {
     title: MessageDescriptor;
     route: string;
@@ -14,6 +17,7 @@ interface UseContentFeatures {
 
 export const useContentFeatures = create<UseContentFeatures>(() => ({
   featureRouter: [],
+  featureRoutes: {},
   featureSamples: () => [],
   featureShuffles: [],
 }));

--- a/src/frontend/apps/standalone_site/src/features/Contents/store/contentsStore.ts
+++ b/src/frontend/apps/standalone_site/src/features/Contents/store/contentsStore.ts
@@ -3,7 +3,7 @@ import { MessageDescriptor } from 'react-intl';
 import { create } from 'zustand';
 
 interface UseContentFeatures {
-  featureRoutes: ReactNode[];
+  featureRouter: ReactNode[];
   featureSamples: (playlistId?: string) => {
     title: MessageDescriptor;
     route: string;
@@ -13,7 +13,7 @@ interface UseContentFeatures {
 }
 
 export const useContentFeatures = create<UseContentFeatures>(() => ({
-  featureRoutes: [],
+  featureRouter: [],
   featureSamples: () => [],
   featureShuffles: [],
 }));

--- a/src/frontend/apps/standalone_site/src/features/HomePage/components/HomePage.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/HomePage/components/HomePage.spec.tsx
@@ -6,6 +6,11 @@ import ReactTestUtils from 'react-dom/test-utils';
 import HomePage from './HomePage';
 
 jest.mock('features/Contents', () => ({
+  useContentRoutes: () => ({
+    CONTENTS: {
+      path: '/contents',
+    },
+  }),
   ContentsShuffle: () => <div>My ContentsShuffle</div>,
 }));
 

--- a/src/frontend/apps/standalone_site/src/features/HomePage/components/HomePage.tsx
+++ b/src/frontend/apps/standalone_site/src/features/HomePage/components/HomePage.tsx
@@ -7,7 +7,7 @@ import styled from 'styled-components';
 import banner from 'assets/img/homepage-banner.png';
 import { ContentsShuffle } from 'features/Contents';
 import { useMenu } from 'features/Menu';
-import { routes } from 'routes';
+import { useRoutes } from 'routes/useRoutes';
 
 const messages = defineMessages({
   SeeEverything: {
@@ -64,6 +64,7 @@ const TextBanner = styled(Text)<LayoutProps>`
 
 const HomePage = () => {
   const intl = useIntl();
+  const routes = useRoutes();
   const { isSmallerBreakpoint, breakpoint, isDesktop } = useResponsive();
   const { isMenuOpen } = useMenu();
   const [isBannerLoaded, setIsBannerLoaded] = useState(false);

--- a/src/frontend/apps/standalone_site/src/features/Menu/components/Menu.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Menu/components/Menu.spec.tsx
@@ -4,6 +4,7 @@ import { render } from 'lib-tests';
 import { Fragment } from 'react';
 import { BrowserRouter } from 'react-router-dom';
 
+import { featureContentLoader } from 'features/Contents';
 import { getFullThemeExtend } from 'styles/theme.extend';
 
 import { useMenu } from '../store/menuStore';
@@ -19,6 +20,8 @@ describe('<Menu />', () => {
   });
 
   test('renders Menu', () => {
+    featureContentLoader();
+
     render(<Menu />, { testingLibraryOptions: { wrapper: BrowserRouter } });
     expect(
       screen.getByRole(/menuitem/i, { name: /My playlists/i }),

--- a/src/frontend/apps/standalone_site/src/features/Menu/components/Menu.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Menu/components/Menu.tsx
@@ -5,7 +5,7 @@ import { useResponsive } from 'lib-components';
 import { defineMessages, useIntl } from 'react-intl';
 import styled from 'styled-components';
 
-import { Route, routes } from 'routes';
+import { Route, useRoutes } from 'routes';
 
 import { useMenu } from '../store/menuStore';
 
@@ -52,6 +52,7 @@ const Menu = () => {
   const intl = useIntl();
   const { isDesktop } = useResponsive();
   const { isMenuOpen } = useMenu();
+  const routes = useRoutes();
   const topRoutes: Route[] = [routes.HOMEPAGE, routes.PROFILE];
   const contents: Route[] = [routes.PLAYLIST, routes.CONTENTS];
 

--- a/src/frontend/apps/standalone_site/src/features/Playlist/features/UpdatePlaylist/components/UpdatePlaylistPage.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Playlist/features/UpdatePlaylist/components/UpdatePlaylistPage.spec.tsx
@@ -4,6 +4,8 @@ import fetchMock from 'fetch-mock';
 import { Playlist } from 'lib-components';
 import { Deferred, render } from 'lib-tests';
 
+import { featureContentLoader } from 'features/Contents';
+
 import { UpdatePlaylistPage } from './UpdatePlaylistPage';
 
 jest.mock('react-router-dom', () => ({
@@ -130,6 +132,8 @@ describe('<UpdatePlaylistPage />', () => {
   });
 
   it('checks the contents render by playlist', async () => {
+    featureContentLoader();
+
     render(<UpdatePlaylistPage />);
 
     deferredPlaylist.resolve(playlist);

--- a/src/frontend/apps/standalone_site/src/routes/AppRoutes.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/routes/AppRoutes.spec.tsx
@@ -4,6 +4,8 @@ import fetchMock from 'fetch-mock';
 import { useCurrentUser, useJwt } from 'lib-components';
 import { render } from 'lib-tests';
 
+import featureContentLoader from 'features/Contents/features/featureLoader';
+
 import AppRoutes from './AppRoutes';
 
 jest.mock('features/Header', () => {
@@ -21,6 +23,7 @@ jest.mock('features/HomePage', () => ({
 }));
 
 jest.mock('features/Contents/', () => ({
+  ...jest.requireActual('features/Contents/'),
   ContentsRouter: () => <div>My ContentsRouter Page</div>,
 }));
 
@@ -43,6 +46,8 @@ jest.mock('features/Authentication', () => ({
 }));
 
 window.scrollTo = jest.fn();
+
+featureContentLoader();
 
 describe('<AppRoutes />', () => {
   beforeEach(() => {
@@ -163,7 +168,7 @@ describe('<AppRoutes />', () => {
 
       expect(await screen.findByText(/My Playlist Page/i)).toBeInTheDocument();
 
-      userEvent.click(screen.getByRole(/menuitem/i, { name: /Classrooms/i }));
+      userEvent.click(screen.getByRole(/menuitem/i, { name: /My Contents/i }));
 
       await waitFor(() => {
         expect(screen.getByText(/My ContentsRouter Page/i)).toBeInTheDocument();

--- a/src/frontend/apps/standalone_site/src/routes/AppRoutes.tsx
+++ b/src/frontend/apps/standalone_site/src/routes/AppRoutes.tsx
@@ -77,7 +77,7 @@ const AnonymousRoutes = () => {
   return (
     <Switch>
       <Route
-        path={routes.CONTENTS.subRoutes.CLASSROOM.subRoutes?.INVITE?.path}
+        path={routes.CONTENTS.subRoutes.CLASSROOM.subRoutes?.INVITE.path}
         exact
       >
         <MainLayout

--- a/src/frontend/apps/standalone_site/src/routes/AppRoutes.tsx
+++ b/src/frontend/apps/standalone_site/src/routes/AppRoutes.tsx
@@ -14,7 +14,7 @@ import { HomePage } from 'features/HomePage';
 import { Menu } from 'features/Menu';
 import { PagesApi, usePagesApi } from 'features/PagesApi';
 
-import { routes } from './routes';
+import { useRoutes } from './useRoutes';
 
 const { AuthRouter } = lazyImport(() => import('features/Authentication'));
 const { ContentsRouter } = lazyImport(() => import('features/Contents/'));
@@ -69,6 +69,7 @@ const AppRoutes = () => {
 
 const AnonymousRoutes = () => {
   const { routesPagesApi, isPagesLoading } = usePagesApi();
+  const routes = useRoutes();
 
   if (isPagesLoading) {
     return <ContentSpinner boxProps={{ height: '100vh' }} />;
@@ -77,7 +78,7 @@ const AnonymousRoutes = () => {
   return (
     <Switch>
       <Route
-        path={routes.CONTENTS.subRoutes.CLASSROOM.subRoutes?.INVITE.path}
+        path={routes.CONTENTS.subRoutes?.CLASSROOM?.subRoutes?.INVITE.path}
         exact
       >
         <MainLayout
@@ -119,6 +120,7 @@ const AnonymousRoutes = () => {
 };
 
 const AuthenticatedRoutes = () => {
+  const routes = useRoutes();
   const history = useHistory();
   const { pathname } = useLocation();
   const { routesPagesApi, isPagesLoading } = usePagesApi();
@@ -130,7 +132,7 @@ const AuthenticatedRoutes = () => {
     if (pathname === routes.LOGIN.path) {
       history.replace(routes.HOMEPAGE.path);
     }
-  }, [history, pathname]);
+  }, [history, pathname, routes]);
 
   if (isPagesLoading) {
     return <ContentSpinner boxProps={{ height: '100vh' }} />;

--- a/src/frontend/apps/standalone_site/src/routes/index.ts
+++ b/src/frontend/apps/standalone_site/src/routes/index.ts
@@ -1,2 +1,3 @@
 export { default as AppRoutes } from './AppRoutes';
 export * from './routes';
+export * from './useRoutes';

--- a/src/frontend/apps/standalone_site/src/routes/routes.tsx
+++ b/src/frontend/apps/standalone_site/src/routes/routes.tsx
@@ -5,7 +5,6 @@ import { ReactComponent as HomeIcon } from 'assets/svg/iko_homesvg.svg';
 import { ReactComponent as StarIcon } from 'assets/svg/iko_starsvg.svg';
 import { ReactComponent as VueListIcon } from 'assets/svg/iko_vuelistesvg.svg';
 import { LoadSVG } from 'components/Assets';
-import routesContent from 'features/Contents/routes';
 
 const messages = defineMessages({
   menuHomePageLabel: {
@@ -44,7 +43,6 @@ enum ERouteNames {
 
   PLAYLIST = 'PLAYLIST',
   ORGANIZATION = 'ORGANIZATION',
-  CONTENTS = 'CONTENTS',
   LOGIN = 'LOGIN',
   PASSWORD_RESET = 'PASSWORD_RESET',
   PASSWORD_RESET_CONFIRM = 'PASSWORD_RESET_CONFIRM',
@@ -71,15 +69,14 @@ export type RouteRequired<T extends string = string> = BasicRoute &
   Pick<Required<Route<T>>, 'subRoutes'>;
 type SubRoute = Route & { hideSubRoute?: boolean };
 
-type Routes = {
+export type MainRoutes = {
   [key in ERouteNames]: BasicRoute;
 } & {
-  [ERouteNames.CONTENTS]: RouteRequired;
   [ERouteNames.PROFILE]: RouteRequired<EMyProfileSubRoutesNames>;
   [ERouteNames.PLAYLIST]: RouteRequired<EPlaylistSubRouteNames>;
 };
 
-export const routes: Routes = {
+export const routes: MainRoutes = {
   HOMEPAGE: {
     label: <FormattedMessage {...messages.menuHomePageLabel} />,
     path: `/`,
@@ -159,5 +156,4 @@ export const routes: Routes = {
       />
     ),
   },
-  ...routesContent,
 };

--- a/src/frontend/apps/standalone_site/src/routes/routes.tsx
+++ b/src/frontend/apps/standalone_site/src/routes/routes.tsx
@@ -2,12 +2,10 @@ import { defineMessages, FormattedMessage } from 'react-intl';
 
 import { ReactComponent as AvatarIcon } from 'assets/svg/iko_avatarsvg.svg';
 import { ReactComponent as HomeIcon } from 'assets/svg/iko_homesvg.svg';
-import { ReactComponent as LiveIcon } from 'assets/svg/iko_live.svg';
-import { ReactComponent as VideoIcon } from 'assets/svg/iko_next.svg';
 import { ReactComponent as StarIcon } from 'assets/svg/iko_starsvg.svg';
 import { ReactComponent as VueListIcon } from 'assets/svg/iko_vuelistesvg.svg';
-import { ReactComponent as ClassroomsIcon } from 'assets/svg/iko_webinairesvg.svg';
 import { LoadSVG } from 'components/Assets';
+import routesContent from 'features/Contents/routes';
 
 const messages = defineMessages({
   menuHomePageLabel: {
@@ -36,36 +34,6 @@ const messages = defineMessages({
       'Label for the My Organizations link in the main navigation menu',
     id: 'routes.routes.menuMyOrganizationsLabel',
   },
-  menuMyContentsLabel: {
-    defaultMessage: 'My Contents',
-    description: 'Label for the MyContents link in the main navigation menu',
-    id: 'routes.routes.menuMyContentsLabel',
-  },
-  menuContentsVideosLabel: {
-    defaultMessage: 'Videos',
-    description: 'Label for the video link in the content navigation menu',
-    id: 'routes.routes.menuContentsVideosLabel',
-  },
-  menuContentsLivesLabel: {
-    defaultMessage: 'Webinars',
-    description: 'Label for the webinars link in the content navigation menu',
-    id: 'routes.routes.menuContentsLivesLabel',
-  },
-  menuContentsClassroomLabel: {
-    defaultMessage: 'Classrooms',
-    description: 'Label for the Classroom link in the content navigation menu',
-    id: 'routes.routes.menuContentsClassroomsLabel',
-  },
-  menuContentsClassroomCreateLabel: {
-    defaultMessage: 'Create Classroom',
-    description: 'Label for the Create Classrooms link',
-    id: 'routes.routes.menuContentsClassroomsCreateLabel',
-  },
-  menuContentsLessonsLabel: {
-    defaultMessage: 'Lessons',
-    description: 'Label for the Lessons link in the content navigation menu',
-    id: 'routes.routes.menuContentsLessonsLabel',
-  },
 });
 
 enum ERouteNames {
@@ -81,12 +49,6 @@ enum ERouteNames {
   PASSWORD_RESET = 'PASSWORD_RESET',
   PASSWORD_RESET_CONFIRM = 'PASSWORD_RESET_CONFIRM',
 }
-enum EMyContentsSubRouteNames {
-  VIDEO = 'VIDEO',
-  LIVE = 'LIVE',
-  CLASSROOM = 'CLASSROOM',
-  //LESSON = 'LESSON',
-}
 enum EMyProfileSubRoutesNames {
   PROFILE_SETTINGS = 'PROFILE_SETTINGS',
 }
@@ -97,37 +59,24 @@ enum EPlaylistSubRouteNames {
 
 type BasicRoute = Omit<Route, 'subRoutes'>;
 
-export interface Route {
+export interface Route<TSubRoute extends string = string> {
   label?: React.ReactNode;
   path: string;
   alias?: string[];
   menuIcon?: React.ReactNode;
   isNavStrict?: boolean; // if true, all the subroutes will be active in the menu
-  subRoutes?: { [key in string]: SubRoute };
+  subRoutes?: Record<TSubRoute, SubRoute>;
 }
+export type RouteRequired<T extends string = string> = BasicRoute &
+  Pick<Required<Route<T>>, 'subRoutes'>;
 type SubRoute = Route & { hideSubRoute?: boolean };
 
 type Routes = {
-  [key in ERouteNames as Exclude<
-    ERouteNames,
-    'CONTENTS' | 'PROFILE' | 'PLAYLIST'
-  >]: BasicRoute;
+  [key in ERouteNames]: BasicRoute;
 } & {
-  [ERouteNames.CONTENTS]: Route & {
-    subRoutes: {
-      [key in EMyContentsSubRouteNames]: SubRoute;
-    };
-  };
-  [ERouteNames.PROFILE]: Route & {
-    subRoutes: {
-      [key in EMyProfileSubRoutesNames]: SubRoute;
-    };
-  };
-  [ERouteNames.PLAYLIST]: Route & {
-    subRoutes: {
-      [key in EPlaylistSubRouteNames]: SubRoute;
-    };
-  };
+  [ERouteNames.CONTENTS]: RouteRequired;
+  [ERouteNames.PROFILE]: RouteRequired<EMyProfileSubRoutesNames>;
+  [ERouteNames.PLAYLIST]: RouteRequired<EPlaylistSubRouteNames>;
 };
 
 export const routes: Routes = {
@@ -210,92 +159,5 @@ export const routes: Routes = {
       />
     ),
   },
-  CONTENTS: {
-    label: <FormattedMessage {...messages.menuMyContentsLabel} />,
-    path: `/my-contents`,
-    menuIcon: (
-      <LoadSVG
-        Icon={VueListIcon}
-        aria-label="svg-menu-my-contents"
-        title={messages.menuMyContentsLabel}
-      />
-    ),
-    subRoutes: {
-      VIDEO: {
-        label: <FormattedMessage {...messages.menuContentsVideosLabel} />,
-        path: `/my-contents/videos`,
-        menuIcon: (
-          <LoadSVG
-            Icon={VideoIcon}
-            aria-label="svg-menu-my-contents-videos"
-            title={messages.menuContentsVideosLabel}
-          />
-        ),
-        subRoutes: {
-          CREATE: {
-            path: `/my-contents/videos/create`,
-          },
-          UPDATE: {
-            path: `/my-contents/videos/:videoId`,
-          },
-        },
-        isNavStrict: true,
-      },
-      LIVE: {
-        label: <FormattedMessage {...messages.menuContentsLivesLabel} />,
-        path: `/my-contents/webinars`,
-        menuIcon: (
-          <LoadSVG
-            Icon={LiveIcon}
-            aria-label="svg-menu-my-contents-live"
-            title={messages.menuContentsLivesLabel}
-          />
-        ),
-        subRoutes: {
-          CREATE: {
-            path: `/my-contents/webinars/create`,
-          },
-          UPDATE: {
-            path: `/my-contents/webinars/:liveId`,
-          },
-        },
-        isNavStrict: true,
-      },
-      CLASSROOM: {
-        label: <FormattedMessage {...messages.menuContentsClassroomLabel} />,
-        path: `/my-contents/classroom`,
-        menuIcon: (
-          <LoadSVG
-            Icon={ClassroomsIcon}
-            aria-label="svg-menu-my-contents-classroom"
-            title={messages.menuContentsClassroomLabel}
-          />
-        ),
-        subRoutes: {
-          CREATE: {
-            path: `/my-contents/classroom/create`,
-          },
-          UPDATE: {
-            path: `/my-contents/classroom/:classroomId`,
-          },
-          INVITE: {
-            path: `/my-contents/classroom/:classroomId/invite/:inviteId`,
-          },
-        },
-        isNavStrict: true,
-      },
-      // LESSON: {
-      //   label: <FormattedMessage {...messages.menuContentsLessonsLabel} />,
-      //   path: `/my-contents/lessons`,
-      //   menuIcon: (
-      //     <CheckListIcon
-      //       width={30}
-      //       height={30}
-      //       role="img"
-      //       aria-label="svg-menu-my-contents-lessons"
-      //     />
-      //   ),
-      // },
-    },
-  },
+  ...routesContent,
 };

--- a/src/frontend/apps/standalone_site/src/routes/useRoutes.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/routes/useRoutes.spec.tsx
@@ -1,0 +1,22 @@
+import { renderHook } from '@testing-library/react-hooks';
+
+import { useContentFeatures } from 'features/Contents';
+
+import { useRoutes } from './useRoutes';
+
+describe('useRoutes', () => {
+  it('checks the states are correctly init', () => {
+    useContentFeatures.setState({
+      featureRoutes: {
+        TEST: { label: 'My feature test' },
+      } as any,
+    });
+
+    const { result } = renderHook(() => useRoutes());
+
+    expect(result.current.LOGIN.path).toBe('/login');
+    expect(result.current.CONTENTS.subRoutes.TEST.label).toBe(
+      'My feature test',
+    );
+  });
+});

--- a/src/frontend/apps/standalone_site/src/routes/useRoutes.tsx
+++ b/src/frontend/apps/standalone_site/src/routes/useRoutes.tsx
@@ -1,0 +1,16 @@
+import { useContentRoutes } from 'features/Contents/';
+
+import { MainRoutes, RouteRequired, routes } from './routes';
+
+type Routes = MainRoutes & {
+  CONTENTS: RouteRequired;
+};
+
+export const useRoutes = (): Routes => {
+  const contentRoutes = useContentRoutes();
+
+  return {
+    ...routes,
+    ...contentRoutes,
+  };
+};


### PR DESCRIPTION
## Purpose

Better routes separation, the feature Contents, Videos, Classroom, Live manage their own routes.
In fino, just by deactivated a feature in `featureLoader`, all the website will have the feature deactivated, it can be usefull in case of white label website when a "client" is by exemple just interested by the classroom feature.

## Proposal

- [x] better routes separation Contents
- [x] better routes separation Videos
- [x] better routes separation Classroom
- [x] better routes separation Webinar
- [x] featureLoader function

[Marsha - routes.webm](https://github.com/openfun/marsha/assets/25994652/3f308ce9-69c6-480b-a492-e6aebc93a5ed)

