### PR TITLE
🐛(back) remove stamp uses in aws stacks names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Video player reset when attributes update (#2300)
 - Fix panel closing and resizing on live video player chat (#2310)
 - Fix download video button when video is not downloadable
+- Fix multiple mediapackage creation by removing stamp in stack name
 
 ## [4.2.1] - 2023-06-20
 

--- a/src/aws/lambda-mediapackage/src/harvest.js
+++ b/src/aws/lambda-mediapackage/src/harvest.js
@@ -37,9 +37,9 @@ module.exports = async (event, lambdaFunctionName) => {
   }
 
   let stamp = undefined;
-  // The harvest id has this pattern : {environment}_{pk}_{stamp}
+  // The harvest id has this pattern : {environment}_{pk}_{stamp}_{jobCount}
   // splitting it give us the information we need
-  const [environment, pk, idStamp] = harvestJob.id.split('_');
+  const [environment, pk, idStamp, jobCount] = harvestJob.id.split('_');
 
   // first fetch origin endpoint to retrieve channel id
   const endpoint = await mediapackage
@@ -48,7 +48,7 @@ module.exports = async (event, lambdaFunctionName) => {
     })
     .promise();
 
-  if (idStamp) {
+  if (jobCount) {
     stamp = idStamp;
   } else {
     stamp = endpoint.Tags.stamp;

--- a/src/aws/lambda-mediapackage/src/harvest.spec.js
+++ b/src/aws/lambda-mediapackage/src/harvest.spec.js
@@ -106,7 +106,7 @@ describe('harvest', () => {
       ],
       detail: {
         harvest_job: {
-          id: 'test_a3e213a7-9c56-4bd3-b71c-fe567b0cfe22_1610546271',
+          id: 'test_a3e213a7-9c56-4bd3-b71c-fe567b0cfe22_1610546271_1',
           arn: 'arn:aws:mediapackage-vod:eu-west-1:aws_account_id:harvest_jobs/test_a3e213a7-9c56-4bd3-b71c-fe567b0cfe22_1610546271',
           status: 'SUCCEEDED',
           origin_endpoint_id:
@@ -138,7 +138,7 @@ describe('harvest', () => {
 
     expect(mockSetRecordingSliceManifestKey).toHaveBeenCalledWith(
       'a3e213a7-9c56-4bd3-b71c-fe567b0cfe22',
-      'test_a3e213a7-9c56-4bd3-b71c-fe567b0cfe22_1610546271',
+      'test_a3e213a7-9c56-4bd3-b71c-fe567b0cfe22_1610546271_1',
       'a3e213a7-9c56-4bd3-b71c-fe567b0cfe22/cmaf/1610546271.m3u8',
     );
 

--- a/src/aws/lambda-mediapackage/src/harvest.spec.js
+++ b/src/aws/lambda-mediapackage/src/harvest.spec.js
@@ -450,7 +450,7 @@ describe('harvest', () => {
       ],
       detail: {
         harvest_job: {
-          id: 'test_a3e213a7-9c56-4bd3-b71c-fe567b0cfe22',
+          id: 'test_a3e213a7-9c56-4bd3-b71c-fe567b0cfe22_2',
           arn: 'arn:aws:mediapackage-vod:eu-west-1:aws_account_id:harvest_jobs/test_a3e213a7-9c56-4bd3-b71c-fe567b0cfe22_1610546271',
           status: 'SUCCEEDED',
           origin_endpoint_id:
@@ -484,7 +484,7 @@ describe('harvest', () => {
 
     expect(mockSetRecordingSliceManifestKey).toHaveBeenCalledWith(
       'a3e213a7-9c56-4bd3-b71c-fe567b0cfe22',
-      'test_a3e213a7-9c56-4bd3-b71c-fe567b0cfe22',
+      'test_a3e213a7-9c56-4bd3-b71c-fe567b0cfe22_2',
       'a3e213a7-9c56-4bd3-b71c-fe567b0cfe22/cmaf/slice_2/1610546271_2.m3u8',
     );
   });

--- a/src/backend/marsha/core/api/video.py
+++ b/src/backend/marsha/core/api/video.py
@@ -479,9 +479,7 @@ class VideoViewSet(
 
         try:
             if video.live_info is None or original_live_state == defaults.HARVESTED:
-                now = timezone.now()
-                stamp = to_timestamp(now)
-                key = f"{video.pk}_{stamp}"
+                key = f"{video.pk}"
                 video.live_info = create_live_stream(key)
                 wait_medialive_channel_is_created(
                     video.get_medialive_channel().get("id")


### PR DESCRIPTION
## Purpose

There is a possibility that several channels are pointing to the same video, which is, in theory, not possible.

## Proposal

Using stamps in aws name stacks remove the possibility to use "unique" names for resources. This is a problem when it two requests are made on the same video, but due to different stamps, two stacks will be created.
Stamps are used elsewhere in the code, so we cannot remove them. Therefore, we move this information to the 'Tags' properties.


