### PR TITLE
🐛(webtorrent) fix jsonwebtoken import

### DIFF
--- a/src/webtorrent/src/verifyClient.ts
+++ b/src/webtorrent/src/verifyClient.ts
@@ -1,5 +1,6 @@
 import { type IncomingMessage, type OutgoingHttpHeaders } from 'http';
-import { verify } from 'jsonwebtoken';
+import pkg from 'jsonwebtoken';
+const { verify } = pkg;
 
 const jwtSecretKey = process.env.JWT_SIGNING_KEY ?? '';
 


### PR DESCRIPTION
## Purpose

Since last js update, the jsonwebtoken import is not working anymore. We have to import first the pkg and then pick the verify function.

## Proposal

- [x] fix jsonwebtoken import

