### PR TITLE
✨(tray) manage multiple ingresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Add a download-video widget directly in the video player
 - Configure sentry in the webtorrent application
 - Add custom frontend site management
+- Manage multiple ingresses
 
 ### Changed
 

--- a/src/tray/templates/services/app/_deploy_base.yml.j2
+++ b/src/tray/templates/services/app/_deploy_base.yml.j2
@@ -56,7 +56,7 @@ spec:
               port: {{ marsha_django_port }}
               httpHeaders:
                 - name: Host
-                  value: "{{ marsha_host }}"
+                  value: "{{ marsha_hosts[0] }}"
             initialDelaySeconds: 60
             periodSeconds: 30
           readinessProbe:
@@ -65,7 +65,7 @@ spec:
               port: {{ marsha_django_port }}
               httpHeaders:
                 - name: Host
-                  value: "{{ marsha_host }}"
+                  value: "{{ marsha_hosts[0] }}"
             initialDelaySeconds: 10
             periodSeconds: 5
           env:
@@ -80,9 +80,9 @@ spec:
             - name: POSTGRES_PORT
               value: "{{ marsha_postgresql_port }}"
             - name: DJANGO_ALLOWED_HOSTS
-              value: "{{ marsha_host | blue_green_hosts }}"
+              value: "{{ marsha_hosts | map('blue_green_hosts') | join(',') }}"
             - name: DJANGO_CSRF_TRUSTED_ORIGINS
-              value: "{{ marsha_host | blue_green_hosts | split(',') | map('regex_replace', '^(.*)$', 'https://\\1') | join(',') }}"
+              value: "{{ marsha_hosts | map('blue_green_hosts') | join(',') | split(',') | map('regex_replace', '^(.*)$', 'https://\\1') | join(',') }}"
             - name: DJANGO_CLOUDFRONT_PRIVATE_KEY_PATH
               value: "{{ marsha_cloudfront_private_key_path }}"
           envFrom:

--- a/src/tray/templates/services/app/job_db_migrate.yml.j2
+++ b/src/tray/templates/services/app/job_db_migrate.yml.j2
@@ -41,7 +41,7 @@ spec:
             - name: POSTGRES_PORT
               value: "{{ marsha_postgresql_port }}"
             - name: DJANGO_ALLOWED_HOSTS
-              value: "{{ marsha_host }}"
+              value: "{{ marsha_hosts[0] }}"
           envFrom:
             - secretRef:
                 name: "{{ marsha_secret_name }}"

--- a/src/tray/templates/services/nginx/ingress.yml.j2
+++ b/src/tray/templates/services/nginx/ingress.yml.j2
@@ -17,6 +17,7 @@ metadata:
 spec:
   ingressClassName: "{{ marsha_ingress_class_name }}"
   rules:
+{% for marsha_host in marsha_hosts %}
   - host: "{{ marsha_host | blue_green_host(prefix) }}"
     http:
       paths:
@@ -27,7 +28,10 @@ spec:
               number: {{ marsha_nginx_port }}
         path: /
         pathType: Prefix
+{% endfor %}
   tls:
+{% for marsha_host in marsha_hosts %}
   - hosts:
     - "{{ marsha_host | blue_green_host(prefix) }}"
-    secretName: "marsha-app-tls-{{ prefix }}-{{ acme_env }}"
+    secretName: "marsha-app-tls-{{ prefix }}-{{ marsha_host }}-{{ acme_env }}"
+{% endfor %}

--- a/src/tray/vars/all/main.yml
+++ b/src/tray/vars/all/main.yml
@@ -1,7 +1,8 @@
 # Application default configuration
 
 # -- ingress
-marsha_host: "marsha.{{ namespace_name }}.{{ domain_name }}"
+marsha_hosts: 
+  - "marsha.{{ namespace_name }}.{{ domain_name }}"
 marsha_ingress_class_name: "{{ default_ingress_class_name }}"
 
 # -- nginx


### PR DESCRIPTION
## Purpose

We can handle mutiple sites for marsha. To use this feature with k8s, we have to declare one ingress per domain and allow this domains in the ALLOWED_HOSTS and CSRF configuration. Blue/green is also managed

## Proposal

- [x] manage multiple ingresses
