### PR TITLE
🐛(back) fix clean_aws_elemental_stack command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Upgrade logging-ldp to be compatible with logging-gelf
+- clean_aws_elemental_stack command removes unreferenced medialive stacks
 
 ## [4.2.0] - 2023-06-15
 

--- a/src/backend/marsha/core/management/commands/sync_medialive_video.py
+++ b/src/backend/marsha/core/management/commands/sync_medialive_video.py
@@ -104,7 +104,7 @@ class Command(BaseCommand):
                     )
                     self.update_video_state(live, channel_state)
             except Video.DoesNotExist:
-                # live exists in AWS but not our DB
+                # live exists in AWS but not in our DB
                 self.stdout.write(
                     f"""Channel {medialive_channel["Name"]} is """
                     f"""attached to a video {live_pk} that does not exist"""


### PR DESCRIPTION
## Purpose

The clean_aws_elemental_stack is failing when medialive channel exists, but its associated video does not.
It is also not catching if a medialive channel is not referenced by a live, thus unused.

## Proposal

When a medialive channel is unused, we should delete the stack of this medialive channel. The same way we did with sync_medialive_video

- [x] delete when not referenced
- [x] delete when video not found

