### PR TITLE
Change downloading statements category related activity 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Replace xAPI downloading statements category related activity value
 - Upgrade frontend to React 18 (#2280)
 - Upgrade to django 4.2
 - `DJANGO_STATICFILES_STORAGE` environment variable is replaced by

--- a/src/backend/marsha/core/tests/test_xapi.py
+++ b/src/backend/marsha/core/tests/test_xapi.py
@@ -517,6 +517,7 @@ class XAPIDocumentStatementTest(TestCase):
                     "43b4-8452-2037fed588df"
                 },
                 "contextActivities": {
+                    "category": [{"id": "https://w3id.org/xapi/lms"}],
                     "parent": [
                         {
                             "id": "course-v1:ufr+mathematics+0001",
@@ -593,6 +594,9 @@ class XAPIDocumentStatementTest(TestCase):
                     "https://w3id.org/xapi/video/extensions/session-id": "a6151456-18b7-"
                     "43b4-8452-2037fed588df"
                 },
+                "contextActivities": {
+                    "category": [{"id": "https://w3id.org/xapi/lms"}]
+                },
             },
         )
         self.assertEqual(statement["verb"], base_statement["verb"])
@@ -660,6 +664,7 @@ class XAPIDocumentStatementTest(TestCase):
                     "43b4-8452-2037fed588df"
                 },
                 "contextActivities": {
+                    "category": [{"id": "https://w3id.org/xapi/lms"}],
                     "parent": [
                         {
                             "id": "course-v1:ufr+mathematics+0001",

--- a/src/backend/marsha/core/tests/xapi/document/test_statement_from_website.py
+++ b/src/backend/marsha/core/tests/xapi/document/test_statement_from_website.py
@@ -67,6 +67,9 @@ class XAPIStatementFromWebsite(TestCase):
                     "https://w3id.org/xapi/video/extensions/session-id": "a6151456-18b7-"
                     "43b4-8452-2037fed588df"
                 },
+                "contextActivities": {
+                    "category": [{"id": "https://w3id.org/xapi/lms"}]
+                },
             },
         )
         self.assertEqual(statement["verb"], base_statement["verb"])

--- a/src/backend/marsha/core/xapi.py
+++ b/src/backend/marsha/core/xapi.py
@@ -92,6 +92,10 @@ class XAPIDocumentStatement(XAPIStatementMixin):
             statement, homepage, user=user, user_id=user_id
         )
 
+        statement["context"].update(
+            {"contextActivities": {"category": [{"id": "https://w3id.org/xapi/lms"}]}}
+        )
+
         statement["object"] = {
             "definition": {
                 "type": "http://id.tincanapi.com/activitytype/document",
@@ -146,19 +150,17 @@ class XAPIDocumentStatement(XAPIStatementMixin):
         )
 
         if jwt_token.payload.get("context_id"):
-            statement["context"].update(
+            statement["context"]["contextActivities"].update(
                 {
-                    "contextActivities": {
-                        "parent": [
-                            {
-                                "id": jwt_token.payload["context_id"],
-                                "objectType": "Activity",
-                                "definition": {
-                                    "type": "http://adlnet.gov/expapi/activities/course"
-                                },
-                            }
-                        ]
-                    }
+                    "parent": [
+                        {
+                            "id": jwt_token.payload["context_id"],
+                            "objectType": "Activity",
+                            "definition": {
+                                "type": "http://adlnet.gov/expapi/activities/course"
+                            },
+                        }
+                    ]
                 }
             )
 
@@ -189,8 +191,14 @@ class XAPIVideoStatement(XAPIStatementMixin):
             statement, homepage, user=user, user_id=user_id
         )
 
+        category_id = (
+            "https://w3id.org/xapi/lms"
+            if statement["verb"]["id"] == "http://id.tincanapi.com/verb/downloaded"
+            else "https://w3id.org/xapi/video"
+        )
+
         statement["context"].update(
-            {"contextActivities": {"category": [{"id": "https://w3id.org/xapi/video"}]}}
+            {"contextActivities": {"category": [{"id": category_id}]}}
         )
 
         statement["object"] = {


### PR DESCRIPTION
## Purpose

Download a video or a document are statements that were not officially defined
in xAPI profiles. A new LMS profile release in the next weeks by Gaia-X DASES
organisation defines the spec for this statement.

## Proposal

The `category` field in context.contextActivities traces this information: it is
added for `download a document` statement definition. `Download a video`
statement was mistakenly related to the official Video profile IRI but was not
part of its specification. It is replaced with the LMS profile IRI.

