### PR TITLE
🐛(website) correctly redirect a user when a resource is deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Save license when a video is created
 - Show an error when a resource has been deleted
 - Allow depositedfiles to have unicode characters in their filename
-- checkbox to delete resource remains displayed on others pages (#2416)
+- Correctly redirect a user when a resource is deleted (#2419)
+- Checkbox to delete resource remains displayed on others pages (#2416)
 
 ## [4.4.0] - 2023-09-08
 

--- a/src/frontend/apps/lti_site/components/VideoWizard/index.tsx
+++ b/src/frontend/apps/lti_site/components/VideoWizard/index.tsx
@@ -70,7 +70,7 @@ const VideoWizard = () => {
               }}
               onPreviousButtonClick={() => {
                 if (history.length > 1) {
-                  navigate(-1);
+                  navigate('..');
                 } else {
                   navigate(builderVideoWizzardRoute());
                 }

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Manage/ClassRoomCreateForm.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Manage/ClassRoomCreateForm.tsx
@@ -153,7 +153,7 @@ const ClassroomCreateForm = () => {
 
         <ModalButton
           label={intl.formatMessage(messages.submitLabel)}
-          onClickCancel={() => navigate(-1)}
+          onClickCancel={() => navigate('..')}
           isSubmitting={isCreating}
           isDisabled={!classroom.title || !classroom.playlist}
         />

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Manage/ClassroomManage.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Manage/ClassroomManage.tsx
@@ -161,7 +161,7 @@ const ClassroomManage = () => {
         <Modal
           isOpen
           onClose={() => {
-            navigate(-1);
+            navigate('..');
           }}
         >
           <Heading

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/Manage/LiveCreateForm.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/Manage/LiveCreateForm.tsx
@@ -166,7 +166,7 @@ const LiveCreateForm = () => {
         <ModalButton
           label={intl.formatMessage(messages.submitLabel)}
           onClickCancel={() => {
-            navigate(-1);
+            navigate('..');
           }}
           isSubmitting={isCreating || isUpdatingToLive}
           isDisabled={!live.title || !live.playlist}

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/Manage/LiveManage.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Live/components/Manage/LiveManage.tsx
@@ -162,7 +162,7 @@ const LiveManage = () => {
         <Modal
           isOpen
           onClose={() => {
-            navigate(-1);
+            navigate('..');
           }}
         >
           <Heading

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Video/components/Manage/VideoCreateForm.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Video/components/Manage/VideoCreateForm.tsx
@@ -203,7 +203,7 @@ const VideoCreateForm = () => {
         <ModalButton
           label={intl.formatMessage(messages.submitLabel)}
           onClickCancel={() => {
-            navigate(-1);
+            navigate('..');
           }}
           isSubmitting={isCreating}
           isDisabled={!video.videoFile || isUploading}

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/Video/components/Manage/VideoManage.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/Video/components/Manage/VideoManage.tsx
@@ -170,7 +170,7 @@ const VideoManage = () => {
         <Modal
           isOpen
           onClose={() => {
-            navigate(-1);
+            navigate('..');
           }}
         >
           <Heading

--- a/src/frontend/apps/standalone_site/src/features/Playlist/components/CreatePlaylistForm.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Playlist/components/CreatePlaylistForm.tsx
@@ -53,7 +53,7 @@ export const CreatePlaylistForm = () => {
         });
       }}
       onCancel={() => {
-        navigate(-1);
+        navigate('..');
       }}
       submitTitle={intl.formatMessage(messages.createPlaylistButtonTitle)}
       isSubmitting={isCreating}

--- a/src/frontend/apps/standalone_site/src/features/Playlist/components/PlaylistPage.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Playlist/components/PlaylistPage.tsx
@@ -151,7 +151,7 @@ export const PlaylistPage = () => {
             <Modal
               isOpen
               onClose={() => {
-                navigate(-1);
+                navigate('..');
               }}
             >
               <CreatePlaylistForm />

--- a/src/frontend/packages/lib_classroom/src/components/ClassroomWidgetProvider/widgets/DeleteClassroom/index.tsx
+++ b/src/frontend/packages/lib_classroom/src/components/ClassroomWidgetProvider/widgets/DeleteClassroom/index.tsx
@@ -80,7 +80,7 @@ export const DeleteClassroom = () => {
       toast.success(intl.formatMessage(messages.classroomDeleteSuccess), {
         position: 'bottom-center',
       });
-      navigate(-1);
+      navigate('..');
     },
     onError: (err: unknown) => {
       report(err);

--- a/src/frontend/packages/lib_markdown/src/components/MarkdownEditor/index.spec.tsx
+++ b/src/frontend/packages/lib_markdown/src/components/MarkdownEditor/index.spec.tsx
@@ -185,8 +185,11 @@ describe('<MarkdownEditor />', () => {
     render(<MarkdownEditor markdownDocumentId={markdownDocument.id} />);
 
     // Wait for rendered content: all loaders gone
-    await waitFor(() =>
-      expect(screen.queryByRole('status')).not.toBeInTheDocument(),
+    await waitFor(
+      () => expect(screen.queryByRole('status')).not.toBeInTheDocument(),
+      {
+        timeout: 1000,
+      },
     );
 
     expect(screen.getByTestId('renderer_container')).toContainHTML(

--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/DeleteVideo/index.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/DeleteVideo/index.tsx
@@ -112,7 +112,7 @@ export const DeleteVideo = () => {
           position: 'bottom-center',
         },
       );
-      navigate(-1);
+      navigate('..');
     },
     onError: (err: unknown) => {
       report(err);


### PR DESCRIPTION
## Purpose

We were redirecting the user to his previous page, sometimes there was no previous page or the previous page was not the most relevant one. Now we redirect to the parent page.
See issue: https://github.com/openfun/marsha/issues/2404



