### PR TITLE
🔧(back) filter dockerflow healthcheck in sentry before_send_transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Delete BBB recording when VOD from a ClassroomRecording is created
 - Add an attribute to consumer site to deactivate classroom recording
   conversion to VOD
+- Filter dockerflow healthcheck in sentry before_send_transaction
 
 ### Changed
 

--- a/src/backend/marsha/core/sentry.py
+++ b/src/backend/marsha/core/sentry.py
@@ -1,0 +1,29 @@
+"""Module dedicated to sentry filtering functions"""
+from urllib.parse import urlparse
+
+from django.conf import settings
+
+from dockerflow.django.middleware import DockerflowMiddleware
+
+
+def _match_dockerflow_urls(url):
+    """Check if the sentry url path matches dockerflow urls."""
+    for pattern, _ in DockerflowMiddleware.viewpatterns:
+        if pattern.match(url):
+            return True
+
+    return False
+
+
+def filter_transactions(event, hint):  # pylint: disable=unused-argument
+    """Filter transactions for Sentry."""
+    event_url = event.get("request", {}).get("url")
+    if not event_url:
+        return event
+
+    url = urlparse(event_url)
+
+    if settings.SENTRY_IGNORE_HEALTH_CHECKS and _match_dockerflow_urls(url.path):
+        return None
+
+    return event

--- a/src/backend/marsha/core/tests/test_sentry.py
+++ b/src/backend/marsha/core/tests/test_sentry.py
@@ -1,0 +1,82 @@
+"""Test for sentry module"""
+
+from django.test import TestCase, override_settings
+
+from marsha.core.sentry import filter_transactions
+
+
+class SentryFilteringTestCase(TestCase):
+    """Test about sentry filtering"""
+
+    @override_settings(SENTRY_IGNORE_HEALTH_CHECKS=True)
+    def test_filtering_without_request_in_event(self):
+        """Without request parameter in the event, the event should be return directly"""
+
+        event = {"foo": "bar"}
+
+        filtered_event = filter_transactions(event, None)
+
+        self.assertEqual(event, filtered_event)
+
+    @override_settings(SENTRY_IGNORE_HEALTH_CHECKS=True)
+    def test_filtering_without_url_in_the_request(self):
+        """Without url in the request, the event should be return directly"""
+
+        event = {
+            "foo": "bar",
+            "request": {
+                "query_string": "query=foobar&page=2",
+            },
+        }
+
+        filtered_event = filter_transactions(event, None)
+
+        self.assertEqual(event, filtered_event)
+
+    @override_settings(SENTRY_IGNORE_HEALTH_CHECKS=False)
+    def test_filtering_setting_disabled_should_return_the_event(self):
+        """When the SENTRY_IGNORE_HEALTH_CHECKS is set to False, the event should be return"""
+
+        event = {
+            "foo": "bar",
+            "request": {
+                "query_string": "query=foobar&page=2",
+                "url": "https://absolute.uri/__heartbeat__/",
+            },
+        }
+
+        filtered_event = filter_transactions(event, None)
+
+        self.assertEqual(event, filtered_event)
+
+    @override_settings(SENTRY_IGNORE_HEALTH_CHECKS=True)
+    def test_filtering_url_matching_dockerflow_heartbeat_should_return_none(self):
+        """When a request url matches a dockerflow heartbeat pattern, should return None"""
+
+        event = {
+            "foo": "bar",
+            "request": {
+                "query_string": "query=foobar&page=2",
+                "url": "https://absolute.uri/__heartbeat__/",
+            },
+        }
+
+        filtered_event = filter_transactions(event, None)
+
+        self.assertIsNone(filtered_event)
+
+    @override_settings(SENTRY_IGNORE_HEALTH_CHECKS=True)
+    def test_filtering_url_matching_dockerflow_lbheartbeat_should_return_none(self):
+        """When a request url matches a dockerflow lbheartbeat pattern, should return None"""
+
+        event = {
+            "foo": "bar",
+            "request": {
+                "query_string": "query=foobar&page=2",
+                "url": "https://absolute.uri/__lbheartbeat__/",
+            },
+        }
+
+        filtered_event = filter_transactions(event, None)
+
+        self.assertIsNone(filtered_event)

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -10,6 +10,7 @@ from datetime import timedelta
 import json
 import os
 
+from django.utils.module_loading import import_string
 from django.utils.translation import gettext_lazy as _
 
 from configurations import Configuration, values
@@ -422,6 +423,7 @@ class Base(Configuration):
     SENTRY_DSN = values.Value(None)
     SENTRY_TRACES_SAMPLE_RATE = values.FloatValue(1.0)
     SENTRY_PROFILES_SAMPLE_RATE = values.FloatValue(1.0)
+    SENTRY_IGNORE_HEALTH_CHECKS = values.BooleanValue(True)
 
     # Resource max file size
     DOCUMENT_SOURCE_MAX_SIZE = values.PositiveIntegerValue(2**30)  # 1GB
@@ -803,6 +805,9 @@ class Base(Configuration):
                 integrations=[DjangoIntegration()],
                 traces_sample_rate=cls.SENTRY_TRACES_SAMPLE_RATE,
                 profiles_sample_rate=cls.SENTRY_PROFILES_SAMPLE_RATE,
+                before_send_transaction=import_string(
+                    "marsha.core.sentry.filter_transactions"
+                ),
             )
             with sentry_sdk.configure_scope() as scope:
                 scope.set_extra("application", "backend")


### PR DESCRIPTION
## Purpose

We want to exclude all requests made by dockerflow healthchecks because they can spam sentry profiling.

## Proposal

- [x] filter dockerflow healthcheck in sentry before_send_transaction

