### PR TITLE
✨(front) disable classroom convert button when converting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Disable classroom convert button when converting
+
 ### Fixed
 
 - Save license when a video is created

--- a/src/frontend/packages/lib_classroom/src/components/ClassroomWidgetProvider/widgets/Recordings/Recording/index.tsx
+++ b/src/frontend/packages/lib_classroom/src/components/ClassroomWidgetProvider/widgets/Recordings/Recording/index.tsx
@@ -7,7 +7,7 @@ import {
   uploadState,
   useCurrentResourceContext,
 } from 'lib-components';
-import React, { useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import { toast } from 'react-hot-toast';
 import { IntlShape, defineMessages, useIntl } from 'react-intl';
 import { NavLink } from 'react-router-dom';
@@ -100,17 +100,24 @@ const VodNotReady = ({
   conversionEnabled,
 }: RecordingProps) => {
   const intl = useIntl();
-  const { refetch: refetchClassroom } = useClassroom(recording.classroom_id);
+  const [converting, setConverting] = useState(false);
+  const { refetch: refetchClassroom } = useClassroom(
+    recording.classroom_id,
+    {},
+  );
 
   const convertVOD = useCallback(
     (recording: ClassroomRecording) => {
+      setConverting(true);
       let title = buildRecordingTitle(recording, intl);
       if (classroomTitle) {
         title = `${classroomTitle} - ${title}`;
       }
 
       createVOD(recording, title).then(() => {
-        refetchClassroom();
+        refetchClassroom().then(() => {
+          setConverting(false);
+        });
       });
     },
     [classroomTitle, intl, refetchClassroom],
@@ -169,7 +176,7 @@ const VodNotReady = ({
           label={intl.formatMessage(messages.convertVODLabel)}
           onClick={() => convertVOD(recording)}
           size="xsmall"
-          disabled={!conversionEnabled}
+          disabled={!conversionEnabled || converting}
         />
       )}
     </Box>


### PR DESCRIPTION
## Purpose

When a user click on the convert button, to convert a recording in VOD, the button state does not change and the user can think the click didn't work. To avoid this confusion, the button is disabled while the classroom refetch is not made.

## Proposal

- [x] Disable classroom convert button when converting

