### PR TITLE
LTI user association

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Manage shibboleth config per site config
 - Add a shared media widget directly in the video player
 - Add a transcript plugin to the video player
+- Add a link to LTI resources to retrieve them in the standalone website
 
 ### Changed
 

--- a/src/backend/marsha/core/admin.py
+++ b/src/backend/marsha/core/admin.py
@@ -464,6 +464,7 @@ class LtiUserAssociationAdmin(admin.ModelAdmin):
         "user",
         "created_on",
     )
+    readonly_fields = ("created_on",)
     verbose_name = _("LTI user association")
 
 

--- a/src/backend/marsha/core/api/lti_user_association.py
+++ b/src/backend/marsha/core/api/lti_user_association.py
@@ -1,8 +1,13 @@
 """Declare API endpoints for LTI User Association with Django RestFramework viewsets."""
+from django.core.exceptions import ValidationError
 from django.db import IntegrityError
 
 from rest_framework.response import Response
-from rest_framework.status import HTTP_201_CREATED, HTTP_409_CONFLICT
+from rest_framework.status import (
+    HTTP_201_CREATED,
+    HTTP_400_BAD_REQUEST,
+    HTTP_409_CONFLICT,
+)
 from rest_framework.viewsets import GenericViewSet
 
 from marsha.core import permissions
@@ -32,17 +37,28 @@ class LtiUserAssociationViewSet(APIViewMixin, GenericViewSet):
 
     def create(self, request, *args, **kwargs):
         """Create a new LtiUserAssociation."""
-        serializer = LTIUserAssociationCreationSerializer(data=request.data)
-        serializer.is_valid(raise_exception=True)
-        # ValueError should never happen thanks to the serializer validation
-        # and the fact that the user is authenticated
+        if "association_jwt" in request.data:
+            serializer = LTIUserAssociationCreationSerializer(data=request.data)
+            serializer.is_valid(raise_exception=True)
+            lti_user_id = serializer.validated_data["lti_user_id"]
+            lti_consumer_site_id = serializer.validated_data["lti_consumer_site_id"]
+            user_id = request.user.id
+            # ValueError should never happen thanks to the serializer validation
+            # and the fact that the user is authenticated
+        elif "lti_user_id" in request.data and "lti_consumer_site_id" in request.data:
+            lti_user_id = request.data["lti_user_id"]
+            lti_consumer_site_id = request.data["lti_consumer_site_id"]
+            user_id = request.user.id
+        else:
+            return Response({}, status=HTTP_400_BAD_REQUEST)
+
         try:
-            create_user_association(
-                serializer.validated_data["lti_consumer_site_id"],
-                serializer.validated_data["lti_user_id"],
-                request.user.id,
-            )
+            create_user_association(lti_consumer_site_id, lti_user_id, user_id)
         except IntegrityError:
+            # The association already exists
             return Response({}, status=HTTP_409_CONFLICT)
+        except ValidationError:
+            # The association JWT is invalid
+            return Response({}, status=HTTP_400_BAD_REQUEST)
 
         return Response({}, status=HTTP_201_CREATED)

--- a/src/backend/marsha/core/permissions/organization.py
+++ b/src/backend/marsha/core/permissions/organization.py
@@ -6,7 +6,7 @@ from django.core.exceptions import ImproperlyConfigured
 from rest_framework import permissions
 
 from .. import models
-from ..models.account import ADMINISTRATOR
+from ..models.account import ADMINISTRATOR, INSTRUCTOR
 from .base import (
     HasAdminOrInstructorRoleMixIn,
     HasAdminRoleMixIn,
@@ -127,6 +127,31 @@ class IsParamsPlaylistAdminThroughOrganization(permissions.BasePermission):
         return models.OrganizationAccess.objects.filter(
             role=ADMINISTRATOR,
             organization__playlists__id=playlist_id,
+            user__id=request.user.id,
+        ).exists()
+
+
+class IsOrganizationInstructor(permissions.BasePermission):
+    """
+    Allow a request to proceed. Permission class.
+
+    Permission to allow a request to proceed only if the user is organization instructor.
+    """
+
+    def has_permission(self, request, view):
+        """
+        Allow the request.
+
+        Allow the request only if the playlist from the params of body of the request exists
+        and the current logged-in user is one of the instructors of its parent organization.
+        """
+        try:
+            uuid.UUID(request.user.id)
+        except (ValueError, TypeError):
+            return False
+
+        return models.OrganizationAccess.objects.filter(
+            role=INSTRUCTOR,
             user__id=request.user.id,
         ).exists()
 

--- a/src/backend/marsha/core/tests/api/playlists/test_claim.py
+++ b/src/backend/marsha/core/tests/api/playlists/test_claim.py
@@ -41,7 +41,7 @@ class PlaylistClaimAPITest(TestCase):
         self.assertFalse(PlaylistAccess.objects.filter(playlist=playlist).exists())
 
     def test_claim_playlist_by_orga_administrator(self):
-        """Organization administrators can claim playlists."""
+        """Organization administrators can't claim playlists."""
         organization_access = factories.OrganizationAccessFactory(role=ADMINISTRATOR)
         playlist = factories.PlaylistFactory(
             organization=organization_access.organization,

--- a/src/backend/marsha/core/tests/api/playlists/test_claim.py
+++ b/src/backend/marsha/core/tests/api/playlists/test_claim.py
@@ -1,0 +1,116 @@
+"""Tests for the Playlist claim API of the Marsha project."""
+
+from django.test import TestCase
+
+from marsha.core import factories
+from marsha.core.models import ADMINISTRATOR, INSTRUCTOR, PlaylistAccess
+from marsha.core.simple_jwt.factories import UserAccessTokenFactory
+
+
+class PlaylistClaimAPITest(TestCase):
+    """Test the claim API for playlist objects."""
+
+    maxDiff = None
+
+    def test_claim_playlist_by_anonymous_user(self):
+        """Anonymous users cannot claim playlists."""
+        playlist = factories.PlaylistFactory()
+        response = self.client.post(
+            f"/api/playlists/{playlist.id}/claim/",
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 401)
+        playlist.refresh_from_db()
+        self.assertFalse(PlaylistAccess.objects.filter(playlist=playlist).exists())
+
+    def test_claim_playlist_by_random_logged_in_user(self):
+        """Random logged-in users cannot claim playlists unrelated to them."""
+        user = factories.UserFactory()
+        playlist = factories.PlaylistFactory()
+
+        jwt_token = UserAccessTokenFactory(user=user)
+
+        response = self.client.post(
+            f"/api/playlists/{playlist.id}/claim/",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 403)
+        playlist.refresh_from_db()
+        self.assertFalse(PlaylistAccess.objects.filter(playlist=playlist).exists())
+
+    def test_claim_playlist_by_orga_administrator(self):
+        """Organization administrators can claim playlists."""
+        organization_access = factories.OrganizationAccessFactory(role=ADMINISTRATOR)
+        playlist = factories.PlaylistFactory(
+            organization=organization_access.organization,
+        )
+
+        jwt_token = UserAccessTokenFactory(user=organization_access.user)
+
+        response = self.client.post(
+            f"/api/playlists/{playlist.id}/claim/",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 403)
+        playlist.refresh_from_db()
+        self.assertFalse(PlaylistAccess.objects.filter(playlist=playlist).exists())
+
+    def test_claim_playlist_by_orga_instructor_no_other_access(self):
+        """Organization instructors can claim playlists.
+        If no other access exists, the instructor is granted administrator access."""
+        organization_access = factories.OrganizationAccessFactory(role=INSTRUCTOR)
+        playlist = factories.PlaylistFactory(
+            organization=organization_access.organization,
+        )
+
+        jwt_token = UserAccessTokenFactory(user=organization_access.user)
+
+        response = self.client.post(
+            f"/api/playlists/{playlist.id}/claim/",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 201)
+        playlist.refresh_from_db()
+        self.assertTrue(PlaylistAccess.objects.filter(playlist=playlist).exists())
+        self.assertEqual(
+            PlaylistAccess.objects.get(
+                playlist=playlist, user=organization_access.user
+            ).role,
+            ADMINISTRATOR,
+        )
+
+    def test_claim_playlist_by_orga_instructor_with_other_access(self):
+        """Organization instructors can claim playlists.
+        If other access exists, the instructor is granted instructor access."""
+        organization_access = factories.OrganizationAccessFactory(role=INSTRUCTOR)
+        playlist = factories.PlaylistFactory(
+            organization=organization_access.organization,
+        )
+        factories.PlaylistAccessFactory(
+            playlist=playlist,
+            role=ADMINISTRATOR,
+        )
+
+        jwt_token = UserAccessTokenFactory(user=organization_access.user)
+
+        response = self.client.post(
+            f"/api/playlists/{playlist.id}/claim/",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 201)
+        playlist.refresh_from_db()
+        self.assertTrue(PlaylistAccess.objects.filter(playlist=playlist).exists())
+        self.assertEqual(
+            PlaylistAccess.objects.get(
+                playlist=playlist, user=organization_access.user
+            ).role,
+            INSTRUCTOR,
+        )

--- a/src/backend/marsha/core/tests/api/playlists/test_is_claimed.py
+++ b/src/backend/marsha/core/tests/api/playlists/test_is_claimed.py
@@ -1,0 +1,101 @@
+"""Tests for the Playlist is-claimed API of the Marsha project."""
+
+from django.test import TestCase
+
+from marsha.core import factories
+from marsha.core.lti.user_association import clean_lti_user_id
+from marsha.core.models import ADMINISTRATOR, INSTRUCTOR
+from marsha.core.simple_jwt.factories import (
+    InstructorOrAdminLtiTokenFactory,
+    StudentLtiTokenFactory,
+)
+
+
+class PlaylistIsClaimedAPITest(TestCase):
+    """Test the API endpoint to check if a playlist is claimed."""
+
+    maxDiff = None
+
+    def test_playlist_is_claimed_anonymous(self):
+        """Anonymous users cannot check if a playlist is claimed."""
+        playlist = factories.PlaylistFactory()
+        response = self.client.get(
+            f"/api/playlists/{playlist.id}/is-claimed/",
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 401)
+
+    def test_playlist_is_claimed_student(self):
+        """Random logged-in users cannot check if a playlist is claimed."""
+        video = factories.VideoFactory()
+        jwt_token = StudentLtiTokenFactory(resource=video)
+
+        response = self.client.get(
+            f"/api/playlists/{video.playlist.id}/is-claimed/",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_playlist_is_claimed_LTI_administrator(self):
+        """LTI administrators can check if a playlist is claimed."""
+        video = factories.VideoFactory()
+
+        jwt_token = InstructorOrAdminLtiTokenFactory(
+            resource=video,
+            roles=[ADMINISTRATOR],
+        )
+
+        response = self.client.get(
+            f"/api/playlists/{video.playlist.id}/is-claimed/",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"is_claimed": False})
+
+    def test_playlist_is_claimed_LTI_instructor(self):
+        """LTI instructors can check if a playlist is claimed."""
+        video = factories.VideoFactory()
+
+        jwt_token = InstructorOrAdminLtiTokenFactory(
+            resource=video,
+            roles=[INSTRUCTOR],
+        )
+
+        response = self.client.get(
+            f"/api/playlists/{video.playlist.id}/is-claimed/",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"is_claimed": False})
+
+    def test_playlist_is_claimed_LTI_instructor_claimed(self):
+        """LTI instructors can check if a playlist is claimed."""
+        video = factories.VideoFactory(upload_state="pending")
+        consumer_site = factories.ConsumerSiteFactory()
+        jwt_token = InstructorOrAdminLtiTokenFactory(
+            resource=video,
+            roles=[INSTRUCTOR],
+            consumer_site=str(consumer_site.id),
+        )
+        lti_user_association = factories.LtiUserAssociationFactory(
+            consumer_site=consumer_site,
+            lti_user_id=clean_lti_user_id(jwt_token.get("user").get("id")),
+        )
+        factories.PlaylistAccessFactory(
+            playlist=video.playlist, user_id=lti_user_association.user.id
+        )
+
+        response = self.client.get(
+            f"/api/playlists/{video.playlist.id}/is-claimed/",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"is_claimed": True})

--- a/src/backend/marsha/core/tests/views/test_lti_base.py
+++ b/src/backend/marsha/core/tests/views/test_lti_base.py
@@ -104,7 +104,9 @@ class BaseLTIViewForPortabilityTestCase(TestCase):
             self.lti_user_id,
         )
 
-    def assertLTIViewReturnsPortabilityContextForAdminOrInstructor(self, resource):
+    def assertLTIViewReturnsPortabilityContextForAdminOrInstructor(
+        self, resource, frontend_home_url="http://localhost:3000"
+    ):
         """Assert the LTI view returns the portability context for an admin or an instructor."""
         lti_role = random.choice((INSTRUCTOR, ADMINISTRATOR))
 
@@ -119,10 +121,13 @@ class BaseLTIViewForPortabilityTestCase(TestCase):
         self.assertEqual(
             context["portability"]["for_playlist_id"], str(resource.playlist.id)
         )
+        self.assertEqual(context["frontend_home_url"], frontend_home_url)
 
         # Test user association token
         parsed_redirect_to_url = urlparse(context["portability"]["redirect_to"])
-        self.assertEqual(parsed_redirect_to_url.netloc, "localhost:3000")
+        self.assertEqual(
+            parsed_redirect_to_url.netloc, urlparse(frontend_home_url).netloc
+        )
         self.assertEqual(parsed_redirect_to_url.path, "/portability-requests/pending/")
 
         association_token_str = parse_qs(parsed_redirect_to_url.query)[
@@ -169,7 +174,9 @@ class BaseLTIViewForPortabilityTestCase(TestCase):
 
         # Test user association token is not present
         parsed_redirect_to_url = urlparse(context["portability"]["redirect_to"])
-        self.assertEqual(parsed_redirect_to_url.netloc, "localhost:3000")
+        self.assertEqual(
+            parsed_redirect_to_url.netloc, urlparse(frontend_home_url).netloc
+        )
         self.assertEqual(parsed_redirect_to_url.path, "/portability-requests/pending/")
 
         self.assertFalse("association_jwt" in parse_qs(parsed_redirect_to_url.query))

--- a/src/backend/marsha/core/views.py
+++ b/src/backend/marsha/core/views.py
@@ -453,6 +453,10 @@ class BaseLTIView(BaseModelResourceView, ABC):
         permissions = {"can_access_dashboard": False, "can_update": False}
         session_id = str(uuid.uuid4())
 
+        frontend_home_url = settings.FRONTEND_HOME_URL
+        if frontend_home_url.endswith("/"):
+            frontend_home_url = frontend_home_url[:-1]
+
         if app_data is None:
             is_instructor_or_admin = self.lti.is_instructor or self.lti.is_admin
 
@@ -508,6 +512,7 @@ class BaseLTIView(BaseModelResourceView, ABC):
                 jwt_token = refresh_token.access_token
                 app_data["jwt"] = str(jwt_token)
                 app_data["refresh_token"] = str(refresh_token)
+                app_data["frontend_home_url"] = frontend_home_url
                 return app_data
 
             permissions = {
@@ -538,6 +543,7 @@ class BaseLTIView(BaseModelResourceView, ABC):
             jwt_token = refresh_token.access_token
             app_data["jwt"] = str(jwt_token)
             app_data["refresh_token"] = str(refresh_token)
+            app_data["frontend_home_url"] = frontend_home_url
 
         return app_data
 

--- a/src/frontend/apps/lti_site/components/App/AppContentLoader/index.tsx
+++ b/src/frontend/apps/lti_site/components/App/AppContentLoader/index.tsx
@@ -33,6 +33,7 @@ import {
   useIntl,
 } from 'react-intl';
 
+import { ClaimLink } from 'components/ClaimLink';
 import { createIntl } from 'utils/lang';
 import { GlobalStyles } from 'utils/theme/baseStyles';
 
@@ -105,7 +106,12 @@ const AppContent = () => {
     });
   }, [decodedJwt]);
 
-  return <Content />;
+  return (
+    <React.Fragment>
+      <ClaimLink decodedJwt={decodedJwt} />
+      <Content />
+    </React.Fragment>
+  );
 };
 
 const AppContentLoader = () => {

--- a/src/frontend/apps/lti_site/components/ClaimLink/index.spec.tsx
+++ b/src/frontend/apps/lti_site/components/ClaimLink/index.spec.tsx
@@ -1,0 +1,219 @@
+import fetchMock from 'fetch-mock';
+import { screen } from '@testing-library/react';
+import {
+  AppConfigProvider,
+  appNames,
+  appState,
+  DecodedJwtLTI,
+  modelName,
+  playlistMockFactory,
+  videoMockFactory,
+} from 'lib-components';
+import { render } from 'lib-tests';
+import React from 'react';
+
+import { ClaimLink } from '.';
+
+describe('<ClaimLink />', () => {
+  afterEach(() => {
+    fetchMock.restore();
+  });
+
+  it('shows claim link', async () => {
+    const playlist = playlistMockFactory({ id: '488db2d0' });
+    const video = videoMockFactory({ playlist });
+
+    fetchMock.get('/api/playlists/488db2d0/is-claimed/', {
+      status: 200,
+      body: {
+        is_claimed: false,
+      },
+    });
+
+    render(
+      <AppConfigProvider
+        value={{
+          appName: appNames.CLASSROOM,
+          attendanceDelay: 10,
+          state: appState.SUCCESS,
+          modelName: modelName.VIDEOS,
+          resource: video,
+          sentry_dsn: 'test.dns.com',
+          environment: 'tests',
+          frontend: 'test-frontend',
+          frontend_home_url: 'http://localhost:8000/',
+          release: 'debug',
+          static: {
+            svg: {
+              icons: '',
+            },
+            img: {
+              liveBackground: '',
+              liveErrorBackground: '',
+              marshaWhiteLogo: '',
+              videoWizardBackground: '',
+              errorMain: '',
+            },
+          },
+          uploadPollInterval: 10,
+          p2p: {
+            isEnabled: false,
+            webTorrentTrackerUrls: [],
+            stunServerUrls: [],
+          },
+        }}
+      >
+        <ClaimLink
+          decodedJwt={
+            {
+              playlist_id: '488db2d0',
+              resource_id: 'e8c0b8d0',
+              consumer_site: '32a1c2d0',
+              user: { id: '6b45a4d6' },
+            } as DecodedJwtLTI
+          }
+        />
+      </AppConfigProvider>,
+    );
+
+    expect(fetchMock.calls()).toHaveLength(1);
+
+    const link = await screen.findByText(
+      'Please login to manage this resource on http://localhost:8000/',
+    );
+    expect(link.getAttribute('href')).toEqual(
+      'http://localhost:8000//claim-resource?lti_consumer_site_id=32a1c2d0&resource_id=e8c0b8d0&modelName=videos&playlist_id=488db2d0&lti_user_id=6b45a4d6',
+    );
+    expect(link.getAttribute('target')).toEqual('_blank');
+    expect(link.getAttribute('rel')).toEqual('noopener noreferrer');
+  });
+
+  it('does not show claim link if resource is claimed', async () => {
+    const playlist = playlistMockFactory({ id: '488db2d0' });
+    const video = videoMockFactory({ playlist });
+
+    fetchMock.get('/api/playlists/488db2d0/is-claimed/', {
+      status: 200,
+      body: {
+        is_claimed: true,
+      },
+    });
+
+    render(
+      <AppConfigProvider
+        value={{
+          appName: appNames.CLASSROOM,
+          attendanceDelay: 10,
+          state: appState.SUCCESS,
+          modelName: modelName.VIDEOS,
+          resource: video,
+          sentry_dsn: 'test.dns.com',
+          environment: 'tests',
+          frontend: 'test-frontend',
+          frontend_home_url: 'http://localhost:8000/',
+          release: 'debug',
+          static: {
+            svg: {
+              icons: '',
+            },
+            img: {
+              liveBackground: '',
+              liveErrorBackground: '',
+              marshaWhiteLogo: '',
+              videoWizardBackground: '',
+              errorMain: '',
+            },
+          },
+          uploadPollInterval: 10,
+          p2p: {
+            isEnabled: false,
+            webTorrentTrackerUrls: [],
+            stunServerUrls: [],
+          },
+        }}
+      >
+        <ClaimLink
+          decodedJwt={
+            {
+              playlist_id: '488db2d0',
+              resource_id: 'e8c0b8d0',
+              consumer_site: '32a1c2d0',
+              user: { id: '6b45a4d6' },
+            } as DecodedJwtLTI
+          }
+        />
+      </AppConfigProvider>,
+    );
+
+    expect(fetchMock.calls()).toHaveLength(1);
+    expect(
+      screen.queryByText(
+        'Please login to manage this resource on marsha.education.',
+      ),
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not show claim link if resource is undefined', async () => {
+    const playlist = playlistMockFactory({ id: '488db2d0' });
+
+    fetchMock.get('/api/playlists/488db2d0/is-claimed/', {
+      status: 200,
+      body: {
+        is_claimed: true,
+      },
+    });
+
+    render(
+      <AppConfigProvider
+        value={{
+          appName: appNames.CLASSROOM,
+          attendanceDelay: 10,
+          state: appState.SUCCESS,
+          modelName: modelName.VIDEOS,
+          resource: undefined,
+          sentry_dsn: 'test.dns.com',
+          environment: 'tests',
+          frontend: 'test-frontend',
+          frontend_home_url: 'http://localhost:8000/',
+          release: 'debug',
+          static: {
+            svg: {
+              icons: '',
+            },
+            img: {
+              liveBackground: '',
+              liveErrorBackground: '',
+              marshaWhiteLogo: '',
+              videoWizardBackground: '',
+              errorMain: '',
+            },
+          },
+          uploadPollInterval: 10,
+          p2p: {
+            isEnabled: false,
+            webTorrentTrackerUrls: [],
+            stunServerUrls: [],
+          },
+        }}
+      >
+        <ClaimLink
+          decodedJwt={
+            {
+              playlist_id: '488db2d0',
+              resource_id: 'e8c0b8d0',
+              consumer_site: '32a1c2d0',
+              user: { id: '6b45a4d6' },
+            } as DecodedJwtLTI
+          }
+        />
+      </AppConfigProvider>,
+    );
+
+    expect(fetchMock.calls()).toHaveLength(0);
+    expect(
+      screen.queryByText(
+        'Please login to manage this resource on marsha.education.',
+      ),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/frontend/apps/lti_site/components/ClaimLink/index.tsx
+++ b/src/frontend/apps/lti_site/components/ClaimLink/index.tsx
@@ -1,0 +1,71 @@
+import React, { useEffect, useState } from 'react';
+import { Anchor, Box } from 'grommet';
+import {
+  AppDataRessource,
+  DecodedJwtLTI,
+  DepositedFile,
+  useAppConfig,
+} from 'lib-components';
+import { usePlaylistIsClaimed } from 'data/queries';
+import { defineMessages, useIntl } from 'react-intl';
+
+const messages = defineMessages({
+  claimResource: {
+    defaultMessage:
+      'Please login to manage this resource on {frontend_home_url}',
+    description: 'Message displayed to the user for claiming a resource',
+    id: 'components.ClaimLink',
+  },
+});
+
+type ClaimLinkProps = {
+  decodedJwt: DecodedJwtLTI;
+};
+
+export const ClaimLink = ({ decodedJwt }: ClaimLinkProps) => {
+  const appConfig = useAppConfig();
+  const intlShape = useIntl();
+
+  const resource = (appConfig.resource ||
+    appConfig.video ||
+    appConfig.document) as Exclude<AppDataRessource, DepositedFile>;
+
+  if (!resource) {
+    return null;
+  }
+
+  const [showClaimLink, setShowClaimLink] = useState(
+    ['videos', 'classrooms'].includes(appConfig.modelName) && !!decodedJwt.user,
+  );
+  const { data } = usePlaylistIsClaimed(resource.playlist.id, {
+    enabled: showClaimLink,
+  });
+
+  useEffect(() => {
+    if (data?.is_claimed) {
+      setShowClaimLink(false);
+    } else {
+      return;
+    }
+  }, [data?.is_claimed]);
+
+  let claimUrl = `${appConfig.frontend_home_url}/claim-resource`;
+  if (showClaimLink) {
+    claimUrl += `?lti_consumer_site_id=${decodedJwt.consumer_site}`;
+    claimUrl += `&resource_id=${decodedJwt.resource_id}`;
+    claimUrl += `&modelName=${appConfig.modelName}`;
+    claimUrl += `&playlist_id=${resource.playlist.id}`;
+    claimUrl += `&lti_user_id=${decodedJwt.user?.id}`;
+    return (
+      <Box align="center" pad="medium">
+        <Anchor href={claimUrl} target="_blank" rel="noopener noreferrer">
+          {intlShape.formatMessage(messages.claimResource, {
+            frontend_home_url: appConfig.frontend_home_url,
+          })}
+        </Anchor>
+      </Box>
+    );
+  }
+
+  return null;
+};

--- a/src/frontend/apps/lti_site/data/queries/index.tsx
+++ b/src/frontend/apps/lti_site/data/queries/index.tsx
@@ -85,6 +85,23 @@ export const useUpdatePlaylist = (
   });
 };
 
+type usePlaylistIsClaimedResponse = { is_claimed: boolean };
+export const usePlaylistIsClaimed = (
+  playlistId: string,
+  queryConfig?: UseQueryOptions<
+    usePlaylistIsClaimedResponse,
+    'playlists',
+    usePlaylistIsClaimedResponse
+  >,
+) => {
+  const key = ['playlists', playlistId, 'is-claimed'];
+  return useQuery<usePlaylistIsClaimedResponse, 'playlists'>(
+    key,
+    fetchOne,
+    queryConfig,
+  );
+};
+
 type PlaylistsResponse = APIList<Playlist>;
 type UsePlaylistsParams = { organization: Maybe<string> };
 export const usePlaylists = (

--- a/src/frontend/apps/standalone_site/src/api/useLtiUserAssociations/index.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/api/useLtiUserAssociations/index.spec.tsx
@@ -3,7 +3,7 @@ import fetchMock from 'fetch-mock';
 import { useJwt } from 'lib-components';
 import { WrapperReactQuery } from 'lib-tests';
 
-import { useCreateLtiUserAssociation } from './useLtiUserAssociations';
+import { useCreateLtiUserAssociation } from '.';
 
 describe('features/PortabilityRequests/api/useLtiUserAssociations', () => {
   beforeEach(() => {

--- a/src/frontend/apps/standalone_site/src/api/useLtiUserAssociations/index.ts
+++ b/src/frontend/apps/standalone_site/src/api/useLtiUserAssociations/index.ts
@@ -3,17 +3,15 @@ import {
   useMutation,
   useQueryClient,
 } from '@tanstack/react-query';
-import { createOne } from 'lib-components';
+import { FetchResponseError, createOne } from 'lib-components';
 
 type UseCreateLtiUserAssociationData = {
-  association_jwt: string;
+  association_jwt?: string;
+  lti_consumer_site_id?: string;
+  lti_user_id?: string;
 };
 type UseCreateLtiUserAssociationError =
-  | { code: 'exception' }
-  | {
-      code: 'invalid';
-      errors: { [key in keyof UseCreateLtiUserAssociationData]?: string[] }[];
-    };
+  FetchResponseError<UseCreateLtiUserAssociationData>;
 type UseCreateLtiUserAssociationOptions = UseMutationOptions<
   null, // TData, the mutation result : nothing
   UseCreateLtiUserAssociationError,

--- a/src/frontend/apps/standalone_site/src/features/App/AppRoutes.tsx
+++ b/src/frontend/apps/standalone_site/src/features/App/AppRoutes.tsx
@@ -24,6 +24,7 @@ const { PortabilityRequestsRouteComponent } = lazyImport(
   () => import('features/PortabilityRequests'),
 );
 const { ProfileRouter } = lazyImport(() => import('features/Profile'));
+const { ClaimResource } = lazyImport(() => import('features/ClaimResource'));
 
 const messages = defineMessages({
   metaTitle: {
@@ -206,6 +207,15 @@ const AuthenticatedRoutes = () => {
             }
           />
         ))}
+
+        <Route
+          path={`${routes.CLAIM_RESOURCE.path}/*`}
+          element={
+            <Suspense fallback={<ContentSpinner />}>
+              <ClaimResource />
+            </Suspense>
+          }
+        />
 
         <Route path="*" element={<Text404 />} />
       </Routes>

--- a/src/frontend/apps/standalone_site/src/features/ClaimResource/api/useClaimResource.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/ClaimResource/api/useClaimResource.spec.tsx
@@ -1,0 +1,69 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import fetchMock from 'fetch-mock';
+import { playlistMockFactory, useJwt } from 'lib-components';
+import { WrapperReactQuery } from 'lib-tests';
+
+import { useClaimResource } from './useClaimResource';
+
+describe('useClaimResource', () => {
+  beforeEach(() => {
+    useJwt.getState().setJwt('some token');
+  });
+
+  afterEach(() => {
+    fetchMock.restore();
+    jest.resetAllMocks();
+    useJwt.getState().resetJwt();
+  });
+
+  it('succeeds to claim resource', async () => {
+    const playlist = playlistMockFactory();
+    fetchMock.postOnce(`/api/playlists/${playlist.id}/claim/`, playlist);
+
+    const { result } = renderHook(() => useClaimResource(playlist.id), {
+      wrapper: WrapperReactQuery,
+    });
+    result.current.mutate();
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBeTruthy();
+    });
+
+    expect(fetchMock.lastCall()![0]).toEqual(
+      `/api/playlists/${playlist.id}/claim/`,
+    );
+    expect(fetchMock.lastCall()![1]).toEqual({
+      headers: {
+        Authorization: 'Bearer some token',
+        'Content-Type': 'application/json',
+      },
+      method: 'POST',
+    });
+  });
+
+  it('fails to claim resource', async () => {
+    const playlist = playlistMockFactory();
+    fetchMock.postOnce(`/api/playlists/${playlist.id}/claim/`, {
+      status: 400,
+      body: { error: 'some error' },
+    });
+
+    const { result } = renderHook(() => useClaimResource(playlist.id), {
+      wrapper: WrapperReactQuery,
+    });
+    result.current.mutate();
+    await waitFor(() => {
+      expect(result.current.isError).toBeTruthy();
+    });
+
+    expect(fetchMock.lastCall()![0]).toEqual(
+      `/api/playlists/${playlist.id}/claim/`,
+    );
+    expect(fetchMock.lastCall()![1]).toEqual({
+      headers: {
+        Authorization: 'Bearer some token',
+        'Content-Type': 'application/json',
+      },
+      method: 'POST',
+    });
+  });
+});

--- a/src/frontend/apps/standalone_site/src/features/ClaimResource/api/useClaimResource.ts
+++ b/src/frontend/apps/standalone_site/src/features/ClaimResource/api/useClaimResource.ts
@@ -1,0 +1,32 @@
+import {
+  UseMutationOptions,
+  useMutation,
+  useQueryClient,
+} from '@tanstack/react-query';
+import { FetchResponseError, actionOne } from 'lib-components';
+
+type UseClaimResourceData = {
+  playlist_id: string;
+};
+type UseClaimResourceError = FetchResponseError<UseClaimResourceData>;
+
+export const useClaimResource = (
+  id: string,
+  options?: UseMutationOptions<UseClaimResourceError, UseClaimResourceData>,
+) => {
+  const queryClient = useQueryClient();
+  return useMutation<UseClaimResourceError, UseClaimResourceData>({
+    mutationFn: () =>
+      actionOne({
+        name: 'playlists',
+        id: id,
+        action: 'claim',
+        method: 'POST',
+      }),
+    ...options,
+    onSuccess: (data, variables, context) => {
+      queryClient.invalidateQueries(['playlists']);
+      options?.onSuccess?.(data, variables, context);
+    },
+  });
+};

--- a/src/frontend/apps/standalone_site/src/features/ClaimResource/components/ClaimResource.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/ClaimResource/components/ClaimResource.spec.tsx
@@ -1,0 +1,211 @@
+import { screen, waitFor } from '@testing-library/react';
+import fetchMock from 'fetch-mock';
+import {
+  playlistMockFactory,
+  useCurrentUser,
+  useJwt,
+  userMockFactory,
+} from 'lib-components';
+import { render } from 'lib-tests';
+
+import { ClaimResource } from './ClaimResource';
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+// don't pollute test output with react-query errors
+const consoleError = jest
+  .spyOn(console, 'error')
+  .mockImplementation(() => jest.fn());
+
+describe('<ClaimResource />', () => {
+  beforeEach(() => {
+    useJwt.getState().setJwt('some token');
+    useCurrentUser.setState({
+      currentUser: userMockFactory({
+        id: '23fc4a',
+      }),
+    });
+  });
+
+  afterEach(() => {
+    fetchMock.restore();
+    jest.resetAllMocks();
+    useJwt.getState().resetJwt();
+    consoleError.mockClear();
+  });
+
+  it('creates a user association and claims playlist', async () => {
+    const playlist = playlistMockFactory();
+    fetchMock.get(`/api/playlists/${playlist.id}/`, playlist);
+    fetchMock.postOnce('/api/lti-user-associations/', 'null');
+    fetchMock.postOnce(`/api/playlists/${playlist.id}/claim/`, playlist);
+
+    render(<ClaimResource />, {
+      routerOptions: {
+        history: [
+          `/my-contents/claim-resource?lti_consumer_site_id=36fff96e&resource_id=81d56c42&modelName=classrooms&playlist_id=${playlist.id}&lti_user_id=7ff674f`,
+        ],
+      },
+    });
+
+    expect(screen.getByText('Claiming resource…')).toBeInTheDocument();
+
+    expect(
+      await screen.findByText(
+        'Your account has been successfully linked to the LMS identifiers.',
+      ),
+    ).toBeInTheDocument();
+
+    expect(
+      await screen.findByText('Resource claimed with success.'),
+    ).toBeInTheDocument();
+
+    expect(fetchMock.calls()[0][0]).toEqual('/api/lti-user-associations/');
+    expect(fetchMock.calls()[0][1]).toEqual({
+      headers: {
+        Authorization: 'Bearer some token',
+        'Content-Type': 'application/json',
+      },
+      method: 'POST',
+      body: JSON.stringify({
+        lti_consumer_site_id: '36fff96e',
+        lti_user_id: '7ff674f',
+      }),
+    });
+
+    expect(fetchMock.calls()[1][0]).toEqual(
+      `/api/playlists/${playlist.id}/claim/`,
+    );
+    expect(fetchMock.calls()[1][1]).toEqual({
+      headers: {
+        Authorization: 'Bearer some token',
+        'Content-Type': 'application/json',
+      },
+      method: 'POST',
+    });
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(
+        '/my-contents/classroom/81d56c42',
+      );
+    });
+  });
+
+  it('only claims playlist when user already associated', async () => {
+    const playlist = playlistMockFactory();
+    fetchMock.get(`/api/playlists/${playlist.id}/`, playlist);
+    fetchMock.postOnce('/api/lti-user-associations/', 409);
+    fetchMock.postOnce(`/api/playlists/${playlist.id}/claim/`, playlist);
+
+    render(<ClaimResource />, {
+      routerOptions: {
+        history: [
+          `/my-contents/claim-resource?lti_consumer_site_id=36fff96e&resource_id=81d56c42&modelName=classrooms&playlist_id=${playlist.id}&lti_user_id=7ff674f`,
+        ],
+      },
+    });
+
+    expect(screen.getByText('Claiming resource…')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText(
+          'Your account has been successfully linked to the LMS identifiers.',
+        ),
+      ).not.toBeInTheDocument();
+    });
+
+    expect(
+      await screen.findByText('Resource claimed with success.'),
+    ).toBeInTheDocument();
+
+    expect(fetchMock.calls()[0][0]).toEqual('/api/lti-user-associations/');
+    expect(fetchMock.calls()[0][1]).toEqual({
+      headers: {
+        Authorization: 'Bearer some token',
+        'Content-Type': 'application/json',
+      },
+      method: 'POST',
+      body: JSON.stringify({
+        lti_consumer_site_id: '36fff96e',
+        lti_user_id: '7ff674f',
+      }),
+    });
+
+    expect(fetchMock.calls()[1][0]).toEqual(
+      `/api/playlists/${playlist.id}/claim/`,
+    );
+    expect(fetchMock.calls()[1][1]).toEqual({
+      headers: {
+        Authorization: 'Bearer some token',
+        'Content-Type': 'application/json',
+      },
+      method: 'POST',
+    });
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(
+        '/my-contents/classroom/81d56c42',
+      );
+    });
+  });
+
+  it('displays errors for user association and claim playlist', async () => {
+    const playlist = playlistMockFactory();
+    fetchMock.get(`/api/playlists/${playlist.id}/`, playlist);
+    fetchMock.postOnce('/api/lti-user-associations/', 500);
+    fetchMock.postOnce(`/api/playlists/${playlist.id}/claim/`, 500);
+
+    render(<ClaimResource />, {
+      routerOptions: {
+        history: [
+          `/my-contents/claim-resource?lti_consumer_site_id=36fff96e&resource_id=81d56c42&modelName=classrooms&playlist_id=${playlist.id}&lti_user_id=7ff674f`,
+        ],
+      },
+    });
+
+    expect(screen.getByText('Claiming resource…')).toBeInTheDocument();
+
+    expect(
+      await screen.findByText(
+        'An error occurred when linking your account to the LMS identifiers, please try to refresh the page.',
+      ),
+    ).toBeInTheDocument();
+
+    expect(
+      await screen.findByText('An error occurred when claiming the resource.'),
+    ).toBeInTheDocument();
+
+    expect(fetchMock.calls()[0][0]).toEqual('/api/lti-user-associations/');
+    expect(fetchMock.calls()[0][1]).toEqual({
+      headers: {
+        Authorization: 'Bearer some token',
+        'Content-Type': 'application/json',
+      },
+      method: 'POST',
+      body: JSON.stringify({
+        lti_consumer_site_id: '36fff96e',
+        lti_user_id: '7ff674f',
+      }),
+    });
+
+    expect(fetchMock.calls()[1][0]).toEqual(
+      `/api/playlists/${playlist.id}/claim/`,
+    );
+    expect(fetchMock.calls()[1][1]).toEqual({
+      headers: {
+        Authorization: 'Bearer some token',
+        'Content-Type': 'application/json',
+      },
+      method: 'POST',
+    });
+
+    await waitFor(() => {
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/frontend/apps/standalone_site/src/features/ClaimResource/components/ClaimResource.tsx
+++ b/src/frontend/apps/standalone_site/src/features/ClaimResource/components/ClaimResource.tsx
@@ -1,0 +1,104 @@
+import { AnonymousUser, useCurrentUser } from 'lib-components';
+import { useEffect, useMemo } from 'react';
+import { toast } from 'react-hot-toast';
+import { defineMessages, useIntl } from 'react-intl';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+import { useCreateLtiUserAssociation } from 'api/useLtiUserAssociations';
+
+import { useClaimResource } from '../api/useClaimResource';
+
+const messages = defineMessages({
+  title: {
+    defaultMessage: 'Claiming resource…',
+    description: 'Title of the claim resource page',
+    id: 'features.ClaimResource.components.ClaimResource.title',
+  },
+  ltiUserAssociationSuccess: {
+    defaultMessage:
+      'Your account has been successfully linked to the LMS identifiers.',
+    description:
+      'Displayed message in toast when the LTI user association API call has been successfully created.',
+    id: 'features.ClaimResource.components.ClaimResource.ltiUserAssociationSuccess',
+  },
+  ltiUserAssociationFailure: {
+    defaultMessage:
+      'An error occurred when linking your account to the LMS identifiers, please try to refresh the page.',
+    description:
+      'Displayed message in toast when the LTI user association API call has failed.',
+    id: 'features.ClaimResource.components.ClaimResource.ltiUserAssociationFailure',
+  },
+  resourceClaimedSuccess: {
+    defaultMessage: 'Resource claimed with success.',
+    description:
+      'Displayed message in toast when the resource has been claimed with success.',
+    id: 'features.ClaimResource.components.ClaimResource.resourceClaimedSuccess',
+  },
+  resourceClaimedFailure: {
+    defaultMessage: 'An error occurred when claiming the resource.',
+    description:
+      'Displayed message in toast when the resource claim API call has failed.',
+    id: 'features.ClaimResource.components.ClaimResource.resourceClaimedFailure',
+  },
+});
+
+export const ClaimResource = () => {
+  const intl = useIntl();
+  const { search } = useLocation();
+  const params = useMemo(() => new URLSearchParams(search), [search]);
+  const lti_consumer_site_id = params.get('lti_consumer_site_id');
+  const lti_user_id = params.get('lti_user_id');
+  const modelName = params.get('modelName');
+  const resource_id = params.get('resource_id');
+
+  const { mutate: createLtiUserAssociation } = useCreateLtiUserAssociation({
+    onSuccess: () => {
+      toast.success(intl.formatMessage(messages.ltiUserAssociationSuccess));
+    },
+    onError: (error) => {
+      if (error.status !== 409) {
+        // 409 is the status code when the association already exists
+        toast.error(intl.formatMessage(messages.ltiUserAssociationFailure));
+      }
+    },
+    onSettled: () => {
+      claimResource.mutate(undefined, {
+        onSuccess: () => {
+          if (modelName && resource_id) {
+            let modelNamePath = modelName;
+            if (modelName === 'classrooms') {
+              modelNamePath = 'classroom';
+            }
+            navigate(`/my-contents/${modelNamePath}/${resource_id}`);
+          }
+        },
+      });
+    },
+  });
+  const { currentUser } = useCurrentUser();
+  const claimResource = useClaimResource(params.get('playlist_id') || '', {
+    onSuccess: () => {
+      toast.success(intl.formatMessage(messages.resourceClaimedSuccess));
+    },
+    onError: () => {
+      toast.error(intl.formatMessage(messages.resourceClaimedFailure));
+    },
+  });
+  const navigate = useNavigate();
+
+  const idUser =
+    currentUser && currentUser !== AnonymousUser.ANONYMOUS
+      ? currentUser.id
+      : undefined;
+
+  useEffect(() => {
+    if (lti_consumer_site_id && lti_user_id && idUser) {
+      createLtiUserAssociation({
+        lti_consumer_site_id: lti_consumer_site_id,
+        lti_user_id: lti_user_id,
+      });
+    }
+  }, [createLtiUserAssociation, idUser, lti_consumer_site_id, lti_user_id]);
+
+  return <h1>{intl.formatMessage(messages.title)}</h1>;
+};

--- a/src/frontend/apps/standalone_site/src/features/ClaimResource/index.tsx
+++ b/src/frontend/apps/standalone_site/src/features/ClaimResource/index.tsx
@@ -1,0 +1,1 @@
+export * from './components/ClaimResource';

--- a/src/frontend/apps/standalone_site/src/features/PortabilityRequests/hooks/useLtiUserAssociationJwtQueryParam.tsx
+++ b/src/frontend/apps/standalone_site/src/features/PortabilityRequests/hooks/useLtiUserAssociationJwtQueryParam.tsx
@@ -3,7 +3,7 @@ import { toast } from 'react-hot-toast';
 import { defineMessages, useIntl } from 'react-intl';
 import { useLocation, useNavigate } from 'react-router-dom';
 
-import { useCreateLtiUserAssociation } from '../api/useLtiUserAssociations';
+import { useCreateLtiUserAssociation } from 'api/useLtiUserAssociations';
 
 const messages = defineMessages({
   // Toast

--- a/src/frontend/apps/standalone_site/src/routes/routes.tsx
+++ b/src/frontend/apps/standalone_site/src/routes/routes.tsx
@@ -38,6 +38,7 @@ enum ERouteNames {
   ORGANIZATION = 'ORGANIZATION',
   LOGIN = 'LOGIN',
   PASSWORD_RESET = 'PASSWORD_RESET',
+  CLAIM_RESOURCE = 'CLAIM_RESOURCE',
 }
 enum EPasswordResetSubRoutesNames {
   CONFIRM = 'CONFIRM',
@@ -96,6 +97,9 @@ export const routes: MainRoutes = {
         pathKey: 'confirm/:uid/:token',
       },
     },
+  },
+  CLAIM_RESOURCE: {
+    path: `/claim-resource`,
   },
   PORTABILITY_REQUESTS: {
     path: '/portability-requests',

--- a/src/frontend/packages/lib_components/src/types/AppData.ts
+++ b/src/frontend/packages/lib_components/src/types/AppData.ts
@@ -75,6 +75,7 @@ export interface AppConfig {
   sentry_dsn: Nullable<string>;
   environment: string;
   frontend: string;
+  frontend_home_url?: string;
   release: string;
   static: {
     svg: {


### PR DESCRIPTION
## Purpose

We want the standalone site users to manage the resource they created through LTI.

## Proposal

- [x] LTI: Add a link to manage current resource in the standalone site if no association exists
- [x] Standalone site: add a route with parameters (lti_consumer_site_id, lti_user_id)
  - [x] associate current user to the parameters, which represent the LTI user
  - [x] claim current resource by adding a PlaylistAccess with the current user (instructor if an access already exists, else admin)

