### PR TITLE
💄(website) add padding on renater select field

### DIFF
--- a/src/frontend/apps/standalone_site/src/features/Authentication/components/RenaterAuthenticator.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Authentication/components/RenaterAuthenticator.tsx
@@ -41,7 +41,7 @@ export const RenaterAuthenticator = () => {
   const ERRORTOKEN = 'social-auth';
 
   const renderOption = (option: RenaterSamlFerIdp) => (
-    <Box align="center" direction="row">
+    <Box align="center" direction="row" pad="small">
       <Image
         src={
           option.logo ||


### PR DESCRIPTION
## Purpose

An previous commit removed the padding on the select field from the theme, this commit adds it back.

![Screenshot (5)](https://github.com/openfun/marsha/assets/25994652/7d7a46e5-ac51-4c76-8df9-7c2e04fbff72)

![Screenshot (6)](https://github.com/openfun/marsha/assets/25994652/170f694e-8370-4443-a9cd-91c72abb8150)
