### PR TITLE
🥅(frontend) filter TypeError from sentry capture

### DIFF
--- a/src/frontend/packages/lib_components/src/data/stores/useSentry/index.spec.ts
+++ b/src/frontend/packages/lib_components/src/data/stores/useSentry/index.spec.ts
@@ -1,5 +1,7 @@
 import { configureScope, init } from '@sentry/browser';
 
+import { beforeSendSentry } from '@lib-components/utils';
+
 import { useSentry } from '.';
 
 jest.mock('@sentry/browser', () => ({
@@ -21,6 +23,7 @@ describe('useSentry', () => {
       .setSentry('sentry_dsn', 'environment', 'release', 'test');
 
     expect(mockInit).toHaveBeenCalledWith({
+      beforeSend: beforeSendSentry,
       dsn: 'sentry_dsn',
       environment: 'environment',
       release: 'release',

--- a/src/frontend/packages/lib_components/src/data/stores/useSentry/index.ts
+++ b/src/frontend/packages/lib_components/src/data/stores/useSentry/index.ts
@@ -1,6 +1,8 @@
 import { configureScope, init } from '@sentry/browser';
 import { create } from 'zustand';
 
+import { beforeSendSentry } from '@lib-components/utils';
+
 interface SentryStore {
   isSentryReady: boolean;
   setSentry: (
@@ -23,6 +25,7 @@ export const useSentry = create<SentryStore>((set) => ({
       dsn,
       environment,
       release,
+      beforeSend: beforeSendSentry,
     });
 
     configureScope((scope) => scope.setExtra('application', application));

--- a/src/frontend/packages/lib_components/src/utils/beforeSendSentry.spec.ts
+++ b/src/frontend/packages/lib_components/src/utils/beforeSendSentry.spec.ts
@@ -1,0 +1,25 @@
+import { ErrorEvent } from '@sentry/types/types/event';
+
+import { beforeSendSentry } from './beforeSendSentry';
+
+describe('beforeSendSentry', () => {
+  it('should return null if error is TypeError "Load failed"', () => {
+    const error = new TypeError('Load failed');
+    const hint = { originalException: error };
+    const errorEvent = {};
+
+    const result = beforeSendSentry(errorEvent as ErrorEvent, hint);
+
+    expect(result).toBeNull();
+  });
+
+  it('should return event if error is not TypeError "Load failed"', () => {
+    const error = new Error('Other error');
+    const hint = { originalException: error };
+    const event = {};
+
+    const result = beforeSendSentry(event as ErrorEvent, hint);
+
+    expect(result).toBe(event);
+  });
+});

--- a/src/frontend/packages/lib_components/src/utils/beforeSendSentry.ts
+++ b/src/frontend/packages/lib_components/src/utils/beforeSendSentry.ts
@@ -1,0 +1,9 @@
+import { ErrorEvent, EventHint } from '@sentry/types/types/event';
+
+export const beforeSendSentry = (event: ErrorEvent, hint: EventHint) => {
+  const error = hint.originalException;
+  if (error instanceof TypeError && error.message === 'Load failed') {
+    return null;
+  }
+  return event;
+};

--- a/src/frontend/packages/lib_components/src/utils/index.ts
+++ b/src/frontend/packages/lib_components/src/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './beforeSendSentry';
 export * from './checkToken';
 export * from './createContext';
 export * from './debounce';


### PR DESCRIPTION

## Purpose

As we have many errors related to a Safari bug.
https://bugs.webkit.org/show_bug.cgi?id=231150

Although it has been fixed, we decided to filter it from Sentry to avoid flooding.

## Proposal

Don't capture errors for TypeError("Load failed")

