### PR TITLE
🐛(frontend) video player reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - `DJANGO_STATICFILES_STORAGE` environment variable is replaced by
   `DJANGO_STORAGES_STATICFILES_BACKEND`
 
+### Fixed
+
+- Video player reset when attributes update (#2300)
+
 ## [4.2.1] - 2023-06-20
 
 ### Fixed
@@ -34,7 +38,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Add a downloadable ICS file to scheduled student classrooms
 - frontend bulk delete for videos, webinars and classrooms
 - Can choose inactive resource by site (#2276)
-- Setting for instructor classroom invitation link expiration 
+- Setting for instructor classroom invitation link expiration
 - ClassroomRecording Delete API
   - delete BBB recordings
   - delete ClassroomsRecording
@@ -47,7 +51,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Restrict video list endpoint to organisation admin
   and playlist admin or instructor
-- Refacto classroom invite link. the invite token is saved in 
+- Refacto classroom invite link. the invite token is saved in
   the classroom model and no access token is generated in the serializer
 
 ### Fixed
@@ -56,7 +60,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Blacklist the refresh token on the frontend side (#2265)
 - Legale pages not accessible from url (#2266)
 - Remove old svg from the back to the front application (#1485)
-- Sync medialive command deletes medialive stack when video not found 
+- Sync medialive command deletes medialive stack when video not found
 
 ### Changed
 

--- a/src/frontend/packages/lib_video/src/components/common/VideoPlayer/index.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoPlayer/index.tsx
@@ -1,13 +1,13 @@
 import { Box } from 'grommet';
 import { Maybe, Nullable } from 'lib-common';
 import {
-  useThumbnail,
   TimedText,
-  timedTextMode,
   Video,
+  timedTextMode,
+  useThumbnail,
   videoSize,
 } from 'lib-components';
-import React, { useRef, useMemo, useEffect } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import { useIntl } from 'react-intl';
 import { useQueryClient } from 'react-query';
 
@@ -115,10 +115,10 @@ export const VideoPlayer = ({
   }, [setPlayerCurrentTime]);
 
   useEffect(() => {
-    if (video?.urls?.manifests && playerRef.current) {
+    if (video?.urls?.manifests?.hls && playerRef.current) {
       playerRef.current.setSource(video.urls.manifests.hls);
     }
-  }, [video?.urls?.manifests]);
+  }, [video?.urls?.manifests?.hls]);
 
   const oldTimedTextTracks = useRef(timedTextTracks);
   useEffect(() => {

--- a/src/frontend/packages/lib_video/src/hooks/useSetVideoState/index.tsx
+++ b/src/frontend/packages/lib_video/src/hooks/useSetVideoState/index.tsx
@@ -1,14 +1,15 @@
 import { Nullable } from 'lib-common';
 import {
-  useVideo,
-  useTimedTextTrack,
-  useThumbnail,
-  useSharedLiveMedia,
   Video,
+  useSharedLiveMedia,
+  useThumbnail,
+  useTimedTextTrack,
+  useVideo,
 } from 'lib-components';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 export const useSetVideoState = (video?: Nullable<Video>) => {
+  const videoId = useRef<string>();
   const addVideo = useVideo((state) => state.addResource);
 
   const { addMultipleTimedTextTrack, resetTimedTextTrack } = useTimedTextTrack(
@@ -30,33 +31,49 @@ export const useSetVideoState = (video?: Nullable<Video>) => {
     }));
 
   useEffect(() => {
-    if (!video) {
+    if (!video?.id || videoId.current === video.id) {
       return;
     }
 
-    resetThumbnail();
-    resetSharedLiveMedia();
-    resetTimedTextTrack();
-
+    videoId.current = video.id;
     addVideo(video);
+  }, [addVideo, video?.id, video]);
 
-    if (video.thumbnail) {
+  useEffect(() => {
+    if (video?.thumbnail) {
       addThumbnail(video.thumbnail);
     }
-    if (video.timed_text_tracks && video.timed_text_tracks.length > 0) {
-      addMultipleTimedTextTrack(video.timed_text_tracks);
-    }
-    if (video.shared_live_medias && video.shared_live_medias.length > 0) {
+
+    return () => {
+      resetThumbnail();
+    };
+  }, [addThumbnail, resetThumbnail, video?.thumbnail]);
+
+  useEffect(() => {
+    if (video?.shared_live_medias && video.shared_live_medias.length > 0) {
       addMultipleSharedLiveMedia(video.shared_live_medias);
     }
+
+    return () => {
+      resetSharedLiveMedia();
+    };
+  }, [
+    addMultipleSharedLiveMedia,
+    resetSharedLiveMedia,
+    video?.shared_live_medias,
+  ]);
+
+  useEffect(() => {
+    if (video?.timed_text_tracks && video.timed_text_tracks.length > 0) {
+      addMultipleTimedTextTrack(video.timed_text_tracks);
+    }
+
+    return () => {
+      resetTimedTextTrack();
+    };
   }, [
     addMultipleTimedTextTrack,
-    addMultipleSharedLiveMedia,
-    addThumbnail,
-    addVideo,
-    resetSharedLiveMedia,
-    resetThumbnail,
     resetTimedTextTrack,
-    video,
+    video?.timed_text_tracks,
   ]);
 };


### PR DESCRIPTION
## Purpose

When a attribute of the video was updated, the video player was reset. 
If a student was looking at the video at this moment, the video was stopped and the student had to restart the video.

## Proposal

- [x] fix the bug by beeing more accurate in the dependency of the useEffect loading the source of the video
- [x] improve the refresh state of the video

