### PR TITLE
🔧(back) enable sentry performance and profiling in django

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   (thumbnails, timed_text_track, shared_live_media...) (#2228)
 - Change wording on modals
 - use existing setting DEFAULT_FROM_EMAIL instead of EMAIL_FROM
+- enable sentry performance and profiling in django
 
 ### Fixed
 

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -419,6 +419,8 @@ class Base(Configuration):
     VIDEO_ATTENDANCES_CACHE_DURATION = values.Value(300)  # 5 minutes
 
     SENTRY_DSN = values.Value(None)
+    SENTRY_TRACES_SAMPLE_RATE = values.FloatValue(1.0)
+    SENTRY_PROFILES_SAMPLE_RATE = values.FloatValue(1.0)
 
     # Resource max file size
     DOCUMENT_SOURCE_MAX_SIZE = values.PositiveIntegerValue(2**30)  # 1GB
@@ -798,6 +800,8 @@ class Base(Configuration):
                 environment=cls._get_environment(),
                 release=get_release(),
                 integrations=[DjangoIntegration()],
+                traces_sample_rate=cls.SENTRY_TRACES_SAMPLE_RATE,
+                profiles_sample_rate=cls.SENTRY_PROFILES_SAMPLE_RATE,
             )
             with sentry_sdk.configure_scope() as scope:
                 scope.set_extra("application", "backend")


### PR DESCRIPTION
## Purpose

We want to enable and configure the sentry performance and profiling feature. New settings SENTRY_TRACES_SAMPLE_RATE and SENTRY_PROFILES_SAMPLE_RATE are added to control these features.

## Proposal

- [x] enable sentry performance and profiling in django

