### PR TITLE
🩹(backend) check for playlist claimability when claiming

### DIFF
--- a/src/backend/marsha/core/api/playlist.py
+++ b/src/backend/marsha/core/api/playlist.py
@@ -155,6 +155,8 @@ class PlaylistViewSet(APIViewMixin, ObjectPkMixin, viewsets.ModelViewSet):
     def claim(self, request, *args, **kwargs):
         """Claim a playlist by creating a PlaylistAccess."""
         playlist = self.get_object()
+        if not playlist.is_claimable:
+            return Response(status=status.HTTP_403_FORBIDDEN)
         playlist_access_exists = PlaylistAccess.objects.filter(
             playlist=playlist,
         ).exists()

--- a/src/backend/marsha/core/serializers/playlist.py
+++ b/src/backend/marsha/core/serializers/playlist.py
@@ -28,6 +28,7 @@ class PlaylistSerializer(serializers.ModelSerializer):
             "is_portable_to_playlist",
             "is_portable_to_consumer_site",
             "is_public",
+            "is_claimable",
             "lti_id",
             "organization",
             "portable_to",

--- a/src/backend/marsha/core/tests/api/playlists/test_create.py
+++ b/src/backend/marsha/core/tests/api/playlists/test_create.py
@@ -120,6 +120,7 @@ class PlaylistCreateAPITest(TestCase):
                 "is_portable_to_playlist": False,
                 "is_portable_to_consumer_site": False,
                 "is_public": False,
+                "is_claimable": False,
                 "lti_id": "playlist_twenty",
                 "organization": {
                     "id": str(org.id),
@@ -182,6 +183,7 @@ class PlaylistCreateAPITest(TestCase):
                 "is_portable_to_playlist": False,
                 "is_portable_to_consumer_site": False,
                 "is_public": False,
+                "is_claimable": False,
                 "lti_id": "playlist_twenty",
                 "organization": {
                     "id": str(org.id),

--- a/src/backend/marsha/core/tests/api/playlists/test_list.py
+++ b/src/backend/marsha/core/tests/api/playlists/test_list.py
@@ -94,6 +94,7 @@ class PlaylistListAPITest(TestCase):
                     "is_portable_to_consumer_site": False,
                     "is_portable_to_playlist": True,
                     "is_public": False,
+                    "is_claimable": True,
                     "lti_id": "playlist#two",
                     "organization": {
                         "id": str(org_2.id),
@@ -120,6 +121,7 @@ class PlaylistListAPITest(TestCase):
                     "is_portable_to_consumer_site": False,
                     "is_portable_to_playlist": True,
                     "is_public": False,
+                    "is_claimable": True,
                     "lti_id": "playlist#one",
                     "organization": {
                         "id": str(org_1.id),
@@ -198,6 +200,7 @@ class PlaylistListAPITest(TestCase):
                     "is_portable_to_consumer_site": False,
                     "is_portable_to_playlist": True,
                     "is_public": False,
+                    "is_claimable": True,
                     "lti_id": "playlist#eleven",
                     "organization": {
                         "id": str(org_1.id),
@@ -285,6 +288,7 @@ class PlaylistListAPITest(TestCase):
                     "is_portable_to_consumer_site": False,
                     "is_portable_to_playlist": True,
                     "is_public": False,
+                    "is_claimable": True,
                     "lti_id": "playlist#five",
                     "organization": None,
                     "portable_to": [],
@@ -308,6 +312,7 @@ class PlaylistListAPITest(TestCase):
                     "is_portable_to_consumer_site": False,
                     "is_portable_to_playlist": True,
                     "is_public": False,
+                    "is_claimable": True,
                     "lti_id": "playlist#four",
                     "organization": None,
                     "portable_to": [],
@@ -331,6 +336,7 @@ class PlaylistListAPITest(TestCase):
                     "is_portable_to_consumer_site": False,
                     "is_portable_to_playlist": True,
                     "is_public": False,
+                    "is_claimable": True,
                     "lti_id": "playlist#three",
                     "organization": {
                         "id": str(org_2.id),
@@ -357,6 +363,7 @@ class PlaylistListAPITest(TestCase):
                     "is_portable_to_consumer_site": False,
                     "is_portable_to_playlist": True,
                     "is_public": False,
+                    "is_claimable": True,
                     "lti_id": "playlist#one",
                     "organization": {
                         "id": str(org_1.id),
@@ -477,6 +484,7 @@ class PlaylistListAPITest(TestCase):
                     "is_portable_to_consumer_site": False,
                     "is_portable_to_playlist": True,
                     "is_public": False,
+                    "is_claimable": True,
                     "lti_id": "playlist#one",
                     "organization": {
                         "id": str(org_1.id),
@@ -503,6 +511,7 @@ class PlaylistListAPITest(TestCase):
                     "is_portable_to_consumer_site": False,
                     "is_portable_to_playlist": True,
                     "is_public": False,
+                    "is_claimable": True,
                     "lti_id": "playlist#three",
                     "organization": {
                         "id": str(org_2.id),
@@ -529,6 +538,7 @@ class PlaylistListAPITest(TestCase):
                     "is_portable_to_consumer_site": False,
                     "is_portable_to_playlist": True,
                     "is_public": False,
+                    "is_claimable": True,
                     "lti_id": "playlist#four",
                     "organization": None,
                     "portable_to": [],

--- a/src/backend/marsha/core/tests/api/playlists/test_retrieve.py
+++ b/src/backend/marsha/core/tests/api/playlists/test_retrieve.py
@@ -107,6 +107,7 @@ class PlaylistRetrieveAPITest(TestCase):
                 "is_portable_to_consumer_site": False,
                 "is_portable_to_playlist": True,
                 "is_public": False,
+                "is_claimable": True,
                 "lti_id": playlist.lti_id,
                 "organization": None,
                 "portable_to": [],
@@ -148,6 +149,7 @@ class PlaylistRetrieveAPITest(TestCase):
                 "is_portable_to_consumer_site": False,
                 "is_portable_to_playlist": True,
                 "is_public": False,
+                "is_claimable": True,
                 "lti_id": playlist.lti_id,
                 "organization": {
                     "id": str(organization.id),

--- a/src/frontend/apps/lti_site/components/App/AppContentLoader/index.tsx
+++ b/src/frontend/apps/lti_site/components/App/AppContentLoader/index.tsx
@@ -10,6 +10,7 @@ import {
   ResourceContext,
   User,
   appNames,
+  retryQuery,
   useAppConfig,
   useCurrentSession,
   useCurrentUser,
@@ -117,7 +118,14 @@ const AppContent = () => {
 const AppContentLoader = () => {
   const appData = useAppConfig();
   const [isLoaded, setIsLoaded] = useState(false);
-  const queryClient = new QueryClient();
+
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: retryQuery,
+      },
+    },
+  });
 
   //  load it from the store to prevent having a dependency and recompute decodedJwt
   const decodedJwt = useMemo(() => {

--- a/src/frontend/apps/standalone_site/src/features/App/App.tsx
+++ b/src/frontend/apps/standalone_site/src/features/App/App.tsx
@@ -2,6 +2,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { Grommet } from 'grommet';
 import { colors } from 'lib-common';
+import { retryQuery } from 'lib-components';
 import { Toaster } from 'react-hot-toast';
 import { BrowserRouter } from 'react-router-dom';
 
@@ -11,7 +12,13 @@ import AppConfig from './AppConfig';
 import AppRoutes from './AppRoutes';
 
 const themeExtended = getFullThemeExtend();
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: retryQuery,
+    },
+  },
+});
 
 const App = () => {
   return (

--- a/src/frontend/packages/lib_components/src/utils/index.ts
+++ b/src/frontend/packages/lib_components/src/utils/index.ts
@@ -9,6 +9,7 @@ export * from './localstorage';
 export * from './serviceWorker';
 export * from './system';
 export * from './tests/factories';
+export * from './retryQuery';
 export * from './router';
 export * from './truncateFilename';
 export * from './useFetchButton';

--- a/src/frontend/packages/lib_components/src/utils/retryQuery.spec.ts
+++ b/src/frontend/packages/lib_components/src/utils/retryQuery.spec.ts
@@ -1,0 +1,48 @@
+import { FetchResponseError } from '@lib-components/utils/errors/exception';
+
+import { retryQuery } from './retryQuery';
+
+describe('retryQuery', () => {
+  it('should retry on non-403 errors', () => {
+    const shouldRetry = retryQuery(
+      1,
+      new FetchResponseError({
+        status: 500,
+        code: 'invalid',
+        message: 'Internal error',
+        response: {} as Response,
+      }),
+    );
+    expect(shouldRetry).toBe(true);
+  });
+
+  it('should not retry on FetchResponseError 403 errors', () => {
+    const shouldRetry = retryQuery(
+      1,
+      new FetchResponseError({
+        status: 403,
+        code: 'invalid',
+        message: 'Unauthorized',
+        response: {} as Response,
+      }),
+    );
+    expect(shouldRetry).toBe(false);
+  });
+
+  it('should not retry on 500 errors after 3 failures', () => {
+    // loop 4 times
+    for (let failureCount = 0; failureCount < 4; failureCount++) {
+      const shouldRetry = retryQuery(
+        failureCount,
+        new FetchResponseError({
+          status: 500,
+          code: 'invalid',
+          message: 'Internal error',
+          response: {} as Response,
+        }),
+      );
+      const expectedShouldRetry = failureCount < 3;
+      expect(shouldRetry).toBe(expectedShouldRetry);
+    }
+  });
+});

--- a/src/frontend/packages/lib_components/src/utils/retryQuery.ts
+++ b/src/frontend/packages/lib_components/src/utils/retryQuery.ts
@@ -1,0 +1,16 @@
+import { FetchResponseError } from './errors/exception';
+
+type ShouldRetryFunction<TError> = (
+  failureCount: number,
+  error: TError,
+) => boolean;
+
+export const retryQuery: ShouldRetryFunction<unknown> = (
+  failureCount: number,
+  error,
+) => {
+  if (error instanceof FetchResponseError && error.status === 403) {
+    return false;
+  }
+  return failureCount < 3;
+};


### PR DESCRIPTION
## Purpose

When we introduced playlist.is_claimable, we forgot to check this attribute on playlist claim API endpoint.

## Proposal

- When calling playlist claim endpoint, raise a 403 if playlist is not claimable.
- Don't retry frontend queries if we got a 403 response from API.
- Add is_claimable to playlist serializer
