### PR TITLE
📄(front) change lib-video license to MIT

### DIFF
--- a/src/frontend/packages/lib_video/package.json
+++ b/src/frontend/packages/lib_video/package.json
@@ -2,7 +2,7 @@
   "name": "lib-video",
   "version": "4.2.1",
   "description": "",
-  "license": "ISC",
+  "license": "MIT",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {


### PR DESCRIPTION
## Purpose

The lib-video license used was not the MIT but ISC. Accordingly to the license we use in Marsha we have to change it to the MIT one.

## Proposal

- [x] change lib-video license to MIT

