### PR TITLE
🐛(back) use existing setting DEFAULT_FROM_EMAIL instead of EMAIL_FROM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Nest frontend api routes of video related objects
   (thumbnails, timed_text_track, shared_live_media...) (#2228)
 - Change wording on modals
+- use existing setting DEFAULT_FROM_EMAIL instead of EMAIL_FROM
 
 ### Fixed
 

--- a/src/backend/marsha/core/api/live_session.py
+++ b/src/backend/marsha/core/api/live_session.py
@@ -231,10 +231,10 @@ class LiveSessionViewSet(
                 # pylint:disable=redefined-builtin
                 object = _("Registration validated!")
                 send_mail(
-                    f"{object} {video.title}",
-                    msg_plain,
-                    settings.EMAIL_FROM,
-                    [livesession.email],
+                    subject=f"{object} {video.title}",
+                    message=msg_plain,
+                    from_email=None,
+                    recipient_list=[livesession.email],
                     html_message=msg_html,
                     fail_silently=False,
                 )

--- a/src/backend/marsha/core/management/commands/send_reminders.py
+++ b/src/backend/marsha/core/management/commands/send_reminders.py
@@ -89,10 +89,10 @@ class Command(BaseCommand):
 
                     try:
                         send_mail(
-                            _(mail_object),
-                            msg_plain,
-                            settings.EMAIL_FROM,
-                            [livesession.email],
+                            subject=_(mail_object),
+                            message=msg_plain,
+                            from_email=None,
+                            recipient_list=[livesession.email],
                             html_message=msg_html,
                             fail_silently=False,
                         )

--- a/src/backend/marsha/core/tests/api/live_sessions/base.py
+++ b/src/backend/marsha/core/tests/api/live_sessions/base.py
@@ -21,6 +21,8 @@ class LiveSessionApiTestCase(TestCase):
         # check we send it to the right email
         self.assertEqual(mail.outbox[0].to[0], email)
 
+        self.assertEqual(mail.outbox[0].from_email, "contact@marsha.education")
+
         # check it's the right email content
         self.assertEqual(
             mail.outbox[0].subject, f"Registration validated! {video.title}"

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -495,7 +495,7 @@ class Base(Configuration):
     EMAIL_HOST_PASSWORD = values.Value(None)
     EMAIL_PORT = values.PositiveIntegerValue(None)
     EMAIL_USE_TLS = values.BooleanValue(False)
-    EMAIL_FROM = values.Value("from@fun-mooc.fr")
+    DEFAULT_FROM_EMAIL = values.Value("contact@marsha.education")
 
     # REMINDERS SENT for scheduled webinars
     REMINDER_1, REMINDER_2, REMINDER_3, REMINDER_DATE_UPDATED, REMINDER_ERROR = (


### PR DESCRIPTION
## Purpose

We have defined a setting EMAIL_FROM and this setting is not an existing one in Django. We can remove it and allow to define the existing one DEFAULT_FROM_EMAIL. This setting is use everywhere in Django and is the standard way to define a from_email.

## Proposal

- [x] use existing setting DEFAULT_FROM_EMAIL instead of EMAIL_FROM

