### PR TITLE
➖(back) remove lxml dependency management

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -55,16 +55,6 @@
       "allowedVersions": "<1.27"
     },
     {
-      "enabled": false,
-      "groupName": "ignore python dependencies",
-      "matchManagers": [
-        "setup-cfg"
-      ],
-      "matchPackageNames": [
-        "lxml"
-      ]
-    },
-    {
       "groupName": "allowed docker images",
       "matchDatasources": [
         "docker"

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -51,7 +51,6 @@ install_requires =
     drf-spectacular==0.26.4
     gunicorn==21.2.0
     logging-ldp==0.0.7
-    lxml==4.6.5
     oauthlib==3.2.2
     django-parler==2.3
     psycopg2-binary==2.9.6


### PR DESCRIPTION
## Purpose

We added lxml to our depencies to control the version installed. Since we switch to debian bookworm it is not needed to do it anymore, the libxml2 version used is more recent and we don't have the issue we had with lxml 4.7.x


## Proposal

- [x] remove lxml dependency management

