### PR TITLE
🐛(backend) quote deposited file url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Save license when a video is created
 - Show an error when a resource has been deleted
+- Allow depositedfiles to have unicode characters in their filename
 
 ### Changed
 

--- a/src/backend/marsha/deposit/serializers.py
+++ b/src/backend/marsha/deposit/serializers.py
@@ -1,7 +1,7 @@
 """Structure of deposit related models API responses with Django Rest Framework serializers."""
 import mimetypes
 from os.path import splitext
-from urllib.parse import quote_plus
+from urllib.parse import quote, quote_plus
 
 from django.conf import settings
 from django.urls import reverse
@@ -148,9 +148,12 @@ class DepositedFileSerializer(
             f"{time_utils.to_timestamp(obj.uploaded_on)}"
         )
 
+        response_content_disposition = quote_plus(
+            "attachment; filename=" + quote(obj.filename)
+        )
         url = (
             f"{base:s}{self._get_extension_string(obj)}?"
-            f"response-content-disposition={quote_plus('attachment; filename=' + obj.filename)}"
+            f"response-content-disposition={response_content_disposition}"
         )
 
         if settings.CLOUDFRONT_SIGNED_URLS_ACTIVE:

--- a/src/backend/marsha/deposit/tests/api/depositedfiles/test_list.py
+++ b/src/backend/marsha/deposit/tests/api/depositedfiles/test_list.py
@@ -302,6 +302,9 @@ class FileDepositoryDepositedfilesAPITest(TestCase):
         deposited_files = DepositedFileFactory.create_batch(
             3, file_depository=file_depository, uploaded_on=now
         )
+        unicode_deposited_file = DepositedFileFactory(
+            file_depository=file_depository, uploaded_on=now, filename="test’.pdf"
+        )
         jwt_token = InstructorOrAdminLtiTokenFactory(playlist=file_depository.playlist)
 
         now = datetime(2021, 11, 30, tzinfo=baseTimezone.utc)
@@ -328,10 +331,26 @@ class FileDepositoryDepositedfilesAPITest(TestCase):
         self.assertEqual(
             response.json(),
             {
-                "count": 3,
+                "count": 4,
                 "next": None,
                 "previous": None,
                 "results": [
+                    {
+                        "author_name": unicode_deposited_file.author_name,
+                        "file_depository_id": str(file_depository.id),
+                        "filename": unicode_deposited_file.filename,
+                        "id": str(unicode_deposited_file.id),
+                        "read": False,
+                        "size": unicode_deposited_file.size,
+                        "upload_state": "pending",
+                        "uploaded_on": "2018-08-08T00:00:00Z",
+                        "url": (
+                            f"https://abc.cloudfront.net/{file_depository.id}/depositedfile/"
+                            f"{unicode_deposited_file.id}/1533686400?response-content-disposition"
+                            "=attachment%3B+filename%3Dtest%25E2%2580%2599.pdf"
+                            f"&{expected_cloudfront_signature}"
+                        ),
+                    },
                     {
                         "author_name": deposited_files[2].author_name,
                         "file_depository_id": str(file_depository.id),


### PR DESCRIPTION


## Purpose

Deposited files with some unicode characters in their filename were leading to an error on cloudfront when downloading.

Fixes #2314

## Proposal

add urllib.parse.quote to the filename in response-content-disposition
