### PR TITLE
🐛(front) remove initial / from page slug to use it in the API fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Setting for instructor classroom invitation link expiration 
 
+### Fixed
+
+- remove initial / from page slug to use it in the API fetch
+
 ## [4.1.0] - 2023-05-23
 
 ### Added

--- a/src/frontend/apps/standalone_site/src/features/PagesApi/components/PagesApi.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/PagesApi/components/PagesApi.spec.tsx
@@ -7,7 +7,7 @@ import PagesApi from './PagesApi';
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useLocation: () => ({
-    pathname: 'cgi',
+    pathname: '/cgi',
   }),
 }));
 

--- a/src/frontend/apps/standalone_site/src/features/PagesApi/components/PagesApi.tsx
+++ b/src/frontend/apps/standalone_site/src/features/PagesApi/components/PagesApi.tsx
@@ -24,7 +24,7 @@ const BoxMarkdown = styled(Box)`
 
 const PagesApi = () => {
   const location = useLocation();
-  const { data, isLoading } = usePageApi(location.pathname);
+  const { data, isLoading } = usePageApi(location.pathname.slice(1));
 
   return (
     <Box margin={{ top: 'auto' }}>


### PR DESCRIPTION
## Purpose

The location.pathname always contains the initial / as explain in the MDN documentation. This leads to a malform endpoint when fetching the api page. slash is used twice and matches the wildcard route.

## Proposal

- [x] remove initial / from page slug to use it in the API fetch 

