### PR TITLE
🐛(back) use django.conf module to import settings instead of marsha

### DIFF
--- a/src/backend/marsha/core/models/playlist.py
+++ b/src/backend/marsha/core/models/playlist.py
@@ -2,6 +2,7 @@
 from datetime import timedelta
 import logging
 
+from django.conf import settings
 from django.db import models
 from django.db.models import Q
 from django.utils import timezone
@@ -12,7 +13,6 @@ from safedelete import HARD_DELETE
 from safedelete.managers import SafeDeleteManager
 from safedelete.queryset import SafeDeleteQueryset
 
-from marsha import settings
 from marsha.core.utils import s3_utils
 
 from .account import ADMINISTRATOR, INSTRUCTOR, ROLE_CHOICES

--- a/src/backend/marsha/core/tests/models/test_retention_date_object_mixin.py
+++ b/src/backend/marsha/core/tests/models/test_retention_date_object_mixin.py
@@ -83,7 +83,7 @@ class RetentionDateObjectMixinTextCase(TestCase):
             video.refresh_from_db()
 
             self.mock_s3_utils.update_expiration_date.assert_called_once_with(
-                str(video.pk), date(2022, 1, 31)
+                str(video.pk), date(2022, 1, 16)
             )
 
     def test_soft_undelete_of_retention_date_object_mixin(self):


### PR DESCRIPTION
## Purpose

The marsha module was used to import the settings. This is wrong as the settings are managed by django. The test was reflecting bad usage of the import but it was failing... the test was proving the failure...

## Proposal

- [x]  use django.conf module to import settings instead of marsha

