### PR TITLE
Configure expire rule on source bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Create a default playlist for new shibboleth user
+- Lifecycle rule on source bucket to expire uploaded
+  object after 21 days.
 
 ### Changed
 

--- a/src/aws/.terraform.lock.hcl
+++ b/src/aws/.terraform.lock.hcl
@@ -2,22 +2,25 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "4.29.0"
-  constraints = "~> 4.29"
+  version     = "5.5.0"
+  constraints = "~> 5.5.0"
   hashes = [
-    "h1:cpTUwXfdtmmUqsnYwXFQ5gZjnfz5cgvydmcGxrv+BeA=",
-    "zh:091615c6dddd556b8cc1cd54e1c5c1fe71b593acebacd0b274a2fed7fc4ca802",
-    "zh:4cc11d7252813b2d7cb52e78b24af8eaf377cc242d1d672a7f8bf680758a4976",
-    "zh:565f46308d6e96a21c273e84e0f73d3f39fd8159fc5aaf41bf65c0b0dd6f1de3",
-    "zh:627b6a5574262b5f07c0e012bcb5c73afd97d90b75389c0ab154b5ae4c0dce8f",
-    "zh:91622572d311c28504fbf14e9364120fbafb3adf8e2d49bfdf014752dac9dac0",
-    "zh:98f37f07628b7c2960335b772a544de6bb90f0f390b9d5fdcc3ac211b9cd7def",
-    "zh:9a6338478ba0e7ca75c5b43e0f91dde12d17273b1dc9934c8ff4d631b8bb837a",
+    "h1:WOweXv4ZjePZwdxuzE2UmRWOPhhcQDNxGu2wOcpHFWY=",
+    "zh:10fe0ef4191323c920c1844f27dbc88114547d5f78fad915c1769c908f40d916",
+    "zh:565fc7c3a1f42474fa75f143cb8115e11b894ed7fd9973569b00bd429fb92b4e",
+    "zh:5ba6132b1d442ed679ad8ea89fb5602aa0893e8dcd002a52ab3d76591aa18c8b",
+    "zh:5c2580630cd5034bae800445074c17950aea17f089bcdae7af637173122f8b03",
+    "zh:656d77220c6053fd5adb86d3bfb57dd42f98220d81590ffd643156ffeca36608",
+    "zh:65c7b3e333b734ce641735a23539d4fb392a675a5a9b892e8369781b1f3386a2",
+    "zh:682d55b2e6e9c40e20d679aa53d561797b1f3450e5187c9f4e8c359b69f06df3",
+    "zh:79ebc0993d6128819d70dd896cd743e3bab3e3cdc4c02f2a2dbd138471c23179",
+    "zh:8d44214c738f0410f829e1c761b021c92b3364daf9fcd08097216cc84eaff997",
     "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:a1cc1fc49e406cba1e98250bc04a47be0b6babf5bb42f23baa40f2dc7f8b90f7",
-    "zh:a251e933412036426e2f7b090000c198feee114270d5724bcc8dd9d674d43689",
-    "zh:b0ef3b92947cc8cea75634139dfbfcae2207a9cb5c31d827cd34e523ca04e919",
-    "zh:fb9ede02c9291e7677877bc21ec5c094da38e3cd44df91da5af36f504be399be",
+    "zh:a0b1bc008e95c5a7285f5e7dd116ce60ba7a6c1c3bd8ac3e3b63d4e1438d8e49",
+    "zh:cf40fb60efc5df42fc5716c7e458868251c82fc78b623f12d1bc994b6fcc7ef2",
+    "zh:cfd8f3f391cddecfc5e44fe57f0633067470e9038517115ba69d8ee533d5d74e",
+    "zh:d6552490599e02a756e72b7091b591493cee25548ce7120ad05210b4ff2492bd",
+    "zh:f77dfe665fd4b3d9e36fdc989d7feff4cf6bf17161c0b1a0f25a0fcf402c779d",
   ]
 }
 

--- a/src/aws/bin/terraform
+++ b/src/aws/bin/terraform
@@ -3,7 +3,7 @@
 set -eo pipefail
 
 declare MARSHA_TERRAFORM_ENV_FILE
-declare -r TERRAFORM_VERSION="1.2.8"
+declare -r TERRAFORM_VERSION="1.5.2"
 
 function _check_workspace() {
     current_workspace=$(

--- a/src/aws/provider.tf
+++ b/src/aws/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.29"
+      version = "~> 5.5.0"
     }
     tls = {
       source = "hashicorp/tls"

--- a/src/aws/s3.tf
+++ b/src/aws/s3.tf
@@ -24,6 +24,24 @@ resource "aws_s3_bucket_acl" "marsha_source_acl" {
   acl    = "private"
 }
 
+resource "aws_s3_bucket_lifecycle_configuration" "marsha_source_lifecycle_configuration" {
+  bucket = aws_s3_bucket.marsha_source.id
+
+  rule {
+    id = "marsha-source-expiration-rule"
+    # Apply to all objects in the bucket
+    filter {}
+
+    # A created object will expire after 3 weeks
+    expiration {
+      days = 21
+    } 
+
+    # This rule is enabled
+    status = "Enabled"
+  }
+}
+
 # Create destination S3 Bucket for converted videos and images
 resource "aws_s3_bucket" "marsha_destination" {
   bucket = "${terraform.workspace}-marsha-destination${var.s3_bucket_unique_suffix}"

--- a/src/aws/s3.tf
+++ b/src/aws/s3.tf
@@ -73,6 +73,8 @@ resource "aws_s3_bucket_acl" "marsha_destination_acl" {
 resource "aws_s3_bucket" "marsha_static" {
   bucket = "${terraform.workspace}-marsha-static${var.s3_bucket_unique_suffix}"
 
+  force_destroy = true
+
   tags = {
     Name        = "marsha-static"
     Environment = terraform.workspace


### PR DESCRIPTION
## Purpose

We don't want to keep indefinitely object uploaded in the source bucket.
After 21 days, an uploaded object expires and is deleted permanently.

Also, The static bucket is not used since version 3.17.0 and we never delete
it. To prepare the deletion, we must in a first version set the
force_destroy property on it to true otherwise it is not possible to
delete it using terraform

## Proposal

- [x] upgrade terraform to version 1.5.2
- [x] upgrade aws terraform provider to version 5.5.0
- [x] set an expire fate on object uploaded on source bucket
- [x] set force_destroy on static bucket 
