### PR TITLE
Api related ids

### DIFF
--- a/src/backend/marsha/bbb/api.py
+++ b/src/backend/marsha/bbb/api.py
@@ -56,7 +56,7 @@ class ObjectClassroomRelatedMixin:
         classroom_id = (
             self.kwargs.get("classroom_id")
             # Backward compatibility with old routes
-            or self.request.data.get("classroom")
+            or self.request.data.get("classroom_id")
             or self.request.query_params.get("classroom")
         )
 

--- a/src/backend/marsha/bbb/serializers.py
+++ b/src/backend/marsha/bbb/serializers.py
@@ -297,7 +297,7 @@ class ClassroomDocumentSerializer(
 
         """
         resource = self.context["request"].resource
-        classroom_id = self.context["request"].data.get("classroom")
+        classroom_id = self.context["request"].data.get("classroom_id")
         if not validated_data.get("classroom_id"):
             if resource:
                 validated_data["classroom_id"] = resource.id

--- a/src/backend/marsha/bbb/serializers.py
+++ b/src/backend/marsha/bbb/serializers.py
@@ -35,7 +35,7 @@ class ClassroomRecordingSerializer(ReadOnlyModelSerializer):
         model = ClassroomRecording
         fields = (
             "id",
-            "classroom",
+            "classroom_id",
             "record_id",
             "started_at",
             "video_file_url",
@@ -43,7 +43,7 @@ class ClassroomRecordingSerializer(ReadOnlyModelSerializer):
         )
         read_only_fields = (
             "id",
-            "classroom",
+            "classroom_id",
             "record_id",
             "started_at",
             "video_file_url",
@@ -51,7 +51,7 @@ class ClassroomRecordingSerializer(ReadOnlyModelSerializer):
         )
 
     # Make sure classroom and vod UUIDs are converted to a string during serialization
-    classroom = serializers.PrimaryKeyRelatedField(
+    classroom_id = serializers.PrimaryKeyRelatedField(
         read_only=True, pk_field=serializers.CharField()
     )
     vod = VideoFromRecordingSerializer(read_only=True)
@@ -249,7 +249,7 @@ class ClassroomDocumentSerializer(
     class Meta:  # noqa
         model = ClassroomDocument
         fields = (
-            "classroom",
+            "classroom_id",
             "filename",
             "id",
             "is_default",
@@ -258,7 +258,7 @@ class ClassroomDocumentSerializer(
             "url",
         )
         read_only_fields = (
-            "classroom",
+            "classroom_id",
             "id",
             "upload_state",
             "uploaded_on",
@@ -267,7 +267,7 @@ class ClassroomDocumentSerializer(
 
     url = serializers.SerializerMethodField()
     # Make sure classroom UUID is converted to a string during serialization
-    classroom = serializers.PrimaryKeyRelatedField(
+    classroom_id = serializers.PrimaryKeyRelatedField(
         read_only=True, pk_field=serializers.CharField()
     )
 

--- a/src/backend/marsha/bbb/tests/api/classroom/recordings/test_create_vod.py
+++ b/src/backend/marsha/bbb/tests/api/classroom/recordings/test_create_vod.py
@@ -125,7 +125,7 @@ class ClassroomRecordingCreateVodAPITest(TestCase):
         self.assertDictEqual(
             response.json(),
             {
-                "classroom": str(recording.classroom.id),
+                "classroom_id": str(recording.classroom.id),
                 "id": str(recording.id),
                 "record_id": str(recording.record_id),
                 "started_at": "2019-08-21T15:00:02Z",

--- a/src/backend/marsha/bbb/tests/api/classroom/test_classroomdocuments.py
+++ b/src/backend/marsha/bbb/tests/api/classroom/test_classroomdocuments.py
@@ -79,7 +79,7 @@ class ClassroomClassroomdocumentsAPITest(TestCase):
                 "previous": None,
                 "results": [
                     {
-                        "classroom": str(classroom.id),
+                        "classroom_id": str(classroom.id),
                         "filename": classroom_documents[2].filename,
                         "id": str(classroom_documents[2].id),
                         "is_default": False,
@@ -88,7 +88,7 @@ class ClassroomClassroomdocumentsAPITest(TestCase):
                         "url": None,
                     },
                     {
-                        "classroom": str(classroom.id),
+                        "classroom_id": str(classroom.id),
                         "filename": classroom_documents[1].filename,
                         "id": str(classroom_documents[1].id),
                         "is_default": False,
@@ -134,7 +134,7 @@ class ClassroomClassroomdocumentsAPITest(TestCase):
                 "previous": None,
                 "results": [
                     {
-                        "classroom": str(classroom.id),
+                        "classroom_id": str(classroom.id),
                         "filename": classroom_documents[3].filename,
                         "id": str(classroom_documents[3].id),
                         "is_default": False,
@@ -148,7 +148,7 @@ class ClassroomClassroomdocumentsAPITest(TestCase):
                         ),
                     },
                     {
-                        "classroom": str(classroom.id),
+                        "classroom_id": str(classroom.id),
                         "filename": classroom_documents[2].filename,
                         "id": str(classroom_documents[2].id),
                         "is_default": False,
@@ -163,7 +163,7 @@ class ClassroomClassroomdocumentsAPITest(TestCase):
                         ),
                     },
                     {
-                        "classroom": str(classroom.id),
+                        "classroom_id": str(classroom.id),
                         "filename": classroom_documents[1].filename,
                         "id": str(classroom_documents[1].id),
                         "is_default": False,
@@ -178,7 +178,7 @@ class ClassroomClassroomdocumentsAPITest(TestCase):
                         ),
                     },
                     {
-                        "classroom": str(classroom.id),
+                        "classroom_id": str(classroom.id),
                         "filename": classroom_documents[0].filename,
                         "id": str(classroom_documents[0].id),
                         "is_default": False,
@@ -236,7 +236,7 @@ class ClassroomClassroomdocumentsAPITest(TestCase):
                 "previous": None,
                 "results": [
                     {
-                        "classroom": str(classroom.id),
+                        "classroom_id": str(classroom.id),
                         "filename": classroom_documents[2].filename,
                         "id": str(classroom_documents[2].id),
                         "is_default": False,
@@ -245,7 +245,7 @@ class ClassroomClassroomdocumentsAPITest(TestCase):
                         "url": None,
                     },
                     {
-                        "classroom": str(classroom.id),
+                        "classroom_id": str(classroom.id),
                         "filename": classroom_documents[1].filename,
                         "id": str(classroom_documents[1].id),
                         "is_default": False,
@@ -281,7 +281,7 @@ class ClassroomClassroomdocumentsAPITest(TestCase):
                 "previous": None,
                 "results": [
                     {
-                        "classroom": str(classroom.id),
+                        "classroom_id": str(classroom.id),
                         "filename": classroom_documents[2].filename,
                         "id": str(classroom_documents[2].id),
                         "is_default": False,
@@ -290,7 +290,7 @@ class ClassroomClassroomdocumentsAPITest(TestCase):
                         "url": None,
                     },
                     {
-                        "classroom": str(classroom.id),
+                        "classroom_id": str(classroom.id),
                         "filename": classroom_documents[1].filename,
                         "id": str(classroom_documents[1].id),
                         "is_default": False,

--- a/src/backend/marsha/bbb/tests/api/classroom/test_retrieve.py
+++ b/src/backend/marsha/bbb/tests/api/classroom/test_retrieve.py
@@ -502,7 +502,7 @@ class ClassroomRetrieveAPITest(TestCase):
                 "estimated_duration": None,
                 "recordings": [
                     {
-                        "classroom": str(classroom.id),
+                        "classroom_id": str(classroom.id),
                         "id": str(classroom_recording_2.id),
                         "record_id": str(classroom_recording_2.record_id),
                         "started_at": "2019-08-21T11:00:02Z",
@@ -510,7 +510,7 @@ class ClassroomRetrieveAPITest(TestCase):
                         "vod": None,
                     },
                     {
-                        "classroom": str(classroom.id),
+                        "classroom_id": str(classroom.id),
                         "id": str(classroom_recording_1.id),
                         "record_id": str(classroom_recording_1.record_id),
                         "started_at": "2019-08-21T15:00:02Z",

--- a/src/backend/marsha/bbb/tests/api/classroomdocument/test_create.py
+++ b/src/backend/marsha/bbb/tests/api/classroomdocument/test_create.py
@@ -88,7 +88,7 @@ class ClassroomDocumentCreateAPITest(TestCase):
         self.assertEqual(
             response.json(),
             {
-                "classroom": str(classroom.id),
+                "classroom_id": str(classroom.id),
                 "filename": "test.pdf",
                 "id": str(ClassroomDocument.objects.first().id),
                 "is_default": True,
@@ -128,7 +128,7 @@ class ClassroomDocumentCreateAPITest(TestCase):
         self.assertEqual(
             response.json(),
             {
-                "classroom": str(classroom.id),
+                "classroom_id": str(classroom.id),
                 "filename": "test2.pdf",
                 "id": str(ClassroomDocument.objects.latest("created_on").id),
                 "is_default": False,
@@ -159,7 +159,7 @@ class ClassroomDocumentCreateAPITest(TestCase):
                 {
                     "filename": "test.pdf",
                     "size": 100,
-                    "classroom": str(classroom.id),
+                    "classroom_id": str(classroom.id),
                 }
             ),
         )
@@ -188,7 +188,7 @@ class ClassroomDocumentCreateAPITest(TestCase):
                 {
                     "filename": "test.pdf",
                     "size": 100,
-                    "classroom": str(classroom.id),
+                    "classroom_id": str(classroom.id),
                 }
             ),
         )
@@ -198,7 +198,7 @@ class ClassroomDocumentCreateAPITest(TestCase):
         self.assertEqual(
             response.json(),
             {
-                "classroom": str(classroom.id),
+                "classroom_id": str(classroom.id),
                 "filename": "test.pdf",
                 "id": str(ClassroomDocument.objects.first().id),
                 "is_default": True,
@@ -227,7 +227,7 @@ class ClassroomDocumentCreateAPITest(TestCase):
                 {
                     "filename": "test.pdf",
                     "size": 100,
-                    "classroom": str(classroom.id),
+                    "classroom_id": str(classroom.id),
                 }
             ),
         )
@@ -237,7 +237,7 @@ class ClassroomDocumentCreateAPITest(TestCase):
         self.assertEqual(
             response.json(),
             {
-                "classroom": str(classroom.id),
+                "classroom_id": str(classroom.id),
                 "filename": "test.pdf",
                 "id": str(ClassroomDocument.objects.first().id),
                 "is_default": True,
@@ -266,7 +266,7 @@ class ClassroomDocumentCreateAPITest(TestCase):
                 {
                     "filename": "test.pdf",
                     "size": 100,
-                    "classroom": str(classroom.id),
+                    "classroom_id": str(classroom.id),
                 }
             ),
         )
@@ -276,7 +276,7 @@ class ClassroomDocumentCreateAPITest(TestCase):
         self.assertEqual(
             response.json(),
             {
-                "classroom": str(classroom.id),
+                "classroom_id": str(classroom.id),
                 "filename": "test.pdf",
                 "id": str(ClassroomDocument.objects.first().id),
                 "is_default": True,
@@ -303,7 +303,7 @@ class ClassroomDocumentCreateAPITest(TestCase):
                 {
                     "filename": "test.pdf",
                     "size": 100,
-                    "classroom": str(classroom.id),
+                    "classroom_id": str(classroom.id),
                 }
             ),
         )
@@ -333,7 +333,7 @@ class ClassroomDocumentCreateAPITest(TestCase):
                 {
                     "filename": "test.pdf",
                     "size": 100,
-                    "classroom": str(classroom.id),
+                    "classroom_id": str(classroom.id),
                 }
             ),
         )

--- a/src/backend/marsha/bbb/tests/api/classroomdocument/test_update.py
+++ b/src/backend/marsha/bbb/tests/api/classroomdocument/test_update.py
@@ -68,7 +68,7 @@ class ClassroomDocumentUpdateAPITest(TestCase):
         self.assertEqual(
             response.json(),
             {
-                "classroom": str(classroom_document.classroom.id),
+                "classroom_id": str(classroom_document.classroom.id),
                 "filename": "updated_name.pdf",
                 "id": str(classroom_document.id),
                 "is_default": False,
@@ -99,7 +99,7 @@ class ClassroomDocumentUpdateAPITest(TestCase):
         self.assertEqual(
             response.json(),
             {
-                "classroom": str(second_document.classroom.id),
+                "classroom_id": str(second_document.classroom.id),
                 "filename": second_document.filename,
                 "id": str(second_document.id),
                 "is_default": True,
@@ -147,7 +147,7 @@ class ClassroomDocumentUpdateAPITest(TestCase):
         self.assertEqual(
             response.json(),
             {
-                "classroom": str(classroom_document.classroom.id),
+                "classroom_id": str(classroom_document.classroom.id),
                 "filename": "updated_name.pdf",
                 "id": str(classroom_document.id),
                 "is_default": False,
@@ -176,7 +176,7 @@ class ClassroomDocumentUpdateAPITest(TestCase):
         self.assertEqual(
             response.json(),
             {
-                "classroom": str(classroom_document.classroom.id),
+                "classroom_id": str(classroom_document.classroom.id),
                 "filename": "updated_name.pdf",
                 "id": str(classroom_document.id),
                 "is_default": False,
@@ -205,7 +205,7 @@ class ClassroomDocumentUpdateAPITest(TestCase):
         self.assertEqual(
             response.json(),
             {
-                "classroom": str(classroom_document.classroom.id),
+                "classroom_id": str(classroom_document.classroom.id),
                 "filename": "updated_name.pdf",
                 "id": str(classroom_document.id),
                 "is_default": False,

--- a/src/backend/marsha/deposit/serializers.py
+++ b/src/backend/marsha/deposit/serializers.py
@@ -33,7 +33,7 @@ class DepositedFileSerializer(
             "filename",
             "author_name",
             "id",
-            "file_depository",
+            "file_depository_id",
             "read",
             "url",
             "uploaded_on",
@@ -42,7 +42,7 @@ class DepositedFileSerializer(
         )
         read_only_fields = (
             "id",
-            "file_depository",
+            "file_depository_id",
             "url",
             "uploaded_on",
             "upload_state",
@@ -52,7 +52,7 @@ class DepositedFileSerializer(
     # filename = serializers.SerializerMethodField()
     url = serializers.SerializerMethodField()
     # Make sure file depository UUID is converted to a string during serialization
-    file_depository = serializers.PrimaryKeyRelatedField(
+    file_depository_id = serializers.PrimaryKeyRelatedField(
         read_only=True, pk_field=serializers.CharField()
     )
 

--- a/src/backend/marsha/deposit/serializers.py
+++ b/src/backend/marsha/deposit/serializers.py
@@ -83,7 +83,7 @@ class DepositedFileSerializer(
         """
         resource = self.context["request"].resource
         user = self.context["request"].user
-        file_depository_id = self.context["request"].data.get("file_depository")
+        file_depository_id = self.context["request"].data.get("file_depository_id")
 
         if not validated_data.get("file_depository_id"):
             if resource:

--- a/src/backend/marsha/deposit/tests/api/depositedfiles/test_create.py
+++ b/src/backend/marsha/deposit/tests/api/depositedfiles/test_create.py
@@ -62,7 +62,7 @@ class DepositedFileCreateAPITest(TestCase):
             response.json(),
             {
                 "author_name": jwt_token.get("user").get("user_fullname"),
-                "file_depository": str(file_depository.id),
+                "file_depository_id": str(file_depository.id),
                 "filename": "test.pdf",
                 "id": str(DepositedFile.objects.first().id),
                 "read": False,
@@ -98,7 +98,7 @@ class DepositedFileCreateAPITest(TestCase):
                 {
                     "size": 123,
                     "filename": "test.pdf",
-                    "file_depository": str(file_depository.id),
+                    "file_depository_id": str(file_depository.id),
                 }
             ),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
@@ -130,7 +130,7 @@ class DepositedFileCreateAPITest(TestCase):
                 {
                     "size": 123,
                     "filename": "test.pdf",
-                    "file_depository": str(file_depository.id),
+                    "file_depository_id": str(file_depository.id),
                 }
             ),
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
@@ -160,7 +160,7 @@ class DepositedFileCreateAPITest(TestCase):
                 {
                     "size": 123,
                     "filename": "test.pdf",
-                    "file_depository": str(file_depository.id),
+                    "file_depository_id": str(file_depository.id),
                 }
             ),
         )
@@ -171,7 +171,7 @@ class DepositedFileCreateAPITest(TestCase):
             response.json(),
             {
                 "author_name": organization_access.user.username,
-                "file_depository": str(file_depository.id),
+                "file_depository_id": str(file_depository.id),
                 "filename": "test.pdf",
                 "id": str(DepositedFile.objects.first().id),
                 "read": False,
@@ -204,7 +204,7 @@ class DepositedFileCreateAPITest(TestCase):
                 {
                     "size": 123,
                     "filename": "test.pdf",
-                    "file_depository": str(file_depository.id),
+                    "file_depository_id": str(file_depository.id),
                 }
             ),
         )
@@ -215,7 +215,7 @@ class DepositedFileCreateAPITest(TestCase):
             response.json(),
             {
                 "author_name": organization_access.user.username,
-                "file_depository": str(file_depository.id),
+                "file_depository_id": str(file_depository.id),
                 "filename": "test.pdf",
                 "id": str(DepositedFile.objects.first().id),
                 "read": False,
@@ -247,7 +247,7 @@ class DepositedFileCreateAPITest(TestCase):
                 {
                     "size": 123,
                     "filename": "test.pdf",
-                    "file_depository": str(file_depository.id),
+                    "file_depository_id": str(file_depository.id),
                 }
             ),
         )
@@ -258,7 +258,7 @@ class DepositedFileCreateAPITest(TestCase):
             response.json(),
             {
                 "author_name": playlist_access.user.username,
-                "file_depository": str(file_depository.id),
+                "file_depository_id": str(file_depository.id),
                 "filename": "test.pdf",
                 "id": str(DepositedFile.objects.first().id),
                 "read": False,

--- a/src/backend/marsha/deposit/tests/api/depositedfiles/test_update.py
+++ b/src/backend/marsha/deposit/tests/api/depositedfiles/test_update.py
@@ -68,7 +68,7 @@ class DepositedFileUpdateAPITest(TestCase):
             response.json(),
             {
                 "author_name": deposited_file.author_name,
-                "file_depository": str(deposited_file.file_depository.id),
+                "file_depository_id": str(deposited_file.file_depository.id),
                 "filename": deposited_file.filename,
                 "id": str(deposited_file.id),
                 "read": True,
@@ -117,7 +117,7 @@ class DepositedFileUpdateAPITest(TestCase):
             response.json(),
             {
                 "author_name": deposited_file.author_name,
-                "file_depository": str(deposited_file.file_depository.id),
+                "file_depository_id": str(deposited_file.file_depository.id),
                 "filename": deposited_file.filename,
                 "id": str(deposited_file.id),
                 "read": True,
@@ -151,7 +151,7 @@ class DepositedFileUpdateAPITest(TestCase):
             response.json(),
             {
                 "author_name": deposited_file.author_name,
-                "file_depository": str(deposited_file.file_depository.id),
+                "file_depository_id": str(deposited_file.file_depository.id),
                 "filename": deposited_file.filename,
                 "id": str(deposited_file.id),
                 "read": True,

--- a/src/backend/marsha/deposit/tests/api/filedepositories/test_depositedfiles.py
+++ b/src/backend/marsha/deposit/tests/api/filedepositories/test_depositedfiles.py
@@ -71,7 +71,7 @@ class FileDepositoryDepositedfilesAPITest(TestCase):
                 "results": [
                     {
                         "author_name": owned_deposited_file.author_name,
-                        "file_depository": str(file_depository.id),
+                        "file_depository_id": str(file_depository.id),
                         "filename": owned_deposited_file.filename,
                         "id": str(owned_deposited_file.id),
                         "read": False,
@@ -107,7 +107,7 @@ class FileDepositoryDepositedfilesAPITest(TestCase):
                 "results": [
                     {
                         "author_name": deposited_files[2].author_name,
-                        "file_depository": str(file_depository.id),
+                        "file_depository_id": str(file_depository.id),
                         "filename": deposited_files[2].filename,
                         "id": str(deposited_files[2].id),
                         "read": False,
@@ -118,7 +118,7 @@ class FileDepositoryDepositedfilesAPITest(TestCase):
                     },
                     {
                         "author_name": deposited_files[1].author_name,
-                        "file_depository": str(file_depository.id),
+                        "file_depository_id": str(file_depository.id),
                         "filename": deposited_files[1].filename,
                         "id": str(deposited_files[1].id),
                         "read": False,
@@ -156,7 +156,7 @@ class FileDepositoryDepositedfilesAPITest(TestCase):
                 "results": [
                     {
                         "author_name": deposited_files_new[1].author_name,
-                        "file_depository": str(file_depository.id),
+                        "file_depository_id": str(file_depository.id),
                         "filename": deposited_files_new[1].filename,
                         "id": str(deposited_files_new[1].id),
                         "read": False,
@@ -167,7 +167,7 @@ class FileDepositoryDepositedfilesAPITest(TestCase):
                     },
                     {
                         "author_name": deposited_files_new[0].author_name,
-                        "file_depository": str(file_depository.id),
+                        "file_depository_id": str(file_depository.id),
                         "filename": deposited_files_new[0].filename,
                         "id": str(deposited_files_new[0].id),
                         "read": False,
@@ -178,7 +178,7 @@ class FileDepositoryDepositedfilesAPITest(TestCase):
                     },
                     {
                         "author_name": deposited_files_read[1].author_name,
-                        "file_depository": str(file_depository.id),
+                        "file_depository_id": str(file_depository.id),
                         "filename": deposited_files_read[1].filename,
                         "id": str(deposited_files_read[1].id),
                         "read": True,
@@ -189,7 +189,7 @@ class FileDepositoryDepositedfilesAPITest(TestCase):
                     },
                     {
                         "author_name": deposited_files_read[0].author_name,
-                        "file_depository": str(file_depository.id),
+                        "file_depository_id": str(file_depository.id),
                         "filename": deposited_files_read[0].filename,
                         "id": str(deposited_files_read[0].id),
                         "read": True,
@@ -216,7 +216,7 @@ class FileDepositoryDepositedfilesAPITest(TestCase):
                 "results": [
                     {
                         "author_name": deposited_files_read[1].author_name,
-                        "file_depository": str(file_depository.id),
+                        "file_depository_id": str(file_depository.id),
                         "filename": deposited_files_read[1].filename,
                         "id": str(deposited_files_read[1].id),
                         "read": True,
@@ -227,7 +227,7 @@ class FileDepositoryDepositedfilesAPITest(TestCase):
                     },
                     {
                         "author_name": deposited_files_read[0].author_name,
-                        "file_depository": str(file_depository.id),
+                        "file_depository_id": str(file_depository.id),
                         "filename": deposited_files_read[0].filename,
                         "id": str(deposited_files_read[0].id),
                         "read": True,
@@ -254,7 +254,7 @@ class FileDepositoryDepositedfilesAPITest(TestCase):
                 "results": [
                     {
                         "author_name": deposited_files_new[1].author_name,
-                        "file_depository": str(file_depository.id),
+                        "file_depository_id": str(file_depository.id),
                         "filename": deposited_files_new[1].filename,
                         "id": str(deposited_files_new[1].id),
                         "read": False,
@@ -265,7 +265,7 @@ class FileDepositoryDepositedfilesAPITest(TestCase):
                     },
                     {
                         "author_name": deposited_files_new[0].author_name,
-                        "file_depository": str(file_depository.id),
+                        "file_depository_id": str(file_depository.id),
                         "filename": deposited_files_new[0].filename,
                         "id": str(deposited_files_new[0].id),
                         "read": False,
@@ -323,7 +323,7 @@ class FileDepositoryDepositedfilesAPITest(TestCase):
                 "results": [
                     {
                         "author_name": deposited_files[2].author_name,
-                        "file_depository": str(file_depository.id),
+                        "file_depository_id": str(file_depository.id),
                         "filename": deposited_files[2].filename,
                         "id": str(deposited_files[2].id),
                         "read": False,
@@ -339,7 +339,7 @@ class FileDepositoryDepositedfilesAPITest(TestCase):
                     },
                     {
                         "author_name": deposited_files[1].author_name,
-                        "file_depository": str(file_depository.id),
+                        "file_depository_id": str(file_depository.id),
                         "filename": deposited_files[1].filename,
                         "id": str(deposited_files[1].id),
                         "read": False,
@@ -355,7 +355,7 @@ class FileDepositoryDepositedfilesAPITest(TestCase):
                     },
                     {
                         "author_name": deposited_files[0].author_name,
-                        "file_depository": str(file_depository.id),
+                        "file_depository_id": str(file_depository.id),
                         "filename": deposited_files[0].filename,
                         "id": str(deposited_files[0].id),
                         "read": False,
@@ -415,7 +415,7 @@ class FileDepositoryDepositedfilesAPITest(TestCase):
                 "results": [
                     {
                         "author_name": deposited_files[2].author_name,
-                        "file_depository": str(file_depository.id),
+                        "file_depository_id": str(file_depository.id),
                         "filename": deposited_files[2].filename,
                         "id": str(deposited_files[2].id),
                         "read": False,
@@ -426,7 +426,7 @@ class FileDepositoryDepositedfilesAPITest(TestCase):
                     },
                     {
                         "author_name": deposited_files[1].author_name,
-                        "file_depository": str(file_depository.id),
+                        "file_depository_id": str(file_depository.id),
                         "filename": deposited_files[1].filename,
                         "id": str(deposited_files[1].id),
                         "read": False,
@@ -466,7 +466,7 @@ class FileDepositoryDepositedfilesAPITest(TestCase):
                 "results": [
                     {
                         "author_name": deposited_files[2].author_name,
-                        "file_depository": str(file_depository.id),
+                        "file_depository_id": str(file_depository.id),
                         "filename": deposited_files[2].filename,
                         "id": str(deposited_files[2].id),
                         "read": False,
@@ -477,7 +477,7 @@ class FileDepositoryDepositedfilesAPITest(TestCase):
                     },
                     {
                         "author_name": deposited_files[1].author_name,
-                        "file_depository": str(file_depository.id),
+                        "file_depository_id": str(file_depository.id),
                         "filename": deposited_files[1].filename,
                         "id": str(deposited_files[1].id),
                         "read": False,

--- a/src/frontend/apps/lti_site/apps/deposit/components/Dashboard/DashboardInstructor/index.spec.tsx
+++ b/src/frontend/apps/lti_site/apps/deposit/components/Dashboard/DashboardInstructor/index.spec.tsx
@@ -99,7 +99,7 @@ describe('<DashboardInstructor />', () => {
     const depositedFiles: DepositedFile[] = [];
     for (let i = 0; i < 40; i++) {
       depositedFiles.push(
-        depositedFileMockFactory({ file_depository: fileDepository }),
+        depositedFileMockFactory({ file_depository_id: fileDepository.id }),
       );
     }
     const queryClient = new QueryClient();
@@ -170,7 +170,7 @@ describe('<DashboardInstructor />', () => {
       const readStatus = read ? 'read' : 'new';
       depositedFiles.push(
         depositedFileMockFactory({
-          file_depository: fileDepository,
+          file_depository_id: fileDepository.id,
           filename: `file${i}_${readStatus}.txt`,
           read,
         }),

--- a/src/frontend/apps/lti_site/apps/deposit/data/queries/index.spec.tsx
+++ b/src/frontend/apps/lti_site/apps/deposit/data/queries/index.spec.tsx
@@ -294,7 +294,7 @@ describe('queries', () => {
     it('requests the first page of the resource list', async () => {
       const fileDepository = fileDepositoryMockFactory();
       const depositedFiles = Array(4).fill(
-        depositedFileMockFactory({ file_depository: fileDepository }),
+        depositedFileMockFactory({ file_depository_id: fileDepository.id }),
       );
       fetchMock.mock(
         `/api/filedepositories/${fileDepository.id}/depositedfiles/?limit=3`,
@@ -328,7 +328,7 @@ describe('queries', () => {
     it('requests the second page of the resource list', async () => {
       const fileDepository = fileDepositoryMockFactory();
       const depositedFiles = Array(4).fill(
-        depositedFileMockFactory({ file_depository: fileDepository }),
+        depositedFileMockFactory({ file_depository_id: fileDepository.id }),
       );
       fetchMock.mock(
         `/api/filedepositories/${fileDepository.id}/depositedfiles/?limit=3&offset=3`,
@@ -362,7 +362,7 @@ describe('queries', () => {
     it('fails to get the resource list', async () => {
       const fileDepository = fileDepositoryMockFactory();
       Array(4).fill(
-        depositedFileMockFactory({ file_depository: fileDepository }),
+        depositedFileMockFactory({ file_depository_id: fileDepository.id }),
       );
       fetchMock.mock(
         `/api/filedepositories/${fileDepository.id}/depositedfiles/?limit=3`,

--- a/src/frontend/apps/lti_site/apps/deposit/utils/tests/factories.ts
+++ b/src/frontend/apps/lti_site/apps/deposit/utils/tests/factories.ts
@@ -27,7 +27,7 @@ export const depositedFileMockFactory = (
 ): DepositedFile => {
   return {
     author_name: faker.name.firstName() + ' ' + faker.name.lastName(),
-    file_depository: fileDepositoryMockFactory(),
+    file_depository_id: faker.datatype.uuid(),
     filename: faker.system.fileName(),
     size: faker.datatype.number().toString(),
     id: faker.datatype.uuid(),

--- a/src/frontend/packages/lib_classroom/src/components/ClassroomWidgetProvider/widgets/Recordings/Recording/DeleteClassroomRecordingButton/index.spec.tsx
+++ b/src/frontend/packages/lib_classroom/src/components/ClassroomWidgetProvider/widgets/Recordings/Recording/DeleteClassroomRecordingButton/index.spec.tsx
@@ -49,7 +49,7 @@ describe('<DeleteClassroomRecordingButton />', () => {
       started_at: DateTime.fromJSDate(
         new Date(2022, 1, 29, 11, 0, 0),
       ).toISO() as string,
-      classroom: classroom.id,
+      classroom_id: classroom.id,
     });
     render(<DeleteClassroomRecordingButton recording={classroomRecording} />);
 
@@ -77,7 +77,7 @@ describe('<DeleteClassroomRecordingButton />', () => {
       started_at: DateTime.fromJSDate(
         new Date(2022, 1, 29, 11, 0, 0),
       ).toISO() as string,
-      classroom: classroom.id,
+      classroom_id: classroom.id,
     });
     fetchMock.delete(
       `/api/classrooms/${classroom.id}/recordings/${classroomRecording.id}/`,
@@ -114,7 +114,7 @@ describe('<DeleteClassroomRecordingButton />', () => {
       started_at: DateTime.fromJSDate(
         new Date(2022, 1, 29, 11, 0, 0),
       ).toISO() as string,
-      classroom: classroom.id,
+      classroom_id: classroom.id,
     });
     fetchMock.delete(
       `/api/classrooms/${classroom.id}/recordings/${classroomRecording.id}/`,

--- a/src/frontend/packages/lib_classroom/src/components/ClassroomWidgetProvider/widgets/Recordings/Recording/DeleteClassroomRecordingButton/index.tsx
+++ b/src/frontend/packages/lib_classroom/src/components/ClassroomWidgetProvider/widgets/Recordings/Recording/DeleteClassroomRecordingButton/index.tsx
@@ -91,7 +91,7 @@ export const DeleteClassroomRecordingButton = ({
           onClickSubmit={() => {
             setIsModalOpen(false);
             deleteClassroomRecording.mutate({
-              classroomId: recording.classroom,
+              classroomId: recording.classroom_id,
               classroomRecordingId: recording.id,
             });
           }}

--- a/src/frontend/packages/lib_classroom/src/components/ClassroomWidgetProvider/widgets/Recordings/Recording/index.spec.tsx
+++ b/src/frontend/packages/lib_classroom/src/components/ClassroomWidgetProvider/widgets/Recordings/Recording/index.spec.tsx
@@ -49,7 +49,7 @@ describe('<Recordings />', () => {
       started_at: DateTime.fromJSDate(
         new Date(2022, 1, 29, 11, 0, 0),
       ).toISO() as string,
-      classroom: classroom.id,
+      classroom_id: classroom.id,
     });
 
     render(
@@ -74,7 +74,7 @@ describe('<Recordings />', () => {
     ] as any);
     const classroom = classroomMockFactory();
     const classroomRecording = classroomRecordingMockFactory({
-      classroom: classroom.id,
+      classroom_id: classroom.id,
       vod: classroomRecordingVodMockFactory({
         upload_state: READY,
       }),
@@ -104,7 +104,7 @@ describe('<Recordings />', () => {
       started_at: DateTime.fromJSDate(
         new Date(2022, 1, 29, 11, 0, 0),
       ).toISO() as string,
-      classroom: classroom.id,
+      classroom_id: classroom.id,
     });
 
     fetchMock.mock(
@@ -152,7 +152,7 @@ describe('<Recordings />', () => {
     ] as any);
     const classroom = classroomMockFactory();
     const classroomRecording = classroomRecordingMockFactory({
-      classroom: classroom.id,
+      classroom_id: classroom.id,
       vod: classroomRecordingVodMockFactory({
         upload_state: READY,
       }),
@@ -186,7 +186,7 @@ describe('<Recordings />', () => {
     ] as any);
     const classroom = classroomMockFactory();
     const classroomRecording = classroomRecordingMockFactory({
-      classroom: classroom.id,
+      classroom_id: classroom.id,
       started_at: DateTime.fromJSDate(
         new Date(2022, 1, 29, 11, 0, 0),
       ).toISO() as string,
@@ -219,7 +219,7 @@ describe('<Recordings />', () => {
     ] as any);
     const classroom = classroomMockFactory();
     const classroomRecording = classroomRecordingMockFactory({
-      classroom: classroom.id,
+      classroom_id: classroom.id,
       started_at: DateTime.fromJSDate(
         new Date(2022, 1, 29, 11, 0, 0),
       ).toISO() as string,
@@ -264,7 +264,7 @@ describe('<Recordings />', () => {
     ] as any);
     const classroom = classroomMockFactory();
     const classroomRecording = classroomRecordingMockFactory({
-      classroom: classroom.id,
+      classroom_id: classroom.id,
       started_at: DateTime.fromJSDate(
         new Date(2022, 1, 29, 11, 0, 0),
       ).toISO() as string,
@@ -299,7 +299,7 @@ describe('<Recordings />', () => {
       vod_conversion_enabled: false,
     });
     const classroomRecording = classroomRecordingMockFactory({
-      classroom: classroom.id,
+      classroom_id: classroom.id,
     });
 
     fetchMock.mock(`/api/classrooms/${classroom.id}/`, { classroom });

--- a/src/frontend/packages/lib_classroom/src/components/ClassroomWidgetProvider/widgets/Recordings/Recording/index.tsx
+++ b/src/frontend/packages/lib_classroom/src/components/ClassroomWidgetProvider/widgets/Recordings/Recording/index.tsx
@@ -100,7 +100,7 @@ const VodNotReady = ({
   conversionEnabled,
 }: RecordingProps) => {
   const intl = useIntl();
-  const { refetch: refetchClassroom } = useClassroom(recording.classroom);
+  const { refetch: refetchClassroom } = useClassroom(recording.classroom_id);
 
   const convertVOD = useCallback(
     (recording: ClassroomRecording) => {

--- a/src/frontend/packages/lib_classroom/src/components/ClassroomWidgetProvider/widgets/SupportSharing/UploadDocuments/DocumentRow/index.spec.tsx
+++ b/src/frontend/packages/lib_classroom/src/components/ClassroomWidgetProvider/widgets/SupportSharing/UploadDocuments/DocumentRow/index.spec.tsx
@@ -47,7 +47,7 @@ describe('<DocumentRow />', () => {
     const classroom = classroomMockFactory({ id: '1', started: false });
     const document = classroomDocumentMockFactory({
       filename: 'my_document.pdf',
-      classroom: classroom,
+      classroom_id: classroom.id,
     });
     render(
       wrapInIntlProvider(
@@ -77,7 +77,7 @@ describe('<DocumentRow />', () => {
     const classroom = classroomMockFactory({ id: '1', started: false });
     const document = classroomDocumentMockFactory({
       filename: 'my_document.pdf',
-      classroom: classroom,
+      classroom_id: classroom.id,
       upload_state: uploadState.PROCESSING,
     });
     render(
@@ -109,7 +109,7 @@ describe('<DocumentRow />', () => {
     const classroom = classroomMockFactory({ id: '1', started: false });
     const document = classroomDocumentMockFactory({
       filename: 'my_document.pdf',
-      classroom: classroom,
+      classroom_id: classroom.id,
       upload_state: uploadState.ERROR,
     });
     render(

--- a/src/frontend/packages/lib_classroom/src/data/queries/index.spec.tsx
+++ b/src/frontend/packages/lib_classroom/src/data/queries/index.spec.tsx
@@ -469,7 +469,7 @@ describe('queries', () => {
     it('requests the resource list', async () => {
       const classroom = classroomMockFactory();
       const classroomDocuments = Array(4).fill(
-        classroomDocumentMockFactory({ classroom }),
+        classroomDocumentMockFactory({ classroom_id: classroom.id }),
       );
       fetchMock.mock(
         `/api/classrooms/${classroom.id}/classroomdocuments/?limit=999`,
@@ -501,7 +501,9 @@ describe('queries', () => {
 
     it('fails to get the resource list', async () => {
       const classroom = classroomMockFactory();
-      Array(4).fill(classroomDocumentMockFactory({ classroom }));
+      Array(4).fill(
+        classroomDocumentMockFactory({ classroom_id: classroom.id }),
+      );
       fetchMock.mock(
         `/api/classrooms/${classroom.id}/classroomdocuments/?limit=999`,
         404,

--- a/src/frontend/packages/lib_classroom/src/data/sideEffects/createClassroomDocument/index.spec.ts
+++ b/src/frontend/packages/lib_classroom/src/data/sideEffects/createClassroomDocument/index.spec.ts
@@ -24,7 +24,7 @@ describe('sideEffects/createClassroomDocument', () => {
     const createdClassroomDocument = await createClassroomDocument({
       filename: file.name,
       size: file.size,
-      classroom: classroomDocument.classroom.id,
+      classroom: classroomDocument.classroom_id,
     });
 
     const fetchArgs = fetchMock.lastCall()![1]!;
@@ -48,7 +48,7 @@ describe('sideEffects/createClassroomDocument', () => {
       createClassroomDocument({
         filename: file.name,
         size: file.size,
-        classroom: classroomDocument.classroom.id,
+        classroom: classroomDocument.classroom_id,
       }),
     ).rejects.toThrow('Failed to perform the request');
   });
@@ -61,7 +61,7 @@ describe('sideEffects/createClassroomDocument', () => {
       createClassroomDocument({
         filename: file.name,
         size: file.size,
-        classroom: classroomDocument.classroom.id,
+        classroom: classroomDocument.classroom_id,
       }),
     ).rejects.toThrow();
   });

--- a/src/frontend/packages/lib_classroom/src/data/sideEffects/createVOD/index.spec.ts
+++ b/src/frontend/packages/lib_classroom/src/data/sideEffects/createVOD/index.spec.ts
@@ -17,7 +17,7 @@ describe('sideEffects/createVOD', () => {
   it('calls create-vod for a classroom recording', async () => {
     const classroomRecording = classroomRecordingMockFactory();
     fetchMock.mock(
-      `/api/classrooms/${classroomRecording.classroom}/recordings/${classroomRecording.id}/create-vod/`,
+      `/api/classrooms/${classroomRecording.classroom_id}/recordings/${classroomRecording.id}/create-vod/`,
       {
         key: 'value',
       },
@@ -38,7 +38,7 @@ describe('sideEffects/createVOD', () => {
   it('throws when it fails to call create-vod (request failure)', async () => {
     const classroomRecording = classroomRecordingMockFactory();
     fetchMock.mock(
-      `/api/classrooms/${classroomRecording.classroom}/recordings/${classroomRecording.id}/create-vod/`,
+      `/api/classrooms/${classroomRecording.classroom_id}/recordings/${classroomRecording.id}/create-vod/`,
       Promise.reject(new Error('Failed to perform the request')),
     );
     await expect(createVOD(classroomRecording, 'my title')).rejects.toThrow(
@@ -49,7 +49,7 @@ describe('sideEffects/createVOD', () => {
   it('throws when it fails to call create-vod (API error)', async () => {
     const classroomRecording = classroomRecordingMockFactory();
     fetchMock.mock(
-      `/api/classrooms/${classroomRecording.classroom}/recordings/${classroomRecording.id}/create-vod/`,
+      `/api/classrooms/${classroomRecording.classroom_id}/recordings/${classroomRecording.id}/create-vod/`,
       400,
     );
     await expect(createVOD(classroomRecording, 'my title')).rejects.toThrow();

--- a/src/frontend/packages/lib_classroom/src/data/sideEffects/createVOD/index.ts
+++ b/src/frontend/packages/lib_classroom/src/data/sideEffects/createVOD/index.ts
@@ -18,7 +18,7 @@ export const createVOD = async (
   }
 
   const response = await fetchWrapper(
-    `${API_ENDPOINT}/${ClassroomModelName.CLASSROOMS}/${recording.classroom}/${ClassroomModelName.CLASSROOM_RECORDINGS}/${recording.id}/create-vod/`,
+    `${API_ENDPOINT}/${ClassroomModelName.CLASSROOMS}/${recording.classroom_id}/${ClassroomModelName.CLASSROOM_RECORDINGS}/${recording.id}/create-vod/`,
     {
       headers: {
         Authorization: `Bearer ${jwt}`,

--- a/src/frontend/packages/lib_classroom/src/utils/tests/factories.ts
+++ b/src/frontend/packages/lib_classroom/src/utils/tests/factories.ts
@@ -80,7 +80,7 @@ export const classroomDocumentMockFactory = (
   classroomDocument: Partial<ClassroomDocument> = {},
 ): ClassroomDocument => {
   return {
-    classroom: classroomMockFactory(),
+    classroom_id: faker.datatype.uuid(),
     filename: faker.system.fileName(),
     id: faker.datatype.uuid(),
     is_default: false,
@@ -95,7 +95,7 @@ export const classroomRecordingMockFactory = (
   classroomRecording: Partial<ClassroomRecording> = {},
 ): ClassroomRecording => {
   return {
-    classroom: faker.datatype.uuid(),
+    classroom_id: faker.datatype.uuid(),
     id: faker.datatype.uuid(),
     started_at: faker.date.recent().toISOString(),
     video_file_url: faker.internet.url(),

--- a/src/frontend/packages/lib_components/src/types/apps/classroom/models.ts
+++ b/src/frontend/packages/lib_components/src/types/apps/classroom/models.ts
@@ -128,7 +128,7 @@ export interface EndClassroomActionResponse {
 }
 
 export interface ClassroomDocument extends Resource {
-  classroom: Classroom;
+  classroom_id: Classroom['id'];
   filename: string;
   is_default: boolean;
   upload_state: uploadState;
@@ -142,7 +142,7 @@ export type ClassroomRecordingVod = Pick<
 >;
 
 export interface ClassroomRecording extends Resource {
-  classroom: string;
+  classroom_id: Classroom['id'];
   video_file_url: string;
   started_at: string;
   vod: Nullable<ClassroomRecordingVod>;

--- a/src/frontend/packages/lib_components/src/types/apps/deposit/models.ts
+++ b/src/frontend/packages/lib_components/src/types/apps/deposit/models.ts
@@ -17,7 +17,7 @@ export interface FileDepository extends Resource {
 
 export interface DepositedFile extends Resource {
   author_name: string;
-  file_depository: FileDepository;
+  file_depository_id: FileDepository['id'];
   filename: string;
   size: string;
   read: boolean;


### PR DESCRIPTION
## Purpose

The API actually sends parent resource as id for classroom and deposit related models.
This can lead to mistakes in the frontend.

## Proposal

Rename the attributes, and change the type to string.

- [x] Update classroomdocument.clasroom_id
- [x] Update classroomrecording.clasroom_id
- [x] Update depositedfile.filedeposit_id

