### PR TITLE
🐛(frontend) fix potential side effect with refreshToken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - remove initial / from page slug to use it in the API fetch
+- Blacklist the refresh token on the frontend side (#2265)
 
 ## [4.1.0] - 2023-05-23
 

--- a/src/frontend/packages/lib_components/src/common/queries/fetchReconnectWrapper.tsx
+++ b/src/frontend/packages/lib_components/src/common/queries/fetchReconnectWrapper.tsx
@@ -1,5 +1,6 @@
 import { refreshToken } from '@lib-components/data/sideEffects/refreshToken';
 import { useJwt } from '@lib-components/hooks/stores/useJwt';
+import { sleep } from '@lib-components/utils/system';
 
 let routesExclude = ['/account/api/token/', '/e2e/api/'];
 let routesInclude = ['/api/', '/xapi/'];
@@ -65,6 +66,8 @@ export const fetchReconnectWrapper = async (
        * - If multiple requests are made very quickly, the refresh token can be blacklisted,
        *   in this case, we try to reconnect with the potential new access token.
        */
+      await sleep(400);
+
       jwt = useJwt.getState().getJwt();
       if (jwt) {
         try {

--- a/src/frontend/packages/lib_components/src/data/sideEffects/refreshToken/index.ts
+++ b/src/frontend/packages/lib_components/src/data/sideEffects/refreshToken/index.ts
@@ -1,3 +1,4 @@
+import { useJwt } from '@lib-components/hooks/stores/useJwt';
 import { TokenResponse } from '@lib-components/types/jwt';
 
 const isValidate = (response: unknown): response is TokenResponse => {
@@ -19,6 +20,12 @@ export const refreshToken = async (
   refreshToken: string,
   signal?: AbortSignal,
 ) => {
+  if (useJwt.getState().refreshJwtBlackListed === refreshToken) {
+    throw new Error('Refresh token is blacklisted');
+  }
+
+  useJwt.getState().setRefreshJwtBlackListed(refreshToken);
+
   const response = await fetch('/account/api/token/refresh/', {
     headers: {
       'Content-Type': 'application/json',

--- a/src/frontend/packages/lib_components/src/hooks/stores/useJwt/index.spec.tsx
+++ b/src/frontend/packages/lib_components/src/hooks/stores/useJwt/index.spec.tsx
@@ -84,4 +84,10 @@ describe('useJwt', () => {
 
     expect(useJwt.getState().getJwt()).toEqual('another token');
   });
+
+  it('checks refreshJwtBlackListed', () => {
+    expect(useJwt.getState().refreshJwtBlackListed).toEqual(undefined);
+    useJwt.getState().setRefreshJwtBlackListed('some token');
+    expect(useJwt.getState().refreshJwtBlackListed).toEqual('some token');
+  });
 });

--- a/src/frontend/packages/lib_components/src/hooks/stores/useJwt/index.ts
+++ b/src/frontend/packages/lib_components/src/hooks/stores/useJwt/index.ts
@@ -7,6 +7,7 @@ const JWT_KEY = 'JWT';
 const REFRESH_JWT_KEY = 'REFRESH_JWT';
 
 interface JwtStoreInterface {
+  refreshJwtBlackListed?: string;
   jwt?: string;
   refreshJwt?: string;
   internalDecodedJwt?: DecodedJwt;
@@ -14,12 +15,14 @@ interface JwtStoreInterface {
   setJwt: (jwt: JwtStoreInterface['jwt']) => void;
   getRefreshJwt: () => JwtStoreInterface['refreshJwt'];
   setRefreshJwt: (refreshJwt: JwtStoreInterface['refreshJwt']) => void;
+  setRefreshJwtBlackListed: (refreshJwt: string) => void;
   setDecodedJwt: (jwt: JwtStoreInterface['jwt']) => void;
   getDecodedJwt: () => JwtStoreInterface['internalDecodedJwt'];
   resetJwt: () => void;
 }
 
 const localStore = create<JwtStoreInterface>((set, get) => ({
+  refreshJwtBlackListed: undefined,
   jwt: undefined,
   refreshJwt: undefined,
   internalDecodedJwt: undefined,
@@ -27,6 +30,12 @@ const localStore = create<JwtStoreInterface>((set, get) => ({
   setJwt: (jwt) => set((state) => ({ ...state, jwt })),
   getRefreshJwt: () => get().refreshJwt,
   setRefreshJwt: (refreshJwt) => set((state) => ({ ...state, refreshJwt })),
+  setRefreshJwtBlackListed: (refreshJwt) => {
+    set((state) => ({
+      ...state,
+      refreshJwtBlackListed: refreshJwt,
+    }));
+  },
   setDecodedJwt: (jwt) => {
     const decoded = decodeJwt(jwt);
     set((state) => ({ ...state, internalDecodedJwt: decoded }));
@@ -50,6 +59,7 @@ const localStore = create<JwtStoreInterface>((set, get) => ({
 }));
 
 export const persistentStore = create<JwtStoreInterface>((set, get) => ({
+  refreshJwtBlackListed: undefined,
   jwt: localStorage.getItem(JWT_KEY) || undefined,
   refreshJwt: localStorage.getItem(REFRESH_JWT_KEY) || undefined,
   internalDecodedJwt: undefined,
@@ -77,6 +87,12 @@ export const persistentStore = create<JwtStoreInterface>((set, get) => ({
       ? localStorage.setItem(REFRESH_JWT_KEY, refreshJwt)
       : localStorage.removeItem(REFRESH_JWT_KEY);
     set((state) => ({ ...state, refreshJwt }));
+  },
+  setRefreshJwtBlackListed: (refreshJwt) => {
+    set((state) => ({
+      ...state,
+      refreshJwtBlackListed: refreshJwt,
+    }));
   },
   setDecodedJwt: (jwt) => {
     if (jwt) {

--- a/src/frontend/packages/lib_components/src/utils/system.ts
+++ b/src/frontend/packages/lib_components/src/utils/system.ts
@@ -1,0 +1,2 @@
+export const sleep = (ms: number) =>
+  new Promise((resolve) => setTimeout(resolve, ms));


### PR DESCRIPTION
## Purpose

In some cases, the refreshToken can be called twice in a row without being considerated blacklisted by the backend, this can produce some side effect and log out our user.
We added as well a blacklisting in the frontend side to prevent this kind of behavior.

## Proposal

- [x] Add a blacklist refreshJwt in a store

