### PR TITLE
🐛(frontend) fix problem panel chat on live

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Video player reset when attributes update (#2300)
+- Fix panel closing and resizing on live video player chat (#2310)
 
 ## [4.2.1] - 2023-06-20
 

--- a/src/frontend/packages/lib_components/src/utils/useResizer.tsx
+++ b/src/frontend/packages/lib_components/src/utils/useResizer.tsx
@@ -74,8 +74,7 @@ export const useResizer = (
 
                 const newPanelWidthPx =
                   containerElement.offsetWidth -
-                  containerElement.offsetLeft -
-                  moveEvent.clientX;
+                  (moveEvent.clientX - containerElement.offsetLeft);
                 const newValue = computeWidth(newPanelWidthPx);
                 if (newValue) {
                   setPanelWidthPx(newValue);

--- a/src/frontend/packages/lib_video/src/components/common/VideoLayout/index.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoLayout/index.tsx
@@ -150,7 +150,7 @@ export const VideoLayout = ({
                         position: 'absolute',
                         top: '18px',
                         transform: 'rotate(180deg)',
-                        zIndex: 2,
+                        zIndex: 30,
                       }}
                     />
                   )}


### PR DESCRIPTION
## Purpose

See issue: #2305

## Proposal

Fix 2 problems:

- [x] fix panel visibility on click: the layer order was blocking the click event
- [x] fix panel resizing: the panel resizing had a bug when the main container was not totally on the left of the page, we have a menu on the standalone site, so the bug was more visible on the standalone


[Marsha (2).webm](https://github.com/openfun/marsha/assets/25994652/beddf82b-3cce-45bb-8e8e-490e9fa50a29)

