### PR TITLE
🔨(docker) create a script managing docker compose binary to use

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,16 +32,10 @@ RESET := \033[0m
 GREEN := \033[1;32m
 
 # -- Docker
-# Test if docker compose exists and its version
-DOCKER_COMPOSE_VERSION = $(shell docker compose version > /dev/null 2>&1 && docker compose version --short | cut -c1-1)
 DOCKER_UID           = $(shell id -u)
 DOCKER_GID           = $(shell id -g)
 DOCKER_USER          = $(DOCKER_UID):$(DOCKER_GID)
-ifeq ($(DOCKER_COMPOSE_VERSION),2)
-	COMPOSE              = DOCKER_USER=$(DOCKER_USER) docker compose
-else
-	COMPOSE              = DOCKER_USER=$(DOCKER_USER) docker-compose
-endif
+COMPOSE              = DOCKER_USER=$(DOCKER_USER) ./bin/docker-compose
 COMPOSE_BUILD        = DOCKER_USER=$(DOCKER_USER) COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 $(COMPOSE) build
 COMPOSE_RUN          = $(COMPOSE) run --rm
 COMPOSE_RUN_APP      = $(COMPOSE_RUN) app

--- a/bin/docker-compose
+++ b/bin/docker-compose
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# Test if we have docker compose v2, and keep quiet if we don't.
+version=$(docker compose version > /dev/null 2>&1 && docker compose version --short) || true
+if [[ $version =~ ^v?2 ]]; then
+  dockercompose="docker compose"
+else
+  dockercompose="docker-compose"
+fi
+
+if [[ "${BASH_SOURCE[0]}" != "${0}" ]] ; then
+    export dockercompose
+else
+    $dockercompose "$@"
+fi

--- a/bin/e2e
+++ b/bin/e2e
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# shellcheck source=./bin/docker-compose
+source "$(dirname "${BASH_SOURCE[0]}")/docker-compose"
+
 export ENV_FILE=test
 
 # Allow X server connection
@@ -22,7 +25,7 @@ xhost +local:root
 #    -e DEBUG=pw:api \
 
 
-docker-compose run --rm \
+$dockercompose run --rm \
     -e DISPLAY \
     -e QT_X11_NO_MITSHM=1 \
     -e DJANGO_ALLOW_ASYNC_UNSAFE=1 \

--- a/bin/generate_backend_lti_app
+++ b/bin/generate_backend_lti_app
@@ -1,3 +1,6 @@
 #!/usr/bin/env bash
 
-docker-compose run --rm -w /app/src/backend/marsha app cookiecutter .cookiecutter/ "$@"
+# shellcheck source=./bin/docker-compose
+source "$(dirname "${BASH_SOURCE[0]}")/docker-compose"
+
+$dockercompose run --rm -w /app/src/backend/marsha app cookiecutter .cookiecutter/ "$@"

--- a/bin/generate_frontend_lti_app
+++ b/bin/generate_frontend_lti_app
@@ -1,3 +1,6 @@
 #!/usr/bin/env bash
 
-docker-compose run --rm -w /app/src/frontend/apps/lti_site/apps app cookiecutter .cookiecutter/ "$@"
+# shellcheck source=./bin/docker-compose
+source "$(dirname "${BASH_SOURCE[0]}")/docker-compose"
+
+$dockercompose run --rm -w /app/src/frontend/apps/lti_site/apps app cookiecutter .cookiecutter/ "$@"

--- a/bin/get_ngrok_url
+++ b/bin/get_ngrok_url
@@ -2,10 +2,13 @@
 
 set -eo pipefail
 
+# shellcheck source=./bin/docker-compose
+source "$(dirname "${BASH_SOURCE[0]}")/docker-compose"
+
 # Get current ngrok url from ngrok api launched with command "make ngrok"
-if docker-compose port ngrok 4040 &> /dev/null ; then
+if $dockercompose port ngrok 4040 &> /dev/null ; then
     declare -r JQ="docker run --rm -i fundocker/jq:1.6"
-    curl --no-progress-meter "$(docker-compose port ngrok 4040)/api/tunnels/command_line" | \
+    curl --no-progress-meter "$($dockercompose port ngrok 4040)/api/tunnels/command_line" | \
     ${JQ} .public_url  | \
     sed 's/"//g'
 fi

--- a/bin/playwright
+++ b/bin/playwright
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# shellcheck source=./bin/docker-compose
+source "$(dirname "${BASH_SOURCE[0]}")/docker-compose"
+
 export ENV_FILE=test
 
 # Allow X server connection
@@ -15,7 +18,7 @@ xhost +local:root
 #    -e DEBUG=console \
 
 
-docker-compose run --rm \
+$dockercompose run --rm \
     -e DISPLAY \
     -e QT_X11_NO_MITSHM=1 \
     -e DJANGO_ALLOW_ASYNC_UNSAFE=1 \

--- a/bin/pytest
+++ b/bin/pytest
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 
+# shellcheck source=./bin/docker-compose
+source "$(dirname "${BASH_SOURCE[0]}")/docker-compose"
+
 export ENV_FILE=test
 
-docker-compose run --rm app pytest "$@"
+$dockercompose run --rm app pytest "$@"
 


### PR DESCRIPTION
## Purpose

In the makefile, we made a modification allowing to use docker compose in version 1 or 2. But we also use the `docker-compose` binary in script present in the bin directory. To use the right binary, we created a docker-compose script responsible to check the compose version and we use this script everywhere we want to use docker compose.

## Proposal

- [x] create a script managing docker compose binary to use

