### PR TITLE
🐛(back) save license on video creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Save license when a video is created
+
 ## [4.4.0] - 2023-09-08
 
 ### Added

--- a/src/backend/marsha/core/forms.py
+++ b/src/backend/marsha/core/forms.py
@@ -35,6 +35,7 @@ class VideoForm(ModelForm):
             "playlist",
             "title",
             "upload_state",
+            "license",
         ]
 
     def clean_upload_state(self):

--- a/src/backend/marsha/core/tests/api/video/test_create.py
+++ b/src/backend/marsha/core/tests/api/video/test_create.py
@@ -78,6 +78,7 @@ class VideoCreateAPITest(TestCase):
                 "lti_id": "video_one",
                 "playlist": str(playlist.id),
                 "title": "Some video",
+                "license": "CC_BY-ND",
             },
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
@@ -127,7 +128,7 @@ class VideoCreateAPITest(TestCase):
                 "urls": None,
                 "xmpp": None,
                 "tags": [],
-                "license": None,
+                "license": "CC_BY-ND",
             },
         )
 
@@ -174,6 +175,7 @@ class VideoCreateAPITest(TestCase):
                 "lti_id": "video_one",
                 "playlist": str(playlist.id),
                 "title": "Some video",
+                "license": "CC_BY-ND",
             },
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
@@ -223,7 +225,7 @@ class VideoCreateAPITest(TestCase):
                 "urls": None,
                 "xmpp": None,
                 "tags": [],
-                "license": None,
+                "license": "CC_BY-ND",
             },
         )
 


### PR DESCRIPTION
## Purpose

The license sent in the POST request, when a video is created was missing in the video form. We must add it in order to save the license choose by a user.

## Proposal

- [x] save license on video creation

Fixes #2048