### PR TITLE
♿️(frontend) remove redundant form role in the LTI app

### DIFF
--- a/src/frontend/apps/lti_site/components/SelectContent/index.tsx
+++ b/src/frontend/apps/lti_site/components/SelectContent/index.tsx
@@ -54,7 +54,7 @@ export const SelectContent = ({
         action={lti_select_form_action_url}
         method="POST"
         encType="application/x-www-form-urlencoded"
-        role="form"
+        aria-label="Select content"
       >
         {Object.entries(lti_select_form_data).map(([name, value]) => (
           <input key={name} type="hidden" name={name} value={value} />


### PR DESCRIPTION
It's considered as a bad A11y practice to add redundant semantic. A `<form>` element has already a `form` role, specifying it again is redundant. It might make screen readers behave buggy.

I would suggest adding the `eslint-plugin-jsx-a11y` plugin to the ESLint custom configuration. It's a dependency of `react-scripts`, used by the standalone app but not the LTI app.
