### PR TITLE
⬆️(back) upgrade to django 4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Create a default playlist for new shibboleth user
 
+### Changed
+
+- Upgrade to django 4.2
+- `DJANGO_STATICFILES_STORAGE` environment variable is replaced by
+  `DJANGO_STORAGES_STATICFILES_BACKEND`
+
 ## [4.2.1] - 2023-06-20
 
 ### Fixed

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -7,6 +7,10 @@ not skip minor/major releases while upgrading (fix releases can be skipped).
 The format is inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### 4.2.x to 4.3.0
+
+`DJANGO_STATICFILES_STORAGE` environment variable is not used anymore. You have to replace it by `DJANGO_STORAGES_STATICFILES_BACKEND`.
+
 ## 3.27.x to 4.0.x
 
 ### Before deploying

--- a/docs/env.md
+++ b/docs/env.md
@@ -221,10 +221,10 @@ name of the bucket created by the relevant AWS deployment.
   - `"preprod-marsha-static"` in preprod;
   - `"production-marsha-static"` in production.
 
-### DJANGO_STATICFILES_STORAGE
+### DJANGO_STORAGES_STATICFILES_BACKEND
 
 The static files storage backend that Django should use to serve static files. For more
-information, see [documentation](https://docs.djangoproject.com/en/2.1/ref/contrib/staticfiles/#storages).
+information, see [documentation](https://docs.djangoproject.com/en/4.2/ref/contrib/staticfiles/#storages).
 
 - Type: string
 - Required: No

--- a/renovate.json
+++ b/renovate.json
@@ -33,16 +33,6 @@
       ]
     },
     {
-      "groupName": "allowed django versions",
-      "matchManagers": [
-        "setup-cfg"
-      ],
-      "matchPackageNames": [
-        "django"
-      ],
-      "allowedVersions": "<4.2"
-    },
-    {
       "groupName": "allowed django channels version",
       "matchManagers": [
         "setup-cfg"

--- a/src/backend/marsha/core/tests/test_statics.py
+++ b/src/backend/marsha/core/tests/test_statics.py
@@ -85,7 +85,11 @@ class TestMarshaCompressedManifestStaticFilesStorage(TestCase):
     """Test suite for Marsha's collectstatic command."""
 
     @override_settings(
-        STATICFILES_STORAGE="marsha.core.static.MarshaCompressedManifestStaticFilesStorage",
+        STORAGES={
+            "staticfiles": {
+                "BACKEND": "marsha.core.static.MarshaCompressedManifestStaticFilesStorage",
+            }
+        }
     )
     def test_collectstatic_marsha(self):
         """Files are excluded correctly"""
@@ -103,7 +107,11 @@ class TestMarshaCompressedManifestStaticFilesStorage(TestCase):
             self.assertFalse(os.path.exists(path), f"{path} exists")
 
     @override_settings(
-        STATICFILES_STORAGE="whitenoise.storage.CompressedManifestStaticFilesStorage",
+        STORAGES={
+            "staticfiles": {
+                "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
+            }
+        }
     )
     def test_collectstatic_whitenoise(self):
         """All files are included

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -832,9 +832,14 @@ class Build(Base):
     AWS_MEDIAPACKAGE_HARVEST_JOB_ARN = values.Value("")
     BBB_API_SECRET = values.Value("")
     SECRET_KEY = values.Value("DummyKey")
-    STATICFILES_STORAGE = values.Value(
-        "marsha.core.static.MarshaCompressedManifestStaticFilesStorage"
-    )
+    STORAGES = {
+        "staticfiles": {
+            "BACKEND": values.Value(
+                "marsha.core.static.MarshaCompressedManifestStaticFilesStorage",
+                environ_name="STORAGES_STATICFILES_BACKEND",
+            )
+        }
+    }
 
     STATIC_POSTPROCESS_IGNORE_REGEX = values.Value(
         r"^js\/build\/.*[0-9]*\..*\.js(\.map)?$"
@@ -949,9 +954,14 @@ class Production(Base):
 
     ALLOWED_HOSTS = values.ListValue(None)
 
-    STATICFILES_STORAGE = values.Value(
-        "marsha.core.static.MarshaCompressedManifestStaticFilesStorage"
-    )
+    STORAGES = {
+        "staticfiles": {
+            "BACKEND": values.Value(
+                "marsha.core.static.MarshaCompressedManifestStaticFilesStorage",
+                environ_name="STORAGES_STATICFILES_BACKEND",
+            )
+        }
+    }
     STATIC_POSTPROCESS_IGNORE_REGEX = values.Value(
         r"^js\/build\/.*[0-9]*\..*\.js(\.map)?$"
     )

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -34,7 +34,7 @@ install_requires =
     chardet==5.1.0
     coreapi==2.3.3
     cryptography==41.0.1
-    django<4.2
+    django==4.2.2
     dj-database-url==2.0.0
     dj-rest-auth==4.0.1
     django-configurations==2.4.1


### PR DESCRIPTION
## Purpose

With django 4.2, `STATICFILES_STORAGE` setting is deprecated in favor of `STORAGES`
https://docs.djangoproject.com/en/4.2/releases/4.2/#custom-file-storages

The env var `DJANGO_STATICFILES_STORAGE` has been replaced by `DJANGO_STORAGES_STATICFILES_BACKEND` accordilgly.

## Proposal

- [x] upgrade to django 4.2

