### PR TITLE
Exclude lister lti_user_id to playlist claim process

### DIFF
--- a/src/backend/marsha/core/api/playlist.py
+++ b/src/backend/marsha/core/api/playlist.py
@@ -82,7 +82,7 @@ class PlaylistViewSet(APIViewMixin, ObjectPkMixin, viewsets.ModelViewSet):
                 )
             ]
         elif self.action in ["claim"]:
-            permission_classes = [permissions.IsOrganizationInstructor]
+            permission_classes = [permissions.CanClaimPlaylist]
         elif self.action in ["is_claimed"]:
             permission_classes = [
                 permissions.IsTokenInstructor | permissions.IsTokenAdmin

--- a/src/backend/marsha/core/lti/user_association.py
+++ b/src/backend/marsha/core/lti/user_association.py
@@ -1,4 +1,6 @@
 """Process module to manage association between LTI users and Marsha users."""
+from django.conf import settings
+from django.core.exceptions import ValidationError
 from django.db.transaction import atomic
 
 from marsha.core.models import LtiUserAssociation, PortabilityRequest
@@ -78,6 +80,11 @@ def create_user_association(lti_consumer_site_id, lti_user_id, user_id):
     if not all((lti_consumer_site_id, lti_user_id, user_id)):
         # Can't create an association without all information
         raise ValueError("Missing information to create an association")
+
+    if clean_lti_user_id(lti_user_id) in settings.PLAYLIST_CLAIM_EXCLUDED_LTI_USER_ID:
+        raise ValidationError(
+            "This lti_user_id can not be used to create a LTIUserAssociation."
+        )
 
     LtiUserAssociation.objects.create(
         lti_user_id=clean_lti_user_id(lti_user_id),

--- a/src/backend/marsha/core/tests/api/playlists/test_claim.py
+++ b/src/backend/marsha/core/tests/api/playlists/test_claim.py
@@ -41,7 +41,7 @@ class PlaylistClaimAPITest(TestCase):
         self.assertFalse(PlaylistAccess.objects.filter(playlist=playlist).exists())
 
     def test_claim_playlist_by_orga_administrator(self):
-        """Organization administrators can't claim playlists."""
+        """Organization administrators can claim playlists."""
         organization_access = factories.OrganizationAccessFactory(role=ADMINISTRATOR)
         playlist = factories.PlaylistFactory(
             organization=organization_access.organization,
@@ -55,9 +55,9 @@ class PlaylistClaimAPITest(TestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 201)
         playlist.refresh_from_db()
-        self.assertFalse(PlaylistAccess.objects.filter(playlist=playlist).exists())
+        self.assertTrue(PlaylistAccess.objects.filter(playlist=playlist).exists())
 
     def test_claim_playlist_by_orga_instructor_no_other_access(self):
         """Organization instructors can claim playlists.

--- a/src/backend/marsha/core/tests/lti/test_user_association.py
+++ b/src/backend/marsha/core/tests/lti/test_user_association.py
@@ -2,7 +2,7 @@
 import uuid
 
 from django.core.exceptions import ValidationError
-from django.test import RequestFactory, TestCase
+from django.test import RequestFactory, TestCase, override_settings
 
 from marsha.core.factories import (
     ConsumerSiteFactory,
@@ -166,3 +166,17 @@ class LTIUserAssociationTestCase(TestCase):
         self.assertIsNone(untouched_portability_request.from_user)
         updated_portability_request.refresh_from_db()
         self.assertEqual(updated_portability_request.from_user, user)
+
+    @override_settings(PLAYLIST_CLAIM_EXCLUDED_LTI_USER_ID=["STUDENT"])
+    def test_create_user_association_with_invalud_lti_user_id(self):
+        """Creating a user assoication with an invalid lti_user_id should fail."""
+
+        consumer_site = ConsumerSiteFactory()
+        user = UserFactory()
+
+        with self.assertRaises(ValidationError):
+            create_user_association(
+                lti_consumer_site_id=consumer_site.pk,
+                lti_user_id="student",
+                user_id=user.pk,
+            )

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -711,6 +711,9 @@ class Base(Configuration):
     LRS_AUTH_TOKEN = values.Value()
     LRS_XAPI_VERSION = values.Value()
 
+    # PLAYLIST CLAIM SETTING
+    PLAYLIST_CLAIM_EXCLUDED_LTI_USER_ID = values.ListValue(["STUDENT"])
+
     # pylint: disable=invalid-name
     @property
     def AWS_SOURCE_BUCKET_NAME(self):


### PR DESCRIPTION
## Purpose

In edxapp studio, the lti_user_id used is an anonymous one and has all the time the value
`student`. Creating an association with this value must be forbidden.
Also, organization administrator should be able to claim a playlist

## Proposal

- [x] add new setting PLAYLIST_CLAIM_EXCLUDED_LTI_USER_ID
- [x] force returning is_claimed to true when lti_user_id is excluded
- [x] fail to create user association when lti_user_id is excluded
- [x] organization administrator can claim a playlist
