### PR TITLE
🔧(front) disable audio tack button in videojs

### DIFF
--- a/src/frontend/packages/lib_video/src/components/common/Player/createVideojsPlayer.ts
+++ b/src/frontend/packages/lib_video/src/components/common/Player/createVideojsPlayer.ts
@@ -96,6 +96,9 @@ export const createVideojsPlayer = (
   const options: VideoJsPlayerOptions = {
     autoplay: video.is_live,
     controls: true,
+    controlBar: {
+      audioTrackButton: false,
+    },
     debug: false,
     fluid: true,
     html5: {


### PR DESCRIPTION
## Purpose

With the new usage of videojs-hlsjs-plugin audiotrack button can appear when there are multiple audio tracks but it is not useful to display them.

![image](https://github.com/openfun/marsha/assets/767834/88d5af84-c549-4097-8d3c-8fe9e845c9ad)


## Proposal

- [x] disable audio tack button in videojs

