### PR TITLE
🐛(front) display claim link only when is-claimed request succeeded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Display claim link only when is-claimed request is in success
+
 ## [4.3.0] - 2023-08-29
 
 ### Added

--- a/src/frontend/apps/lti_site/components/ClaimLink/index.spec.tsx
+++ b/src/frontend/apps/lti_site/components/ClaimLink/index.spec.tsx
@@ -77,6 +77,7 @@ describe('<ClaimLink />', () => {
     );
 
     expect(fetchMock.calls()).toHaveLength(1);
+    expect(fetchMock.called('/api/playlists/488db2d0/is-claimed/')).toBe(true);
 
     const link = await screen.findByText(
       'Please login to manage this resource on http://localhost:8000/',
@@ -146,6 +147,68 @@ describe('<ClaimLink />', () => {
     );
 
     expect(fetchMock.calls()).toHaveLength(1);
+    expect(fetchMock.called('/api/playlists/488db2d0/is-claimed/')).toBe(true);
+    expect(
+      screen.queryByText(
+        'Please login to manage this resource on marsha.education.',
+      ),
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not show claim link if is-claimed request fails', () => {
+    const playlist = playlistMockFactory({ id: '488db2d0' });
+    const video = videoMockFactory({ playlist });
+
+    fetchMock.get('/api/playlists/488db2d0/is-claimed/', 403);
+
+    render(
+      <AppConfigProvider
+        value={{
+          appName: appNames.CLASSROOM,
+          attendanceDelay: 10,
+          state: appState.SUCCESS,
+          modelName: modelName.VIDEOS,
+          resource: video,
+          sentry_dsn: 'test.dns.com',
+          environment: 'tests',
+          frontend: 'test-frontend',
+          frontend_home_url: 'http://localhost:8000/',
+          release: 'debug',
+          static: {
+            svg: {
+              icons: '',
+            },
+            img: {
+              liveBackground: '',
+              liveErrorBackground: '',
+              marshaWhiteLogo: '',
+              videoWizardBackground: '',
+              errorMain: '',
+            },
+          },
+          uploadPollInterval: 10,
+          p2p: {
+            isEnabled: false,
+            webTorrentTrackerUrls: [],
+            stunServerUrls: [],
+          },
+        }}
+      >
+        <ClaimLink
+          decodedJwt={
+            {
+              port_to_playlist_id: '488db2d0',
+              playlist_id: 'e8c0b8d0',
+              consumer_site: '32a1c2d0',
+              user: { id: '6b45a4d6' },
+            } as DecodedJwtLTI
+          }
+        />
+      </AppConfigProvider>,
+    );
+
+    expect(fetchMock.calls()).toHaveLength(1);
+    expect(fetchMock.called('/api/playlists/488db2d0/is-claimed/')).toBe(true);
     expect(
       screen.queryByText(
         'Please login to manage this resource on marsha.education.',

--- a/src/frontend/apps/lti_site/components/ClaimLink/index.tsx
+++ b/src/frontend/apps/lti_site/components/ClaimLink/index.tsx
@@ -31,20 +31,22 @@ export const ClaimLink = ({ decodedJwt }: ClaimLinkProps) => {
     appConfig.video ||
     appConfig.document) as Exclude<AppDataRessource, DepositedFile>;
 
-  const [showClaimLink, setShowClaimLink] = useState(
-    ['videos', 'classrooms'].includes(appConfig.modelName) && !!decodedJwt.user,
-  );
-  const { data } = usePlaylistIsClaimed(resource?.playlist.id, {
-    enabled: showClaimLink && !!resource?.playlist.id,
+  const [showClaimLink, setShowClaimLink] = useState(false);
+  const { data, isLoading } = usePlaylistIsClaimed(resource?.playlist.id, {
+    enabled: !!resource?.playlist.id,
   });
 
   useEffect(() => {
-    if (data?.is_claimed) {
-      setShowClaimLink(false);
+    if (isLoading) {
+      return;
+    }
+
+    if (data && data.is_claimed === false) {
+      setShowClaimLink(true);
     } else {
       return;
     }
-  }, [data?.is_claimed]);
+  }, [data, isLoading]);
 
   if (
     !resource ||


### PR DESCRIPTION
## Purpose

The claim link was display by default by setting the state based on appDatata content. This can lead to displaying the link few second and the state is changed only if the resource is-claimed. This introduce a bug because this endpoint can not be fetch by a student, so student have the link display. This fix does the opposite, when mounted, the state is set to false and then the link is display only if the request succeed and is claimed is strictly false.

## Proposal

- [x] Display claim link only when is-claimed request succeeded

