### PR TITLE
♻️(back) redirect to matching site on complete shibboleth route

### DIFF
--- a/src/backend/marsha/account/views.py
+++ b/src/backend/marsha/account/views.py
@@ -5,6 +5,7 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.cache import never_cache
 from django.views.generic import RedirectView
 
+from marsha.core.models import SiteConfig
 from marsha.core.simple_jwt.tokens import ChallengeToken
 
 
@@ -22,10 +23,17 @@ class RedirectToFrontendView(RedirectView):
     def get(self, request, *args, **kwargs):
         """Redirect the user to the frontend providing a challenge token for authentication."""
 
+        redirect_url = settings.FRONTEND_HOME_URL
+        domain = request.get_host()
+
+        if domain not in settings.FRONTEND_HOME_URL:
+            if SiteConfig.objects.filter(site__domain=domain).exists():
+                redirect_url = request.build_absolute_uri("/")
+
         return super().get(
             request,
             *args,
-            frontend_login_url=settings.FRONTEND_HOME_URL,
+            frontend_login_url=redirect_url,
             challenge_token=ChallengeToken.for_user(request.user),
             **kwargs,
         )


### PR DESCRIPTION
## Purpose

The complete route redirect successfuly connected shibboleth user to the default FRONTEND_HOME_URL. If the user comes from an existing site config, we want to redirect it to the same domain.

## Proposal

- [x] redirect to matching site on complete shibboleth route

