### PR TITLE
Force filtering queryset on current related object in each viewset

### DIFF
--- a/src/backend/marsha/bbb/api.py
+++ b/src/backend/marsha/bbb/api.py
@@ -544,6 +544,11 @@ class ClassroomDocumentViewSet(
             permission_classes = self.permission_classes
         return [permission() for permission in permission_classes]
 
+    def get_queryset(self):
+        queryset = super().get_queryset()
+
+        return queryset.filter(classroom=self.get_related_classroom_id())
+
     def create(self, request, *args, **kwargs):
         """Create a ClassroomDocument.
 

--- a/src/backend/marsha/bbb/tests/api/classroomdocument/test_list.py
+++ b/src/backend/marsha/bbb/tests/api/classroomdocument/test_list.py
@@ -65,6 +65,15 @@ class ClassroomClassroomdocumentsAPITest(TestCase):
         )
         jwt_token = InstructorOrAdminLtiTokenFactory(playlist=classroom.playlist)
 
+        # Create documents in a classroom in the same playlist. They should not be listed
+        same_playlist_classroom = ClassroomFactory(playlist=classroom.playlist)
+        ClassroomDocumentFactory.create_batch(3, classroom=same_playlist_classroom)
+
+        # Create documents on a classroom living in an other playlist. They should not be listed
+        other_playlist = PlaylistFactory()
+        other_classroom = ClassroomFactory(playlist=other_playlist)
+        ClassroomDocumentFactory.create_batch(3, classroom=other_classroom)
+
         response = self.client.get(
             f"/api/classrooms/{classroom.id}/classroomdocuments/?limit=2",
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",

--- a/src/backend/marsha/core/api/shared_live_media.py
+++ b/src/backend/marsha/core/api/shared_live_media.py
@@ -100,15 +100,13 @@ class SharedLiveMediaViewSet(
     def get_queryset(self):
         """Redefine the queryset to use based on the current action."""
         queryset = super().get_queryset()
-        if self.action in ["list"]:
-            video_id = self.get_related_video_id()
+        queryset = queryset.filter(
+            video__id=self.get_related_video_id(),
+        )
+        if self.action in ["list"] and self.request.resource:
             queryset = queryset.filter(
-                video__id=video_id,
+                video__playlist__id=self.request.resource.id,
             )
-            if self.request.resource:
-                queryset = queryset.filter(
-                    video__playlist__id=self.request.resource.id,
-                )
 
         return queryset
 

--- a/src/backend/marsha/core/api/thumbnail.py
+++ b/src/backend/marsha/core/api/thumbnail.py
@@ -87,11 +87,7 @@ class ThumbnailViewSet(
     def get_queryset(self):
         """Redefine the queryset to use based on the current action."""
         queryset = super().get_queryset()
-        if self.action in ["list"]:
-            video_id = self.get_related_video_id()
-            return queryset.filter(video__id=video_id)
-
-        return queryset
+        return queryset.filter(video__id=self.get_related_video_id())
 
     @action(methods=["post"], detail=True, url_path="initiate-upload")
     # pylint: disable=unused-argument

--- a/src/backend/marsha/core/api/timed_text_track.py
+++ b/src/backend/marsha/core/api/timed_text_track.py
@@ -89,11 +89,7 @@ class TimedTextTrackViewSet(
     def get_queryset(self):
         """Redefine the queryset to use based on the current action."""
         queryset = super().get_queryset()
-        if self.action in ["list"]:
-            video_id = self.get_related_video_id()
-            return queryset.filter(video__id=video_id)
-
-        return queryset
+        return queryset.filter(video__id=self.get_related_video_id())
 
     @action(methods=["post"], detail=True, url_path="initiate-upload")
     # pylint: disable=unused-argument

--- a/src/backend/marsha/core/tests/api/shared_live_media/test_retrieve.py
+++ b/src/backend/marsha/core/tests/api/shared_live_media/test_retrieve.py
@@ -678,3 +678,21 @@ class SharedLiveMediaRetrieveAPITest(TestCase):
                 "video": str(video.id),
             },
         )
+
+    def test_api_shared_live_media_read_from_another_video(self):
+        """Accessing a shared live media using an other video in the url should return a 404."""
+        shared_live_media = SharedLiveMediaFactory(
+            upload_state=defaults.PENDING,
+            uploaded_on=None,
+            nb_pages=None,
+        )
+        other_video = VideoFactory(playlist=shared_live_media.video.playlist)
+
+        jwt_token = StudentLtiTokenFactory(playlist=shared_live_media.video.playlist)
+
+        response = self.client.get(
+            self._get_url(other_video, shared_live_media),
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+
+        self.assertEqual(response.status_code, 404)

--- a/src/backend/marsha/core/tests/api/thumbnails/test_retrieve.py
+++ b/src/backend/marsha/core/tests/api/thumbnails/test_retrieve.py
@@ -321,3 +321,18 @@ class ThumbnailRetrieveApiTest(TestCase):
                 "video": str(video.id),
             },
         )
+
+    def test_api_thumbnail_retrieve_from_another_video(self):
+        """Trying to retrieve a thumbnail using an other video in the url should return a 404."""
+
+        thumbnail = ThumbnailFactory()
+        other_video = VideoFactory(playlist=thumbnail.video.playlist)
+
+        jwt_token = InstructorOrAdminLtiTokenFactory(playlist=thumbnail.video.playlist)
+
+        response = self.client.get(
+            self._get_url(other_video, thumbnail),
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+
+        self.assertEqual(response.status_code, 404)

--- a/src/backend/marsha/core/tests/api/timed_text_tracks/test_retrieve.py
+++ b/src/backend/marsha/core/tests/api/timed_text_tracks/test_retrieve.py
@@ -8,7 +8,7 @@ from django.test import TestCase, override_settings
 
 from marsha.core import factories, models
 from marsha.core.api import timezone
-from marsha.core.factories import TimedTextTrackFactory, UserFactory
+from marsha.core.factories import TimedTextTrackFactory, UserFactory, VideoFactory
 from marsha.core.simple_jwt.factories import (
     InstructorOrAdminLtiTokenFactory,
     StudentLtiTokenFactory,
@@ -228,6 +228,15 @@ class TimedTextTrackRetrieveAPITest(TestCase):
         self.assertEqual(
             content, {"detail": "You do not have permission to perform this action."}
         )
+
+        # Try getting the timed_text_track using an other video id
+        other_video = VideoFactory(playlist=timed_text_track.video.playlist)
+
+        response = self.client.get(
+            self._get_url(other_video, timed_text_track),
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+        )
+        self.assertEqual(response.status_code, 404)
 
     def test_api_timed_text_track_read_instructor_in_read_only(self):
         """Instructor should not be able to read a timed text track in read_only mode."""

--- a/src/backend/marsha/deposit/api.py
+++ b/src/backend/marsha/deposit/api.py
@@ -260,6 +260,11 @@ class DepositedFileViewSet(
             permission_classes = self.permission_classes
         return [permission() for permission in permission_classes]
 
+    def get_queryset(self):
+        queryset = super().get_queryset()
+
+        return queryset.filter(file_depository=self.get_related_filedepository_id())
+
     def list(self, request, *args, **kwargs):
         """Get a list of deposited files.
 

--- a/src/backend/marsha/deposit/tests/api/depositedfiles/test_list.py
+++ b/src/backend/marsha/deposit/tests/api/depositedfiles/test_list.py
@@ -57,6 +57,13 @@ class FileDepositoryDepositedfilesAPITest(TestCase):
             user__full_username=owned_deposited_file.author_name,
         )
 
+        # Same author as an other deposited file on an other file depository. Should not be listed
+        other_file_depository = FileDepositoryFactory()
+        DepositedFileFactory(
+            file_depository=other_file_depository,
+            author_id=owned_deposited_file.author_id,
+        )
+
         response = self.client.get(
             f"/api/filedepositories/{file_depository.id}/depositedfiles/",
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
@@ -91,6 +98,10 @@ class FileDepositoryDepositedfilesAPITest(TestCase):
             3, file_depository=file_depository
         )
         jwt_token = InstructorOrAdminLtiTokenFactory(playlist=file_depository.playlist)
+
+        # Other deposited files should not be listed
+        other_file_depository = FileDepositoryFactory()
+        DepositedFileFactory.create_batch(3, file_depository=other_file_depository)
 
         response = self.client.get(
             f"/api/filedepositories/{file_depository.id}/depositedfiles/?limit=2",


### PR DESCRIPTION
## Purpose

Every viewset managing a resource related to an other (thumbnail -> video, classroom documents -> classroom) are now accessible using nested URL and we have no control anymore on the current resource because the JWT token is based on the playlist on a LTI context. Every queryset must be filtered using the current related resource in the url.

## Proposal

- [x] filter classroom documents queryset
- [x] filter deposited file queryset
- [x] filter thumbnail queryset
- [x] filter timed text track queryset
- [x] filter shared live media query set   

