### PR TITLE
✨ videojs-download download button on control bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Add a command to delete expired classrooms / videos
 - Add retention duration on playlist form
 - Add retention date widget to video and classroom
+- Add a download-video widget directly in the video player
 
 ### Changed
 

--- a/src/frontend/packages/lib_video/src/components/common/Player/createVideojsPlayer.ts
+++ b/src/frontend/packages/lib_video/src/components/common/Player/createVideojsPlayer.ts
@@ -4,6 +4,7 @@ import 'videojs-contrib-quality-levels';
 import 'videojs-http-source-selector';
 import './videojs/qualitySelectorPlugin';
 import './videojs/p2pHlsPlugin';
+import './videojs/downloadVideoPlugin';
 import { Maybe, Nullable } from 'lib-common';
 import {
   Id3VideoType,
@@ -162,6 +163,9 @@ export const createVideojsPlayer = (
   if (isMSESupported()) {
     if (isP2pQueryEnabled && isP2PEnabled) {
       player.p2pHlsPlugin();
+    }
+    if (!video.is_live && video.urls.mp4) {
+      player.downloadVideoPlugin({ urls: video.urls.mp4 });
     }
     player.httpSourceSelector();
     const qualityLevels = player.qualityLevels();

--- a/src/frontend/packages/lib_video/src/components/common/Player/videojs/downloadVideoPlugin/components/DownloadVideoButton.ts
+++ b/src/frontend/packages/lib_video/src/components/common/Player/videojs/downloadVideoPlugin/components/DownloadVideoButton.ts
@@ -1,0 +1,42 @@
+import { videoSize } from '@lib-components/types';
+import videojs from 'video.js';
+
+import { DownloadVideoPluginOptions } from '../types';
+
+import { DownloadVideoQualityItem } from './DownloadVideoQualityItem';
+
+const MenuButton = videojs.getComponent('MenuButton');
+
+export class DownloadVideoButton extends MenuButton {
+  constructor(player: videojs.Player, options?: videojs.MenuItemOptions) {
+    super(player, options);
+    this.menuButton_.setAttribute('aria-label', 'Download Video');
+  }
+
+  createEl() {
+    return videojs.dom.createEl('div', {
+      className:
+        'vjs-http-download-video vjs-menu-button vjs-menu-button-popup vjs-control vjs-button',
+    });
+  }
+
+  buildCSSClass() {
+    return super.buildCSSClass() + ' vjs-icon-download';
+  }
+
+  createItems() {
+    const { urls } = this.options_ as DownloadVideoPluginOptions;
+    return Object.keys(urls)
+      .map((size) => Number(size) as videoSize)
+      .sort((a, b) => b - a)
+      .map(
+        (size) =>
+          new DownloadVideoQualityItem(this.player_, {
+            label: `${size}p`,
+            src: urls[size],
+          }),
+      );
+  }
+}
+
+videojs.registerComponent('DownloadVideoButton', DownloadVideoButton);

--- a/src/frontend/packages/lib_video/src/components/common/Player/videojs/downloadVideoPlugin/components/DownloadVideoQualityItem.ts
+++ b/src/frontend/packages/lib_video/src/components/common/Player/videojs/downloadVideoPlugin/components/DownloadVideoQualityItem.ts
@@ -1,0 +1,31 @@
+import videojs from 'video.js';
+
+import { DownloadVideoQualityItemOptions } from '../types';
+
+const Component = videojs.getComponent('Component');
+const MenuItem = videojs.getComponent('MenuItem');
+
+export class DownloadVideoQualityItem extends MenuItem {
+  source: string | undefined;
+
+  constructor(
+    player: videojs.Player,
+    options: DownloadVideoQualityItemOptions,
+  ) {
+    options.selectable = false;
+    options.multiSelectable = false;
+
+    super(player, options);
+    this.source = options.src;
+  }
+
+  handleClick() {
+    if (this.source) {
+      const link = document.createElement('a');
+      link.href = this.source;
+      link.click();
+    }
+  }
+}
+
+Component.registerComponent('DownloadVideoMenuItem', DownloadVideoQualityItem);

--- a/src/frontend/packages/lib_video/src/components/common/Player/videojs/downloadVideoPlugin/index.ts
+++ b/src/frontend/packages/lib_video/src/components/common/Player/videojs/downloadVideoPlugin/index.ts
@@ -1,0 +1,24 @@
+import videojs from 'video.js';
+
+import './components/DownloadVideoButton';
+import './components/DownloadVideoQualityItem';
+import { DownloadVideoPluginOptions } from './types';
+
+const Plugin = videojs.getPlugin('plugin');
+
+export class DownloadVideoPlugin extends Plugin {
+  constructor(player: videojs.Player, options: DownloadVideoPluginOptions) {
+    super(player, options);
+
+    const controlBar = this.player.controlBar;
+    const fullscreenToggle = controlBar.getChild('fullscreenToggle')?.el();
+    controlBar
+      .el()
+      .insertBefore(
+        controlBar.addChild('DownloadVideoButton', { urls: options.urls }).el(),
+        fullscreenToggle || null,
+      );
+  }
+}
+
+videojs.registerPlugin('downloadVideoPlugin', DownloadVideoPlugin);

--- a/src/frontend/packages/lib_video/src/components/common/Player/videojs/downloadVideoPlugin/types.ts
+++ b/src/frontend/packages/lib_video/src/components/common/Player/videojs/downloadVideoPlugin/types.ts
@@ -1,0 +1,12 @@
+import { urls } from 'lib-components';
+import videojs from 'video.js';
+
+export interface DownloadVideoQualityItemOptions
+  extends videojs.MenuItemOptions {
+  label: string;
+  src: string | undefined;
+}
+
+export interface DownloadVideoPluginOptions {
+  urls: Partial<urls>;
+}

--- a/src/frontend/packages/lib_video/src/components/common/VideoPlayer/index.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoPlayer/index.tsx
@@ -10,6 +10,7 @@ import {
 import React, { useEffect, useMemo, useRef } from 'react';
 import { useIntl } from 'react-intl';
 import { useQueryClient } from 'react-query';
+import styled from 'styled-components';
 
 import { useTimedTextMetadata } from '@lib-video/api/useTimedTextMetadata';
 import { createPlayer } from '@lib-video/components/common/Player/createPlayer';
@@ -23,6 +24,23 @@ interface BaseVideoPlayerProps {
   timedTextTracks: TimedText[];
   defaultVolume?: number;
 }
+
+export const StyledBox = styled(Box)`
+  /* 
+    This make the control bar visible when the video
+    has not been played yet.
+  */
+  .vjs-control-bar {
+    display: flex;
+  }
+
+  .vjs-icon-download {
+    background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="white" d="M16.59,10 L15,10 L15,5 C15,4.45 14.55,4 14,4 L10,4 C9.45,4 9,4.45 9,5 L9,10 L7.41,10 C6.52,10 6.07,11.08 6.7,11.71 L11.29,16.3 C11.68,16.69 12.31,16.69 12.7,16.3 L17.29,11.71 C17.92,11.08 17.48,10 16.59,10 Z M5,20 C5,20.55 5.45,21 6,21 L18,21 C18.55,21 19,20.55 19,20 C19,19.45 18.55,19 18,19 L6,19 C5.45,19 5,19.45 5,20 Z" /></svg>');
+    background-repeat: no-repeat;
+    background-position: center;
+    fill: white;
+  }
+`;
 
 export const VideoPlayer = ({
   video,
@@ -202,7 +220,7 @@ export const VideoPlayer = ({
   }, [resolutions, thumbnail, video.urls?.thumbnails]);
 
   return (
-    <Box ref={containerVideoRef}>
+    <StyledBox ref={containerVideoRef}>
       <video
         ref={videoNodeRef}
         crossOrigin="anonymous"
@@ -221,6 +239,6 @@ export const VideoPlayer = ({
           />
         ))}
       </video>
-    </Box>
+    </StyledBox>
   );
 };

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/index.spec.tsx
@@ -304,7 +304,7 @@ describe('<VideoWidgetProvider />', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders widget for vod student', async () => {
+  it('renders widget for vod student', () => {
     mockedUseCurrentResourceContext.mockReturnValue([
       {
         permissions: {
@@ -361,8 +361,8 @@ describe('<VideoWidgetProvider />', () => {
       ),
     );
 
-    //  Download video
-    expect(await screen.findByText('Download video')).toBeInTheDocument();
+    //  Download video as student should not appear in the widgets
+    expect(screen.queryByText('Download video')).not.toBeInTheDocument();
 
     //  Transcripts
     expect(screen.getByText('Transcripts')).toBeInTheDocument();

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/index.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/index.tsx
@@ -184,7 +184,6 @@ const teacherVodWidgets: WidgetType[] = [
 const publicLiveWidgets: WidgetType[] = [];
 const publicVodWidgets: WidgetType[] = [
   WidgetType.TRANSCRIPTS,
-  WidgetType.DOWNLOAD_VOD_PUBLIC,
   WidgetType.SHARED_MEDIA_VOD_PUBLIC,
 ];
 

--- a/src/frontend/packages/lib_video/src/components/vod/Student/Dashboard.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/vod/Student/Dashboard.spec.tsx
@@ -217,7 +217,6 @@ describe('<Dashboard />', () => {
     );
 
     screen.getByText('Transcripts');
-    screen.getByText('Download video');
     screen.getByText('Supports sharing');
   });
 
@@ -268,7 +267,6 @@ describe('<Dashboard />', () => {
     );
 
     screen.getByText('Transcripts');
-    screen.getByText('Download video');
   });
 
   it('uses the VideoLayout when the video is a Live-converted VOD', () => {

--- a/src/frontend/packages/lib_video/src/types/libs/video.js/extend.d.ts
+++ b/src/frontend/packages/lib_video/src/types/libs/video.js/extend.d.ts
@@ -1,6 +1,8 @@
 import 'video.js';
 import { Engine } from 'p2p-media-loader-hlsjs';
 
+import { DownloadVideoPluginOptions } from '../../../components/common/Player/videojs/downloadVideoPlugin/types';
+
 declare module 'video.js' {
   interface VideoJsPlayerOptions {
     debug?: boolean;
@@ -24,6 +26,7 @@ declare module 'video.js' {
     // p2p-media-loader-hlsjs
     config: { loader: { getEngine: () => Engine } };
     media: { currentTime: number };
+    downloadVideoPlugin: (options: DownloadVideoPluginOptions) => void;
     p2pHlsPlugin: () => void;
     // videojs-http-source-selector
     httpSourceSelector: () => void;


### PR DESCRIPTION
## Purpose

See https://github.com/openfun/marsha/issues/2312

Some widgets are shown below the video player like downloads and transcript activation, but are not well integrated with other features like subtitles in the player : it breaks page layout and cannot be folded without losing the functionnality.

## Proposal

This PR focuses on the download part, and aims to simplify the UX for downloading videos as a student, by removing the widget from VideoWidgetProvider and adding a button directly on the videojs player.

