### PR TITLE
🐛(backend) xapi cache to avoid duplicate statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Add a transcript plugin to the video player
 - Add a link to LTI resources to retrieve them in the standalone website
 - Add Language Picker in the standalone website (#2366)
+- Add xapi statements cache to avoid duplicate statements
 
 ### Changed
 

--- a/src/backend/marsha/core/defaults.py
+++ b/src/backend/marsha/core/defaults.py
@@ -100,6 +100,7 @@ APP_DATA_STATE_PORTABILITY = "portability"
 APP_DATA_STATE_SUCCESS = "success"
 
 VIDEO_ATTENDANCE_KEY_CACHE = "attendances:video:"
+XAPI_STATEMENT_ID_CACHE = "xapi:statements:"
 
 # Licenses
 

--- a/src/backend/marsha/core/tests/test_api_xapi_statement.py
+++ b/src/backend/marsha/core/tests/test_api_xapi_statement.py
@@ -32,6 +32,7 @@ class XAPIStatementApiTest(TestCase):
         jwt_token = StudentLtiTokenFactory(playlist=video.playlist)
 
         data = {
+            "id": str(uuid.uuid4()),
             "verb": {
                 "id": "http://adlnet.gov/expapi/verbs/initialized",
                 "display": {"en-US": "initialized"},
@@ -82,6 +83,7 @@ class XAPIStatementApiTest(TestCase):
         jwt_token = StudentLtiTokenFactory()
 
         data = {
+            "id": str(uuid.uuid4()),
             "verb": {
                 "id": "http://adlnet.gov/expapi/verbs/initialized",
                 "display": {"en-US": "initialized"},
@@ -110,6 +112,7 @@ class XAPIStatementApiTest(TestCase):
         jwt_token = StudentLtiTokenFactory(playlist=video.playlist)
 
         data = {
+            "id": str(uuid.uuid4()),
             "verb": {
                 "id": "http://adlnet.gov/expapi/verbs/initialized",
                 "display": {"en-US": "initialized"},
@@ -147,6 +150,7 @@ class XAPIStatementApiTest(TestCase):
         jwt_token = StudentLtiTokenFactory(playlist=video.playlist)
 
         data = {
+            "id": str(uuid.uuid4()),
             "verb": {
                 "id": "http://adlnet.gov/expapi/verbs/initialized",
                 "display": {"en-US": "initialized"},
@@ -176,6 +180,7 @@ class XAPIStatementApiTest(TestCase):
         del jwt_token.payload["user"]
 
         data = {
+            "id": str(uuid.uuid4()),
             "verb": {
                 "id": "http://adlnet.gov/expapi/verbs/initialized",
                 "display": {"en-US": "initialized"},
@@ -207,6 +212,7 @@ class XAPIStatementApiTest(TestCase):
         )
 
         data = {
+            "id": str(uuid.uuid4()),
             "verb": {
                 "id": "http://id.tincanapi.com/verb/downloaded",
                 "display": {"en-US": "downloaded"},

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -424,6 +424,7 @@ class Base(Configuration):
     APP_DATA_CACHE_DURATION = values.Value(60)  # 60 secondes
     PUBLIC_RESOURCE_DOMAIN_CACHE_DURATION = values.Value(90)  # 90 seconds
     VIDEO_ATTENDANCES_CACHE_DURATION = values.Value(300)  # 5 minutes
+    XAPI_STATEMENT_ID_CACHE_TIMEOUT = values.Value(120)  # 2 minutes
 
     SENTRY_DSN = values.Value(None)
     SENTRY_TRACES_SAMPLE_RATE = values.FloatValue(1.0)


### PR DESCRIPTION
## Purpose

Sometimes video xAPI statements are sent multiple times, it can happens when a client has network connections issues and the request is retried. #2343 

## Proposal

To avoid duplicate statements, we use the `id` field of the statement to identify if the statement has already been sent using a cache of a few minutes.

- [x] add xapi statement cache to store recent id event 

