### PR TITLE
✨(backend) use a specific duration for moderator classroom link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Setting for instructor classroom invitation link expiration 
+
 ## [4.1.0] - 2023-05-23
 
 ### Added

--- a/src/backend/marsha/bbb/utils/tokens.py
+++ b/src/backend/marsha/bbb/utils/tokens.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 from django.conf import settings
 from django.utils import timezone
 
-from marsha.core.models import NONE
+from marsha.core.models import INSTRUCTOR, NONE
 from marsha.core.simple_jwt.tokens import ResourceAccessToken
 
 
@@ -51,9 +51,12 @@ def create_classroom_stable_invite_jwt(classroom, role=NONE, permissions=None):
     if classroom.starting_at:
         validity_end = classroom.starting_at + timedelta(days=2)
     else:
+        duration = settings.BBB_INVITE_JWT_DEFAULT_DAYS_DURATION
+        if role == INSTRUCTOR:
+            duration = settings.BBB_INVITE_JWT_INSTRUCTOR_DAYS_DURATION
         validity_end = timezone.now().replace(
             hour=0, minute=0, second=0, microsecond=0
-        ) + timedelta(days=settings.BBB_INVITE_JWT_DEFAULT_DAYS_DURATION)
+        ) + timedelta(days=duration)
 
     resource_jwt.set_exp(
         from_time=classroom.created_on,

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -381,6 +381,7 @@ class Base(Configuration):
     BBB_API_TIMEOUT = values.PositiveIntegerValue(10)
     ALLOWED_CLASSROOM_DOCUMENT_MIME_TYPES = values.ListValue(["application/pdf"])
     BBB_INVITE_JWT_DEFAULT_DAYS_DURATION = values.PositiveIntegerValue(30)
+    BBB_INVITE_JWT_INSTRUCTOR_DAYS_DURATION = values.PositiveIntegerValue(30)
 
     # deposit application
     DEPOSIT_ENABLED = values.BooleanValue(False)


### PR DESCRIPTION


## Purpose

When we build a moderator invite link for a classroom, we want to set a specific token expiration, based on a dedicated setting.

Fixes #2247 

## Proposal

Add a BBB_INVITE_JWT_INSTRUCTOR_DAYS_DURATION setting, and use is for calculating the lifetime of an instructor token.
