### PR TITLE
🎨(frontend) refactor videojs features through plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Use alpine for installing mediainfo in lambda docker images
 - Add compatibility with docker compose 2
 - tslint is replaced by eslint in lti app (#2321)
+- refactor videojs id3 tags handling as videojs plugin
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Add compatibility with docker compose 2
 - tslint is replaced by eslint in lti app (#2321)
 - refactor videojs id3 tags handling as videojs plugin
+- refactor videojs xapi handling as videojs plugin
 
 ### Fixed
 

--- a/src/frontend/packages/lib_video/src/components/common/Player/createVideojsPlayer.ts
+++ b/src/frontend/packages/lib_video/src/components/common/Player/createVideojsPlayer.ts
@@ -5,9 +5,10 @@ import 'videojs-http-source-selector';
 import './videojs/qualitySelectorPlugin';
 import './videojs/p2pHlsPlugin';
 import './videojs/downloadVideoPlugin';
+import './videojs/id3Plugin';
+
 import { Maybe, Nullable } from 'lib-common';
 import {
-  Id3VideoType,
   InitializedContextExtensions,
   InteractedContextExtensions,
   Video,
@@ -18,7 +19,6 @@ import {
   useCurrentSession,
   useJwt,
   useP2PConfig,
-  useVideo,
   videoSize,
 } from 'lib-components';
 import videojs, {
@@ -39,10 +39,6 @@ import { isMSESupported } from '@lib-video/utils/isMSESupported';
 
 import { Events } from './videojs/qualitySelectorPlugin/types';
 
-type Id3MessageType = {
-  video: Id3VideoType;
-};
-
 export const createVideojsPlayer = (
   videoNode: HTMLVideoElement,
   dispatchPlayerTimeUpdate: (time: number) => void,
@@ -51,8 +47,6 @@ export const createVideojsPlayer = (
   onReady: Maybe<(player: VideoJsPlayer) => void> = undefined,
 ): VideoJsPlayer => {
   const { jwt } = useJwt.getState();
-  const videoState = useVideo.getState();
-  let lastReceivedVideo: Id3VideoType;
   const { isP2PEnabled } = useP2PConfig.getState();
   // This property should be deleted once the feature has been
   // deployed, tested and approved in a production environment
@@ -126,41 +120,9 @@ export const createVideojsPlayer = (
 
   const player = videojs(videoNode, options, function () {
     if (video.is_live) {
-      videoState.setIsWatchingVideo(true);
       this.play();
     }
     onReady?.(this);
-  });
-
-  player.on('loadedmetadata', () => {
-    const tracks = player.textTracks();
-    for (let index = 0; index < tracks.length; index++) {
-      const track = tracks[index];
-      if (track.label === 'Timed Metadata') {
-        track.addEventListener('cuechange', () => {
-          // VTTCue normally doesn't have value property
-          // Nonetheless, value is set when cue comes from id3 tags
-          // and has a property key: "TXXX" in it
-          const cue = track.activeCues?.[0] as
-            | { value: { key: string } | undefined; text: string }
-            | undefined;
-          if (cue) {
-            if (cue.value?.key !== 'PRIV') {
-              // cue.text should be a video object
-              const data = JSON.parse(cue.text) as Id3MessageType;
-              if (
-                data &&
-                useVideo.getState().isWatchingVideo &&
-                JSON.stringify(data.video) !== JSON.stringify(lastReceivedVideo)
-              ) {
-                lastReceivedVideo = data.video;
-                videoState.setId3Video(data.video);
-              }
-            }
-          }
-        });
-      }
-    }
   });
 
   if (isMSESupported()) {
@@ -176,6 +138,7 @@ export const createVideojsPlayer = (
   } else {
     player.on(Events.PLAYER_SOURCES_CHANGED, () => interacted());
   }
+  player.id3Plugin();
 
   const tracks = player.remoteTextTracks();
 
@@ -184,15 +147,8 @@ export const createVideojsPlayer = (
     (time) => player.currentTime(time),
   );
 
-  player.on('ended', () => {
-    videoState.setId3Video(null);
-    videoState.setIsWatchingVideo(false);
-  });
-
   // When the player is dispose, unsubscribe to the useTranscriptTimeSelector store.
   player.on('dispose', () => {
-    videoState.setId3Video(null);
-    videoState.setIsWatchingVideo(false);
     unsubscribeTranscriptTimeSelector();
   });
 

--- a/src/frontend/packages/lib_video/src/components/common/Player/videojs/id3Plugin/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/Player/videojs/id3Plugin/index.spec.tsx
@@ -1,0 +1,207 @@
+/* eslint-disable testing-library/no-node-access */
+/* eslint-disable testing-library/no-container */
+import { waitFor } from '@testing-library/react';
+import {
+  Id3VideoType,
+  liveMockFactory,
+  liveState,
+  timedTextMode,
+  uploadState,
+  useJwt,
+  useVideo,
+  videoMockFactory,
+} from 'lib-components';
+import { render } from 'lib-tests';
+import React from 'react';
+import videojs from 'video.js';
+
+import { VideoPlayer } from '../../../VideoPlayer';
+import { createPlayer } from '../../createPlayer';
+import { createVideojsPlayer } from '../../createVideojsPlayer';
+
+jest.mock('../../createPlayer', () => ({
+  createPlayer: jest.fn(),
+}));
+
+jest.mock('lib-components', () => ({
+  ...jest.requireActual('lib-components'),
+  useAppConfig: () => ({
+    attendanceDelay: 10,
+    video: mockVideo,
+  }),
+  decodeJwt: () => ({}),
+  XAPIStatement: jest.fn(),
+}));
+
+jest.mock('utils/isMSESupported', () => ({
+  isMSESupported: jest.fn().mockReturnValue(false),
+}));
+
+const mockCreatePlayer = createPlayer as jest.MockedFunction<
+  typeof createPlayer
+>;
+
+// It prevents console to display error when it tries to play a non existing media
+jest.spyOn(console, 'error').mockImplementation(() => jest.fn());
+jest.spyOn(console, 'log').mockImplementation(() => jest.fn());
+
+const mockVideo = videoMockFactory({
+  id: 'video-test-videojs-instance',
+  timed_text_tracks: [
+    {
+      active_stamp: 1549385921,
+      id: 'ttt-1',
+      is_ready_to_show: true,
+      language: 'fr',
+      mode: timedTextMode.SUBTITLE,
+      upload_state: uploadState.READY,
+      source_url: 'https://example.com/timedtext/ttt-1.vtt',
+      url: 'https://example.com/timedtext/ttt-1.vtt',
+      title: 'test',
+      video: 'video-test-videojs-instance',
+    },
+    {
+      active_stamp: 1549385922,
+      id: 'ttt-2',
+      is_ready_to_show: true,
+      language: 'fr',
+      mode: timedTextMode.CLOSED_CAPTIONING,
+      upload_state: uploadState.READY,
+      source_url: 'https://example.com/timedtext/ttt-2.vtt',
+      url: 'https://example.com/timedtext/ttt-2.vtt',
+      title: 'test',
+      video: 'video-test-videojs-instance',
+    },
+  ],
+});
+
+describe('Id3 Plugin', () => {
+  beforeEach(() => {
+    useJwt.setState({
+      jwt: 'foo',
+    });
+
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    // dispose all not disposed players
+    videojs.getAllPlayers().forEach((player) => {
+      if (!player.isDisposed()) {
+        player.dispose();
+      }
+    });
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  it('start and end id3 listening', async () => {
+    expect(useVideo.getState().isWatchingVideo).toBe(false);
+
+    const video = liveMockFactory({
+      live_state: liveState.RUNNING,
+      urls: {
+        manifests: {
+          hls: 'https://google.com',
+        },
+        mp4: {},
+        thumbnails: {},
+      },
+    });
+    const { container } = render(
+      <VideoPlayer video={video} playerType="videojs" timedTextTracks={[]} />,
+    );
+
+    await waitFor(() =>
+      // The player is created
+      expect(mockCreatePlayer).toHaveBeenCalled(),
+    );
+
+    const videoElement = container.querySelector('video');
+    const dispatchPlayerTimeUpdate = jest.fn();
+
+    const player = createVideojsPlayer(
+      videoElement!,
+      dispatchPlayerTimeUpdate,
+      video,
+      'en',
+    );
+
+    await waitFor(() => {
+      expect(useVideo.getState().isWatchingVideo).toBe(true);
+    });
+
+    player.trigger('dispose');
+    expect(useVideo.getState().isWatchingVideo).toBe(false);
+  });
+
+  it('load id3 tags', async () => {
+    const video = liveMockFactory({
+      live_state: liveState.RUNNING,
+      urls: {
+        manifests: {
+          hls: 'https://google.com',
+        },
+        mp4: {},
+        thumbnails: {},
+      },
+    });
+
+    const { container } = render(
+      <VideoPlayer video={video} playerType="videojs" timedTextTracks={[]} />,
+    );
+
+    await waitFor(() =>
+      // The player is created
+      expect(mockCreatePlayer).toHaveBeenCalled(),
+    );
+
+    const videoElement = container.querySelector('video');
+    const dispatchPlayerTimeUpdate = jest.fn();
+
+    const player = createVideojsPlayer(
+      videoElement!,
+      dispatchPlayerTimeUpdate,
+      video,
+      'en',
+    );
+
+    await waitFor(() => {
+      expect(useVideo.getState().isWatchingVideo).toBe(true);
+    });
+
+    // Create listened track
+    player.addTextTrack('metadata', 'Timed Metadata', 'en');
+    const id3Video: Id3VideoType = {
+      live_state: liveState.RUNNING,
+      active_shared_live_media: {
+        id: '1234',
+      },
+      active_shared_live_media_page: null,
+    };
+    player.trigger('loadedmetadata');
+
+    const tracks = player.textTracks();
+    const track = tracks[0];
+    console.log(tracks);
+    // Add cue that should come from id3 tags
+    const newCue = new VTTCue(0, 2, JSON.stringify({ video: id3Video }));
+    track.addCue(newCue);
+
+    // track should contain trigger function but is not typescritped
+    const trackTrigger = track as any as {
+      trigger: (eventName: string) => void;
+    } & TextTrack;
+    if (trackTrigger && trackTrigger.trigger) {
+      trackTrigger.trigger('cuechange');
+    }
+
+    await waitFor(() => {
+      expect(useVideo.getState().id3Video).toStrictEqual(id3Video);
+    });
+
+    player.trigger('dispose');
+    expect(useVideo.getState().id3Video).toBe(null);
+  });
+});

--- a/src/frontend/packages/lib_video/src/components/common/Player/videojs/id3Plugin/index.ts
+++ b/src/frontend/packages/lib_video/src/components/common/Player/videojs/id3Plugin/index.ts
@@ -1,0 +1,77 @@
+import { Id3VideoType, useVideo } from 'lib-components';
+import videojs from 'video.js';
+const Plugin = videojs.getPlugin('plugin');
+
+type Id3MessageType = {
+  video: Id3VideoType;
+};
+
+export class id3Plugin extends Plugin {
+  lastReceivedVideo: Id3VideoType | undefined;
+  videoState;
+
+  constructor(player: videojs.Player, options: unknown) {
+    super(player, options);
+
+    this.videoState = useVideo.getState();
+    this.videoState.setIsWatchingVideo(true);
+
+    player.on('loadedmetadata', this.handleLoadedMetadata.bind(this));
+
+    player.on('play', this.handleStart.bind(this));
+
+    player.on('ended', this.handleEnded.bind(this));
+
+    player.on('dispose', this.handleDispose.bind(this));
+  }
+
+  handleLoadedMetadata() {
+    const tracks = this.player.textTracks();
+    for (let index = 0; index < tracks.length; index++) {
+      const track = tracks[index];
+      if (track.label === 'Timed Metadata') {
+        track.addEventListener('cuechange', () => {
+          // VTTCue normally doesn't have value property
+          // Nonetheless, value is set when cue comes from id3 tags
+          // and has a property key: "TXXX" in it
+          const cue = track.activeCues?.[0] as
+            | { value: { key: string } | undefined; text: string }
+            | undefined;
+          if (cue) {
+            if (cue.value?.key !== 'PRIV') {
+              // cue.text should be a video object
+              const data = JSON.parse(cue.text) as Id3MessageType;
+              if (
+                data &&
+                useVideo.getState().isWatchingVideo &&
+                JSON.stringify(data.video) !==
+                  JSON.stringify(this.lastReceivedVideo)
+              ) {
+                this.lastReceivedVideo = data.video;
+                this.videoState.setId3Video(data.video);
+              }
+            }
+          }
+        });
+      }
+    }
+  }
+
+  handleStart() {
+    if (!useVideo.getState().isWatchingVideo) {
+      this.videoState.setIsWatchingVideo(true);
+    }
+  }
+
+  handleEnded() {
+    this.videoState.setId3Video(null);
+    this.videoState.setIsWatchingVideo(false);
+  }
+
+  handleDispose() {
+    this.videoState.setId3Video(null);
+    this.videoState.setIsWatchingVideo(false);
+  }
+}
+
+videojs.registerPlugin('id3Plugin', id3Plugin);

--- a/src/frontend/packages/lib_video/src/components/common/Player/videojs/xapiPlugin/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/Player/videojs/xapiPlugin/index.spec.tsx
@@ -1,0 +1,302 @@
+/* eslint-disable testing-library/no-node-access */
+/* eslint-disable testing-library/no-container */
+import { waitFor } from '@testing-library/react';
+import {
+  VideoXAPIStatementInterface,
+  XAPIStatement,
+  liveMockFactory,
+  liveState,
+  timedTextMode,
+  uploadState,
+  useJwt,
+  videoMockFactory,
+} from 'lib-components';
+import { render } from 'lib-tests';
+import React from 'react';
+import videojs from 'video.js';
+
+import { pushAttendance } from '@lib-video/api/pushAttendance';
+import { getOrInitAnonymousId } from '@lib-video/utils/getOrInitAnonymousId';
+
+import { VideoPlayer } from '../../../VideoPlayer';
+import { createPlayer } from '../../createPlayer';
+import { createVideojsPlayer } from '../../createVideojsPlayer';
+
+const mockXAPIStatementInterface: VideoXAPIStatementInterface = {
+  initialized: jest.fn(),
+  completed: jest.fn(),
+  downloaded: jest.fn(),
+  interacted: jest.fn(),
+  paused: jest.fn(),
+  played: jest.fn(),
+  seeked: jest.fn(),
+  terminated: jest.fn(),
+};
+
+jest.mock('../../createPlayer', () => ({
+  createPlayer: jest.fn(),
+}));
+
+jest.mock('lib-components', () => ({
+  ...jest.requireActual('lib-components'),
+  useAppConfig: () => ({
+    attendanceDelay: 10,
+    video: mockVideo,
+  }),
+  decodeJwt: () => ({}),
+  XAPIStatement: jest.fn(),
+}));
+const mockXAPIStatement = XAPIStatement as jest.MockedFunction<
+  typeof XAPIStatement
+>;
+mockXAPIStatement.mockReturnValue(mockXAPIStatementInterface);
+
+jest.mock('api/pushAttendance', () => ({
+  pushAttendance: jest.fn(),
+}));
+
+jest.mock('utils/isMSESupported', () => ({
+  isMSESupported: jest.fn().mockReturnValue(true),
+}));
+
+const mockCreatePlayer = createPlayer as jest.MockedFunction<
+  typeof createPlayer
+>;
+
+const mockPushAttendance = pushAttendance as jest.MockedFunction<
+  typeof pushAttendance
+>;
+
+// It prevents console to display error when it tries to play a non existing media
+jest.spyOn(console, 'error').mockImplementation(() => jest.fn());
+jest.spyOn(console, 'log').mockImplementation(() => jest.fn());
+
+const mockVideo = videoMockFactory({
+  id: 'video-test-videojs-instance',
+  timed_text_tracks: [
+    {
+      active_stamp: 1549385921,
+      id: 'ttt-1',
+      is_ready_to_show: true,
+      language: 'fr',
+      mode: timedTextMode.SUBTITLE,
+      upload_state: uploadState.READY,
+      source_url: 'https://example.com/timedtext/ttt-1.vtt',
+      url: 'https://example.com/timedtext/ttt-1.vtt',
+      title: 'test',
+      video: 'video-test-videojs-instance',
+    },
+    {
+      active_stamp: 1549385922,
+      id: 'ttt-2',
+      is_ready_to_show: true,
+      language: 'fr',
+      mode: timedTextMode.CLOSED_CAPTIONING,
+      upload_state: uploadState.READY,
+      source_url: 'https://example.com/timedtext/ttt-2.vtt',
+      url: 'https://example.com/timedtext/ttt-2.vtt',
+      title: 'test',
+      video: 'video-test-videojs-instance',
+    },
+  ],
+});
+
+describe('XAPI plugin', () => {
+  beforeEach(() => {
+    useJwt.setState({
+      jwt: 'foo',
+    });
+
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    // dispose all not disposed players
+    videojs.getAllPlayers().forEach((player) => {
+      if (!player.isDisposed()) {
+        player.dispose();
+      }
+    });
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  it('sends xapi events', async () => {
+    const { container } = render(
+      <VideoPlayer
+        video={mockVideo}
+        playerType="videojs"
+        timedTextTracks={[]}
+      />,
+    );
+
+    await waitFor(() =>
+      // The player is created
+      expect(mockCreatePlayer).toHaveBeenCalled(),
+    );
+
+    const videoElement = container.querySelector('video');
+    const dispatchPlayerTimeUpdate = jest.fn();
+
+    const player = createVideojsPlayer(
+      videoElement!,
+      dispatchPlayerTimeUpdate,
+      mockVideo,
+      'en',
+    );
+
+    expect(mockXAPIStatement).toHaveBeenCalled();
+
+    player.trigger('canplaythrough');
+    expect(mockXAPIStatementInterface.initialized).toHaveBeenCalled();
+
+    player.trigger('play');
+    expect(mockXAPIStatementInterface.played).toHaveBeenCalled();
+
+    player.trigger('pause');
+    expect(mockXAPIStatementInterface.paused).toHaveBeenCalled();
+
+    player.trigger('timeupdate');
+    expect(dispatchPlayerTimeUpdate).toHaveBeenCalled();
+
+    // calling seeked without seeking before should not
+    // send xapi statement
+    player.trigger('seeked');
+    expect(mockXAPIStatementInterface.seeked).not.toHaveBeenCalled();
+
+    player.trigger('seeking');
+    player.trigger('seeked');
+    expect(mockXAPIStatementInterface.seeked).toHaveBeenCalled();
+
+    player.trigger('fullscreenchange');
+    player.trigger('languagechange');
+    player.trigger('ratechange');
+    player.trigger('volumechange');
+    player.qualityLevels().trigger('change');
+    player.remoteTextTracks().dispatchEvent(new Event('change'));
+    expect(mockXAPIStatementInterface.interacted).toHaveBeenCalledTimes(6);
+
+    window.dispatchEvent(new Event('unload'));
+    expect(mockXAPIStatementInterface.terminated).toHaveBeenCalled();
+  });
+
+  it('sends attendance for a student watching a live', async () => {
+    const video = liveMockFactory({
+      urls: {
+        manifests: {
+          hls: 'https://example.com/hls',
+        },
+        mp4: {},
+        thumbnails: {},
+      },
+      live_state: liveState.RUNNING,
+      can_edit: false,
+    });
+    const { container } = render(
+      <VideoPlayer video={video} playerType="videojs" timedTextTracks={[]} />,
+    );
+
+    await waitFor(() =>
+      // The player is created
+      expect(mockCreatePlayer).toHaveBeenCalled(),
+    );
+
+    const videoElement = container.querySelector('video');
+
+    const player = createVideojsPlayer(videoElement!, jest.fn(), video, 'en');
+
+    expect(player.options_.liveui).toBe(true);
+
+    expect(mockPushAttendance).not.toHaveBeenCalled();
+    // to initialize the video for a live
+    player.qualityLevels().trigger('change');
+    Date.now = jest.fn(() => 1651732370000);
+    jest.runOnlyPendingTimers();
+    expect(mockPushAttendance).toHaveBeenCalledWith(
+      video.id,
+      {
+        1651732370: {
+          fullScreen: false,
+          muted: false,
+          player_timer: 0,
+          playing: false,
+          timestamp: 1651732370000,
+          volume: 1,
+        },
+      },
+      'en',
+      getOrInitAnonymousId(),
+    );
+    jest.runOnlyPendingTimers();
+    expect(mockPushAttendance).toHaveBeenCalledTimes(2);
+
+    window.dispatchEvent(new Event('unload'));
+
+    jest.runOnlyPendingTimers();
+
+    // it didn't get called a new time
+    expect(mockPushAttendance).toHaveBeenCalledTimes(2);
+  });
+
+  it("doesn't send attendance for an admin or instructor watching a live", async () => {
+    const video = liveMockFactory({
+      urls: {
+        manifests: {
+          hls: 'https://example.com/hls',
+        },
+        mp4: {},
+        thumbnails: {},
+      },
+      live_state: liveState.RUNNING,
+    });
+    const { container } = render(
+      <VideoPlayer video={video} playerType="videojs" timedTextTracks={[]} />,
+    );
+
+    await waitFor(() =>
+      // The player is created
+      expect(mockCreatePlayer).toHaveBeenCalled(),
+    );
+
+    const videoElement = container.querySelector('video');
+
+    const player = createVideojsPlayer(videoElement!, jest.fn(), video, 'en');
+
+    expect(player.currentSources()).toEqual([
+      { type: 'application/x-mpegURL', src: 'https://example.com/hls' },
+    ]);
+    expect(player.options_.liveui).toBe(true);
+
+    // to initialize the video for a live
+    player.qualityLevels().trigger('change');
+    expect(mockPushAttendance).not.toHaveBeenCalled();
+  });
+
+  it("doesn't send attendance when it's not a live", async () => {
+    const { container } = render(
+      <VideoPlayer
+        video={mockVideo}
+        playerType="videojs"
+        timedTextTracks={[]}
+      />,
+    );
+
+    await waitFor(() =>
+      // The player is created
+      expect(mockCreatePlayer).toHaveBeenCalled(),
+    );
+
+    const videoElement = container.querySelector('video');
+
+    const player = createVideojsPlayer(
+      videoElement!,
+      jest.fn(),
+      mockVideo,
+      'en',
+    );
+
+    player.trigger('canplaythrough');
+    expect(mockPushAttendance).not.toHaveBeenCalled();
+  });
+});

--- a/src/frontend/packages/lib_video/src/components/common/Player/videojs/xapiPlugin/index.ts
+++ b/src/frontend/packages/lib_video/src/components/common/Player/videojs/xapiPlugin/index.ts
@@ -1,0 +1,224 @@
+import { Maybe, Nullable } from '@lib-common/types';
+import {
+  InteractedContextExtensions,
+  Video,
+  VideoXAPIStatementInterface,
+  XAPIStatement,
+  liveState,
+  report,
+  useCurrentSession,
+  useJwt,
+} from 'lib-components';
+import videojs from 'video.js';
+
+import { pushAttendance } from '@lib-video/api/pushAttendance';
+import { useAttendance } from '@lib-video/hooks/useAttendance';
+import { QualityLevels } from '@lib-video/types/libs/video.js/extend';
+import { getOrInitAnonymousId } from '@lib-video/utils/getOrInitAnonymousId';
+import { isMSESupported } from '@lib-video/utils/isMSESupported';
+
+import { Events } from '../qualitySelectorPlugin/types';
+
+import { XapiPluginOptions } from './types';
+
+const Plugin = videojs.getPlugin('plugin');
+
+export class xapiPlugin extends Plugin {
+  private xapiStatement: VideoXAPIStatementInterface;
+  video: Video;
+  currentTime: number;
+  seekingAt: number;
+  hasSeeked: boolean;
+  isInitialized: boolean;
+  interval: number | undefined;
+  hasAttendance: boolean;
+  currentTrack: Nullable<TextTrack>;
+  locale: Maybe<string>;
+
+  constructor(player: videojs.Player, options: XapiPluginOptions) {
+    super(player, options);
+
+    this.video = options.video;
+    this.player = player;
+    this.currentTime = 0;
+    this.seekingAt = 0;
+    this.hasSeeked = false;
+    this.isInitialized = false;
+    this.hasAttendance =
+      this.video.live_state === liveState.RUNNING &&
+      this.video.can_edit === false;
+    this.currentTrack = this.getCurrentTrack();
+    this.locale = options.locale;
+
+    const { jwt } = useJwt.getState();
+    const sessionId = useCurrentSession.getState().sessionId;
+    if (!jwt) {
+      throw new Error('Authenticated jwt is required.');
+    }
+    try {
+      this.xapiStatement = XAPIStatement(jwt, sessionId, options.video);
+    } catch (error) {
+      report(error);
+      throw error;
+    }
+
+    if (isMSESupported()) {
+      const qualityLevels = player.qualityLevels();
+      qualityLevels.on('change', () => this.interacted(qualityLevels));
+    } else {
+      player.on(Events.PLAYER_SOURCES_CHANGED, () => this.interacted());
+    }
+
+    /************************** EVENT BINDINGS **************************/
+
+    player.on('canplaythrough', this.initialize.bind(this));
+    player.on('play', () => {
+      this.xapiStatement.played({
+        time: player.currentTime(),
+      });
+    });
+    player.on('pause', () => {
+      this.xapiStatement.paused({
+        time: player.currentTime(),
+      });
+    });
+
+    player.on('timeupdate', () => {
+      if (this.isInitialized && !player.seeking()) {
+        this.currentTime = player.currentTime();
+      }
+      options.dispatchPlayerTimeUpdate(player.currentTime());
+    });
+
+    player.on('seeking', () => {
+      this.seekingAt = this.currentTime;
+      this.hasSeeked = true;
+    });
+
+    player.on('seeked', () => {
+      if (!this.hasSeeked) {
+        return;
+      }
+      this.hasSeeked = false;
+      this.xapiStatement.seeked({
+        timeFrom: this.seekingAt,
+        timeTo: player.currentTime(),
+      });
+    });
+    player.on('fullscreenchange', this.interacted.bind(this));
+    player.on('languagechange', this.interacted.bind(this));
+    player.on('ratechange', this.interacted.bind(this));
+    player.on('volumechange', this.interacted.bind(this));
+    const tracks = player.remoteTextTracks();
+    tracks.addEventListener('change', () => {
+      this.currentTrack = this.getCurrentTrack();
+      this.interacted();
+    });
+
+    /**************** End interacted event *************************/
+
+    window.addEventListener('unload', () => {
+      if (!this.isInitialized) {
+        return;
+      }
+
+      this.xapiStatement.terminated({ time: player.currentTime() });
+
+      if (this.interval) {
+        player.clearInterval(this.interval);
+      }
+    });
+  }
+
+  private trackAttendance() {
+    const attendance = {
+      [Math.round(Date.now() / 1000)]: {
+        fullScreen: this.player.isFullscreen(),
+        muted: this.player.muted(),
+        player_timer: this.player.currentTime(),
+        playing: !this.player.paused(),
+        timestamp: Date.now(),
+        volume: this.player.volume(),
+      },
+    };
+    if (!this.locale) {
+      throw new Error('Locale is undefined.');
+    }
+    const anonymousId = getOrInitAnonymousId();
+    pushAttendance(this.video.id, attendance, this.locale, anonymousId);
+  }
+
+  private getCurrentTrack() {
+    const tracks = this.player.remoteTextTracks();
+    for (let i = 0; i < tracks.length; i++) {
+      if (tracks[i].mode === 'showing') {
+        return tracks[i];
+      }
+    }
+    return null;
+  }
+
+  private initialize() {
+    if (this.isInitialized) {
+      return;
+    }
+    const contextExtensions = {
+      ccSubtitleEnabled: this.currentTrack !== null,
+      fullScreen: this.player.isFullscreen(),
+      length: this.player.duration(),
+      speed: `${this.player.playbackRate()}x`,
+      volume: this.player.volume(),
+    };
+    this.xapiStatement.initialized(contextExtensions);
+    this.isInitialized = true;
+    if (this.hasAttendance) {
+      const delay = useAttendance.getState().delay;
+      this.interval = this.player.setInterval(
+        () => this.trackAttendance(),
+        delay,
+      );
+    }
+  }
+
+  private interacted(qualityLevels?: QualityLevels) {
+    if (!this.isInitialized) {
+      // For a live video, no event to detect when the video is fully initialized is triggered
+      // before the first "play" action. To mitigate this, we can call "initialize"
+      // on the first "interact" action and we don't log this interaction. The first interact
+      // action is when the first quality to play is chosen, the default one. To choose it,
+      // all quality available must be read in the HLS manifest. So we can consider at this
+      // time that the video is initialized.
+      if (this.video.is_live) {
+        this.initialize();
+      }
+      return;
+    }
+    let quality: string | number | undefined;
+
+    if (qualityLevels) {
+      quality = qualityLevels[qualityLevels.selectedIndex]?.height;
+    } else {
+      quality = this.player.currentSource().size;
+    }
+
+    const contextExtensions: InteractedContextExtensions = {
+      ccSubtitleEnabled: this.getCurrentTrack() !== null,
+      fullScreen: this.player.isFullscreen(),
+      quality,
+      speed: `${this.player.playbackRate()}x`,
+      volume: this.player.volume(),
+    };
+
+    const currentTrack = this.getCurrentTrack();
+    if (currentTrack !== null) {
+      contextExtensions.ccSubtitleLanguage = currentTrack.language;
+    }
+
+    this.xapiStatement.interacted(
+      { time: this.player.currentTime() },
+      contextExtensions,
+    );
+  }
+}
+
+videojs.registerPlugin('xapiPlugin', xapiPlugin);

--- a/src/frontend/packages/lib_video/src/components/common/Player/videojs/xapiPlugin/types.ts
+++ b/src/frontend/packages/lib_video/src/components/common/Player/videojs/xapiPlugin/types.ts
@@ -1,0 +1,8 @@
+import { Maybe } from 'lib-common';
+import { Video } from 'lib-components';
+
+export interface XapiPluginOptions {
+  video: Video;
+  locale: Maybe<string>;
+  dispatchPlayerTimeUpdate: (time: number) => void;
+}

--- a/src/frontend/packages/lib_video/src/types/libs/video.js/extend.d.ts
+++ b/src/frontend/packages/lib_video/src/types/libs/video.js/extend.d.ts
@@ -28,6 +28,7 @@ declare module 'video.js' {
     media: { currentTime: number };
     downloadVideoPlugin: (options: DownloadVideoPluginOptions) => void;
     p2pHlsPlugin: () => void;
+    id3Plugin: () => void;
     // videojs-http-source-selector
     httpSourceSelector: () => void;
     qualitySelector: () => {

--- a/src/frontend/packages/lib_video/src/types/libs/video.js/extend.d.ts
+++ b/src/frontend/packages/lib_video/src/types/libs/video.js/extend.d.ts
@@ -2,6 +2,7 @@ import 'video.js';
 import { Engine } from 'p2p-media-loader-hlsjs';
 
 import { DownloadVideoPluginOptions } from '../../../components/common/Player/videojs/downloadVideoPlugin/types';
+import { XapiPluginOptions } from '../../../components/common/Player/videojs/xapiPlugin/types';
 
 declare module 'video.js' {
   interface VideoJsPlayerOptions {
@@ -29,6 +30,7 @@ declare module 'video.js' {
     downloadVideoPlugin: (options: DownloadVideoPluginOptions) => void;
     p2pHlsPlugin: () => void;
     id3Plugin: () => void;
+    xapiPlugin: (options: XapiPluginOptions) => void;
     // videojs-http-source-selector
     httpSourceSelector: () => void;
     qualitySelector: () => {


### PR DESCRIPTION
## Purpose

Our handling of our custom features for videojs is made in one file (createVideojsPlayer). It makes this file difficult to read and maintain.

## Proposal

Taking example on p2p plugin or download button, we should move id3 related logic, and xapi related logic into their own plugin.

- [x] create id3 tag plugin
- [x] create xapi plugin

