### PR TITLE
✨ replace grommet select by cunningham select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Save license when a video is created
 
+### Changed
+
+- Replace grommet Select by Cunningham Select (#2400)
+
 ## [4.4.0] - 2023-09-08
 
 ### Added

--- a/src/frontend/apps/lti_site/apps/deposit/components/Dashboard/DashboardInstructor/index.spec.tsx
+++ b/src/frontend/apps/lti_site/apps/deposit/components/Dashboard/DashboardInstructor/index.spec.tsx
@@ -214,7 +214,7 @@ describe('<DashboardInstructor />', () => {
       },
     );
 
-    const fileFilter = screen.getByRole('button', { name: /Filter files/i });
+    const fileFilter = screen.getByRole('combobox', { name: /Filter files/i });
     await userEvent.click(fileFilter);
     await userEvent.click(
       await screen.findByRole('option', { name: 'Unread' }),

--- a/src/frontend/apps/lti_site/apps/deposit/components/Dashboard/DashboardInstructor/index.tsx
+++ b/src/frontend/apps/lti_site/apps/deposit/components/Dashboard/DashboardInstructor/index.tsx
@@ -1,4 +1,5 @@
-import { Box, Heading, Pagination, Paragraph, Select, Text } from 'grommet';
+import { Select } from '@openfun/cunningham-react';
+import { Box, Heading, Pagination, Paragraph, Text } from 'grommet';
 import { Maybe } from 'lib-common';
 import { FileDepository, Loader } from 'lib-components';
 import React, { FocusEvent, useState } from 'react';
@@ -9,6 +10,8 @@ import {
   useDepositedFiles,
   useUpdateFileDepository,
 } from 'apps/deposit/data/queries';
+
+type SelectProps = React.ComponentPropsWithoutRef<typeof Select>;
 
 const PAGE_SIZE = 10;
 
@@ -77,7 +80,7 @@ export const DashboardInstructor = ({
   const [indices, setIndices] = useState([0, PAGE_SIZE]);
   const [readFilter, setReadFilter] = useState<Maybe<string>>(undefined);
 
-  const { data, isError, isLoading, refetch } = useDepositedFiles(
+  const { data, isError, isLoading } = useDepositedFiles(
     fileDepository.id,
     {
       limit: `${PAGE_SIZE}`,
@@ -103,9 +106,8 @@ export const DashboardInstructor = ({
     },
   ];
 
-  const onReadFilterChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
-    setReadFilter(event.target.value);
-    refetch();
+  const onReadFilterChange: SelectProps['onChange'] = (event) => {
+    setReadFilter(event.target.value as Maybe<string>);
   };
 
   const { mutate } = useUpdateFileDepository(fileDepository.id);
@@ -190,17 +192,11 @@ export const DashboardInstructor = ({
                 pad="medium"
               >
                 <Select
-                  a11yTitle={intl.formatMessage(messages.readFilterTitle)}
-                  id="readFilterSelect"
-                  name="read"
-                  placeholder={intl.formatMessage(
-                    messages.readFilterPlaceholder,
-                  )}
-                  value={readFilter}
-                  options={readFilterOptions}
-                  labelKey="label"
-                  valueKey={{ key: 'value', reduce: true }}
+                  aria-label={intl.formatMessage(messages.readFilterTitle)}
+                  label={intl.formatMessage(messages.readFilterTitle)}
                   onChange={onReadFilterChange}
+                  options={readFilterOptions}
+                  value={readFilter}
                 />
                 <Text>
                   <FormattedMessage

--- a/src/frontend/apps/lti_site/apps/markdown/components/MarkdownWizard/index.spec.tsx
+++ b/src/frontend/apps/lti_site/apps/markdown/components/MarkdownWizard/index.spec.tsx
@@ -111,7 +111,7 @@ describe('MarkdownWizard', () => {
       'Mon titre',
     );
     await userEvent.click(
-      screen.getByRole('button', { name: /Select language/i }),
+      screen.getByRole('combobox', { name: /Select language/i }),
     );
     await userEvent.click(
       await screen.findByRole('option', { name: /French/i }),

--- a/src/frontend/apps/lti_site/apps/markdown/components/MarkdownWizard/index.tsx
+++ b/src/frontend/apps/lti_site/apps/markdown/components/MarkdownWizard/index.tsx
@@ -100,12 +100,14 @@ export const MarkdownWizard = ({ markdownDocumentId }: MarkdownWizardProps) => {
               maxLength={255}
               onChange={(event) => setLocalTitle(event.target.value)}
               value={localTitle}
+              fullWidth
             />
           </Box>
           <LanguageSelector
             currentLanguage={language}
             onLanguageChange={setLanguage}
             disabled={false}
+            fullWidth
           />
 
           <Button

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Video/components/Manage/VideoCreateForm.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Video/components/Manage/VideoCreateForm.spec.tsx
@@ -111,9 +111,12 @@ describe('<VideoCreateForm />', () => {
       screen.getByText('Add a video or drag & drop it'),
     ).toBeInTheDocument();
     expect(
-      await screen.findByRole('button', {
-        name: 'Select the license under which you want to publish your video; Selected: CC_BY',
+      await screen.findByRole('combobox', {
+        name: 'Select the license',
       }),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText('Creative Common By Attribution'),
     ).toBeInTheDocument();
     expect(
       screen.getByRole('button', { name: /Add Video/i }),
@@ -147,9 +150,12 @@ describe('<VideoCreateForm />', () => {
       screen.getByText('Add a video or drag & drop it'),
     ).toBeInTheDocument();
     expect(
-      await screen.findByRole('button', {
-        name: 'Select the license under which you want to publish your video; Selected: CC_BY',
+      await screen.findByRole('combobox', {
+        name: 'Select the license',
       }),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText('Creative Common By Attribution'),
     ).toBeInTheDocument();
     expect(
       screen.getByRole('button', { name: /Add Video/i }),
@@ -254,9 +260,13 @@ describe('<VideoCreateForm />', () => {
     ).toBeInTheDocument();
 
     expect(
-      await screen.findByRole('button', {
-        name: 'Select the license under which you want to publish your video; Selected: CC_BY',
+      await screen.findByRole('combobox', {
+        name: 'Select the license',
       }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText('Creative Common By Attribution'),
     ).toBeInTheDocument();
 
     const hiddenInput = screen.getByTestId('input-video-test-id');
@@ -334,9 +344,13 @@ describe('<VideoCreateForm />', () => {
     ).toBeInTheDocument();
 
     expect(
-      await screen.findByRole('button', {
-        name: 'Select the license under which you want to publish your video; Selected: CC_BY',
+      await screen.findByRole('combobox', {
+        name: 'Select the license',
       }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText('Creative Common By Attribution'),
     ).toBeInTheDocument();
 
     const hiddenInput = screen.getByTestId('input-video-test-id');

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Video/components/Manage/VideoCreateForm.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Video/components/Manage/VideoCreateForm.tsx
@@ -191,19 +191,13 @@ const VideoCreateForm = () => {
             videoUploadState={newVideo?.upload_state}
           />
 
-          <FormField
-            label={intl.formatMessage(messages.licenseLabel)}
-            htmlFor="select-license-id"
-            name="license"
-            required
-            margin={{ vertical: 'small' }}
-          >
+          <Field className="mt-s" fullWidth>
             <LicenseSelect
               onChange={(option) =>
                 setVideo((_video) => ({ ..._video, license: option.value }))
               }
             />
-          </FormField>
+          </Field>
         </Box>
 
         <ModalButton

--- a/src/frontend/apps/standalone_site/src/features/Playlist/components/CreatePlaylistForm.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Playlist/components/CreatePlaylistForm.spec.tsx
@@ -91,21 +91,17 @@ describe('<CreatePlaylistForm />', () => {
 
     expect(await screen.findByText('Create a playlist')).toBeInTheDocument();
 
-    await userEvent.click(
-      await screen.findByRole('button', { name: 'Open Drop; Selected: id' }),
-    );
+    expect(screen.getByText('org')).toBeInTheDocument();
 
     await userEvent.click(
-      await screen.findByRole('option', { name: 'other-org' }),
-    );
-
-    expect(
-      await screen.findByRole('button', {
-        name: 'Open Drop; Selected: other-id',
+      screen.getByRole('combobox', {
+        name: 'Organization',
       }),
-    ).toBeInTheDocument();
-    expect(screen.getByDisplayValue('other-org')).toBeInTheDocument();
-    expect(screen.queryByDisplayValue('org')).not.toBeInTheDocument();
+    );
+    await userEvent.click(screen.getByRole('option', { name: 'other-org' }));
+
+    expect(screen.getByText('other-org')).toBeInTheDocument();
+    expect(screen.queryByText('org')).not.toBeInTheDocument();
 
     await userEvent.type(
       screen.getByRole('textbox', { name: 'Name' }),

--- a/src/frontend/apps/standalone_site/src/features/Playlist/components/PlaylistForm.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Playlist/components/PlaylistForm.spec.tsx
@@ -56,7 +56,11 @@ describe('<PlaylistForm />', () => {
     deferred.resolve({ count: 0, results: [] });
 
     await waitForElementToBeRemoved(loader);
-    expect(screen.getByLabelText('Organization*required')).toBeInTheDocument();
+    expect(
+      await screen.findByRole('combobox', {
+        name: 'Organization',
+      }),
+    ).toBeInTheDocument();
     expect(screen.getByLabelText('Name')).toBeInTheDocument();
 
     const submitButton = screen.getByRole('button', { name: 'Save' });
@@ -86,13 +90,11 @@ describe('<PlaylistForm />', () => {
     );
 
     expect(
-      await screen.findByLabelText('Organization*required'),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', {
-        name: 'Open Drop; Selected: first id',
+      await screen.findByRole('combobox', {
+        name: 'Organization',
       }),
     ).toBeInTheDocument();
+    expect(screen.getByText('first organization')).toBeInTheDocument();
     expect(screen.getByLabelText('Name')).toBeInTheDocument();
 
     expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
@@ -132,13 +134,11 @@ describe('<PlaylistForm />', () => {
     );
 
     expect(
-      await screen.findByLabelText('Organization*required'),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', {
-        name: 'Open Drop; Selected: second id',
+      await screen.findByRole('combobox', {
+        name: 'Organization',
       }),
     ).toBeInTheDocument();
+    expect(screen.getByText('second organization')).toBeInTheDocument();
     expect(screen.getByDisplayValue('some initial name')).toBeInTheDocument();
 
     expect(fetchMock.calls().length).toEqual(1);
@@ -178,13 +178,11 @@ describe('<PlaylistForm />', () => {
     );
 
     expect(
-      await screen.findByLabelText('Organization*required'),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', {
-        name: 'Open Drop; Selected: third id',
+      await screen.findByRole('combobox', {
+        name: 'Organization',
       }),
     ).toBeInTheDocument();
+    expect(screen.getByText('third organization')).toBeInTheDocument();
     expect(screen.getByDisplayValue('some initial name')).toBeInTheDocument();
 
     expect(fetchMock.calls().length).toEqual(2);
@@ -225,11 +223,8 @@ describe('<PlaylistForm />', () => {
     );
 
     expect(
-      await screen.findByLabelText('Organization*required'),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', {
-        name: 'Open Drop',
+      await screen.findByRole('combobox', {
+        name: 'Organization',
       }),
     ).toBeInTheDocument();
     expect(screen.getByDisplayValue('some initial name')).toBeInTheDocument();
@@ -276,7 +271,9 @@ describe('<PlaylistForm />', () => {
     );
 
     expect(
-      await screen.findByLabelText('Organization*required'),
+      await screen.findByRole('combobox', {
+        name: 'Organization',
+      }),
     ).toBeInTheDocument();
 
     await userEvent.click(screen.getByRole('button', { name: 'Save' }));
@@ -285,7 +282,7 @@ describe('<PlaylistForm />', () => {
     expect(mockedOnSubmit).toHaveBeenCalledWith({
       name: 'some initial name',
       organizationId: 'third id',
-      retention_duration: 365,
+      retention_duration: '365',
     });
 
     await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
@@ -328,7 +325,9 @@ describe('<PlaylistForm />', () => {
     );
     await userEvent.click(screen.getByRole('button', { name: 'Retry' }));
     expect(
-      await screen.findByLabelText('Organization*required'),
+      await screen.findByRole('combobox', {
+        name: 'Organization',
+      }),
     ).toBeInTheDocument();
   });
 
@@ -358,13 +357,11 @@ describe('<PlaylistForm />', () => {
     );
 
     expect(
-      await screen.findByLabelText('Organization*required'),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', {
-        name: 'Open Drop; Selected: first id',
+      await screen.findByRole('combobox', {
+        name: 'Organization',
       }),
     ).toBeInTheDocument();
+    expect(screen.getByText('first organization')).toBeInTheDocument();
     expect(screen.getByLabelText('Name')).toBeInTheDocument();
     expect(screen.getByDisplayValue('some initial name')).toBeInTheDocument();
 
@@ -374,11 +371,7 @@ describe('<PlaylistForm />', () => {
       screen.queryByRole('button', { name: 'Delete playlist' }),
     ).not.toBeInTheDocument();
 
-    await userEvent.click(
-      screen.getByRole('button', {
-        name: 'Open Drop; Selected: first id',
-      }),
-    );
+    await userEvent.click(screen.getByText('first organization'));
     await userEvent.click(
       await screen.findByRole('option', { name: 'second organization' }),
     );
@@ -389,11 +382,7 @@ describe('<PlaylistForm />', () => {
       'an other awesome name',
     );
 
-    expect(
-      await screen.findByRole('button', {
-        name: 'Open Drop; Selected: second id',
-      }),
-    ).toBeInTheDocument();
+    expect(screen.getByText('second organization')).toBeInTheDocument();
     expect(
       await screen.findByDisplayValue('an other awesome name'),
     ).toBeInTheDocument();
@@ -403,13 +392,11 @@ describe('<PlaylistForm />', () => {
     await waitFor(() => expect(mockedOnCancel).toHaveBeenCalled());
 
     expect(
-      await screen.findByLabelText('Organization*required'),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', {
-        name: 'Open Drop; Selected: first id',
+      await screen.findByRole('combobox', {
+        name: 'Organization',
       }),
     ).toBeInTheDocument();
+    expect(screen.getByText('first organization')).toBeInTheDocument();
     expect(screen.getByLabelText('Name')).toBeInTheDocument();
     expect(screen.getByDisplayValue('some initial name')).toBeInTheDocument();
   });
@@ -433,13 +420,11 @@ describe('<PlaylistForm />', () => {
     );
 
     expect(
-      await screen.findByLabelText('Organization*required'),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', {
-        name: 'Open Drop; Selected: first id',
+      await screen.findByRole('combobox', {
+        name: 'Organization',
       }),
     ).toBeInTheDocument();
+    expect(screen.getByText('first organization')).toBeInTheDocument();
     expect(screen.getByLabelText('Name')).toBeInTheDocument();
 
     expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
@@ -470,13 +455,11 @@ describe('<PlaylistForm />', () => {
     );
 
     expect(
-      await screen.findByLabelText('Organization*required'),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', {
-        name: 'Open Drop; Selected: first id',
+      await screen.findByRole('combobox', {
+        name: 'Organization',
       }),
     ).toBeInTheDocument();
+    expect(screen.getByText('first organization')).toBeInTheDocument();
     expect(screen.getByLabelText('Name')).toBeInTheDocument();
 
     const deleteButton = screen.getByRole('button', {
@@ -517,13 +500,11 @@ describe('<PlaylistForm />', () => {
     );
 
     expect(
-      await screen.findByLabelText('Organization*required'),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', {
-        name: 'Open Drop; Selected: first id',
+      await screen.findByRole('combobox', {
+        name: 'Organization',
       }),
     ).toBeInTheDocument();
+    expect(screen.getByText('first organization')).toBeInTheDocument();
     expect(screen.getByLabelText('Name')).toBeInTheDocument();
 
     const deleteButton = screen.getByRole('button', {
@@ -561,13 +542,11 @@ describe('<PlaylistForm />', () => {
     );
 
     expect(
-      await screen.findByLabelText('Organization*required'),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', {
-        name: 'Open Drop; Selected: first id',
+      await screen.findByRole('combobox', {
+        name: 'Organization',
       }),
     ).toBeInTheDocument();
+    expect(screen.getByText('first organization')).toBeInTheDocument();
     expect(screen.getByLabelText('Name')).toBeInTheDocument();
 
     const deleteButton = screen.getByRole('button', {

--- a/src/frontend/apps/standalone_site/src/features/Playlist/components/PlaylistForm.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Playlist/components/PlaylistForm.tsx
@@ -1,12 +1,10 @@
-import { Input } from '@openfun/cunningham-react';
-import { Box, Button, Heading, Select, Text, ThemeContext } from 'grommet';
+import { Input, Select } from '@openfun/cunningham-react';
+import { Box, Button, Heading, Text, ThemeContext } from 'grommet';
 import { Nullable } from 'lib-common';
 import {
   ButtonLoaderStyle,
   FetchResponseError,
   Form,
-  FormField,
-  FormHelpText,
   Modal,
   ModalButton,
   Organization,
@@ -80,7 +78,7 @@ const messages = defineMessages({
   },
   playlistRetentionDurationHelper: {
     defaultMessage:
-      'This retention duration is use to know how long related resources will be kept.',
+      'This retention duration is used to know how long related resources will be kept.',
     description: 'Playlist retention duration helper in create playlist form .',
     id: 'feature.Playlist.PlaylistForm.playlistRetentionDurationHelper',
   },
@@ -179,7 +177,7 @@ export const PlaylistForm = ({
   const [formValues, setFormValues] = useState<Partial<PlaylistFormValues>>({
     organizationId: initialValues?.organizationId,
     name: initialValues?.name || '',
-    retention_duration: initialValues?.retention_duration || null,
+    retention_duration: initialValues?.retention_duration,
   });
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const [currentOrganizationPage, setCurrentOrganizationPage] = useState(0);
@@ -268,25 +266,25 @@ export const PlaylistForm = ({
         label: intl.formatMessage(
           messages.playlistRetentionDurationChoiceNoDuration,
         ),
-        value: null,
+        value: '',
       },
       {
         label: intl.formatMessage(
           messages.playlistRetentionDurationChoice30Days,
         ),
-        value: 30,
+        value: '30',
       },
       {
         label: intl.formatMessage(
           messages.playlistRetentionDurationChoice1Year,
         ),
-        value: 365,
+        value: '365',
       },
       {
         label: intl.formatMessage(
           messages.playlistRetentionDurationChoice5years,
         ),
-        value: 365 * 5,
+        value: `${365 * 5}`,
       },
     ],
     [intl],
@@ -365,37 +363,25 @@ export const PlaylistForm = ({
           )}
 
           <Box>
-            <FormField
-              required
-              disabled={!isEditable}
+            <Select
+              aria-label={intl.formatMessage(messages.organizationFieldLabel)}
               label={intl.formatMessage(messages.organizationFieldLabel)}
-              htmlFor="select-organization-id"
-              name="organizationId"
-              margin="0"
-            >
-              <Select
-                disabled={!isEditable}
-                name="organizationId"
-                id="select-organization-id"
-                options={organizations}
-                onMore={() => {
-                  if (!organizationResponse) {
-                    return;
-                  }
-
-                  if (organizations.length < organizationResponse.count) {
-                    setCurrentOrganizationPage(
-                      (currentPage) => currentPage + 1,
-                    );
-                  }
-                }}
-                labelKey="name"
-                valueKey={{ key: 'id', reduce: true }}
-              />
-            </FormField>
-            <FormHelpText>
-              {intl.formatMessage(messages.organizationHelper)}
-            </FormHelpText>
+              disabled={!isEditable}
+              clearable={false}
+              options={organizations.map((organization) => ({
+                label: organization.name,
+                value: organization.id,
+              }))}
+              onChange={(e) => {
+                setFormValues((value) => ({
+                  ...value,
+                  organizationId: e.target.value as string,
+                }));
+              }}
+              fullWidth
+              text={intl.formatMessage(messages.organizationHelper)}
+              value={formValues.organizationId}
+            />
           </Box>
 
           <Input
@@ -416,31 +402,31 @@ export const PlaylistForm = ({
           />
 
           <Box>
-            <FormField
-              disabled={!isEditable}
+            <Select
+              aria-label={intl.formatMessage(
+                messages.playlistRetentionDurationFieldLabel,
+              )}
               label={intl.formatMessage(
                 messages.playlistRetentionDurationFieldLabel,
               )}
-              htmlFor="select-retention_duration-id"
-              name="retention_duration"
-              margin="0"
-            >
-              <Select
-                aria-label={intl.formatMessage(
-                  messages.playlistRetentionDurationFieldLabel,
-                )}
-                defaultValue={retentionDurationChoices[0]}
-                id="select-retention_duration-id"
-                name="retention_duration"
-                labelKey="label"
-                options={retentionDurationChoices}
-                replace={false}
-                valueKey={{ key: 'value', reduce: true }}
-              />
-            </FormField>
-            <FormHelpText>
-              {intl.formatMessage(messages.playlistRetentionDurationHelper)}
-            </FormHelpText>
+              disabled={!isEditable}
+              options={retentionDurationChoices}
+              onChange={(e) => {
+                setFormValues((value) => ({
+                  ...value,
+                  retention_duration: (e.target.value as number) || null,
+                }));
+              }}
+              fullWidth
+              text={intl.formatMessage(
+                messages.playlistRetentionDurationHelper,
+              )}
+              value={
+                formValues.retention_duration
+                  ? `${formValues.retention_duration}`
+                  : undefined
+              }
+            />
           </Box>
         </Box>
         <Box gap="xsmall">

--- a/src/frontend/apps/standalone_site/src/features/Playlist/components/PlaylistPage.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Playlist/components/PlaylistPage.tsx
@@ -10,6 +10,7 @@ import { Modal, Playlist, useResponsive } from 'lib-components';
 import { Fragment, useEffect, useMemo, useState } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import { Route, Routes, useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
 
 import { WhiteCard } from 'components/Cards';
 import { ITEM_PER_PAGE } from 'conf/global';
@@ -66,6 +67,18 @@ const messages = defineMessages({
     id: 'features.Playlist.columnNameOrganization',
   },
 });
+
+export const BoxDatagrid = styled(Box)`
+  .c__datagrid {
+    display: block;
+    overflow: auto;
+  }
+  .c__datagrid td {
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+  }
+`;
 
 /**
  * Clean the data to be displayed in the table
@@ -217,51 +230,57 @@ export const PlaylistPage = () => {
               </Box>
             )}
             {!shouldDisplayNoPlaylistYetMessage && (
-              <DataGrid
-                columns={[
-                  {
-                    field: 'created_on',
-                    headerName: intl.formatMessage(
-                      messages.columnNameCreatedOn,
-                    ),
-                  },
-                  {
-                    field: 'title',
-                    headerName: intl.formatMessage(messages.columnNameTitle),
-                  },
-                  {
-                    enableSorting: false,
-                    field: 'organization',
-                    headerName: intl.formatMessage(
-                      messages.columnNameOrganization,
-                    ),
-                  },
-                  {
-                    id: 'column-actions',
-                    renderCell: ({ row }) => (
-                      <ButtonCunningham
-                        color="tertiary"
-                        aria-label={intl.formatMessage(
-                          messages.updatePlaylist,
-                          {
-                            playlistName: row.title,
-                          },
-                        )}
-                        size="small"
-                        onClick={() => {
-                          navigate(`${routes.PLAYLIST.path}/${row.id}/update`);
-                        }}
-                        icon={<span className="material-icons">settings</span>}
-                      />
-                    ),
-                  },
-                ]}
-                rows={rows}
-                pagination={pagination}
-                sortModel={sortModel}
-                onSortModelChange={setSortModel}
-                isLoading={isLoading}
-              />
+              <BoxDatagrid>
+                <DataGrid
+                  columns={[
+                    {
+                      field: 'created_on',
+                      headerName: intl.formatMessage(
+                        messages.columnNameCreatedOn,
+                      ),
+                    },
+                    {
+                      field: 'title',
+                      headerName: intl.formatMessage(messages.columnNameTitle),
+                    },
+                    {
+                      enableSorting: false,
+                      field: 'organization',
+                      headerName: intl.formatMessage(
+                        messages.columnNameOrganization,
+                      ),
+                    },
+                    {
+                      id: 'column-actions',
+                      renderCell: ({ row }) => (
+                        <ButtonCunningham
+                          color="tertiary"
+                          aria-label={intl.formatMessage(
+                            messages.updatePlaylist,
+                            {
+                              playlistName: row.title,
+                            },
+                          )}
+                          size="small"
+                          onClick={() => {
+                            navigate(
+                              `${routes.PLAYLIST.path}/${row.id}/update`,
+                            );
+                          }}
+                          icon={
+                            <span className="material-icons">settings</span>
+                          }
+                        />
+                      ),
+                    },
+                  ]}
+                  rows={rows}
+                  pagination={pagination}
+                  sortModel={sortModel}
+                  onSortModelChange={setSortModel}
+                  isLoading={isLoading}
+                />
+              </BoxDatagrid>
             )}
           </Fragment>
         </WhiteCard>

--- a/src/frontend/apps/standalone_site/src/features/Playlist/features/UpdatePlaylist/api/useUpdatePlaylistAccess/index.ts
+++ b/src/frontend/apps/standalone_site/src/features/Playlist/features/UpdatePlaylist/api/useUpdatePlaylistAccess/index.ts
@@ -1,8 +1,4 @@
-import {
-  UseMutationOptions,
-  useMutation,
-  useQueryClient,
-} from '@tanstack/react-query';
+import { UseMutationOptions, useMutation } from '@tanstack/react-query';
 import { updateOne } from 'lib-components';
 
 import { PlaylistAccess, PlaylistRole } from '../../types/playlistAccess';
@@ -17,7 +13,7 @@ type UseUpdatePlaylistAccessError =
       errors: { [key in keyof UseUpdatePlaylistAccessData]?: string[] };
     }[];
 
-export const useUpdatePlaylistAcess = (
+export const useUpdatePlaylistAccess = (
   id: string,
   options?: UseMutationOptions<
     PlaylistAccess,
@@ -25,7 +21,6 @@ export const useUpdatePlaylistAcess = (
     UseUpdatePlaylistAccessData
   >,
 ) => {
-  const queryClient = useQueryClient();
   return useMutation<
     PlaylistAccess,
     UseUpdatePlaylistAccessError,
@@ -39,7 +34,6 @@ export const useUpdatePlaylistAcess = (
       }),
     ...options,
     onSuccess: (data, variables, context) => {
-      queryClient.invalidateQueries(['playlist-accesses']);
       options?.onSuccess?.(data, variables, context);
     },
   });

--- a/src/frontend/apps/standalone_site/src/features/Playlist/features/UpdatePlaylist/components/AddUserAccessForm.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Playlist/features/UpdatePlaylist/components/AddUserAccessForm.spec.tsx
@@ -72,7 +72,9 @@ describe('AddUserAccessForm', () => {
     await userEvent.click(
       screen.getByRole('button', { name: 'Add user User 1 in playlist' }),
     );
-    await userEvent.click(screen.getByRole('button', { name: /Select role/i }));
+    await userEvent.click(
+      screen.getByRole('combobox', { name: /Select role/i }),
+    );
     await userEvent.click(
       await screen.findByRole('option', { name: /Instructor/i }),
     );
@@ -153,7 +155,9 @@ describe('AddUserAccessForm', () => {
     await userEvent.click(
       screen.getByRole('button', { name: 'Add user User 1 in playlist' }),
     );
-    await userEvent.click(screen.getByRole('button', { name: /Select role/i }));
+    await userEvent.click(
+      screen.getByRole('combobox', { name: /Select role/i }),
+    );
     await userEvent.click(
       await screen.findByRole('option', { name: /Instructor/i }),
     );

--- a/src/frontend/apps/standalone_site/src/features/Playlist/features/UpdatePlaylist/components/AddUserAccessForm.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Playlist/features/UpdatePlaylist/components/AddUserAccessForm.tsx
@@ -1,5 +1,5 @@
-import { Input } from '@openfun/cunningham-react';
-import { Box, Heading, Paragraph, Select } from 'grommet';
+import { Input, Select } from '@openfun/cunningham-react';
+import { Box, Heading, Paragraph } from 'grommet';
 import { Nullable } from 'lib-common';
 import { ModalButton } from 'lib-components';
 import { debounce } from 'lodash';
@@ -67,7 +67,7 @@ export const AddUserAccessForm = ({
   const [searchedUser, setSearchedUser] = useState('');
   const [selectedUser, setSelectedUser] = useState<Nullable<UserLite>>(null);
   const [roleValue, setRoleValue] = useState(
-    options.find((option) => option.key === PlaylistRole.STUDENT),
+    options.find((option) => option.value === PlaylistRole.STUDENT),
   );
   const { mutate: createPlaylistAccess } = useCreatePlaylistAccess({
     onSuccess: () => {
@@ -101,17 +101,17 @@ export const AddUserAccessForm = ({
         <Box gap="small">
           <SearchUserListRow user={selectedUser}>
             <Select
-              a11yTitle={intl.formatMessage(messages.roleSelectLabel)}
-              labelKey="label"
-              value={roleValue}
+              aria-label={intl.formatMessage(messages.roleSelectLabel)}
+              label={intl.formatMessage(messages.roleSelectLabel)}
               options={options}
-              onChange={({
-                option,
-              }: {
-                option: { label: string; key: PlaylistRole };
-              }) => {
-                setRoleValue(option);
+              onChange={(evt) => {
+                setRoleValue(
+                  options?.find((option) => option.value === evt.target.value),
+                );
               }}
+              fullWidth
+              value={roleValue?.value}
+              clearable={false}
             />
           </SearchUserListRow>
           <ModalButton
@@ -121,7 +121,7 @@ export const AddUserAccessForm = ({
                 createPlaylistAccess({
                   playlist: playlistId,
                   user: selectedUser.id,
-                  role: roleValue.key,
+                  role: roleValue.value,
                 });
               }
             }}

--- a/src/frontend/apps/standalone_site/src/features/Playlist/features/UpdatePlaylist/components/PlaylistUserList.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Playlist/features/UpdatePlaylist/components/PlaylistUserList.spec.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import fetchMock from 'fetch-mock';
 import { Deferred, render } from 'lib-tests';
@@ -74,7 +74,9 @@ describe('<PlaylistUserList />', () => {
 
     render(<PlaylistUserList playlistId="some-id" />);
 
-    expect(await screen.findByText('sbire 1')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText('sbire 1')).toBeInTheDocument();
+    });
     expect(screen.getByText('sbire 2')).toBeInTheDocument();
     expect(screen.getByText('sbire 3')).toBeInTheDocument();
   });

--- a/src/frontend/apps/standalone_site/src/features/Playlist/features/UpdatePlaylist/components/UpdatePlaylistPage.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Playlist/features/UpdatePlaylist/components/UpdatePlaylistPage.spec.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import fetchMock from 'fetch-mock';
 import { Playlist } from 'lib-components';
@@ -78,13 +78,20 @@ describe('<UpdatePlaylistPage />', () => {
     expect(
       await screen.findByRole('heading', { name: 'Main informations' }),
     ).toBeInTheDocument();
+    expect(await screen.findByText('first orga')).toBeInTheDocument();
     expect(
-      await screen.findByRole('button', {
-        name: 'Open Drop; Selected: id orga',
+      screen.queryByRole('combobox', {
+        name: 'Organization',
       }),
     ).not.toBeDisabled();
     expect(screen.getByDisplayValue('playlist title')).not.toBeDisabled();
-    expect(screen.getByDisplayValue('1 year')).not.toBeDisabled();
+
+    expect(screen.getByText('1 year')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('combobox', {
+        name: 'Retention duration',
+      }),
+    ).not.toBeDisabled();
 
     expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
 
@@ -103,12 +110,6 @@ describe('<UpdatePlaylistPage />', () => {
 
     await userEvent.click(screen.getByRole('button', { name: 'Save' }));
 
-    await waitFor(() =>
-      expect(
-        screen.getByRole('button', { name: 'Open Drop; Selected: id orga' }),
-      ).toBeDisabled(),
-    );
-
     fetchMock.mock('/api/playlists/some-id/', playlist, {
       overwriteRoutes: true,
     });
@@ -117,12 +118,6 @@ describe('<UpdatePlaylistPage />', () => {
     expect(
       await screen.findByText('Playlist updated with success.'),
     ).toBeInTheDocument();
-
-    await waitFor(() =>
-      expect(
-        screen.getByRole('button', { name: 'Open Drop; Selected: id orga' }),
-      ).not.toBeDisabled(),
-    );
 
     expect(
       screen.getByRole('button', { name: 'Delete playlist' }),

--- a/src/frontend/apps/standalone_site/src/features/Playlist/features/UpdatePlaylist/components/UserListRow.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Playlist/features/UpdatePlaylist/components/UserListRow.spec.tsx
@@ -76,17 +76,12 @@ describe('<UserListRow />', () => {
       screen.getByText('my full name (my-email@openfun.fr)'),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('button', { name: /Open Drop/ }),
-    ).toBeInTheDocument();
-    expect(screen.getByRole('textbox')).toHaveValue('Administrator');
-    expect(
       screen.getByRole('button', { name: 'Delete user.' }),
     ).toBeInTheDocument();
 
-    await userEvent.click(screen.getByRole('button', { name: /Open Drop/ }));
-
+    await userEvent.click(screen.getByText('Administrator'));
     expect(
-      await screen.findByRole('option', { name: 'Instructor' }),
+      screen.getByRole('option', { name: 'Instructor' }),
     ).toBeInTheDocument();
     expect(screen.getByRole('option', { name: 'Student' })).toBeInTheDocument();
     expect(
@@ -109,8 +104,7 @@ describe('<UserListRow />', () => {
       />,
     );
 
-    await userEvent.click(screen.getByRole('button', { name: /Open Drop/ }));
-
+    await userEvent.click(screen.getByText('Administrator'));
     const instructorOption = screen.getByRole('option', {
       name: 'Instructor',
     });
@@ -118,7 +112,7 @@ describe('<UserListRow />', () => {
 
     await userEvent.click(instructorOption);
 
-    expect(screen.getByRole('textbox')).toHaveValue('Instructor');
+    expect(screen.getByText('Instructor')).toBeInTheDocument();
     expect(
       await screen.findByText('Right has been updated with success.'),
     ).toBeInTheDocument();
@@ -144,8 +138,9 @@ describe('<UserListRow />', () => {
       />,
     );
 
-    await userEvent.click(screen.getByRole('button', { name: /Open Drop/ }));
+    expect(screen.queryByText('Instructor')).not.toBeInTheDocument();
 
+    await userEvent.click(screen.getByText('Administrator'));
     const instructorOption = screen.getByRole('option', {
       name: 'Instructor',
     });
@@ -153,7 +148,7 @@ describe('<UserListRow />', () => {
 
     await userEvent.click(instructorOption);
 
-    expect(screen.getByRole('textbox')).toHaveValue('Instructor');
+    expect(screen.getByText('Instructor')).toBeInTheDocument();
 
     deferred.reject();
 
@@ -161,7 +156,7 @@ describe('<UserListRow />', () => {
       await screen.findByText('An error occurred while updating the right.'),
     ).toBeInTheDocument();
 
-    expect(screen.getByRole('textbox')).toHaveValue('Administrator');
+    expect(await screen.findByText('Administrator')).toBeInTheDocument();
   });
 
   it('calls for delete', async () => {
@@ -260,8 +255,9 @@ describe('<UserListRow />', () => {
     expect(
       screen.getByText('my full name (my-email@openfun.fr)'),
     ).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Open Drop/ })).toBeDisabled();
-    expect(screen.getByRole('textbox')).toHaveValue('Administrator');
+    const select = screen.getByRole('combobox');
+    expect(select.contains(screen.getByText('Administrator'))).toBeTruthy();
+    expect(select.hasAttribute('disabled')).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Delete user.' })).toBeDisabled();
   });
 });

--- a/src/frontend/apps/standalone_site/src/features/Playlist/features/UpdatePlaylist/components/UserRoleOptions.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Playlist/features/UpdatePlaylist/components/UserRoleOptions.spec.tsx
@@ -8,9 +8,9 @@ describe('UserRoleOptions', () => {
       locale: 'en',
     });
     const expectedOptions = [
-      { label: 'Administrator', key: 'administrator' },
-      { label: 'Instructor', key: 'instructor' },
-      { label: 'Student', key: 'student' },
+      { label: 'Administrator', value: 'administrator' },
+      { label: 'Instructor', value: 'instructor' },
+      { label: 'Student', value: 'student' },
     ];
     expect(userRoleOptions(intl)).toEqual(expectedOptions);
   });

--- a/src/frontend/apps/standalone_site/src/features/Playlist/features/UpdatePlaylist/components/UserRoleOptions.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Playlist/features/UpdatePlaylist/components/UserRoleOptions.tsx
@@ -23,14 +23,14 @@ const messages = defineMessages({
 export const userRoleOptions = (intl: IntlShape) => [
   {
     label: intl.formatMessage(messages.adminLabel),
-    key: PlaylistRole.ADMINISTRATOR,
+    value: PlaylistRole.ADMINISTRATOR,
   },
   {
     label: intl.formatMessage(messages.instructorLabel),
-    key: PlaylistRole.INSTRUCTOR,
+    value: PlaylistRole.INSTRUCTOR,
   },
   {
     label: intl.formatMessage(messages.studentLabel),
-    key: PlaylistRole.STUDENT,
+    value: PlaylistRole.STUDENT,
   },
 ];

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -42,7 +42,7 @@
     "@codemirror/language-data": "6.3.1",
     "@codemirror/state": "6.2.1",
     "@codemirror/view": "6.18.1",
-    "@openfun/cunningham-react": "1.0.1",
+    "@openfun/cunningham-react": "1.1.0",
     "@tanstack/react-query": "4.35.0",
     "@tanstack/react-query-devtools": "4.35.0",
     "@testing-library/jest-dom": "6.1.3",

--- a/src/frontend/packages/lib_classroom/src/components/ClassroomWidgetProvider/widgets/RetentionDate/index.spec.tsx
+++ b/src/frontend/packages/lib_classroom/src/components/ClassroomWidgetProvider/widgets/RetentionDate/index.spec.tsx
@@ -59,7 +59,7 @@ describe('Classroom <RetentionDate />', () => {
       screen.getByTestId('retention-date-picker'),
     ).getByRole('presentation');
 
-    expect(inputRetentionDate).toHaveTextContent('mm/dd/yyyy');
+    expect(inputRetentionDate).toHaveTextContent('MM/DD/YYYY');
 
     const retentionDate = DateTime.local()
       .plus({ days: 1 })

--- a/src/frontend/packages/lib_common/src/cunningham-style.css
+++ b/src/frontend/packages/lib_common/src/cunningham-style.css
@@ -55,7 +55,7 @@ input:-webkit-autofill:focus {
   color: var(--c--theme--colors--primary-500);
   font-size: var(--c--theme--font--size-datagrid-cell);
 }
-.c__datagrid > table th {
+.c__datagrid > table th .c__datagrid__header {
   color: var(--c--theme--colors--primary-500);
   font-weight: var(--c--theme--font--weights-datagrid-header);
   font-size: var(--c--theme--font--size-datagrid-header);

--- a/src/frontend/packages/lib_common/src/cunningham-style.css
+++ b/src/frontend/packages/lib_common/src/cunningham-style.css
@@ -41,17 +41,34 @@ input:-webkit-autofill:focus {
     color 0s 600000s;
 }
 /**
+ * Select
+*/
+.c_select__no_border .c__select .c__select__wrapper,
+.c_select__no_border .c__select .c__select__wrapper:hover, 
+.c_select__no_border .c__select:not(.c__select--disabled) .c__select__wrapper:hover {
+  border: none;
+  box-shadow: none;
+}
+.c__select__wrapper {
+  transition: all var(--c--theme--transitions--duration)
+    var(--c--theme--transitions--ease-out);
+}
+.c__select:not(.c__select--disabled) .c__select__wrapper:hover {
+  box-shadow: var(--c--theme--colors--primary-500) 0px 0px 0px 2px;
+}
+.c__select__menu__item {
+  transition: all var(--c--theme--transitions--duration)
+    var(--c--theme--transitions--ease-out);
+}
+.c__select--disabled .c__select__wrapper label, .c__select--disabled .c__select__wrapper input {
+  background: none;
+}
+/**
  * DataGrid
 */
-.c__datagrid {
-  display: block;
-  overflow: auto;
-}
 .c__datagrid > table td {
   max-width: 10rem;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  white-space: normal;
   color: var(--c--theme--colors--primary-500);
   font-size: var(--c--theme--font--size-datagrid-cell);
 }

--- a/src/frontend/packages/lib_common/src/cunningham-tokens.css
+++ b/src/frontend/packages/lib_common/src/cunningham-tokens.css
@@ -138,5 +138,24 @@
   --c--components--forms-datepicker--border-color--hover: var(
     --c--components--forms-datepicker--border-color
   );
+  /**
+   * Select
+  **/
+  --c--components--forms-select--border-color: var(--c--theme--colors--primary-500);
+  --c--components--forms-select--border-radius--hover: var(
+    --c--components--forms-select--border-radius
+  );
+  --c--components--forms-select--border-radius--focus: var(
+    --c--components--forms-select--border-radius
+  );
+  --c--components--forms-select--color: var(--c--theme--colors--primary-500);
+  --c--components--forms-select--value-color: var(--c--components--forms-select--color);
+  --c--components--forms-select--item-color: var(--c--theme--colors--primary-500);
+  --c--components--forms-select--item-color: var(--c--theme--colors--primary-500);
+  --c--components--forms-select--item-background-color--hover: var(
+    --c--theme--colors--primary-100
+  );
+  --c--components--forms-select--font-size: var(--c--theme--font--sizes--ml);
+  --c--components--forms-select--value-color--disabled: var(--c--theme--colors--greyscale-400);
   --c--components--forms-labelledbox--label-color--big: var(--c--theme--colors--primary-500);
 }

--- a/src/frontend/packages/lib_common/src/cunningham-tokens.css
+++ b/src/frontend/packages/lib_common/src/cunningham-tokens.css
@@ -97,10 +97,19 @@
   --c--theme--transitions--ease-out: cubic-bezier(0.33, 1, 0.68, 1);
   --c--theme--transitions--ease-in-out: cubic-bezier(0.65, 0, 0.35, 1);
   --c--theme--transitions--duration: 250ms;
+ /**
+   * Field
+  **/
   --c--components--forms-field--color: var(--c--theme--colors--primary-500);
+  /**
+   * Datagrid
+  **/
   --c--theme--font--weights-datagrid-header: var(--c--theme--font--weights--extrabold);
   --c--theme--font--size-datagrid-header: var(--c--theme--font--sizes--ml);
   --c--theme--font--size-datagrid-cell: var(--c--theme--font--sizes--ml);
+  /**
+   * Input
+  */
   --c--components--forms-input--border-color: var(--c--theme--colors--primary-500);
   --c--components--forms-input--border-radius--hover: var(
     --c--components--forms-input--border-radius
@@ -110,9 +119,13 @@
   );
   --c--components--forms-input--border-color--hover: var(--c--components--forms-input--border-color);
   --c--components--forms-input--color: var(--c--theme--colors--primary-500);
+  /**
+   * Datepicker
+  **/
   --c--components--forms-datepicker--color: var(
     --c--theme--colors--primary-400
   );
+  --c--components--forms-datepicker--value-color: var(--c--components--forms-datepicker--color);
   --c--components--forms-datepicker--border-color: var(
     --c--theme--colors--primary-500
   );
@@ -125,5 +138,5 @@
   --c--components--forms-datepicker--border-color--hover: var(
     --c--components--forms-datepicker--border-color
   );
-  --c--components--forms-field--color: var(--c--theme--colors--primary-500);
+  --c--components--forms-labelledbox--label-color--big: var(--c--theme--colors--primary-500);
 }

--- a/src/frontend/packages/lib_components/src/common/SchedulingFields/index.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/SchedulingFields/index.spec.tsx
@@ -26,7 +26,7 @@ describe('<SchedulingFields />', () => {
     const inputStartingAtDate = within(
       screen.getByTestId('starting-at-date-picker'),
     ).getByRole('presentation');
-    expect(inputStartingAtDate).toHaveTextContent('mm/dd/yyyy');
+    expect(inputStartingAtDate).toHaveTextContent('MM/DD/YYYY');
 
     const startingAt = DateTime.local()
       .plus({ days: 1 })
@@ -114,7 +114,7 @@ describe('<SchedulingFields />', () => {
       }),
     );
 
-    expect(inputStartingAtDate).toHaveTextContent('mm/dd/yyyy');
+    expect(inputStartingAtDate).toHaveTextContent('MM/DD/YYYY');
 
     expect(onStartingAtChange).toHaveBeenCalledWith(null);
 
@@ -144,7 +144,7 @@ describe('<SchedulingFields />', () => {
     const inputStartingAtDate = within(
       screen.getByTestId('starting-at-date-picker'),
     ).getByRole('presentation');
-    expect(inputStartingAtDate).toHaveTextContent('mm/dd/yyyy');
+    expect(inputStartingAtDate).toHaveTextContent('MM/DD/YYYY');
     await userTypeDatePicker(
       startingAtPast,
       screen.getByText(/Starting date/i),

--- a/src/frontend/packages/lib_components/src/common/Widgets/RetentionDate/index.spec.tsx
+++ b/src/frontend/packages/lib_components/src/common/Widgets/RetentionDate/index.spec.tsx
@@ -43,7 +43,7 @@ describe('RetentionDate', () => {
       screen.getByTestId('retention-date-picker'),
     ).getByRole('presentation');
 
-    expect(inputStartingAtDate).toHaveTextContent('mm/dd/yyyy');
+    expect(inputStartingAtDate).toHaveTextContent('MM/DD/YYYY');
 
     const startingAt = DateTime.local()
       .plus({ days: 1 })
@@ -76,7 +76,7 @@ describe('RetentionDate', () => {
       screen.getByTestId('retention-date-picker'),
     ).getByRole('presentation');
 
-    expect(inputStartingAtDate).toHaveTextContent('mm/dd/yyyy');
+    expect(inputStartingAtDate).toHaveTextContent('MM/DD/YYYY');
 
     const startingAt = DateTime.local()
       .minus({ days: 1 })
@@ -117,6 +117,6 @@ describe('RetentionDate', () => {
     await userEvent.click(deleteButton);
 
     await waitFor(() => expect(mockedOnChange).toHaveBeenCalledTimes(1));
-    expect(inputStartingAtDate).toHaveTextContent('mm/dd/yyyy');
+    expect(inputStartingAtDate).toHaveTextContent('MM/DD/YYYY');
   });
 });

--- a/src/frontend/packages/lib_components/src/utils/tests/factories.ts
+++ b/src/frontend/packages/lib_components/src/utils/tests/factories.ts
@@ -147,7 +147,7 @@ export const videoMockFactory = (video: Partial<Video> = {}): Video => {
     is_public: false,
     join_mode: JoinMode.APPROVAL,
     lti_url: `https://example.com/lti/videos/${id}`,
-    license: 'All rights reserved',
+    license: 'NO_CC',
     show_download: true,
     starting_at: null,
     estimated_duration: null,

--- a/src/frontend/packages/lib_markdown/src/components/LanguageSelector/index.spec.tsx
+++ b/src/frontend/packages/lib_markdown/src/components/LanguageSelector/index.spec.tsx
@@ -18,7 +18,7 @@ describe('<LanguageSelector />', () => {
     );
 
     await userEvent.click(
-      screen.getByRole('button', { name: /Select language/i }),
+      screen.getByRole('combobox', { name: /Select language/i }),
     );
     await userEvent.click(
       await screen.findByRole('option', { name: /French/i }),
@@ -36,7 +36,7 @@ describe('<LanguageSelector />', () => {
     );
 
     await userEvent.click(
-      screen.getByRole('button', { name: /Select language/i }),
+      screen.getByRole('combobox', { name: /Select language/i }),
     );
     await userEvent.click(
       await screen.findByRole('option', { name: /English/i }),
@@ -59,7 +59,7 @@ describe('<LanguageSelector />', () => {
     );
 
     await userEvent.click(
-      screen.getByRole('button', { name: /Select language/i }),
+      screen.getByRole('combobox', { name: /Select language/i }),
     );
 
     expect(screen.queryByText('French')).not.toBeInTheDocument();
@@ -78,7 +78,7 @@ describe('<LanguageSelector />', () => {
     );
 
     await userEvent.click(
-      screen.getByRole('button', { name: /Select language/i }),
+      screen.getByRole('combobox', { name: /Select language/i }),
     );
     await userEvent.click(
       await screen.findByRole('option', { name: /French/i }),

--- a/src/frontend/packages/lib_markdown/src/components/LanguageSelector/index.tsx
+++ b/src/frontend/packages/lib_markdown/src/components/LanguageSelector/index.tsx
@@ -1,5 +1,4 @@
-import { Select } from 'grommet';
-import React from 'react';
+import { Select } from '@openfun/cunningham-react';
 import { defineMessages, useIntl } from 'react-intl';
 
 const messages = defineMessages({
@@ -15,6 +14,7 @@ type LanguageSelectorProps = {
   onLanguageChange: (selectedLanguage: string) => void;
   disabled: boolean;
   availableLanguages?: string[];
+  fullWidth?: boolean;
 };
 
 export const LanguageSelector = ({
@@ -22,6 +22,7 @@ export const LanguageSelector = ({
   onLanguageChange,
   disabled,
   availableLanguages,
+  fullWidth,
 }: LanguageSelectorProps) => {
   const intl = useIntl();
   let languageList = ['en', 'fr']; // may prefer an API call to fetch values
@@ -31,22 +32,23 @@ export const LanguageSelector = ({
     );
   }
 
-  const displayedLanguage = intl.formatDisplayName(currentLanguage, {
-    type: 'language',
-  });
   return (
     <Select
-      margin="xsmall"
-      a11yTitle={intl.formatMessage(messages.selectLanguageLabel)}
-      value={displayedLanguage}
-      disabled={disabled}
+      aria-label={intl.formatMessage(messages.selectLanguageLabel)}
+      label={intl.formatMessage(messages.selectLanguageLabel)}
       options={languageList.map((lang) => ({
-        label: intl.formatDisplayName(lang, { type: 'language' }),
+        label: intl.formatDisplayName(lang, { type: 'language' }) as string,
         value: lang,
       }))}
-      onChange={({ option }: { option: { label: string; value: string } }) => {
-        onLanguageChange(option.value);
+      fullWidth={fullWidth}
+      value={currentLanguage}
+      onChange={(evt) => {
+        if (evt.target.value !== currentLanguage) {
+          onLanguageChange(evt.target.value as string);
+        }
       }}
+      clearable={false}
+      disabled={disabled}
     />
   );
 };

--- a/src/frontend/packages/lib_markdown/src/components/MarkdownEditor/index.spec.tsx
+++ b/src/frontend/packages/lib_markdown/src/components/MarkdownEditor/index.spec.tsx
@@ -159,11 +159,14 @@ describe('<MarkdownEditor />', () => {
     act(() => documentDeferred.resolve(markdownDocument));
 
     await screen.findByDisplayValue(markdownDocument.translations[0].title);
+
+    const selectLanguage = screen.getByRole('combobox', {
+      name: /Select language/i,
+    });
+    expect(selectLanguage).toBeInTheDocument();
     expect(
-      screen.getByRole('button', {
-        name: /Select language; Selected: French/i,
-      }),
-    ).toBeVisible();
+      await within(selectLanguage).findByText('French'),
+    ).toBeInTheDocument();
     await waitFor(() =>
       expect(
         screen.getAllByText(markdownDocument.translations[0].content).length,
@@ -251,7 +254,7 @@ describe('<MarkdownEditor />', () => {
 
     // Change language to fr
     await userEvent.click(
-      screen.getByRole('button', { name: /Select language/i }),
+      screen.getByRole('combobox', { name: /Select language/i }),
     );
     await userEvent.click(
       await screen.findByRole('option', { name: /French/i }),
@@ -591,7 +594,12 @@ describe('<MarkdownEditor />', () => {
       ).toHaveTextContent(`[//]: # (${markdownImageId})`),
     );
 
-    expect(screen.getByRole('status')).toHaveTextContent('cats.gif0%');
+    const status = await screen.findByRole('status', {
+      description: (_, element) =>
+        element?.textContent?.includes('cats.gif') ?? false,
+    });
+
+    expect(status).toHaveTextContent('cats.gif0%');
 
     // Image is uploaded
     fetchMock.get(
@@ -610,15 +618,11 @@ describe('<MarkdownEditor />', () => {
     });
 
     await waitFor(() =>
-      expect(screen.getByRole('status')).toHaveTextContent(
-        'Processing cats.gif',
-      ),
+      expect(status).toHaveTextContent('Processing cats.gif'),
     );
 
     // Image is processed
-    expect(await screen.findByRole('status')).toHaveTextContent(
-      'Uploaded cats.gif',
-    );
+    await waitFor(() => expect(status).toHaveTextContent('Uploaded cats.gif'));
     await waitFor(() =>
       expect(
         container.querySelector('div[class="cm-line"]')!,

--- a/src/frontend/packages/lib_markdown/src/components/MarkdownEditor/index.tsx
+++ b/src/frontend/packages/lib_markdown/src/components/MarkdownEditor/index.tsx
@@ -294,17 +294,18 @@ export const MarkdownEditor = ({ markdownDocumentId }: MarkdownEditorProps) => {
             />
           </Box>
 
-          <Box direction="row">
+          <Box direction="row" align="center">
             <ScreenDispositionSelector
               screenDisposition={screenDisposition}
               setScreenDisposition={setScreenDisposition}
             />
-            <Box flex="grow" />
-            <LanguageSelector
-              currentLanguage={language}
-              onLanguageChange={setLanguage}
-              disabled={contentChanged.current}
-            />
+            <Box flex="grow" margin="xsmall" align="end">
+              <LanguageSelector
+                currentLanguage={language}
+                onLanguageChange={setLanguage}
+                disabled={contentChanged.current}
+              />
+            </Box>
           </Box>
         </Box>
 

--- a/src/frontend/packages/lib_markdown/src/components/MarkdownViewer/index.spec.tsx
+++ b/src/frontend/packages/lib_markdown/src/components/MarkdownViewer/index.spec.tsx
@@ -45,7 +45,7 @@ describe('<MarkdownViewer />', () => {
 
     // Change language to fr
     await userEvent.click(
-      screen.getByRole('button', { name: /Select language/i }),
+      screen.getByRole('combobox', { name: /Select language/i }),
     );
     await userEvent.click(
       await screen.findByRole('option', { name: /French/i }),
@@ -75,7 +75,7 @@ describe('<MarkdownViewer />', () => {
 
     // Change language to fr
     await userEvent.click(
-      screen.getByRole('button', { name: /Select language/i }),
+      screen.getByRole('combobox', { name: /Select language/i }),
     );
     await userEvent.click(
       await screen.findByRole('option', { name: /French/i }),
@@ -127,7 +127,7 @@ describe('<MarkdownViewer />', () => {
 
     // Change language to fr
     await userEvent.click(
-      screen.getByRole('button', { name: /Select language/i }),
+      screen.getByRole('combobox', { name: /Select language/i }),
     );
     await userEvent.click(
       await screen.findByRole('option', { name: /French/i }),

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/LocalizedTimedTextTrackUpload/LanguageSelect/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/LocalizedTimedTextTrackUpload/LanguageSelect/index.spec.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import fetchMock from 'fetch-mock';
 import {
@@ -26,8 +26,6 @@ const languageChoices = [
 ];
 
 describe('<LanguageSelect />', () => {
-  //jest.spyOn(console, 'error').mockImplementation(() => jest.fn());
-
   afterEach(() => {
     fetchMock.restore();
   });
@@ -49,14 +47,10 @@ describe('<LanguageSelect />', () => {
       }),
     );
 
-    screen.getByRole('button', {
-      name: 'Select the language for which you want to upload a timed text file; Selected: fr',
+    const button = await screen.findByRole('combobox', {
+      name: 'Choose the language',
     });
-    expect(
-      screen.getByRole('textbox', {
-        name: 'Select the language for which you want to upload a timed text file, fr',
-      }),
-    ).toHaveValue('French');
+    expect(within(button).getByText('French')).toBeInTheDocument();
   });
 
   it('renders the component with instructor local language unavailable', async () => {
@@ -76,14 +70,10 @@ describe('<LanguageSelect />', () => {
       }),
     );
 
-    screen.getByRole('button', {
-      name: 'Select the language for which you want to upload a timed text file; Selected: en',
+    const button = await screen.findByRole('combobox', {
+      name: 'Choose the language',
     });
-    expect(
-      screen.getByRole('textbox', {
-        name: 'Select the language for which you want to upload a timed text file, en',
-      }),
-    ).toHaveValue('English');
+    expect(within(button).getByText('English')).toBeInTheDocument();
   });
 
   it('renders the component with some languages already having some subtitles uploaded', async () => {
@@ -114,17 +104,12 @@ describe('<LanguageSelect />', () => {
       }),
     );
 
-    expect(
-      screen.getByRole('textbox', {
-        name: 'Select the language for which you want to upload a timed text file, fr',
-      }),
-    ).toHaveValue('French');
+    const button = await screen.findByRole('combobox', {
+      name: 'Choose the language',
+    });
+    expect(within(button).getByText('French')).toBeInTheDocument();
 
-    await userEvent.click(
-      screen.getByRole('button', {
-        name: 'Select the language for which you want to upload a timed text file; Selected: fr',
-      }),
-    );
+    await userEvent.click(button);
 
     screen.getByRole('option', { name: 'English' });
     screen.getByRole('option', { name: 'French' });
@@ -162,14 +147,12 @@ describe('<LanguageSelect />', () => {
       }),
     ).not.toBeInTheDocument();
 
-    screen.getByRole('button', {
-      name: 'Select the language for which you want to upload a timed text file; Selected: error',
+    const button = await screen.findByRole('combobox', {
+      name: 'Choose the language',
     });
     expect(
-      screen.getByRole('textbox', {
-        name: 'Select the language for which you want to upload a timed text file, error',
-      }),
-    ).toHaveValue('No language availables');
+      within(button).getByText('No language availables'),
+    ).toBeInTheDocument();
   });
 
   it('changes the selected language', async () => {
@@ -189,29 +172,12 @@ describe('<LanguageSelect />', () => {
       }),
     );
 
-    expect(
-      await screen.findByRole('textbox', {
-        name: 'Select the language for which you want to upload a timed text file, fr',
-      }),
-    ).toHaveValue('French');
-
-    await userEvent.click(
-      screen.getByRole('button', {
-        name: 'Select the language for which you want to upload a timed text file; Selected: fr',
-      }),
-    );
-
-    const englishButtonOption = screen.getByRole('option', { name: 'English' });
-
-    await userEvent.click(englishButtonOption);
-
-    screen.getByRole('button', {
-      name: 'Select the language for which you want to upload a timed text file; Selected: en',
+    const button = await screen.findByRole('combobox', {
+      name: 'Choose the language',
     });
-    expect(
-      screen.getByRole('textbox', {
-        name: 'Select the language for which you want to upload a timed text file, en',
-      }),
-    ).toHaveValue('English');
+    expect(within(button).getByText('French')).toBeInTheDocument();
+    await userEvent.click(button);
+    await userEvent.click(screen.getByRole('option', { name: 'English' }));
+    expect(within(button).getByText('English')).toBeInTheDocument();
   });
 });

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/LocalizedTimedTextTrackUpload/LanguageSelect/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/LocalizedTimedTextTrackUpload/LanguageSelect/index.spec.tsx
@@ -53,7 +53,7 @@ describe('<LanguageSelect />', () => {
     expect(within(button).getByText('French')).toBeInTheDocument();
   });
 
-  it('renders the component with instructor local language unavailable', async () => {
+  it('propagates correctly undefined when the local language is unavailable', async () => {
     render(
       <LanguageSelect
         onChange={onChangeMock}
@@ -64,16 +64,14 @@ describe('<LanguageSelect />', () => {
     );
 
     await waitFor(() =>
-      expect(onChangeMock).toHaveBeenLastCalledWith({
-        label: 'English',
-        value: 'en',
-      }),
+      expect(onChangeMock).toHaveBeenLastCalledWith(undefined),
     );
 
-    const button = await screen.findByRole('combobox', {
-      name: 'Choose the language',
-    });
-    expect(within(button).getByText('English')).toBeInTheDocument();
+    expect(
+      await screen.findByRole('combobox', {
+        name: 'Choose the language',
+      }),
+    ).toBeInTheDocument();
   });
 
   it('renders the component with some languages already having some subtitles uploaded', async () => {
@@ -118,41 +116,6 @@ describe('<LanguageSelect />', () => {
     expect(
       screen.queryByRole('option', { name: 'Swedish' }),
     ).not.toBeInTheDocument();
-  });
-
-  it('renders the component with no languages', async () => {
-    render(
-      <LanguageSelect
-        onChange={onChangeMock}
-        timedTextModeWidget={timedTextMode.SUBTITLE}
-      />,
-      { intlOptions: { locale: 'fr-FR' } },
-    );
-
-    await waitFor(() =>
-      expect(onChangeMock).toHaveBeenLastCalledWith({
-        label: 'No language availables',
-        value: 'error',
-      }),
-    );
-
-    expect(
-      screen.queryByRole('button', {
-        name: 'Select the language for which you want to upload a timed text file; Selected: fr',
-      }),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole('textbox', {
-        name: 'Select the language for which you want to upload a timed text file, fr',
-      }),
-    ).not.toBeInTheDocument();
-
-    const button = await screen.findByRole('combobox', {
-      name: 'Choose the language',
-    });
-    expect(
-      within(button).getByText('No language availables'),
-    ).toBeInTheDocument();
   });
 
   it('changes the selected language', async () => {

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/LocalizedTimedTextTrackUpload/LanguageSelect/index.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/LocalizedTimedTextTrackUpload/LanguageSelect/index.tsx
@@ -1,4 +1,5 @@
-import { Select, timedTextMode, useTimedTextTrack } from 'lib-components';
+import { Select } from '@openfun/cunningham-react';
+import { timedTextMode, useTimedTextTrack } from 'lib-components';
 import { useEffect, useMemo, useState } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 
@@ -6,11 +7,17 @@ import { LanguageChoice } from '@lib-video/types/SelectOptions';
 
 const messages = defineMessages({
   selectLanguageLabel: {
-    defaultMessage:
-      'Select the language for which you want to upload a timed text file',
+    defaultMessage: 'Choose the language',
     description:
       'The label of the select used for choosing the language for which the user wants to upload a file.',
     id: 'components.LanguageSelect.selectLanguageLabel',
+  },
+  selectLanguageInfo: {
+    defaultMessage:
+      'The language for which you want to upload a timed text file',
+    description:
+      'The text under the select used for choosing the language for which the user wants to upload a file.',
+    id: 'components.LanguageSelect.selectLanguageInfo',
   },
   noLanguageAvailableLabel: {
     defaultMessage: 'No language availables',
@@ -98,14 +105,19 @@ export const LanguageSelect = ({
   return (
     <Select
       aria-label={intl.formatMessage(messages.selectLanguageLabel)}
+      label={intl.formatMessage(messages.selectLanguageLabel)}
       options={availableSelectableLanguages ?? [errorLanguageChoice]}
-      replace={false}
-      labelKey="label"
       value={selectedLanguage.value}
-      valueKey={{ key: 'value', reduce: true }}
-      onChange={({ option }: { option: { label: string; value: string } }) => {
-        setSelectedLanguage(option);
+      onChange={(evt) => {
+        setSelectedLanguage(
+          availableSelectableLanguages?.find(
+            (lang) => lang.value === evt.target.value,
+          ) ?? errorLanguageChoice,
+        );
       }}
+      fullWidth
+      clearable={false}
+      text={intl.formatMessage(messages.selectLanguageInfo)}
     />
   );
 };

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/LocalizedTimedTextTrackUpload/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/LocalizedTimedTextTrackUpload/index.spec.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import fetchMock from 'fetch-mock';
 import {
@@ -90,14 +90,10 @@ describe('<LocalizedTimedTextTrackUpload />', () => {
       { intlOptions: { locale: 'fr-FR' } },
     );
 
-    await screen.findByRole('button', {
-      name: 'Select the language for which you want to upload a timed text file; Selected: fr',
+    const button = await screen.findByRole('combobox', {
+      name: 'Choose the language',
     });
-    expect(
-      screen.getByRole('textbox', {
-        name: 'Select the language for which you want to upload a timed text file, fr',
-      }),
-    ).toHaveValue('French');
+    expect(await within(button).findByText('French')).toBeInTheDocument();
     screen.getByText('No uploaded files');
 
     screen.getByRole('button', { name: 'Upload file' });

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/LocalizedTimedTextTrackUpload/index.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/LocalizedTimedTextTrackUpload/index.tsx
@@ -1,7 +1,8 @@
 import { Box, Button } from 'grommet';
-import { Nullable } from 'lib-common';
+import { Maybe, Nullable } from 'lib-common';
 import {
   ItemList,
+  TimedTextTrackState,
   formatSizeErrorScale,
   modelName,
   report,
@@ -61,9 +62,15 @@ export const LocalizedTimedTextTrackUpload = ({
   const intl = useIntl();
   const video = useCurrentVideo();
   const { addUpload, resetUpload, uploadManagerState } = useUploadManager();
-  const timedTextTracks = useTimedTextTrack((state) =>
-    state.getTimedTextTracks(),
+
+  const timedTextTrackFn = useCallback(
+    (state: TimedTextTrackState) => ({
+      timedTextTracks: state.getTimedTextTracks(),
+    }),
+    [],
   );
+
+  const { timedTextTracks } = useTimedTextTrack(timedTextTrackFn);
   const filteredTimedTextTracks = timedTextTracks.filter(
     (track) => track.mode === timedTextModeWidget,
   );
@@ -160,7 +167,7 @@ export const LocalizedTimedTextTrackUpload = ({
   ]);
 
   const onChangeLanguageSelect = useCallback(
-    (option: LanguageChoice) => setSelectedLanguage(option),
+    (option: Maybe<LanguageChoice>) => setSelectedLanguage(option || null),
     [],
   );
 
@@ -213,6 +220,7 @@ export const LocalizedTimedTextTrackUpload = ({
         primary
         style={{ height: '50px', fontFamily: 'Roboto-Medium' }}
         title={intl.formatMessage(messages.uploadButtonLabel)}
+        disabled={!selectedLanguage}
       />
     </Box>
   );

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/index.spec.tsx
@@ -226,13 +226,14 @@ describe('<VideoWidgetProvider />', () => {
       render(wrapInVideo(<VideoWidgetProvider isLive isTeacher />, mockVideo));
 
       await screen.findByText('Join the discussion');
-      const button = screen.getByRole('button', {
-        name: /select join the discussion mode/i,
+      const button = screen.getByRole('combobox', {
+        name: 'Join the discussion mode',
       });
-      const select = within(button).getByRole('textbox');
-      expect(select).toHaveValue(
-        'Accept joining the discussion after approval',
-      );
+      expect(
+        within(button).getByText(
+          'Accept joining the discussion after approval',
+        ),
+      ).toBeInTheDocument();
     });
 
     it('tests DashboardLiveWidgetThumbnail', async () => {

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/DownloadVideo/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/DownloadVideo/index.spec.tsx
@@ -43,8 +43,8 @@ describe('<InstructorDownloadVideo />', () => {
 
     await userEvent.click(screen.getByRole('button', { name: 'help' }));
 
-    const button = screen.getByRole('button', {
-      name: 'This input allows you to select the quality you desire for your download.; Selected: 1080 p',
+    const button = screen.getByRole('combobox', {
+      name: 'Download quality',
     });
     within(button).getByText('1080 p');
 
@@ -63,9 +63,10 @@ describe('<InstructorDownloadVideo />', () => {
       ),
     );
 
-    const defaultButtonSelect = screen.getByRole('button', {
-      name: 'This input allows you to select the quality you desire for your download.; Selected: 1080 p',
+    const defaultButtonSelect = screen.getByRole('combobox', {
+      name: 'Download quality',
     });
+    expect(within(defaultButtonSelect).getByText('1080 p')).toBeInTheDocument();
 
     await userEvent.click(defaultButtonSelect);
 

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/DownloadVideo/index.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/DownloadVideo/index.tsx
@@ -1,4 +1,5 @@
-import { Box, Button, Select, Text } from 'grommet';
+import { Select } from '@openfun/cunningham-react';
+import { Box, Button } from 'grommet';
 import {
   FoldableItem,
   ToggleInput,
@@ -27,10 +28,14 @@ const messages = defineMessages({
     id: 'components.DownloadVideo.title',
   },
   selectQualityLabel: {
-    defaultMessage:
-      'This input allows you to select the quality you desire for your download.',
+    defaultMessage: 'Download quality',
     description: 'Label of the select button.',
     id: 'components.DownloadVideo.selectQualityLabel',
+  },
+  selectQualityInfo: {
+    defaultMessage: 'Select the quality you desire for your download.',
+    description: 'Text explaining the select button.',
+    id: 'components.DownloadVideo.selectQualityInfo',
   },
   noResolutionsAvailableOption: {
     defaultMessage: 'No resolutions available',
@@ -104,10 +109,9 @@ export const DownloadVideo = ({ isTeacher }: DownloadVideoProps) => {
     options.push(noResolutionsAvailableOption);
   }
 
-  const [selectedOption, setSelectedOption] = useState<{
-    label: string;
-    value: string;
-  }>(options[options.length - 1]);
+  const [selectedQuality, setSelectedQuality] = useState(
+    options[options.length - 1].value,
+  );
 
   const [toggleAllowDownload, setToggleAllowDownload] = useState(
     video.show_download,
@@ -175,24 +179,15 @@ export const DownloadVideo = ({ isTeacher }: DownloadVideoProps) => {
       <Box direction="column" gap="small" style={{ marginTop: '0.75rem' }}>
         <Select
           aria-label={intl.formatMessage(messages.selectQualityLabel)}
+          label={intl.formatMessage(messages.selectQualityLabel)}
           options={options}
-          replace={false}
-          labelKey="label"
-          value={selectedOption.label}
-          valueKey={{ key: 'value', reduce: true }}
-          valueLabel={(label: string) => (
-            <Box pad="small">
-              <Text color="blue-active">{`${label}`}</Text>
-            </Box>
-          )}
-          onChange={({
-            option,
-          }: {
-            option: { label: string; value: string };
-          }) => {
-            setSelectedOption(option);
+          fullWidth
+          value={selectedQuality}
+          onChange={(evt) => {
+            setSelectedQuality(evt.target.value as string);
           }}
-          title={intl.formatMessage(messages.selectQualityLabel)}
+          clearable={false}
+          text={intl.formatMessage(messages.selectQualityInfo)}
         />
         <StyledAnchorButton
           a11yTitle={intl.formatMessage(messages.downloadButtonLabel)}
@@ -202,7 +197,7 @@ export const DownloadVideo = ({ isTeacher }: DownloadVideoProps) => {
           label={intl.formatMessage(messages.downloadButtonLabel)}
           href={
             video.urls
-              ? video.urls.mp4[Number(selectedOption.value) as videoSize]
+              ? video.urls.mp4[Number(selectedQuality) as videoSize]
               : undefined
           }
           target="_blank"

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/LicenseManager/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/LicenseManager/index.spec.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import fetchMock from 'fetch-mock';
 import {
@@ -62,10 +62,12 @@ describe('<LicenseManager />', () => {
     );
 
     expect(screen.getByText('License')).toBeInTheDocument();
-    const textbox = await screen.findByRole('textbox', {
-      name: 'Select the license under which you want to publish your video, NO_CC',
+    const selectButton = await screen.findByRole('combobox', {
+      name: 'Select the license',
     });
-    expect(textbox).toHaveValue('All rights reserved');
+    expect(
+      await within(selectButton).findByText('All rights reserved'),
+    ).toBeInTheDocument();
   });
 
   it('renders the component with no license', async () => {
@@ -83,10 +85,11 @@ describe('<LicenseManager />', () => {
     );
 
     expect(screen.getByText('License')).toBeInTheDocument();
-    const textbox = await screen.findByRole('textbox', {
-      name: 'Select the license under which you want to publish your video',
-    });
-    expect(textbox).toHaveValue('');
+    expect(
+      await screen.findByRole('combobox', {
+        name: 'Select the license',
+      }),
+    ).toBeInTheDocument();
   });
 
   it('renders the component with a license and successfully updates it', async () => {
@@ -105,21 +108,20 @@ describe('<LicenseManager />', () => {
     );
 
     expect(screen.getByText('License')).toBeInTheDocument();
-    const selectButton = await screen.findByRole('button', {
-      name: 'Select the license under which you want to publish your video; Selected: NO_CC',
+    const selectButton = await screen.findByRole('combobox', {
+      name: 'Select the license',
     });
+    expect(
+      await within(selectButton).findByText('All rights reserved'),
+    ).toBeInTheDocument();
     await userEvent.click(selectButton);
     const CreativeCommonButtonOption = screen.getByRole('option', {
       name: 'Creative Common By Attribution',
     });
     await userEvent.click(CreativeCommonButtonOption);
-    await waitFor(() =>
-      expect(
-        screen.getByRole('textbox', {
-          name: 'Select the license under which you want to publish your video, CC_BY',
-        }),
-      ).toHaveValue('Creative Common By Attribution'),
-    );
+    expect(
+      await within(selectButton).findByText('Creative Common By Attribution'),
+    ).toBeInTheDocument();
   });
 
   it('renders the component with no license choice', async () => {
@@ -139,8 +141,8 @@ describe('<LicenseManager />', () => {
     );
 
     expect(screen.getByText('License')).toBeInTheDocument();
-    const selectButton = await screen.findByRole('button', {
-      name: 'Select the license under which you want to publish your video; Selected: All rights reserved',
+    const selectButton = await screen.findByRole('combobox', {
+      name: 'Select the license',
     });
     await userEvent.click(selectButton);
     await screen.findByText('No license available');
@@ -161,9 +163,12 @@ describe('<LicenseManager />', () => {
     );
 
     expect(screen.getByText('License')).toBeInTheDocument();
-    const selectButton = await screen.findByRole('button', {
-      name: 'Select the license under which you want to publish your video; Selected: NO_CC',
+    const selectButton = await screen.findByRole('combobox', {
+      name: 'Select the license',
     });
+    expect(
+      await within(selectButton).findByText('All rights reserved'),
+    ).toBeInTheDocument();
     await userEvent.click(selectButton);
     const CreativeCommonButtonOption = screen.getByRole('option', {
       name: 'Creative Common By Attribution',

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/LiveJoinMode/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/LiveJoinMode/index.spec.tsx
@@ -46,11 +46,12 @@ describe('<LiveJoinMode />', () => {
     );
 
     screen.getByText('Join the discussion');
-    const button = screen.getByRole('button', {
-      name: /select join the discussion mode/i,
+    const button = screen.getByRole('combobox', {
+      name: 'Join the discussion mode',
     });
-    const select = within(button).getByRole('textbox');
-    expect(select).toHaveValue('Accept joining the discussion after approval');
+    expect(
+      within(button).getByText('Accept joining the discussion after approval'),
+    ).toBeInTheDocument();
   });
 
   it('selects join mode denied', async () => {
@@ -72,11 +73,12 @@ describe('<LiveJoinMode />', () => {
       ),
     );
 
-    const button = screen.getByRole('button', {
-      name: /select join the discussion mode/i,
+    const button = screen.getByRole('combobox', {
+      name: 'Join the discussion mode',
     });
-    const select = within(button).getByRole('textbox');
-    expect(select).toHaveValue('Accept joining the discussion after approval');
+    expect(
+      within(button).getByText('Accept joining the discussion after approval'),
+    ).toBeInTheDocument();
 
     await userEvent.click(button);
     await userEvent.click(screen.getByText(/not allowed/i));
@@ -106,7 +108,7 @@ describe('<LiveJoinMode />', () => {
         { ...mockedVideo, join_mode: JoinMode.DENIED },
       ),
     );
-    expect(within(button).getByRole('textbox')).toHaveValue('Not allowed');
+    expect(within(button).getByText('Not allowed')).toBeInTheDocument();
   });
 
   it('selects join mode ask for approval', async () => {
@@ -128,11 +130,10 @@ describe('<LiveJoinMode />', () => {
       ),
     );
 
-    const button = screen.getByRole('button', {
-      name: /select join the discussion mode/i,
+    const button = screen.getByRole('combobox', {
+      name: 'Join the discussion mode',
     });
-    const select = within(button).getByRole('textbox');
-    expect(select).toHaveValue('Not allowed');
+    expect(within(button).getByText('Not allowed')).toBeInTheDocument();
 
     await userEvent.click(button);
     await userEvent.click(
@@ -164,9 +165,9 @@ describe('<LiveJoinMode />', () => {
         { ...mockedVideo, join_mode: JoinMode.APPROVAL },
       ),
     );
-    expect(within(button).getByRole('textbox')).toHaveValue(
-      'Accept joining the discussion after approval',
-    );
+    expect(
+      within(button).getByText('Accept joining the discussion after approval'),
+    ).toBeInTheDocument();
   });
 
   it('selects join mode forced', async () => {
@@ -188,11 +189,12 @@ describe('<LiveJoinMode />', () => {
       ),
     );
 
-    const button = screen.getByRole('button', {
-      name: /select join the discussion mode/i,
+    const button = screen.getByRole('combobox', {
+      name: 'Join the discussion mode',
     });
-    const select = within(button).getByRole('textbox');
-    expect(select).toHaveValue('Accept joining the discussion after approval');
+    expect(
+      within(button).getByText('Accept joining the discussion after approval'),
+    ).toBeInTheDocument();
 
     await userEvent.click(button);
     await userEvent.click(
@@ -224,9 +226,9 @@ describe('<LiveJoinMode />', () => {
         { ...mockedVideo, join_mode: JoinMode.FORCED },
       ),
     );
-    expect(within(button).getByRole('textbox')).toHaveValue(
-      'Everybody will join the discussion',
-    );
+    expect(
+      within(button).getByText('Everybody will join the discussion'),
+    ).toBeInTheDocument();
   });
 
   it('selects join mode denied, but backend returns an error', async () => {
@@ -245,11 +247,12 @@ describe('<LiveJoinMode />', () => {
       ),
     );
 
-    const button = screen.getByRole('button', {
-      name: /select join the discussion mode/i,
+    const button = screen.getByRole('combobox', {
+      name: 'Join the discussion mode',
     });
-    const select = within(button).getByRole('textbox');
-    expect(select).toHaveValue('Accept joining the discussion after approval');
+    expect(
+      within(button).getByText('Accept joining the discussion after approval'),
+    ).toBeInTheDocument();
 
     await userEvent.click(button);
     await userEvent.click(screen.getByText(/not allowed/i));

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/LiveJoinMode/index.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/LiveJoinMode/index.tsx
@@ -1,4 +1,5 @@
-import { Box, Select } from 'grommet';
+import { Select } from '@openfun/cunningham-react';
+import { Box } from 'grommet';
 import { FoldableItem, JoinMode, report } from 'lib-components';
 import React from 'react';
 import { toast } from 'react-hot-toast';
@@ -22,9 +23,14 @@ const messages = defineMessages({
     id: 'components.LiveJoinMode.title',
   },
   selectLabel: {
-    defaultMessage: 'Select join the discussion mode',
+    defaultMessage: 'Join the discussion mode',
     description: 'The label for the select to set join modes.',
     id: 'components.LiveJoinMode.selectLabel',
+  },
+  selectLabelInfo: {
+    defaultMessage: 'Choose the mode when someone join the discussion',
+    description: 'The text under the select to set join modes.',
+    id: 'components.LiveJoinMode.selectLabelInfo',
   },
   approval: {
     defaultMessage: 'Accept joining the discussion after approval',
@@ -95,20 +101,19 @@ export const LiveJoinMode = () => {
       <Box direction="column" gap="small">
         <Select
           aria-label={intl.formatMessage(messages.selectLabel)}
+          label={intl.formatMessage(messages.selectLabel)}
           options={options}
-          labelKey="label"
-          replace={false}
-          valueKey={{ key: 'value', reduce: true }}
+          fullWidth
           value={video.join_mode}
-          onChange={({
-            option,
-          }: {
-            option: { label: string; value: JoinMode };
-          }) => {
-            videoMutation.mutate({
-              join_mode: option.value,
-            });
+          onChange={(evt) => {
+            if (evt.target.value !== video.join_mode) {
+              videoMutation.mutate({
+                join_mode: evt.target.value as JoinMode,
+              });
+            }
           }}
+          clearable={false}
+          text={intl.formatMessage(messages.selectLabelInfo)}
         />
       </Box>
     </FoldableItem>

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/RetentionDate/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/RetentionDate/index.spec.tsx
@@ -60,7 +60,7 @@ describe('Video <RetentionDate />', () => {
       screen.getByTestId('retention-date-picker'),
     ).getByRole('presentation');
 
-    expect(inputRetentionDate).toHaveTextContent('mm/dd/yyyy');
+    expect(inputRetentionDate).toHaveTextContent('MM/DD/YYYY');
 
     const retentionDate = DateTime.local()
       .plus({ days: 1 })

--- a/src/frontend/packages/lib_video/src/components/common/VideoWizard/CreateVOD/LicenseSelect/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWizard/CreateVOD/LicenseSelect/index.spec.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import fetchMock from 'fetch-mock';
 import { useJwt } from 'lib-components';
@@ -55,16 +55,12 @@ describe('<LicenseSelect />', () => {
       }),
     );
 
+    const selectButton = await screen.findByRole('combobox', {
+      name: 'Select the license',
+    });
     expect(
-      screen.getByRole('button', {
-        name: 'Select the license under which you want to publish your video; Selected: CC_BY',
-      }),
-    ).not.toBeDisabled();
-    expect(
-      screen.getByRole('textbox', {
-        name: 'Select the license under which you want to publish your video, CC_BY',
-      }),
-    ).toHaveValue('Creative Common By Attribution');
+      await within(selectButton).findByText('Creative Common By Attribution'),
+    ).toBeInTheDocument();
   });
 
   it('renders the component but is disabled', async () => {
@@ -85,16 +81,12 @@ describe('<LicenseSelect />', () => {
       }),
     );
 
+    const selectButton = await screen.findByRole('combobox', {
+      name: 'Select the license',
+    });
     expect(
-      screen.getByRole('button', {
-        name: 'Select the license under which you want to publish your video; Selected: CC_BY',
-      }),
-    ).toBeDisabled();
-    expect(
-      screen.getByRole('textbox', {
-        name: 'Select the license under which you want to publish your video, CC_BY',
-      }),
-    ).toHaveValue('Creative Common By Attribution');
+      await within(selectButton).findByText('Creative Common By Attribution'),
+    ).toBeInTheDocument();
   });
 
   it('renders the component with no licenses', async () => {
@@ -110,24 +102,15 @@ describe('<LicenseSelect />', () => {
     );
 
     expect(
-      screen.queryByRole('button', {
-        name: 'Select the license under which you want to publish your video; Selected: CC_BY',
-      }),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole('textbox', {
-        name: 'Select the license under which you want to publish your video, CC_BY',
-      }),
+      screen.queryByText('Creative Common By Attribution'),
     ).not.toBeInTheDocument();
 
-    screen.getByRole('button', {
-      name: 'Select the license under which you want to publish your video; Selected: error',
+    const selectButton = await screen.findByRole('combobox', {
+      name: 'Select the license',
     });
     expect(
-      screen.getByRole('textbox', {
-        name: 'Select the license under which you want to publish your video, error',
-      }),
-    ).toHaveValue('No license availables');
+      await within(selectButton).findByText('No license availables'),
+    ).toBeInTheDocument();
   });
 
   it('changes the selected license', async () => {
@@ -148,17 +131,14 @@ describe('<LicenseSelect />', () => {
       }),
     );
 
+    const selectButton = await screen.findByRole('combobox', {
+      name: 'Select the license',
+    });
     expect(
-      await screen.findByRole('textbox', {
-        name: /Select the license under which you want to publish your video, CC_BY/i,
-      }),
-    ).toHaveValue('Creative Common By Attribution');
+      await within(selectButton).findByText('Creative Common By Attribution'),
+    ).toBeInTheDocument();
 
-    await userEvent.click(
-      screen.getByRole('button', {
-        name: 'Select the license under which you want to publish your video; Selected: CC_BY',
-      }),
-    );
+    await userEvent.click(selectButton);
 
     const allRightsReservedButtonOption = screen.getByRole('option', {
       name: 'All rights reserved',
@@ -166,13 +146,8 @@ describe('<LicenseSelect />', () => {
 
     await userEvent.click(allRightsReservedButtonOption);
 
-    screen.getByRole('button', {
-      name: 'Select the license under which you want to publish your video; Selected: NO_CC',
-    });
     expect(
-      screen.getByRole('textbox', {
-        name: 'Select the license under which you want to publish your video, NO_CC',
-      }),
-    ).toHaveValue('All rights reserved');
+      await within(selectButton).findByText('All rights reserved'),
+    ).toBeInTheDocument();
   });
 });

--- a/src/frontend/packages/lib_video/src/components/common/VideoWizard/CreateVOD/LicenseSelect/index.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWizard/CreateVOD/LicenseSelect/index.tsx
@@ -1,4 +1,4 @@
-import { Select } from 'grommet';
+import { Select } from '@openfun/cunningham-react';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 
@@ -7,11 +7,17 @@ import { LicenseChoice } from '@lib-video/types/SelectOptions';
 
 const messages = defineMessages({
   selectLicenseLabel: {
-    defaultMessage:
-      'Select the license under which you want to publish your video',
+    defaultMessage: 'Select the license',
     description:
       'The label of the select used for choosing the license under which the instructor wants to publish your video',
     id: 'components.LicenseSelect.selectLicenseLabel',
+  },
+  selectLicenseInfo: {
+    defaultMessage:
+      'Select the license under which you want to publish your video',
+    description:
+      'The info under the select used for choosing the license under which the instructor wants to publish your video',
+    id: 'components.LicenseSelect.selectLicenseInfo',
   },
   noLicenseAvailableLabel: {
     defaultMessage: 'No license availables',
@@ -70,18 +76,23 @@ export const LicenseSelect = ({ disabled, onChange }: LicenseSelectProps) => {
   return (
     <Select
       aria-label={intl.formatMessage(messages.selectLicenseLabel)}
-      id="select-license-id"
-      name="license"
-      disabled={disabled}
-      labelKey="label"
-      onChange={({ option }: { option: { label: string; value: string } }) => {
-        setSelectedLicense(option);
-        onChange(option);
-      }}
+      label={intl.formatMessage(messages.selectLicenseLabel)}
       options={choices ?? [errorLicenseChoice]}
-      replace={false}
+      fullWidth
       value={selectedLicense.value}
-      valueKey={{ key: 'value', reduce: true }}
+      onChange={(evt) => {
+        if (evt.target.value !== selectedLicense.value) {
+          const choice =
+            choices?.find((option) => option.value === evt.target.value) ||
+            errorLicenseChoice;
+
+          setSelectedLicense(choice);
+          onChange(choice);
+        }
+      }}
+      clearable={false}
+      disabled={disabled}
+      text={intl.formatMessage(messages.selectLicenseInfo)}
     />
   );
 };

--- a/src/frontend/packages/lib_video/src/components/common/VideoWizard/CreateVOD/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWizard/CreateVOD/index.spec.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable testing-library/no-node-access */
 /* eslint-disable testing-library/no-container */
-import { screen, waitFor } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import fetchMock from 'fetch-mock';
 import {
@@ -121,13 +121,14 @@ describe('<CreateVOD />', () => {
     screen.getByRole('textbox', { name: 'Enter title of your video here' });
     screen.getByText('Add a video or drag & drop it');
     screen.getByTestId('input-video-test-id');
-    await waitFor(() =>
-      expect(
-        screen.getByRole('textbox', {
-          name: 'Select the license under which you want to publish your video, CC_BY',
-        }),
-      ).toHaveValue('Creative Common By Attribution'),
-    );
+    const rerenderedLicense = await screen.findByRole('combobox', {
+      name: 'Select the license',
+    });
+    expect(
+      await within(rerenderedLicense).findByText(
+        'Creative Common By Attribution',
+      ),
+    ).toBeInTheDocument();
 
     const goBackButton = screen.getByRole('button', { name: 'Go back' });
     const createVideoButton = screen.getByRole('button', {
@@ -200,13 +201,14 @@ describe('<CreateVOD />', () => {
     ).toBeInTheDocument();
 
     screen.getByTestId('input-video-test-id');
-    await waitFor(() =>
-      expect(
-        screen.getByRole('textbox', {
-          name: 'Select the license under which you want to publish your video, CC_BY',
-        }),
-      ).toHaveValue('Creative Common By Attribution'),
-    );
+    const rerenderedLicense = await screen.findByRole('combobox', {
+      name: 'Select the license',
+    });
+    expect(
+      await within(rerenderedLicense).findByText(
+        'Creative Common By Attribution',
+      ),
+    ).toBeInTheDocument();
 
     const goBackButton = screen.getByRole('button', { name: 'Go back' });
     const createVideoButton = screen.getByRole('button', {
@@ -354,9 +356,14 @@ describe('<CreateVOD />', () => {
     const rerenderedTitle = screen.getByRole('textbox', {
       name: 'Enter title of your video here',
     });
-    const rerenderedLicense = screen.getByRole('textbox', {
-      name: 'Select the license under which you want to publish your video, CC_BY',
+    const rerenderedLicense = await screen.findByRole('combobox', {
+      name: 'Select the license',
     });
+    expect(
+      await within(rerenderedLicense).findByText(
+        'Creative Common By Attribution',
+      ),
+    ).toBeInTheDocument();
     const rerenderedCreateVideoButton = screen.getByRole('button', {
       name: 'Create a video',
     });
@@ -364,7 +371,7 @@ describe('<CreateVOD />', () => {
       name: 'Go back',
     });
     expect(rerenderedTitle).toBeDisabled();
-    expect(rerenderedLicense).toBeDisabled();
+    expect(rerenderedLicense.hasAttribute('disabled')).toBeTruthy();
     expect(rerenderedGoBackButton).toBeDisabled();
     expect(rerenderedCreateVideoButton).toBeDisabled();
 
@@ -607,9 +614,14 @@ describe('<CreateVOD />', () => {
     const rerenderedTitle = screen.getByRole('textbox', {
       name: 'Enter title of your video here',
     });
-    const rerenderedLicense = screen.getByRole('textbox', {
-      name: 'Select the license under which you want to publish your video, CC_BY',
+    const rerenderedLicense = await screen.findByRole('combobox', {
+      name: 'Select the license',
     });
+    expect(
+      await within(rerenderedLicense).findByText(
+        'Creative Common By Attribution',
+      ),
+    ).toBeInTheDocument();
     const rerenderedCreateVideoButton = screen.getByRole('button', {
       name: 'Create a video',
     });
@@ -618,7 +630,7 @@ describe('<CreateVOD />', () => {
     });
     screen.getByText('50 %');
     expect(rerenderedTitle).toBeDisabled();
-    expect(rerenderedLicense).toBeDisabled();
+    expect(rerenderedLicense.hasAttribute('disabled')).toBeTruthy();
     expect(rerenderedGoBackButton).toBeDisabled();
     expect(rerenderedCreateVideoButton).toBeDisabled();
 

--- a/src/frontend/packages/lib_video/src/components/common/VideoWizard/CreateVOD/index.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWizard/CreateVOD/index.tsx
@@ -181,6 +181,7 @@ export const CreateVOD = ({
               })
             }
             value={wizardedVideo.title || ''}
+            fullWidth
           />
 
           <UploadVideoForm

--- a/src/frontend/yarn.lock
+++ b/src/frontend/yarn.lock
@@ -4313,10 +4313,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@openfun/cunningham-react@*", "@openfun/cunningham-react@1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@openfun/cunningham-react/-/cunningham-react-1.0.1.tgz#19db23ba2afb18bac654d005f398480367c4fe4a"
-  integrity sha512-PEX/idXa0UuePYMVvdvFWmZPsy//Q3s8cjpkINLFQJYkaBuPg79N//bP4gKzTJdKIWLmYK03QIYvB5DAARSA7w==
+"@openfun/cunningham-react@*", "@openfun/cunningham-react@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@openfun/cunningham-react/-/cunningham-react-1.1.0.tgz#bac3992930017cc189997f1b5ee1d6d1982ef6be"
+  integrity sha512-Q4bwvPpDchgCVZ76TU7NrgMSx2/tMSMOIKiSYPSA48NKRSFzphCsxFDN/raoy9k0yPSWiudhqhqg95O3fbQ6wA==
   dependencies:
     "@fontsource-variable/roboto-flex" "5.0.8"
     "@fontsource/material-icons" "5.0.7"


### PR DESCRIPTION
## Purpose

Replace partially grommet select by cunningham select.

The Cunnigham Select doesn't fit all our needs, but we can still replace a part of the select.
This PR helps us as well to identify our different needs, an feature request issue has been opened alongside this PR: https://github.com/openfun/cunningham/issues/155

## Proposal

- [x] replace every grommet `Select` by cunningham `Select`
- [x] tests

## Select left

. [LanguagePicker ](https://github.com/openfun/marsha/blob/master/src/frontend/apps/standalone_site/src/features/Language/components/LanguagePicker.tsx): We need an icon on the left of the select.
. [useSelectPlaylist](https://github.com/openfun/marsha/blob/master/src/frontend/apps/standalone_site/src/features/Playlist/hooks/useSelectPlaylist.tsx): We need the virtualization - We can have lot of playlist
. [RenaterAuthenticator](https://github.com/openfun/marsha/blob/master/src/frontend/apps/standalone_site/src/features/Authentication/components/RenaterAuthenticator.tsx): We need options with `JSX.Element[]` type
. [SchedulingFields](https://github.com/openfun/marsha/blob/master/src/frontend/packages/lib_components/src/common/SchedulingFields/index.tsx): We need `suggestion` prop, to start the scroll to a specific value and `searchableFree` prop, to search a potential value but let as well the possibility to use the value taped by the user (see [example](https://mui.com/material-ui/react-autocomplete/#free-solo))




