### PR TITLE
🔧(tray) change webtorrent container name and pull policy

### DIFF
--- a/src/tray/templates/services/webtorrent/deploy.yml.j2
+++ b/src/tray/templates/services/webtorrent/deploy.yml.j2
@@ -33,7 +33,8 @@ spec:
 {% endif %}
       containers:
         - image: "{{ marsha_webtorrent_image_name }}:{{ marsha_webtorrent_image_tag }}"
-          name: nginx
+          imagePullPolicy: Always
+          name: webtorrent
           env:
             - name: APP_PORT
               value: "{{ marsha_webtorrent_port }}"


### PR DESCRIPTION
## Purpose

The webtorrent deployment had a wrong name for the container, we change it for webtorrent. No image pull policy was defined and we must set to Always otherwise the last master image is never used.

## Proposal

- [x] change webtorrent container name and pull policy

