### PR TITLE
JWT token scope extended to a playlist instead of a resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Restrict video list endpoint to organisation admin
   and playlist admin or instructor
+- Change scope of the Resource token into a new Playlist token
 
 ### Fixed
 


### PR DESCRIPTION
See https://github.com/openfun/marsha/issues/1342 and https://github.com/openfun/marsha/issues/2249

## Purpose

The JWT token used in the application (the LTI one) is only focused on a resource (a video or a document). We would like to extend this scope to a playlist. If you can access a resource in a playlist, then you should also have the right to access the other resources in the same playlist.

## Proposal

Create a new token focused on playlist access, and a new  `IsTokenPlaylistRouteObject` permission verifying the user has access to a playlist in `core.permissions`.

Replace `IsTokenResourceRouteObject` and  `IsTokenResourceRouteObjectRelated___`  occurences by the new `IsTokenPlaylistRouteObject` in the API in : 

- `VideoViewSet`
- `ClassroomViewSet` 
- `DocumentViewSet`
- `FileDepositoryViewSet`
- `MarkdownDocumentViewSet`
For `IsTokenResourceRouteObject`

And :
- `TimedTextTrackViewSet`
-  `LiveSessionViewSet`
- `SharedLiveMediaViewSet` 
- `ThumbnailViewSet`
- `class ClassroomDocumentViewSet`
For `IsTokenResourceRouteObjectRelated___`