### PR TITLE
🌐(lib_components) add the language in the request header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Add playlist is_claimable attribute
+- Add the Accept-Language header to most of the http request (#2394)
 
 ## [4.3.1] - 2023-08-31
 

--- a/src/frontend/apps/lti_site/apps/deposit/components/Dashboard/DashboardInstructor/index.spec.tsx
+++ b/src/frontend/apps/lti_site/apps/deposit/components/Dashboard/DashboardInstructor/index.spec.tsx
@@ -294,6 +294,7 @@ describe('<DashboardInstructor />', () => {
       headers: {
         Authorization: 'Bearer json web token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify({ title: 'My file depository title updated' }),
@@ -346,6 +347,7 @@ describe('<DashboardInstructor />', () => {
       headers: {
         Authorization: 'Bearer json web token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify({
@@ -401,6 +403,7 @@ describe('<DashboardInstructor />', () => {
       headers: {
         Authorization: 'Bearer json web token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify({
@@ -453,6 +456,7 @@ describe('<DashboardInstructor />', () => {
       headers: {
         Authorization: 'Bearer json web token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify({

--- a/src/frontend/apps/lti_site/apps/deposit/components/Dashboard/common/DepositedFileRow/index.spec.tsx
+++ b/src/frontend/apps/lti_site/apps/deposit/components/Dashboard/common/DepositedFileRow/index.spec.tsx
@@ -56,6 +56,7 @@ describe('<DepositedFileRow />', () => {
       headers: {
         Authorization: 'Bearer json web token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify({ read: true }),

--- a/src/frontend/apps/lti_site/apps/deposit/data/queries/index.spec.tsx
+++ b/src/frontend/apps/lti_site/apps/deposit/data/queries/index.spec.tsx
@@ -57,6 +57,7 @@ describe('queries', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
       });
       expect(result.current.data).toEqual(fileDepositories);
@@ -82,6 +83,7 @@ describe('queries', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
       });
       expect(result.current.data).toEqual(undefined);
@@ -115,6 +117,7 @@ describe('queries', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
       });
       expect(result.current.data).toEqual(fileDepository);
@@ -143,6 +146,7 @@ describe('queries', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
       });
       expect(result.current.data).toEqual(undefined);
@@ -172,6 +176,7 @@ describe('queries', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
         method: 'POST',
         body: JSON.stringify({
@@ -204,6 +209,7 @@ describe('queries', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
         method: 'POST',
         body: JSON.stringify({
@@ -245,6 +251,7 @@ describe('queries', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
         method: 'PATCH',
         body: JSON.stringify({
@@ -279,6 +286,7 @@ describe('queries', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
         method: 'PATCH',
         body: JSON.stringify({
@@ -319,6 +327,7 @@ describe('queries', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
       });
       expect(result.current.data).toEqual(depositedFiles.slice(0, 3));
@@ -353,6 +362,7 @@ describe('queries', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
       });
       expect(result.current.data).toEqual(depositedFiles.slice(3, 4));
@@ -387,6 +397,7 @@ describe('queries', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
       });
       expect(result.current.data).toEqual(undefined);
@@ -426,6 +437,7 @@ describe('queries', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
         method: 'PATCH',
         body: JSON.stringify({
@@ -467,6 +479,7 @@ describe('queries', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
         method: 'PATCH',
         body: JSON.stringify({

--- a/src/frontend/apps/lti_site/apps/deposit/data/sideEffects/createDepositedFile/index.spec.ts
+++ b/src/frontend/apps/lti_site/apps/deposit/data/sideEffects/createDepositedFile/index.spec.ts
@@ -46,6 +46,7 @@ describe('sideEffects/createDepositedFile', () => {
     expect(fetchArgs.headers).toEqual({
       Authorization: 'Bearer token',
       'Content-Type': 'application/json',
+      'Accept-Language': 'en',
     });
     expect(fetchArgs.method).toEqual('POST');
   });

--- a/src/frontend/apps/lti_site/components/DashboardDocument/index.spec.tsx
+++ b/src/frontend/apps/lti_site/components/DashboardDocument/index.spec.tsx
@@ -67,6 +67,7 @@ describe('<DashboardDocument />', () => {
     );
     expect(fetchMock.lastCall()![1]!.headers).toEqual({
       Authorization: 'Bearer cool_token_m8',
+      'Accept-Language': 'en',
     });
     screen.getByText('Processing');
 
@@ -105,6 +106,7 @@ describe('<DashboardDocument />', () => {
     );
     expect(fetchMock.lastCall()![1]!.headers).toEqual({
       Authorization: 'Bearer cool_token_m8',
+      'Accept-Language': 'en',
     });
 
     expect(

--- a/src/frontend/apps/lti_site/components/PlaylistPortability/index.spec.tsx
+++ b/src/frontend/apps/lti_site/components/PlaylistPortability/index.spec.tsx
@@ -64,6 +64,7 @@ describe('<PlaylistPortability />', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
     });
 
@@ -101,6 +102,7 @@ describe('<PlaylistPortability />', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify({
@@ -117,6 +119,7 @@ describe('<PlaylistPortability />', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
     });
 

--- a/src/frontend/apps/lti_site/data/queries/index.spec.tsx
+++ b/src/frontend/apps/lti_site/data/queries/index.spec.tsx
@@ -55,6 +55,7 @@ describe('queries', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
       });
       expect(result.current.data).toEqual(organization);
@@ -80,6 +81,7 @@ describe('queries', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
       });
       expect(result.current.data).toBeUndefined();
@@ -106,6 +108,7 @@ describe('queries', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
       });
       expect(result.current.data).toEqual(playlist);
@@ -131,6 +134,7 @@ describe('queries', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
       });
       expect(result.current.data).toEqual(undefined);
@@ -160,6 +164,7 @@ describe('queries', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
         method: 'PATCH',
         body: JSON.stringify({
@@ -191,6 +196,7 @@ describe('queries', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
         method: 'PATCH',
         body: JSON.stringify({
@@ -221,6 +227,7 @@ describe('queries', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
       });
       expect(result.current.data).toEqual(playlists);
@@ -245,6 +252,7 @@ describe('queries', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
       });
       expect(result.current.data).toEqual(undefined);
@@ -278,6 +286,7 @@ describe('queries', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
       });
       expect(result.current.data).toEqual(thumbnail);
@@ -309,6 +318,7 @@ describe('queries', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
       });
       expect(result.current.data).toEqual(undefined);
@@ -337,6 +347,7 @@ describe('queries', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
         method: 'POST',
         body: JSON.stringify({
@@ -370,6 +381,7 @@ describe('queries', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
         method: 'POST',
         body: JSON.stringify({
@@ -405,6 +417,7 @@ describe('queries', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
         method: 'POST',
         body: JSON.stringify({
@@ -441,6 +454,7 @@ describe('queries', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
         method: 'POST',
         body: JSON.stringify({

--- a/src/frontend/apps/lti_site/data/sideEffects/deleteTimedTextTrack/index.spec.ts
+++ b/src/frontend/apps/lti_site/data/sideEffects/deleteTimedTextTrack/index.spec.ts
@@ -18,6 +18,7 @@ describe('sideEffects/deleteTimedTextTrack', () => {
 
     expect(fetchMock.lastCall()![1]!.headers).toEqual({
       Authorization: 'Bearer some token',
+      'Accept-Language': 'en',
     });
     expect(response).toBe(true);
   });

--- a/src/frontend/apps/standalone_site/src/api/useConfig/index.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/api/useConfig/index.spec.tsx
@@ -30,6 +30,7 @@ describe('useConfig', () => {
     expect(fetchMock.lastCall()![1]).toEqual({
       headers: {
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
     });
     expect(result.current.data).toEqual({
@@ -55,6 +56,7 @@ describe('useConfig', () => {
     expect(fetchMock.lastCall()![0]).toEqual('/api/config/');
     expect(fetchMock.lastCall()![1]).toEqual({
       headers: {
+        'Accept-Language': 'en',
         'Content-Type': 'application/json',
       },
     });

--- a/src/frontend/apps/standalone_site/src/api/useLtiUserAssociations/index.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/api/useLtiUserAssociations/index.spec.tsx
@@ -35,6 +35,7 @@ describe('features/PortabilityRequests/api/useLtiUserAssociations', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
         method: 'POST',
         body: JSON.stringify({
@@ -65,6 +66,7 @@ describe('features/PortabilityRequests/api/useLtiUserAssociations', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
         method: 'POST',
         body: JSON.stringify({

--- a/src/frontend/apps/standalone_site/src/features/Authentication/api/basicLogin/index.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Authentication/api/basicLogin/index.spec.tsx
@@ -33,6 +33,7 @@ describe('features/Authentication/api/basicLogin', () => {
       expect(fetchMock.lastCall()![1]).toEqual({
         headers: {
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
         method: 'POST',
         body: JSON.stringify({
@@ -70,6 +71,7 @@ describe('features/Authentication/api/basicLogin', () => {
       expect(fetchMock.lastCall()![1]).toEqual({
         headers: {
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
         method: 'POST',
         body: JSON.stringify({

--- a/src/frontend/apps/standalone_site/src/features/Authentication/api/usePasswordReset/index.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Authentication/api/usePasswordReset/index.spec.tsx
@@ -31,6 +31,7 @@ describe('features/Authentication/api/usePasswordReset', () => {
       expect(fetchMock.lastCall()![1]).toEqual({
         headers: {
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
         method: 'POST',
         body: JSON.stringify({
@@ -64,6 +65,7 @@ describe('features/Authentication/api/usePasswordReset', () => {
       expect(fetchMock.lastCall()![1]).toEqual({
         headers: {
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
         method: 'POST',
         body: JSON.stringify({

--- a/src/frontend/apps/standalone_site/src/features/Authentication/api/usePasswordResetConfirm/index.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Authentication/api/usePasswordResetConfirm/index.spec.tsx
@@ -35,6 +35,7 @@ describe('features/Authentication/api/usePasswordResetConfirm', () => {
       expect(fetchMock.lastCall()![1]).toEqual({
         headers: {
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
         method: 'POST',
         body: JSON.stringify({
@@ -74,6 +75,7 @@ describe('features/Authentication/api/usePasswordResetConfirm', () => {
       expect(fetchMock.lastCall()![1]).toEqual({
         headers: {
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
         method: 'POST',
         body: JSON.stringify({

--- a/src/frontend/apps/standalone_site/src/features/Authentication/components/LoginForm.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Authentication/components/LoginForm.spec.tsx
@@ -79,6 +79,7 @@ describe('<LoginFrom />', () => {
     expect(fetchMock.lastCall()![1]).toEqual({
       headers: {
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'POST',
       body: JSON.stringify({

--- a/src/frontend/apps/standalone_site/src/features/Authentication/components/PasswordResetConfirmForm.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Authentication/components/PasswordResetConfirmForm.spec.tsx
@@ -80,6 +80,7 @@ describe('<PasswordResetConfirmForm />', () => {
     expect(fetchMock.lastCall()![1]).toEqual({
       headers: {
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'POST',
       body: JSON.stringify({
@@ -122,6 +123,7 @@ describe('<PasswordResetConfirmForm />', () => {
     expect(fetchMock.lastCall()![1]).toEqual({
       headers: {
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'POST',
       body: JSON.stringify({

--- a/src/frontend/apps/standalone_site/src/features/Authentication/components/PasswordResetForm.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Authentication/components/PasswordResetForm.spec.tsx
@@ -55,6 +55,7 @@ describe('<PasswordResetForm />', () => {
     expect(fetchMock.lastCall()![1]).toEqual({
       headers: {
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'POST',
       body: JSON.stringify({

--- a/src/frontend/apps/standalone_site/src/features/ClaimResource/api/useClaimResource.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/ClaimResource/api/useClaimResource.spec.tsx
@@ -35,6 +35,7 @@ describe('useClaimResource', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'POST',
     });
@@ -62,6 +63,7 @@ describe('useClaimResource', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'POST',
     });

--- a/src/frontend/apps/standalone_site/src/features/ClaimResource/components/ClaimResource.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/ClaimResource/components/ClaimResource.spec.tsx
@@ -69,6 +69,7 @@ describe('<ClaimResource />', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'POST',
       body: JSON.stringify({
@@ -84,6 +85,7 @@ describe('<ClaimResource />', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'POST',
     });
@@ -128,6 +130,7 @@ describe('<ClaimResource />', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'POST',
       body: JSON.stringify({
@@ -143,6 +146,7 @@ describe('<ClaimResource />', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'POST',
     });
@@ -185,6 +189,7 @@ describe('<ClaimResource />', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'POST',
       body: JSON.stringify({
@@ -200,6 +205,7 @@ describe('<ClaimResource />', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'POST',
     });

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Manage/ClassRoomCreateForm.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Manage/ClassRoomCreateForm.spec.tsx
@@ -140,7 +140,7 @@ describe('<ClassRoomCreateForm />', () => {
     });
 
     expect(fetchMock.lastCall()?.[1]).toEqual({
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', 'Accept-Language': 'en' },
       method: 'POST',
       body: JSON.stringify({
         playlist: 'an-other-playlist',

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Manage/ClassroomManage.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Manage/ClassroomManage.spec.tsx
@@ -159,6 +159,7 @@ describe('<ClassroomManage />', () => {
     expect(fetchMock.lastCall()![1]).toEqual({
       headers: {
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       body: `{"ids":["id1","id2"]}`,
       method: 'DELETE',
@@ -196,6 +197,7 @@ describe('<ClassroomManage />', () => {
     expect(fetchMock.lastCall()![1]).toEqual({
       headers: {
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       body: `{"ids":["id1","id2"]}`,
       method: 'DELETE',

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/Manage/LiveCreateForm.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/Manage/LiveCreateForm.spec.tsx
@@ -185,7 +185,10 @@ describe('<LiveCreateForm />', () => {
           method: 'POST',
         })?.[1],
       ).toEqual({
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept-Language': 'en',
+        },
         method: 'POST',
         body: JSON.stringify({
           playlist: 'an-other-playlist',

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/Manage/LiveManage.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/Manage/LiveManage.spec.tsx
@@ -158,6 +158,7 @@ describe('<LiveManage />', () => {
     expect(fetchMock.lastCall()![1]).toEqual({
       headers: {
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       body: `{"ids":["id1","id2"]}`,
       method: 'DELETE',
@@ -195,6 +196,7 @@ describe('<LiveManage />', () => {
     expect(fetchMock.lastCall()![1]).toEqual({
       headers: {
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       body: `{"ids":["id1","id2"]}`,
       method: 'DELETE',

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Video/components/Manage/VideoCreateForm.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Video/components/Manage/VideoCreateForm.spec.tsx
@@ -275,7 +275,10 @@ describe('<VideoCreateForm />', () => {
           method: 'POST',
         })?.[1],
       ).toEqual({
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept-Language': 'en',
+        },
         method: 'POST',
         body: JSON.stringify({
           playlist: 'an-other-playlist',

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Video/components/Manage/VideoManage.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Video/components/Manage/VideoManage.spec.tsx
@@ -151,6 +151,7 @@ describe('<VideoManage />', () => {
     expect(fetchMock.lastCall()![1]).toEqual({
       headers: {
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       body: `{"ids":["id1","id2"]}`,
       method: 'DELETE',
@@ -186,6 +187,7 @@ describe('<VideoManage />', () => {
     expect(fetchMock.lastCall()![1]).toEqual({
       headers: {
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       body: `{"ids":["id1","id2"]}`,
       method: 'DELETE',

--- a/src/frontend/apps/standalone_site/src/features/PagesApi/api/usePageApi.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/PagesApi/api/usePageApi.spec.tsx
@@ -29,6 +29,7 @@ describe('usePageApi', () => {
     expect(fetchMock.lastCall()![1]).toEqual({
       headers: {
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
     });
     expect(result.current.data).toEqual({
@@ -54,6 +55,7 @@ describe('usePageApi', () => {
     expect(fetchMock.lastCall()![1]).toEqual({
       headers: {
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
     });
     expect(result.current.data).toEqual(undefined);

--- a/src/frontend/apps/standalone_site/src/features/Playlist/features/UpdatePlaylist/components/AddUserAccessForm.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Playlist/features/UpdatePlaylist/components/AddUserAccessForm.spec.tsx
@@ -87,6 +87,7 @@ describe('AddUserAccessForm', () => {
       headers: {
         Authorization: 'Bearer json web token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'POST',
       body: JSON.stringify({

--- a/src/frontend/apps/standalone_site/src/features/Playlist/features/UpdatePlaylist/components/UserListRow.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Playlist/features/UpdatePlaylist/components/UserListRow.spec.tsx
@@ -199,7 +199,7 @@ describe('<UserListRow />', () => {
       ),
     );
     expect(fetchMock.lastCall()![1]).toEqual({
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', 'Accept-Language': 'en' },
       method: 'DELETE',
     });
   });
@@ -239,7 +239,7 @@ describe('<UserListRow />', () => {
       ),
     );
     expect(fetchMock.lastCall()![1]).toEqual({
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', 'Accept-Language': 'en' },
       method: 'DELETE',
     });
   });

--- a/src/frontend/apps/standalone_site/src/features/PortabilityRequests/api/usePortabilityRequests.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/PortabilityRequests/api/usePortabilityRequests.spec.tsx
@@ -46,6 +46,7 @@ describe('features/PortabilityRequests/api/usePortabilityRequests', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
         method: 'POST',
         body: JSON.stringify({}),
@@ -81,6 +82,7 @@ describe('features/PortabilityRequests/api/usePortabilityRequests', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
         method: 'POST',
         body: JSON.stringify({}),
@@ -116,6 +118,7 @@ describe('features/PortabilityRequests/api/usePortabilityRequests', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
         method: 'POST',
         body: JSON.stringify({}),
@@ -151,6 +154,7 @@ describe('features/PortabilityRequests/api/usePortabilityRequests', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
         method: 'POST',
         body: JSON.stringify({}),
@@ -194,6 +198,7 @@ describe('features/PortabilityRequests/api/usePortabilityRequests', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
       });
       expect(result.current.data).toEqual(portabilityRequestList);
@@ -229,6 +234,7 @@ describe('features/PortabilityRequests/api/usePortabilityRequests', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
       });
       expect(result.current.data).toEqual(undefined);

--- a/src/frontend/apps/standalone_site/src/features/PortabilityRequests/hooks/useLtiUserAssociationJwtQueryParam.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/PortabilityRequests/hooks/useLtiUserAssociationJwtQueryParam.spec.tsx
@@ -60,6 +60,7 @@ describe('features/PortabilityRequests/hooks/useLtiUserAssociationJwtQueryParam'
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
         method: 'POST',
         body: JSON.stringify({
@@ -95,6 +96,7 @@ describe('features/PortabilityRequests/hooks/useLtiUserAssociationJwtQueryParam'
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
         method: 'POST',
         body: JSON.stringify({

--- a/src/frontend/packages/lib_classroom/src/components/ClassroomInfoBar/index.spec.tsx
+++ b/src/frontend/packages/lib_classroom/src/components/ClassroomInfoBar/index.spec.tsx
@@ -70,6 +70,7 @@ describe('<ClassroomInfoBar />', () => {
     expect(fetchMock.lastCall()![1]).toEqual({
       headers: {
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify({
@@ -137,6 +138,7 @@ describe('<ClassroomInfoBar />', () => {
     expect(fetchMock.lastCall()![1]).toEqual({
       headers: {
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify({

--- a/src/frontend/packages/lib_classroom/src/components/ClassroomWidgetProvider/widgets/Description/index.spec.tsx
+++ b/src/frontend/packages/lib_classroom/src/components/ClassroomWidgetProvider/widgets/Description/index.spec.tsx
@@ -89,6 +89,7 @@ describe('<Description />', () => {
     expect(fetchMock.calls()[0]![1]).toEqual({
       headers: {
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify({

--- a/src/frontend/packages/lib_classroom/src/components/ClassroomWidgetProvider/widgets/Scheduling/index.spec.tsx
+++ b/src/frontend/packages/lib_classroom/src/components/ClassroomWidgetProvider/widgets/Scheduling/index.spec.tsx
@@ -141,6 +141,7 @@ describe('<Scheduling />', () => {
     expect(fetchMock.calls()[0]![1]).toEqual({
       headers: {
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify({
@@ -152,6 +153,7 @@ describe('<Scheduling />', () => {
     expect(fetchMock.calls()[1]![1]).toEqual({
       headers: {
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify({

--- a/src/frontend/packages/lib_classroom/src/components/ClassroomWidgetProvider/widgets/SupportSharing/UploadDocuments/index.spec.tsx
+++ b/src/frontend/packages/lib_classroom/src/components/ClassroomWidgetProvider/widgets/SupportSharing/UploadDocuments/index.spec.tsx
@@ -392,6 +392,7 @@ describe('<UploadDocuments />', () => {
     expect(deleteCall[0][1]).toEqual({
       headers: {
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'DELETE',
     });

--- a/src/frontend/packages/lib_classroom/src/components/ClassroomWidgetProvider/widgets/ToolsAndApplications/index.spec.tsx
+++ b/src/frontend/packages/lib_classroom/src/components/ClassroomWidgetProvider/widgets/ToolsAndApplications/index.spec.tsx
@@ -73,6 +73,7 @@ describe('<ToolsAndApplications />', () => {
     expect(fetchMock.lastCall()![1]).toEqual({
       headers: {
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: '{"enable_chat":false}',
@@ -102,6 +103,7 @@ describe('<ToolsAndApplications />', () => {
     expect(fetchMock.lastCall()![1]).toEqual({
       headers: {
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: '{"enable_shared_notes":false}',
@@ -131,6 +133,7 @@ describe('<ToolsAndApplications />', () => {
     expect(fetchMock.lastCall()![1]).toEqual({
       headers: {
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: '{"enable_waiting_room":true}',
@@ -175,6 +178,7 @@ describe('<ToolsAndApplications />', () => {
     expect(fetchMock.lastCall()![1]).toEqual({
       headers: {
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: '{"enable_recordings":false}',
@@ -231,6 +235,7 @@ describe('<ToolsAndApplications />', () => {
     expect(fetchMock.lastCall()![1]).toEqual({
       headers: {
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: `{"recording_purpose":"${recording_purpose_updated}"}`,

--- a/src/frontend/packages/lib_classroom/src/components/DashboardClassroom/index.spec.tsx
+++ b/src/frontend/packages/lib_classroom/src/components/DashboardClassroom/index.spec.tsx
@@ -240,6 +240,7 @@ describe('<DashboardClassroom />', () => {
       headers: {
         Authorization: 'Bearer token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify({

--- a/src/frontend/packages/lib_classroom/src/components/DashboardClassroomInstructor/index.spec.tsx
+++ b/src/frontend/packages/lib_classroom/src/components/DashboardClassroomInstructor/index.spec.tsx
@@ -103,6 +103,7 @@ describe('<DashboardClassroomInstructor />', () => {
     expect(fetchMock.calls()[0]![1]).toEqual({
       headers: {
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify({}),

--- a/src/frontend/packages/lib_classroom/src/data/queries/index.spec.tsx
+++ b/src/frontend/packages/lib_classroom/src/data/queries/index.spec.tsx
@@ -58,6 +58,7 @@ describe('queries', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
       });
       expect(result.current.data).toEqual(classrooms);
@@ -83,6 +84,7 @@ describe('queries', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
       });
       expect(result.current.data).toEqual(undefined);
@@ -109,6 +111,7 @@ describe('queries', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
       });
       expect(result.current.data).toEqual(classroom);
@@ -134,6 +137,7 @@ describe('queries', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
       });
       expect(result.current.data).toEqual(undefined);
@@ -162,6 +166,7 @@ describe('queries', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
         method: 'POST',
         body: JSON.stringify({
@@ -194,6 +199,7 @@ describe('queries', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
         method: 'POST',
         body: JSON.stringify({
@@ -226,6 +232,7 @@ describe('queries', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
         method: 'DELETE',
       });
@@ -253,6 +260,7 @@ describe('queries', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
         method: 'DELETE',
       });
@@ -283,6 +291,7 @@ describe('queries', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
         method: 'PATCH',
         body: JSON.stringify({
@@ -314,6 +323,7 @@ describe('queries', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
         method: 'PATCH',
         body: JSON.stringify({
@@ -350,6 +360,7 @@ describe('queries', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
         method: 'PATCH',
         body: JSON.stringify({
@@ -383,6 +394,7 @@ describe('queries', () => {
       expect(fetchMock.lastCall()![1]).toEqual({
         headers: {
           Authorization: 'Bearer some token',
+          'Accept-Language': 'en',
           'Content-Type': 'application/json',
         },
         method: 'PATCH',
@@ -418,6 +430,7 @@ describe('queries', () => {
       );
       expect(fetchMock.lastCall()![1]).toEqual({
         headers: {
+          'Accept-Language': 'en',
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
         },
@@ -452,6 +465,7 @@ describe('queries', () => {
       );
       expect(fetchMock.lastCall()![1]).toEqual({
         headers: {
+          'Accept-Language': 'en',
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
         },
@@ -491,6 +505,7 @@ describe('queries', () => {
       );
       expect(fetchMock.lastCall()![1]).toEqual({
         headers: {
+          'Accept-Language': 'en',
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
         },
@@ -525,6 +540,7 @@ describe('queries', () => {
       );
       expect(fetchMock.lastCall()![1]).toEqual({
         headers: {
+          'Accept-Language': 'en',
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
         },
@@ -564,6 +580,7 @@ describe('queries', () => {
       );
       expect(fetchMock.lastCall()![1]).toEqual({
         headers: {
+          'Accept-Language': 'en',
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
         },
@@ -605,6 +622,7 @@ describe('queries', () => {
       );
       expect(fetchMock.lastCall()![1]).toEqual({
         headers: {
+          'Accept-Language': 'en',
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
         },
@@ -648,6 +666,7 @@ describe('useDeleteClassrooms', () => {
     expect(fetchMock.lastCall()![0]).toEqual(`/api/classrooms/`);
     expect(fetchMock.lastCall()![1]).toEqual({
       headers: {
+        'Accept-Language': 'en',
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
       },
@@ -676,6 +695,7 @@ describe('useDeleteClassrooms', () => {
     expect(fetchMock.lastCall()![0]).toEqual(`/api/classrooms/`);
     expect(fetchMock.lastCall()![1]).toEqual({
       headers: {
+        'Accept-Language': 'en',
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
       },

--- a/src/frontend/packages/lib_classroom/src/data/sideEffects/createClassroomDocument/index.spec.ts
+++ b/src/frontend/packages/lib_classroom/src/data/sideEffects/createClassroomDocument/index.spec.ts
@@ -36,6 +36,7 @@ describe('sideEffects/createClassroomDocument', () => {
     expect(fetchArgs.headers).toEqual({
       Authorization: 'Bearer token',
       'Content-Type': 'application/json',
+      'Accept-Language': 'en',
     });
     expect(fetchArgs.method).toEqual('POST');
   });

--- a/src/frontend/packages/lib_classroom/src/data/sideEffects/createVOD/index.spec.ts
+++ b/src/frontend/packages/lib_classroom/src/data/sideEffects/createVOD/index.spec.ts
@@ -31,6 +31,7 @@ describe('sideEffects/createVOD', () => {
     expect(fetchArgs.headers).toEqual({
       Authorization: 'Bearer token',
       'Content-Type': 'application/json',
+      'Accept-Language': 'en',
     });
     expect(fetchArgs.method).toEqual('POST');
   });

--- a/src/frontend/packages/lib_components/src/common/queries/actionOne.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/queries/actionOne.spec.tsx
@@ -26,6 +26,7 @@ describe('queries/actionOne', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify(objectToUpdate),
@@ -49,6 +50,7 @@ describe('queries/actionOne', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
     });
@@ -74,6 +76,7 @@ describe('queries/actionOne', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'GET',
       body: JSON.stringify(objectToUpdate),
@@ -98,6 +101,7 @@ describe('queries/actionOne', () => {
     expect(fetchMock.lastCall()?.[1]).toEqual({
       headers: {
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify(objectToUpdate),
@@ -128,6 +132,7 @@ describe('queries/actionOne', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify(objectToUpdate),
@@ -168,6 +173,7 @@ describe('queries/actionOne', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify(objectToUpdate),

--- a/src/frontend/packages/lib_components/src/common/queries/bulkDelete.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/queries/bulkDelete.spec.tsx
@@ -27,6 +27,7 @@ describe('queries/bulkDelete', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'DELETE',
       body: '{"ids":["id1","id2"]}',
@@ -66,6 +67,7 @@ describe('queries/bulkDelete', () => {
     expect(fetchMock.lastCall()?.[1]).toEqual({
       headers: {
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'DELETE',
       body: '{"ids":["id1","id2"]}',
@@ -92,6 +94,7 @@ describe('queries/bulkDelete', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'DELETE',
       body: '{"ids":["id1","id2"]}',
@@ -133,6 +136,7 @@ describe('queries/bulkDelete', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'DELETE',
       body: '{"ids":["id1","id2"]}',

--- a/src/frontend/packages/lib_components/src/common/queries/createOne.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/queries/createOne.spec.tsx
@@ -24,6 +24,7 @@ describe('queries/createOne', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'POST',
       body: JSON.stringify(objectToCreate),
@@ -46,6 +47,7 @@ describe('queries/createOne', () => {
     expect(fetchMock.lastCall()?.[1]).toEqual({
       headers: {
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'POST',
       body: JSON.stringify(objectToCreate),
@@ -74,6 +76,7 @@ describe('queries/createOne', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'POST',
       body: JSON.stringify(objectToCreate),
@@ -113,6 +116,7 @@ describe('queries/createOne', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'POST',
       body: JSON.stringify(objectToCreate),
@@ -156,6 +160,7 @@ describe('queries/createOne', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'POST',
       body: JSON.stringify(objectToCreate),

--- a/src/frontend/packages/lib_components/src/common/queries/deleteOne.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/queries/deleteOne.spec.tsx
@@ -23,6 +23,7 @@ describe('queries/deleteOne', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'DELETE',
     });
@@ -58,6 +59,7 @@ describe('queries/deleteOne', () => {
     expect(fetchMock.lastCall()?.[1]).toEqual({
       headers: {
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'DELETE',
     });
@@ -83,6 +85,7 @@ describe('queries/deleteOne', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'DELETE',
     });
@@ -123,6 +126,7 @@ describe('queries/deleteOne', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'DELETE',
     });

--- a/src/frontend/packages/lib_components/src/common/queries/fetchList.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/queries/fetchList.spec.tsx
@@ -23,6 +23,7 @@ describe('queries/fetchList', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
     });
     expect(response).toEqual({ key: 'value' });
@@ -46,6 +47,7 @@ describe('queries/fetchList', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
     });
     expect(response).toEqual({ key: 'value' });
@@ -66,6 +68,7 @@ describe('queries/fetchList', () => {
     expect(fetchMock.lastCall()?.[1]).toEqual({
       headers: {
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
     });
     expect(response).toEqual({ key: 'value' });
@@ -92,6 +95,7 @@ describe('queries/fetchList', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
     });
   });
@@ -114,6 +118,7 @@ describe('queries/fetchList', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
     });
   });

--- a/src/frontend/packages/lib_components/src/common/queries/fetchOne.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/queries/fetchOne.spec.tsx
@@ -23,6 +23,7 @@ describe('queries/fetchOne', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
     });
     expect(response).toEqual({ key: 'value' });
@@ -43,6 +44,7 @@ describe('queries/fetchOne', () => {
     expect(fetchMock.lastCall()?.[1]).toEqual({
       headers: {
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
     });
     expect(response).toEqual({ key: 'value' });
@@ -69,6 +71,7 @@ describe('queries/fetchOne', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
     });
   });
@@ -91,6 +94,7 @@ describe('queries/fetchOne', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
     });
   });
@@ -111,6 +115,7 @@ describe('queries/fetchOne', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
     });
     expect(response).toEqual({ key: 'value' });
@@ -131,6 +136,7 @@ describe('queries/fetchOne', () => {
     expect(fetchMock.lastCall()?.[1]).toEqual({
       headers: {
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
     });
     expect(response).toEqual({ key: 'value' });
@@ -157,6 +163,7 @@ describe('queries/fetchOne', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
     });
   });
@@ -179,6 +186,7 @@ describe('queries/fetchOne', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
     });
   });

--- a/src/frontend/packages/lib_components/src/common/queries/fetchWrapper.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/queries/fetchWrapper.spec.tsx
@@ -29,14 +29,14 @@ describe('fetchWrapper', () => {
     expect(mockedFetchReconnectWrapper).toHaveBeenCalled();
     expect(mockedFetchReconnectWrapper).toHaveBeenCalledWith(
       'some request',
-      { body: 'some body' },
+      { body: 'some body', headers: { 'Accept-Language': 'en' } },
       { isRetry: true },
     );
 
     expect(fetchMock.calls().length).toEqual(0);
   });
 
-  it('loads without reconnet wrapper option', () => {
+  it('loads without reconnect wrapper option', () => {
     fetchMock.mock('http://some.url.com', 200);
 
     fetchWrapper(
@@ -54,6 +54,30 @@ describe('fetchWrapper', () => {
     expect(fetchMock.calls()[0][1]).toEqual({
       body: 'some body',
       method: 'POST',
+      headers: {
+        'Accept-Language': 'en',
+      },
+    });
+  });
+
+  it('let the header language if already set', () => {
+    fetchMock.mock('http://some.url.com', 200);
+
+    fetchWrapper(
+      'http://some.url.com',
+      {
+        headers: { 'Accept-Language': 'test' },
+      },
+      {
+        withoutReconnectWrapper: true,
+      },
+    );
+
+    expect(fetchMock.calls().length).toEqual(1);
+    expect(fetchMock.calls()[0][1]).toEqual({
+      headers: {
+        'Accept-Language': 'test',
+      },
     });
   });
 });

--- a/src/frontend/packages/lib_components/src/common/queries/fetchWrapper.tsx
+++ b/src/frontend/packages/lib_components/src/common/queries/fetchWrapper.tsx
@@ -1,3 +1,5 @@
+import { getIntl } from 'lib-common';
+
 import {
   fetchReconnectWrapper,
   fetchReconnectWrapperOptions,
@@ -13,6 +15,15 @@ export const fetchWrapper = (
   init?: RequestInit,
   options?: FetchWrapperOptions,
 ): Promise<Response> => {
+  const headers = init?.headers as Record<string, string> | undefined;
+  init = {
+    ...init,
+    headers: {
+      ...headers,
+      'Accept-Language': headers?.['Accept-Language'] || getIntl().locale,
+    },
+  };
+
   if (!options?.withoutReconnectWrapper) {
     return fetchReconnectWrapper(input, init, options?.optionsReconnectWrapper);
   }

--- a/src/frontend/packages/lib_components/src/common/queries/updateOne.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/queries/updateOne.spec.tsx
@@ -25,6 +25,7 @@ describe('queries/updateOne', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify(objectToUpdate),
@@ -48,6 +49,7 @@ describe('queries/updateOne', () => {
     expect(fetchMock.lastCall()?.[1]).toEqual({
       headers: {
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify(objectToUpdate),
@@ -77,6 +79,7 @@ describe('queries/updateOne', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify(objectToUpdate),
@@ -117,6 +120,7 @@ describe('queries/updateOne', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify(objectToUpdate),
@@ -161,6 +165,7 @@ describe('queries/updateOne', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify(objectToUpdate),

--- a/src/frontend/packages/lib_components/src/data/sideEffects/initiateUpload/index.spec.ts
+++ b/src/frontend/packages/lib_components/src/data/sideEffects/initiateUpload/index.spec.ts
@@ -30,6 +30,7 @@ describe('sideEffects/initiateUpload', () => {
     expect(fetchMock.lastCall()![1]!.headers).toEqual({
       Authorization: 'Bearer some token',
       'Content-Type': 'application/json',
+      'Accept-Language': 'en',
     });
   });
 

--- a/src/frontend/packages/lib_components/src/utils/XAPI/DocumentXapiStatement.spec.ts
+++ b/src/frontend/packages/lib_components/src/utils/XAPI/DocumentXapiStatement.spec.ts
@@ -25,6 +25,7 @@ describe('DocumentXapiStatement', () => {
     expect(requestParameters.headers).toEqual({
       Authorization: 'Bearer jwt',
       'Content-Type': 'application/json',
+      'Accept-Language': 'en',
     });
 
     const body = JSON.parse(requestParameters.body as string);

--- a/src/frontend/packages/lib_components/src/utils/XAPI/LiveXapiStatement.spec.ts
+++ b/src/frontend/packages/lib_components/src/utils/XAPI/LiveXapiStatement.spec.ts
@@ -36,6 +36,7 @@ describe('LiveXapiStatement', () => {
     expect(requestParameters.headers).toEqual({
       Authorization: 'Bearer jwt',
       'Content-Type': 'application/json',
+      'Accept-Language': 'en',
     });
 
     const body = JSON.parse(requestParameters.body as string);
@@ -77,6 +78,7 @@ describe('LiveXapiStatement', () => {
     expect(requestParameters.headers).toEqual({
       Authorization: 'Bearer jwt',
       'Content-Type': 'application/json',
+      'Accept-Language': 'en',
     });
 
     const body = JSON.parse(requestParameters.body as string);
@@ -110,6 +112,7 @@ describe('LiveXapiStatement', () => {
     expect(requestParameters.headers).toEqual({
       Authorization: 'Bearer jwt',
       'Content-Type': 'application/json',
+      'Accept-Language': 'en',
     });
 
     const body = JSON.parse(requestParameters.body as string);
@@ -145,6 +148,7 @@ describe('LiveXapiStatement', () => {
     expect(requestParameters.headers).toEqual({
       Authorization: 'Bearer jwt',
       'Content-Type': 'application/json',
+      'Accept-Language': 'en',
     });
 
     const body = JSON.parse(requestParameters.body as string);
@@ -192,6 +196,7 @@ describe('LiveXapiStatement', () => {
     expect(requestParameters.headers).toEqual({
       Authorization: 'Bearer jwt',
       'Content-Type': 'application/json',
+      'Accept-Language': 'en',
     });
 
     const body = JSON.parse(requestParameters.body as string);
@@ -240,6 +245,7 @@ describe('LiveXapiStatement', () => {
     expect(requestParameters.headers).toEqual({
       Authorization: 'Bearer jwt',
       'Content-Type': 'application/json',
+      'Accept-Language': 'en',
     });
 
     const body = JSON.parse(requestParameters.body as string);

--- a/src/frontend/packages/lib_components/src/utils/XAPI/VideoXAPIStatement.spec.ts
+++ b/src/frontend/packages/lib_components/src/utils/XAPI/VideoXAPIStatement.spec.ts
@@ -129,6 +129,7 @@ describe('VideoXAPIStatement', () => {
       expect(requestParameters.headers).toEqual({
         Authorization: 'Bearer jwt',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       });
 
       const body = JSON.parse(requestParameters.body as string);
@@ -175,6 +176,7 @@ describe('VideoXAPIStatement', () => {
       expect(requestParameters.headers).toEqual({
         Authorization: 'Bearer jwt',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       });
 
       const body = JSON.parse(requestParameters.body as string);
@@ -225,6 +227,7 @@ describe('VideoXAPIStatement', () => {
       expect(requestParameters.headers).toEqual({
         Authorization: 'Bearer jwt',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       });
 
       const body = JSON.parse(requestParameters.body as string);
@@ -263,6 +266,7 @@ describe('VideoXAPIStatement', () => {
       expect(requestParameters.headers).toEqual({
         Authorization: 'Bearer jwt',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       });
 
       const body = JSON.parse(requestParameters.body as string);
@@ -308,6 +312,7 @@ describe('VideoXAPIStatement', () => {
       expect(requestParameters.headers).toEqual({
         Authorization: 'Bearer jwt',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       });
 
       const body = JSON.parse(requestParameters.body as string);
@@ -351,6 +356,7 @@ describe('VideoXAPIStatement', () => {
       expect(requestParameters.headers).toEqual({
         Authorization: 'Bearer jwt',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       });
 
       const body = JSON.parse(requestParameters.body as string);
@@ -402,6 +408,7 @@ describe('VideoXAPIStatement', () => {
       expect(requestParameters.headers).toEqual({
         Authorization: 'Bearer jwt',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       });
 
       const body = JSON.parse(requestParameters.body as string);
@@ -448,6 +455,7 @@ describe('VideoXAPIStatement', () => {
       expect(requestParameters.headers).toEqual({
         Authorization: 'Bearer jwt',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       });
 
       const body = JSON.parse(requestParameters.body as string);
@@ -500,6 +508,7 @@ describe('VideoXAPIStatement', () => {
       expect(requestParameters.headers).toEqual({
         Authorization: 'Bearer jwt',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       });
 
       const body = JSON.parse(requestParameters.body as string);
@@ -556,6 +565,7 @@ describe('VideoXAPIStatement', () => {
       expect(requestParameters.headers).toEqual({
         Authorization: 'Bearer jwt',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       });
 
       const body = JSON.parse(requestParameters.body as string);
@@ -732,6 +742,7 @@ describe('VideoXAPIStatement', () => {
       expect(requestParameters.headers).toEqual({
         Authorization: 'Bearer jwt',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       });
 
       const body = JSON.parse(requestParameters.body as string);

--- a/src/frontend/packages/lib_markdown/src/components/MarkdownEditor/index.spec.tsx
+++ b/src/frontend/packages/lib_markdown/src/components/MarkdownEditor/index.spec.tsx
@@ -404,6 +404,7 @@ describe('<MarkdownEditor />', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify({
@@ -501,6 +502,7 @@ describe('<MarkdownEditor />', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify({

--- a/src/frontend/packages/lib_markdown/src/components/MdxRenderer/index.spec.tsx
+++ b/src/frontend/packages/lib_markdown/src/components/MdxRenderer/index.spec.tsx
@@ -303,6 +303,7 @@ describe('<MdxRenderer />', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'POST',
       body: JSON.stringify({

--- a/src/frontend/packages/lib_markdown/src/data/queries/index.spec.tsx
+++ b/src/frontend/packages/lib_markdown/src/data/queries/index.spec.tsx
@@ -53,6 +53,7 @@ describe('queries', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
       });
       expect(result.current.data).toEqual(markdownDocument);
@@ -81,6 +82,7 @@ describe('queries', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
       });
       expect(result.current.data).toEqual(undefined);
@@ -109,6 +111,7 @@ describe('queries', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
         method: 'POST',
         body: JSON.stringify({
@@ -141,6 +144,7 @@ describe('queries', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
         method: 'POST',
         body: JSON.stringify({
@@ -181,6 +185,7 @@ describe('queries', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
         method: 'PATCH',
         body: JSON.stringify({
@@ -215,6 +220,7 @@ describe('queries', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
         method: 'PATCH',
         body: JSON.stringify({
@@ -257,6 +263,7 @@ describe('queries', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
         method: 'PATCH',
         body: JSON.stringify({
@@ -300,6 +307,7 @@ describe('queries', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
         method: 'PATCH',
         body: JSON.stringify({
@@ -331,6 +339,7 @@ describe('queries', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
         method: 'POST',
         body: JSON.stringify({
@@ -361,6 +370,7 @@ describe('queries', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
         method: 'POST',
         body: JSON.stringify({

--- a/src/frontend/packages/lib_markdown/src/data/sideEffects/createMarkdownImage/index.spec.tsx
+++ b/src/frontend/packages/lib_markdown/src/data/sideEffects/createMarkdownImage/index.spec.tsx
@@ -44,6 +44,7 @@ describe('createMarkdownImage', () => {
     expect(fetchArgs.headers).toEqual({
       Authorization: 'Bearer token',
       'Content-Type': 'application/json',
+      'Accept-Language': 'en',
     });
     expect(fetchArgs.method).toEqual('POST');
   });

--- a/src/frontend/packages/lib_video/src/api/createLiveSession/index.spec.ts
+++ b/src/frontend/packages/lib_video/src/api/createLiveSession/index.spec.ts
@@ -46,6 +46,7 @@ describe('sideEffects/createLiveSession', () => {
     expect(fetchArgs.headers).toEqual({
       Authorization: 'Bearer token',
       'Content-Type': 'application/json',
+      'Accept-Language': 'en',
     });
   });
 
@@ -87,6 +88,7 @@ describe('sideEffects/createLiveSession', () => {
     expect(fetchArgs.headers).toEqual({
       Authorization: 'Bearer token',
       'Content-Type': 'application/json',
+      'Accept-Language': 'en',
     });
   });
 

--- a/src/frontend/packages/lib_video/src/api/createSharedLiveMedia/index.spec.ts
+++ b/src/frontend/packages/lib_video/src/api/createSharedLiveMedia/index.spec.ts
@@ -37,6 +37,7 @@ describe('sideEffects/createSharedLiveMedia', () => {
     expect(fetchArgs.headers).toEqual({
       Authorization: 'Bearer token',
       'Content-Type': 'application/json',
+      'Accept-Language': 'en',
     });
     expect(fetchArgs.method).toEqual('POST');
   });

--- a/src/frontend/packages/lib_video/src/api/createThumbnail/index.spec.ts
+++ b/src/frontend/packages/lib_video/src/api/createThumbnail/index.spec.ts
@@ -39,6 +39,7 @@ describe('sideEffects/createThumbnail', () => {
     expect(fetchArgs.headers).toEqual({
       Authorization: 'Bearer token',
       'Content-Type': 'application/json',
+      'Accept-Language': 'en',
     });
     expect(fetchArgs.method).toEqual('POST');
   });

--- a/src/frontend/packages/lib_video/src/api/createTimedTextTrack/index.spec.ts
+++ b/src/frontend/packages/lib_video/src/api/createTimedTextTrack/index.spec.ts
@@ -32,6 +32,7 @@ describe('sideEffects/createTimedTextTrack()', () => {
     expect(fetchArgs.headers).toEqual({
       Authorization: 'Bearer some token',
       'Content-Type': 'application/json',
+      'Accept-Language': 'en',
     });
     expect(fetchArgs.method).toEqual('POST');
   });

--- a/src/frontend/packages/lib_video/src/api/harvestLive/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/api/harvestLive/index.spec.tsx
@@ -31,6 +31,7 @@ describe('harvestLive', () => {
     expect(fetchMock.lastCall()![1]!.headers).toEqual({
       Authorization: 'Bearer some token',
       'Content-Type': 'application/json',
+      'Accept-Language': 'en',
     });
   });
 

--- a/src/frontend/packages/lib_video/src/api/initiateLive/index.spec.ts
+++ b/src/frontend/packages/lib_video/src/api/initiateLive/index.spec.ts
@@ -56,6 +56,7 @@ describe('sideEffects/initiateLive', () => {
     expect(fetchMock.lastCall()![1]!.headers).toEqual({
       Authorization: 'Bearer some token',
       'Content-Type': 'application/json',
+      'Accept-Language': 'en',
     });
   });
 
@@ -93,6 +94,7 @@ describe('sideEffects/initiateLive', () => {
     expect(fetchMock.lastCall()![1]!.headers).toEqual({
       Authorization: 'Bearer some token',
       'Content-Type': 'application/json',
+      'Accept-Language': 'en',
     });
   });
 

--- a/src/frontend/packages/lib_video/src/api/navigateSharingDoc/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/api/navigateSharingDoc/index.spec.tsx
@@ -29,6 +29,7 @@ describe('navigateSharingDoc', () => {
     expect(fetchMock.lastCall()![1]!.headers).toEqual({
       Authorization: 'Bearer some token',
       'Content-Type': 'application/json',
+      'Accept-Language': 'en',
     });
   });
 

--- a/src/frontend/packages/lib_video/src/api/startLive/index.spec.ts
+++ b/src/frontend/packages/lib_video/src/api/startLive/index.spec.ts
@@ -32,6 +32,7 @@ describe('sideEffects/startLive', () => {
     expect(fetchMock.lastCall()![1]!.headers).toEqual({
       Authorization: 'Bearer some token',
       'Content-Type': 'application/json',
+      'Accept-Language': 'en',
     });
   });
 

--- a/src/frontend/packages/lib_video/src/api/stopLive/index.spec.ts
+++ b/src/frontend/packages/lib_video/src/api/stopLive/index.spec.ts
@@ -30,6 +30,7 @@ describe('sideEffects/stopLive', () => {
     expect(fetchMock.lastCall()![1]!.headers).toEqual({
       Authorization: 'Bearer some token',
       'Content-Type': 'application/json',
+      'Accept-Language': 'en',
     });
   });
 

--- a/src/frontend/packages/lib_video/src/api/updateLiveParticipants/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/api/updateLiveParticipants/index.spec.tsx
@@ -41,6 +41,7 @@ describe('updateLiveParticipants', () => {
       expect(fetchMock.lastCall()![1]!.headers).toEqual({
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       });
     });
 
@@ -102,6 +103,7 @@ describe('updateLiveParticipants', () => {
       expect(fetchMock.lastCall()![1]!.headers).toEqual({
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       });
     });
 
@@ -163,6 +165,7 @@ describe('updateLiveParticipants', () => {
       expect(fetchMock.lastCall()![1]!.headers).toEqual({
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       });
     });
 
@@ -224,6 +227,7 @@ describe('updateLiveParticipants', () => {
       expect(fetchMock.lastCall()![1]!.headers).toEqual({
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       });
     });
 

--- a/src/frontend/packages/lib_video/src/api/useCreateVideo/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/api/useCreateVideo/index.spec.tsx
@@ -41,6 +41,7 @@ describe('useCreateVideo', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'POST',
       body: JSON.stringify({
@@ -74,6 +75,7 @@ describe('useCreateVideo', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'POST',
       body: JSON.stringify({
@@ -117,6 +119,7 @@ describe('useCreateVideo', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'POST',
       body: JSON.stringify({
@@ -155,6 +158,7 @@ describe('useCreateVideo', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'POST',
       body: JSON.stringify({

--- a/src/frontend/packages/lib_video/src/api/useDeleteSharedLiveMedia/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/api/useDeleteSharedLiveMedia/index.spec.tsx
@@ -45,6 +45,7 @@ describe('useDeleteSharedLiveMedia', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'DELETE',
     });
@@ -77,6 +78,7 @@ describe('useDeleteSharedLiveMedia', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'DELETE',
     });

--- a/src/frontend/packages/lib_video/src/api/useDeleteThumbnail/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/api/useDeleteThumbnail/index.spec.tsx
@@ -45,6 +45,7 @@ describe('useDeleteThumbnail', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'DELETE',
     });
@@ -77,6 +78,7 @@ describe('useDeleteThumbnail', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'DELETE',
     });

--- a/src/frontend/packages/lib_video/src/api/useDeleteTimedTextTrack/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/api/useDeleteTimedTextTrack/index.spec.tsx
@@ -45,6 +45,7 @@ describe('useDeleteTimedTextTracks', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'DELETE',
     });
@@ -77,6 +78,7 @@ describe('useDeleteTimedTextTracks', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'DELETE',
     });

--- a/src/frontend/packages/lib_video/src/api/useDeleteVideo/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/api/useDeleteVideo/index.spec.tsx
@@ -37,6 +37,7 @@ describe('useDeleteVideo', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'DELETE',
     });
@@ -62,6 +63,7 @@ describe('useDeleteVideo', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'DELETE',
     });

--- a/src/frontend/packages/lib_video/src/api/useDeleteVideos/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/api/useDeleteVideos/index.spec.tsx
@@ -41,6 +41,7 @@ describe('useDeleteVideos', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       body: `{"ids":["${video1.id}","${video2.id}"]}`,
       method: 'DELETE',
@@ -69,6 +70,7 @@ describe('useDeleteVideos', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       body: `{"ids":["${video.id}"]}`,
       method: 'DELETE',

--- a/src/frontend/packages/lib_video/src/api/useLiveAttendances/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/api/useLiveAttendances/index.spec.tsx
@@ -47,6 +47,7 @@ describe('useLiveAttendances', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
     });
     expect(result.current.data).toEqual(liveAttendances);
@@ -74,6 +75,7 @@ describe('useLiveAttendances', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
     });
     expect(result.current.data).toEqual(undefined);

--- a/src/frontend/packages/lib_video/src/api/useLiveSessions/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/api/useLiveSessions/index.spec.tsx
@@ -44,6 +44,7 @@ describe('useLiveSessions', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
     });
     expect(result.current.data).toEqual(liveSessions);
@@ -75,6 +76,7 @@ describe('useLiveSessions', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
     });
     expect(result.current.data).toEqual(liveSessions);
@@ -99,6 +101,7 @@ describe('useLiveSessions', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
     });
     expect(result.current.data).toEqual(undefined);

--- a/src/frontend/packages/lib_video/src/api/usePairingVideo/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/api/usePairingVideo/index.spec.tsx
@@ -41,6 +41,7 @@ describe('usePairingingVideo', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'GET',
     });
@@ -67,6 +68,7 @@ describe('usePairingingVideo', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'GET',
     });

--- a/src/frontend/packages/lib_video/src/api/useStartLiveRecording/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/api/useStartLiveRecording/index.spec.tsx
@@ -43,6 +43,7 @@ describe('useStartLiveRecording', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
     });
@@ -75,6 +76,7 @@ describe('useStartLiveRecording', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
     });

--- a/src/frontend/packages/lib_video/src/api/useStartSharingMedia/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/api/useStartSharingMedia/index.spec.tsx
@@ -61,6 +61,7 @@ describe('useStartSharingMedia', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify({ sharedlivemedia: sharedLiveMedia.id }),
@@ -103,6 +104,7 @@ describe('useStartSharingMedia', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify({ sharedlivemedia: sharedLiveMedia.id }),

--- a/src/frontend/packages/lib_video/src/api/useStopLiveRecording/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/api/useStopLiveRecording/index.spec.tsx
@@ -43,6 +43,7 @@ describe('useStopLiveRecording', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
     });
@@ -75,6 +76,7 @@ describe('useStopLiveRecording', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
     });

--- a/src/frontend/packages/lib_video/src/api/useStopSharingMedia/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/api/useStopSharingMedia/index.spec.tsx
@@ -36,6 +36,7 @@ describe('useStopSharingMedia', () => {
     fetchMock.patch(`/api/videos/${video.id}/end-sharing/`, {
       headers: {
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       status: 200,
       body: JSON.stringify(video),
@@ -61,6 +62,7 @@ describe('useStopSharingMedia', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
     });
@@ -102,6 +104,7 @@ describe('useStopSharingMedia', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
     });

--- a/src/frontend/packages/lib_video/src/api/useUpdateSharedLiveMedia/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/api/useUpdateSharedLiveMedia/index.spec.tsx
@@ -47,6 +47,7 @@ describe('useUpdateSharedLiveMedia', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify({
@@ -84,6 +85,7 @@ describe('useUpdateSharedLiveMedia', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify({

--- a/src/frontend/packages/lib_video/src/api/useUpdateVideo/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/api/useUpdateVideo/index.spec.tsx
@@ -39,6 +39,7 @@ describe('useUpdateVideo', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify({
@@ -68,6 +69,7 @@ describe('useUpdateVideo', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify({

--- a/src/frontend/packages/lib_video/src/api/useVideos/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/api/useVideos/index.spec.tsx
@@ -37,6 +37,7 @@ describe('queries', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
       });
       expect(result.current.data).toEqual(video);
@@ -60,6 +61,7 @@ describe('queries', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
       });
       expect(result.current.data).toEqual(undefined);
@@ -86,6 +88,7 @@ describe('queries', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
       });
       expect(result.current.data).toEqual(videos);
@@ -110,6 +113,7 @@ describe('queries', () => {
         headers: {
           Authorization: 'Bearer some token',
           'Content-Type': 'application/json',
+          'Accept-Language': 'en',
         },
       });
       expect(result.current.data).toEqual(undefined);

--- a/src/frontend/packages/lib_video/src/components/common/VideoInfoBar/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoInfoBar/index.spec.tsx
@@ -192,6 +192,7 @@ describe('<VideoInfoBar />', () => {
       headers: {
         Authorization: 'Bearer json web token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify({
@@ -261,6 +262,7 @@ describe('<VideoInfoBar />', () => {
       headers: {
         Authorization: 'Bearer json web token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify({

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/DescriptionWidget/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/DescriptionWidget/index.spec.tsx
@@ -104,6 +104,7 @@ describe('<DescriptionWidget />', () => {
       headers: {
         Authorization: 'Bearer json web token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify({
@@ -148,6 +149,7 @@ describe('<DescriptionWidget />', () => {
       headers: {
         Authorization: 'Bearer json web token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify({
@@ -193,6 +195,7 @@ describe('<DescriptionWidget />', () => {
       headers: {
         Authorization: 'Bearer json web token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify({

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/DownloadVideo/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/DownloadVideo/index.spec.tsx
@@ -206,6 +206,7 @@ describe('<InstructorDownloadVideo />', () => {
       headers: {
         'Content-Type': 'application/json',
         Authorization: 'Bearer json web token',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: '{"show_download":true}',
@@ -247,6 +248,7 @@ describe('<InstructorDownloadVideo />', () => {
       headers: {
         'Content-Type': 'application/json',
         Authorization: 'Bearer json web token',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: '{"show_download":false}',

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/LiveJoinMode/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/LiveJoinMode/index.spec.tsx
@@ -87,6 +87,7 @@ describe('<LiveJoinMode />', () => {
       headers: {
         Authorization: 'Bearer json web token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify({
@@ -144,6 +145,7 @@ describe('<LiveJoinMode />', () => {
       headers: {
         Authorization: 'Bearer json web token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify({
@@ -203,6 +205,7 @@ describe('<LiveJoinMode />', () => {
       headers: {
         Authorization: 'Bearer json web token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify({
@@ -257,6 +260,7 @@ describe('<LiveJoinMode />', () => {
       headers: {
         Authorization: 'Bearer json web token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify({

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/LivePairing/LivePairingButton/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/LivePairing/LivePairingButton/index.spec.tsx
@@ -47,6 +47,7 @@ describe('<DashboardLivePairing />', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'GET',
     });

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/SchedulingAndDescription/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/SchedulingAndDescription/index.spec.tsx
@@ -135,6 +135,7 @@ describe('<SchedulingAndDescription />', () => {
       headers: {
         Authorization: 'Bearer json web token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify({
@@ -179,6 +180,7 @@ describe('<SchedulingAndDescription />', () => {
       headers: {
         Authorization: 'Bearer json web token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify({
@@ -335,6 +337,7 @@ describe('<SchedulingAndDescription />', () => {
       headers: {
         Authorization: 'Bearer json web token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify({
@@ -378,6 +381,7 @@ describe('<SchedulingAndDescription />', () => {
       headers: {
         Authorization: 'Bearer json web token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify({
@@ -419,6 +423,7 @@ describe('<SchedulingAndDescription />', () => {
       headers: {
         Authorization: 'Bearer json web token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify({

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/SharedLiveMedia/SharedLiveMediaItem/AllowedDownloadButton/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/SharedLiveMedia/SharedLiveMediaItem/AllowedDownloadButton/index.spec.tsx
@@ -60,6 +60,7 @@ describe('<AllowedDownloadButton />', () => {
       headers: {
         Authorization: 'Bearer json web token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify({
@@ -101,6 +102,7 @@ describe('<AllowedDownloadButton />', () => {
       headers: {
         Authorization: 'Bearer json web token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify({

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/SharedLiveMedia/SharedLiveMediaItem/DisallowedDownloadButton/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/SharedLiveMedia/SharedLiveMediaItem/DisallowedDownloadButton/index.spec.tsx
@@ -60,6 +60,7 @@ describe('<DisallowedDownloadButton />', () => {
       headers: {
         Authorization: 'Bearer json web token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify({
@@ -103,6 +104,7 @@ describe('<DisallowedDownloadButton />', () => {
       headers: {
         Authorization: 'Bearer json web token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify({

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/SharedLiveMedia/SharedLiveMediaItem/StartSharingButton/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/SharedLiveMedia/SharedLiveMediaItem/StartSharingButton/index.spec.tsx
@@ -66,6 +66,7 @@ describe('<StartSharingButton />', () => {
       headers: {
         Authorization: 'Bearer json web token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify({
@@ -107,6 +108,7 @@ describe('<StartSharingButton />', () => {
       headers: {
         Authorization: 'Bearer json web token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify({

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/SharedLiveMedia/SharedLiveMediaItem/StopSharingButton/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/SharedLiveMedia/SharedLiveMediaItem/StopSharingButton/index.spec.tsx
@@ -58,6 +58,7 @@ describe('<StopSharingButton />', () => {
       headers: {
         Authorization: 'Bearer json web token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
     });
@@ -93,6 +94,7 @@ describe('<StopSharingButton />', () => {
       headers: {
         Authorization: 'Bearer json web token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
     });

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/SharedLiveMedia/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/SharedLiveMedia/index.spec.tsx
@@ -145,6 +145,7 @@ describe('<SharedLiveMedia />', () => {
       headers: {
         Authorization: 'Bearer json web token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'POST',
     });
@@ -226,6 +227,7 @@ describe('<SharedLiveMedia />', () => {
       headers: {
         Authorization: 'Bearer json web token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'DELETE',
     });
@@ -305,6 +307,7 @@ describe('<SharedLiveMedia />', () => {
       headers: {
         Authorization: 'Bearer json web token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'DELETE',
     });

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/ToolsAndApplications/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/ToolsAndApplications/index.spec.tsx
@@ -88,6 +88,7 @@ describe('<ToolsAndApplications />', () => {
       headers: {
         Authorization: 'Bearer json web token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify({
@@ -132,6 +133,7 @@ describe('<ToolsAndApplications />', () => {
       headers: {
         Authorization: 'Bearer json web token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify({
@@ -174,6 +176,7 @@ describe('<ToolsAndApplications />', () => {
       headers: {
         Authorization: 'Bearer json web token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify({
@@ -262,6 +265,7 @@ describe('<ToolsAndApplications />', () => {
       headers: {
         Authorization: 'Bearer json web token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify({
@@ -305,6 +309,7 @@ describe('<ToolsAndApplications />', () => {
       headers: {
         Authorization: 'Bearer json web token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify({

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/UploadSubtitles/ToggleSubtitlesAsTranscript/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/UploadSubtitles/ToggleSubtitlesAsTranscript/index.spec.tsx
@@ -151,6 +151,7 @@ describe('<ToggleSubtitlesAsTranscript />', () => {
       headers: {
         'Content-Type': 'application/json',
         Authorization: 'Bearer json web token',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: '{"should_use_subtitle_as_transcript":true}',
@@ -185,6 +186,7 @@ describe('<ToggleSubtitlesAsTranscript />', () => {
       headers: {
         'Content-Type': 'application/json',
         Authorization: 'Bearer json web token',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: '{"should_use_subtitle_as_transcript":false}',

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/VisibilityAndInteraction/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/VisibilityAndInteraction/index.spec.tsx
@@ -121,6 +121,7 @@ describe('<VisibilityAndInteraction />', () => {
       headers: {
         Authorization: 'Bearer json web token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify({
@@ -295,6 +296,7 @@ describe('<VisibilityAndInteraction />', () => {
       headers: {
         Authorization: 'Bearer json web token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify({
@@ -356,6 +358,7 @@ describe('<VisibilityAndInteraction />', () => {
       headers: {
         Authorization: 'Bearer json web token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: JSON.stringify({

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/WidgetThumbnail/ThumbnailRemoveButton/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/WidgetThumbnail/ThumbnailRemoveButton/index.spec.tsx
@@ -78,6 +78,7 @@ describe('<ThumbnailRemoveButton />', () => {
       headers: {
         Authorization: 'Bearer json web token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'DELETE',
     });
@@ -120,6 +121,7 @@ describe('<ThumbnailRemoveButton />', () => {
       headers: {
         Authorization: 'Bearer json web token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'DELETE',
     });

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/wrappers/SharedLiveMediaModalWrapper/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/wrappers/SharedLiveMediaModalWrapper/index.spec.tsx
@@ -105,6 +105,7 @@ describe('<SharedLiveMediaModalWrapper />', () => {
       headers: {
         Authorization: 'Bearer json web token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'DELETE',
     });
@@ -147,6 +148,7 @@ describe('<SharedLiveMediaModalWrapper />', () => {
       headers: {
         Authorization: 'Bearer json web token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'DELETE',
     });

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/wrappers/TimedTrackModalWrapper/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/wrappers/TimedTrackModalWrapper/index.spec.tsx
@@ -102,6 +102,7 @@ describe('<TimedTrackModalWrapper />', () => {
       headers: {
         Authorization: 'Bearer json web token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'DELETE',
     });
@@ -142,6 +143,7 @@ describe('<TimedTrackModalWrapper />', () => {
       headers: {
         Authorization: 'Bearer json web token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'DELETE',
     });

--- a/src/frontend/packages/lib_video/src/components/common/VideoWizard/CreateVOD/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWizard/CreateVOD/index.spec.tsx
@@ -460,6 +460,7 @@ describe('<CreateVOD />', () => {
       headers: {
         'Content-Type': 'application/json',
         Authorization: 'Bearer json web token',
+        'Accept-Language': 'en',
       },
       method: 'PATCH',
       body: '{"title":"video title","license":"CC_BY"}',

--- a/src/frontend/packages/lib_video/src/hooks/useVideoStats/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/hooks/useVideoStats/index.spec.tsx
@@ -28,6 +28,7 @@ describe('useStatsVideo', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
     });
     expect(result.current.data).toEqual({ nb_views: 123 });
@@ -50,6 +51,7 @@ describe('useStatsVideo', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
     });
     expect(result.current.data).toEqual(undefined);

--- a/src/frontend/packages/lib_video/src/utils/conversejs/converse-plugins/marshaJoinDiscussionPlugin/handler.spec.ts
+++ b/src/frontend/packages/lib_video/src/utils/conversejs/converse-plugins/marshaJoinDiscussionPlugin/handler.spec.ts
@@ -74,6 +74,7 @@ describe('marshaJoinDiscussionPluginHandler', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'POST',
       body: JSON.stringify({
@@ -113,6 +114,7 @@ describe('marshaJoinDiscussionPluginHandler', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'POST',
       body: JSON.stringify(targetParticipant),
@@ -199,6 +201,7 @@ describe('marshaJoinDiscussionPluginHandler', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'DELETE',
       body: JSON.stringify(targetParticipant),
@@ -254,6 +257,7 @@ describe('marshaJoinDiscussionPluginHandler', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'DELETE',
       body: JSON.stringify(targetParticipant),
@@ -289,6 +293,7 @@ describe('marshaJoinDiscussionPluginHandler', () => {
       headers: {
         Authorization: 'Bearer some token',
         'Content-Type': 'application/json',
+        'Accept-Language': 'en',
       },
       method: 'DELETE',
       body: JSON.stringify({


### PR DESCRIPTION
## Purpose

During an http request, the language sent to the backend was the browser one, we now send the language setted in the app to get some possible backend messages internationalized.

## Proposal

Description...

- [x] Add `Accept-Language` to the header from the `fetchWrapper`
- [x] Tests


[Marsha (7).webm](https://github.com/openfun/marsha/assets/25994652/fca09c36-d80e-49b7-93d7-3c2e82908607)

## Review

The main changes are [here](https://github.com/openfun/marsha/pull/2394/files#diff-beffe461d2ec10971ecde5ff6a8329e3162946cb14f12eed5e21706c9a3fb137R18-R25) and [here](https://github.com/openfun/marsha/pull/2394/files#diff-a80694f12256f1d8870174265a1ff5676a3adaea7e8fd8a7bde7444bb8687420R57-R80).

