### PR TITLE
🐛(frontend) fix videojs download video button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Video player reset when attributes update (#2300)
 - Fix panel closing and resizing on live video player chat (#2310)
+- Fix download video button when video is not downloadable
 
 ## [4.2.1] - 2023-06-20
 

--- a/src/frontend/packages/lib_video/src/components/common/Player/createVideojsPlayer.ts
+++ b/src/frontend/packages/lib_video/src/components/common/Player/createVideojsPlayer.ts
@@ -110,7 +110,7 @@ export const createVideojsPlayer = (
     if (isP2pQueryEnabled && isP2PEnabled) {
       player.p2pHlsPlugin();
     }
-    if (!video.is_live && video.urls.mp4) {
+    if (!video.is_live && video.show_download) {
       player.downloadVideoPlugin({ urls: video.urls.mp4 });
     }
     if (video.shared_live_medias && video.shared_live_medias.length) {

--- a/src/frontend/packages/lib_video/src/components/common/Player/videojs/downloadVideoPlugin/components/DownloadVideoButton.ts
+++ b/src/frontend/packages/lib_video/src/components/common/Player/videojs/downloadVideoPlugin/components/DownloadVideoButton.ts
@@ -1,4 +1,6 @@
 import { videoSize } from '@lib-components/types';
+import { getIntl } from 'lib-common';
+import { defineMessages } from 'react-intl';
 import videojs from 'video.js';
 
 import { DownloadVideoPluginOptions } from '../types';
@@ -6,11 +8,20 @@ import { DownloadVideoPluginOptions } from '../types';
 import { DownloadVideoQualityItem } from './DownloadVideoQualityItem';
 
 const MenuButton = videojs.getComponent('MenuButton');
-
+const messages = defineMessages({
+  downloadVideoButton: {
+    defaultMessage: 'Download Video',
+    description: 'Title of the download video button inside the video player.',
+    id: 'videojs.menu.downloadVideoButton',
+  },
+});
 export class DownloadVideoButton extends MenuButton {
   constructor(player: videojs.Player, options?: videojs.MenuItemOptions) {
     super(player, options);
-    this.menuButton_.setAttribute('aria-label', 'Download Video');
+    this.menuButton_.setAttribute(
+      'title',
+      getIntl().formatMessage(messages.downloadVideoButton),
+    );
   }
 
   createEl() {

--- a/src/frontend/packages/lib_video/src/components/common/Player/videojs/downloadVideoPlugin/components/DownloadVideoQualityItem.ts
+++ b/src/frontend/packages/lib_video/src/components/common/Player/videojs/downloadVideoPlugin/components/DownloadVideoQualityItem.ts
@@ -16,15 +16,20 @@ export class DownloadVideoQualityItem extends MenuItem {
     options.multiSelectable = false;
 
     super(player, options);
+    this.setAttribute('title', options.label);
     this.source = options.src;
   }
 
   handleClick() {
     if (this.source) {
-      const link = document.createElement('a');
-      link.href = this.source;
-      link.click();
+      this.downloadVideoQuality(this.source);
     }
+  }
+
+  downloadVideoQuality(source: string) {
+    const link = document.createElement('a');
+    link.href = source;
+    link.click();
   }
 }
 

--- a/src/frontend/packages/lib_video/src/components/common/Player/videojs/downloadVideoPlugin/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/Player/videojs/downloadVideoPlugin/index.spec.tsx
@@ -1,0 +1,87 @@
+import { screen } from '@testing-library/react';
+import fetchMock from 'fetch-mock';
+import { useJwt, videoMockFactory } from 'lib-components';
+import { render } from 'lib-tests';
+import React from 'react';
+
+import { VideoPlayer } from '@lib-video/components/common/VideoPlayer';
+
+import { DownloadVideoQualityItem } from './components/DownloadVideoQualityItem';
+
+const mockVideo = videoMockFactory({
+  id: '1234',
+});
+
+jest.mock('utils/isMSESupported', () => ({
+  isMSESupported: jest.fn().mockReturnValue(true),
+}));
+
+let mockedDownload = jest
+  .spyOn(DownloadVideoQualityItem.prototype, 'downloadVideoQuality')
+  .mockImplementation();
+
+describe('Download Video Plugin', () => {
+  beforeEach(() => {
+    mockedDownload = jest
+      .spyOn(DownloadVideoQualityItem.prototype, 'downloadVideoQuality')
+      .mockImplementation();
+    useJwt.setState({
+      jwt: 'token',
+      getDecodedJwt: () =>
+        ({
+          permissions: {
+            can_update: false,
+          },
+        }) as any,
+    });
+  });
+
+  afterEach(() => {
+    fetchMock.restore();
+    jest.clearAllMocks();
+  });
+
+  it('displays the video player without download video button when show download is false', async () => {
+    const video = videoMockFactory({
+      ...mockVideo,
+      show_download: false,
+    });
+
+    render(
+      <VideoPlayer video={video} playerType="videojs" timedTextTracks={[]} />,
+    );
+
+    await screen.findByRole('button', {
+      name: 'Fullscreen',
+    });
+    expect(
+      screen.queryByRole('button', {
+        name: 'Download Video',
+      }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('displays the video player with download video button and items', async () => {
+    const video = videoMockFactory({
+      ...mockVideo,
+    });
+
+    render(
+      <VideoPlayer video={video} playerType="videojs" timedTextTracks={[]} />,
+    );
+
+    await screen.findByRole('button', {
+      name: 'Fullscreen',
+    });
+    screen.getByRole('button', {
+      name: 'Download Video',
+    });
+
+    const menuItemDownloadQuality = screen.getByRole('menuitem', {
+      name: '1080p',
+    });
+    expect(menuItemDownloadQuality).toBeInTheDocument();
+    menuItemDownloadQuality.click();
+    expect(mockedDownload).toHaveBeenCalledWith('https://example.com/mp4/1080');
+  });
+});


### PR DESCRIPTION
## Purpose

The "download video" on the videojs player was always displayed even if the video was not downloadable

## Proposal

- [x] fix the bug when show_download is false
- [x] add some tests

