### PR TITLE
🐛(website) fix checkbox to delete resource remains displayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,16 +11,14 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Disable classroom convert button when converting
+- Replace grommet Select by Cunningham Select (#2400)
 
 ### Fixed
 
 - Save license when a video is created
 - Show an error when a resource has been deleted
 - Allow depositedfiles to have unicode characters in their filename
-
-### Changed
-
-- Replace grommet Select by Cunningham Select (#2400)
+- checkbox to delete resource remains displayed on others pages (#2416)
 
 ## [4.4.0] - 2023-09-08
 

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Manage/ClassroomManage.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Manage/ClassroomManage.spec.tsx
@@ -203,4 +203,19 @@ describe('<ClassroomManage />', () => {
       method: 'DELETE',
     });
   });
+
+  it('controls that the component does not stay selectable when unmount', () => {
+    const { unmount } = render(<ClassroomManage />);
+    act(() =>
+      useSelectFeatures.setState({
+        isSelectionEnabled: true,
+      }),
+    );
+
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+
+    unmount();
+
+    expect(useSelectFeatures.getState().isSelectionEnabled).toBe(false);
+  });
 });

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Manage/ClassroomManage.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Manage/ClassroomManage.tsx
@@ -112,10 +112,10 @@ const ClassroomManage = () => {
   });
 
   useEffect(() => {
-    if (!isSelectionEnabled) {
+    return () => {
       resetSelection();
-    }
-  }, [isSelectionEnabled, resetSelection]);
+    };
+  }, [resetSelection]);
 
   return (
     <Fragment>

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/Manage/LiveManage.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/Manage/LiveManage.spec.tsx
@@ -202,4 +202,19 @@ describe('<LiveManage />', () => {
       method: 'DELETE',
     });
   });
+
+  it('controls that the component does not stay selectable when unmount', () => {
+    const { unmount } = render(<LiveManage />);
+    act(() =>
+      useSelectFeatures.setState({
+        isSelectionEnabled: true,
+      }),
+    );
+
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+
+    unmount();
+
+    expect(useSelectFeatures.getState().isSelectionEnabled).toBe(false);
+  });
 });

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/Manage/LiveManage.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/Manage/LiveManage.tsx
@@ -112,10 +112,10 @@ const LiveManage = () => {
   });
 
   useEffect(() => {
-    if (!isSelectionEnabled) {
+    return () => {
       resetSelection();
-    }
-  }, [isSelectionEnabled, resetSelection]);
+    };
+  }, [resetSelection]);
 
   return (
     <Fragment>

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Video/components/Manage/VideoManage.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Video/components/Manage/VideoManage.spec.tsx
@@ -193,4 +193,19 @@ describe('<VideoManage />', () => {
       method: 'DELETE',
     });
   });
+
+  it('controls that the component does not stay selectable when unmount', () => {
+    const { unmount } = render(<VideoManage />);
+    act(() =>
+      useSelectFeatures.setState({
+        isSelectionEnabled: true,
+      }),
+    );
+
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+
+    unmount();
+
+    expect(useSelectFeatures.getState().isSelectionEnabled).toBe(false);
+  });
 });

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Video/components/Manage/VideoManage.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Video/components/Manage/VideoManage.tsx
@@ -118,10 +118,10 @@ const VideoManage = () => {
   });
 
   useEffect(() => {
-    if (!isSelectionEnabled) {
+    return () => {
       resetSelection();
-    }
-  }, [isSelectionEnabled, resetSelection]);
+    };
+  }, [resetSelection]);
 
   return (
     <Fragment>


### PR DESCRIPTION
## Purpose

When we were deleting a resource, the checkbox to delete it remained displayed on the cards even on the other pages. 
See: https://github.com/openfun/marsha/issues/2409

