### PR TITLE
♻️(back) remove deprecation about timezone

### DIFF
--- a/src/backend/marsha/bbb/factories.py
+++ b/src/backend/marsha/bbb/factories.py
@@ -1,4 +1,5 @@
 """Factories for the ``bbb`` app of the Marsha project."""
+from datetime import timezone
 
 import factory
 from factory.django import DjangoModelFactory
@@ -44,4 +45,4 @@ class ClassroomRecordingFactory(DjangoModelFactory):
 
     classroom = factory.SubFactory(ClassroomFactory)
     record_id = factory.Faker("uuid4")
-    started_at = factory.Faker("date_time")
+    started_at = factory.Faker("date_time", tzinfo=timezone.utc)

--- a/src/backend/marsha/bbb/management/commands/refresh_bbb_recordings.py
+++ b/src/backend/marsha/bbb/management/commands/refresh_bbb_recordings.py
@@ -1,7 +1,10 @@
 """Test update recording management command."""
+from datetime import timezone
 import logging
 
 from django.core.management.base import BaseCommand
+
+from dateutil.parser import parse
 
 from marsha.bbb.models import Classroom, ClassroomRecording
 from marsha.bbb.utils.bbb_utils import get_recordings, process_recordings
@@ -67,10 +70,12 @@ class Command(BaseCommand):
             classroom_recordings = classroom.recordings.all()
             if before:
                 classroom_recordings = classroom_recordings.filter(
-                    started_at__lt=before
+                    started_at__lt=parse(before).replace(tzinfo=timezone.utc)
                 )
             if after:
-                classroom_recordings = classroom_recordings.filter(started_at__gt=after)
+                classroom_recordings = classroom_recordings.filter(
+                    started_at__gt=parse(after).replace(tzinfo=timezone.utc)
+                )
             known_recording_ids = classroom_recordings.values_list(
                 "record_id", flat=True
             )

--- a/src/backend/marsha/bbb/tests/test_command_refresh_bbb_recordings.py
+++ b/src/backend/marsha/bbb/tests/test_command_refresh_bbb_recordings.py
@@ -1,4 +1,5 @@
 """Test the development ``refresh_bbb_recordings` management command."""
+from datetime import datetime, timezone
 from logging import Logger
 from unittest import mock
 
@@ -572,7 +573,7 @@ class RefreshBBBRecordingsTestCase(TransactionTestCase):
             id="0fabc045-6b9b-4914-bfbd-8b90c9eee9fc",
             record_id="d58d38e9e31b71a04b993c041d7ca74ef8d5f0dd-1673007560234",
             classroom=classroom,
-            started_at="2023-01-09",
+            started_at=datetime(2023, 1, 9, tzinfo=timezone.utc),
         )
 
         responses.add(
@@ -708,7 +709,7 @@ class RefreshBBBRecordingsTestCase(TransactionTestCase):
             id="0fabc045-6b9b-4914-bfbd-8b90c9eee9fc",
             record_id="d58d38e9e31b71a04b993c041d7ca74ef8d5f0dd-1673007560234",
             classroom=classroom,
-            started_at="2023-01-09",
+            started_at=datetime(2023, 1, 9, tzinfo=timezone.utc),
         )
 
         responses.add(

--- a/src/backend/marsha/bbb/tests/test_delete_outdated_classrooms.py
+++ b/src/backend/marsha/bbb/tests/test_delete_outdated_classrooms.py
@@ -1,5 +1,5 @@
 """Test delete_outdated_classrooms command."""
-from datetime import date, datetime
+from datetime import date, datetime, timezone as baseTimezone
 from unittest.mock import patch
 
 from django.core.management import call_command
@@ -35,7 +35,9 @@ class DeleteOutdatedClassroomsTestCase(TestCase):
         """
         Test the delete_outdated_classrooms command.
         """
-        with patch.object(timezone, "now", return_value=datetime(2022, 1, 2)):
+        with patch.object(
+            timezone, "now", return_value=datetime(2022, 1, 2, tzinfo=baseTimezone.utc)
+        ):
             call_command("delete_outdated_classrooms")
             self.assertEqual(Classroom.objects.count(), 2)
 

--- a/src/backend/marsha/core/tests/management_commands/test_delete_outdated_videos.py
+++ b/src/backend/marsha/core/tests/management_commands/test_delete_outdated_videos.py
@@ -1,5 +1,5 @@
 """Test delete_outdated_videos command."""
-from datetime import date, datetime
+from datetime import date, datetime, timezone as baseTimezone
 from unittest.mock import patch
 
 from django.core.management import call_command
@@ -35,7 +35,9 @@ class DeleteOutdatedVideosTestCase(TestCase):
         """
         Test the delete_outdated_videos command.
         """
-        with patch.object(timezone, "now", return_value=datetime(2022, 1, 2)):
+        with patch.object(
+            timezone, "now", return_value=datetime(2022, 1, 2, tzinfo=baseTimezone.utc)
+        ):
             call_command("delete_outdated_videos")
             self.assertEqual(Video.objects.count(), 2)
 

--- a/src/backend/marsha/core/tests/models/test_retention_date_object_mixin.py
+++ b/src/backend/marsha/core/tests/models/test_retention_date_object_mixin.py
@@ -1,5 +1,5 @@
 """Tests for the RetentionDateObjectMixin in the ``core`` app of the Marsha project."""
-from datetime import date, datetime
+from datetime import date, datetime, timezone as baseTimezone
 from unittest.mock import Mock, patch
 
 from django.test import TestCase, override_settings
@@ -39,7 +39,9 @@ class RetentionDateObjectMixinTextCase(TestCase):
         """
         with patch(
             "marsha.core.models.playlist.s3_utils", new=self.mock_s3_utils
-        ), patch.object(timezone, "now", return_value=datetime(2022, 1, 1)):
+        ), patch.object(
+            timezone, "now", return_value=datetime(2022, 1, 1, tzinfo=baseTimezone.utc)
+        ):
             video = VideoFactory(playlist=self.playlist)
 
             self.assertEqual(video.retention_date, date(2022, 1, 31))
@@ -56,8 +58,10 @@ class RetentionDateObjectMixinTextCase(TestCase):
 
         with patch(
             "marsha.core.models.playlist.s3_utils", new=self.mock_s3_utils
-        ), patch.object(timezone, "now", return_value=datetime(2022, 1, 15)):
-            video.retention_date = datetime(2022, 1, 1)
+        ), patch.object(
+            timezone, "now", return_value=datetime(2022, 1, 15, tzinfo=baseTimezone.utc)
+        ):
+            video.retention_date = datetime(2022, 1, 1, tzinfo=baseTimezone.utc)
             video.save()
             video.refresh_from_db()
 
@@ -78,7 +82,9 @@ class RetentionDateObjectMixinTextCase(TestCase):
 
         with patch(
             "marsha.core.models.playlist.s3_utils", new=self.mock_s3_utils
-        ), patch.object(timezone, "now", return_value=datetime(2022, 1, 1)):
+        ), patch.object(
+            timezone, "now", return_value=datetime(2022, 1, 1, tzinfo=baseTimezone.utc)
+        ):
             video.delete()
             video.refresh_from_db()
 
@@ -99,7 +105,9 @@ class RetentionDateObjectMixinTextCase(TestCase):
 
         with patch(
             "marsha.core.models.playlist.s3_utils", new=self.mock_s3_utils
-        ), patch.object(timezone, "now", return_value=datetime(2022, 1, 1)):
+        ), patch.object(
+            timezone, "now", return_value=datetime(2022, 1, 1, tzinfo=baseTimezone.utc)
+        ):
             video.undelete()
             video.refresh_from_db()
 

--- a/src/backend/marsha/core/tests/test_api_playlist_portability.py
+++ b/src/backend/marsha/core/tests/test_api_playlist_portability.py
@@ -39,7 +39,7 @@ class PlaylistPortabilityAPITest(TestCase):
             response = self._patch_video(video, {})
 
         self.assertEqual(response.status_code, 200)
-        self.assertQuerysetEqual(video.playlist.portable_to.all(), [])
+        self.assertQuerySetEqual(video.playlist.portable_to.all(), [])
 
     def test_no_portability_empty_portable_to(self):
         """
@@ -54,7 +54,7 @@ class PlaylistPortabilityAPITest(TestCase):
             response = self._patch_video(video, {"portable_to": []})
 
         self.assertEqual(response.status_code, 200)
-        self.assertQuerysetEqual(video.playlist.portable_to.all(), [])
+        self.assertQuerySetEqual(video.playlist.portable_to.all(), [])
 
     def test_no_portability_portable_to_new(self):
         """
@@ -70,7 +70,7 @@ class PlaylistPortabilityAPITest(TestCase):
             response = self._patch_video(video, {"portable_to": [str(new_playlist.id)]})
 
         self.assertEqual(response.status_code, 200)
-        self.assertQuerysetEqual(video.playlist.portable_to.all(), [new_playlist])
+        self.assertQuerySetEqual(video.playlist.portable_to.all(), [new_playlist])
 
     def test_no_portability_portable_to_invalid_uuid(self):
         """
@@ -88,7 +88,7 @@ class PlaylistPortabilityAPITest(TestCase):
         self.assertEqual(
             response.json(), {"portable_to": "“invalid_uuid” is not a valid UUID."}
         )
-        self.assertQuerysetEqual(video.playlist.portable_to.all(), [])
+        self.assertQuerySetEqual(video.playlist.portable_to.all(), [])
 
     def test_no_portability_portable_to_unknown(self):
         """
@@ -108,7 +108,7 @@ class PlaylistPortabilityAPITest(TestCase):
             response.json(),
             {"portable_to": f"Some playlists don't exist: {unknown_id}."},
         )
-        self.assertQuerysetEqual(video.playlist.portable_to.all(), [])
+        self.assertQuerySetEqual(video.playlist.portable_to.all(), [])
 
     def test_no_portability_portable_to_unknown_and_new(self):
         """
@@ -131,7 +131,7 @@ class PlaylistPortabilityAPITest(TestCase):
             response.json(),
             {"portable_to": f"Some playlists don't exist: {unknown_id}."},
         )
-        self.assertQuerysetEqual(video.playlist.portable_to.all(), [])
+        self.assertQuerySetEqual(video.playlist.portable_to.all(), [])
 
     def test_no_portability_portable_to_self(self):
         """
@@ -149,7 +149,7 @@ class PlaylistPortabilityAPITest(TestCase):
         self.assertEqual(
             response.json(), {"portable_to": "Playlist is not portable to itself."}
         )
-        self.assertQuerysetEqual(video.playlist.portable_to.all(), [])
+        self.assertQuerySetEqual(video.playlist.portable_to.all(), [])
 
     def test_no_portability_portable_to_multiple_self(self):
         """
@@ -169,7 +169,7 @@ class PlaylistPortabilityAPITest(TestCase):
         self.assertEqual(
             response.json(), {"portable_to": "Playlist is not portable to itself."}
         )
-        self.assertQuerysetEqual(video.playlist.portable_to.all(), [])
+        self.assertQuerySetEqual(video.playlist.portable_to.all(), [])
 
     def test_no_portability_portable_to_self_and_new(self):
         """
@@ -190,7 +190,7 @@ class PlaylistPortabilityAPITest(TestCase):
         self.assertEqual(
             response.json(), {"portable_to": "Playlist is not portable to itself."}
         )
-        self.assertQuerysetEqual(video.playlist.portable_to.all(), [])
+        self.assertQuerySetEqual(video.playlist.portable_to.all(), [])
 
     def test_no_portability_portable_to_self_and_unknown(self):
         """
@@ -211,7 +211,7 @@ class PlaylistPortabilityAPITest(TestCase):
         self.assertEqual(
             response.json(), {"portable_to": "Playlist is not portable to itself."}
         )
-        self.assertQuerysetEqual(video.playlist.portable_to.all(), [])
+        self.assertQuerySetEqual(video.playlist.portable_to.all(), [])
 
     def test_no_portability_portable_to_self_new_and_unknown(self):
         """
@@ -240,7 +240,7 @@ class PlaylistPortabilityAPITest(TestCase):
         self.assertEqual(
             response.json(), {"portable_to": "Playlist is not portable to itself."}
         )
-        self.assertQuerysetEqual(video.playlist.portable_to.all(), [])
+        self.assertQuerySetEqual(video.playlist.portable_to.all(), [])
 
     def test_has_portability_no_portable_to(self):
         """
@@ -257,7 +257,7 @@ class PlaylistPortabilityAPITest(TestCase):
             response = self._patch_video(video, {})
 
         self.assertEqual(response.status_code, 200)
-        self.assertQuerysetEqual(video.playlist.portable_to.all(), [ported_to_playlist])
+        self.assertQuerySetEqual(video.playlist.portable_to.all(), [ported_to_playlist])
 
     def test_has_portability_empty_portable_to(self):
         """
@@ -274,7 +274,7 @@ class PlaylistPortabilityAPITest(TestCase):
             response = self._patch_video(video, {"portable_to": []})
 
         self.assertEqual(response.status_code, 200)
-        self.assertQuerysetEqual(video.playlist.portable_to.all(), [])
+        self.assertQuerySetEqual(video.playlist.portable_to.all(), [])
 
     def test_has_portability_portable_to_ported(self):
         """
@@ -293,7 +293,7 @@ class PlaylistPortabilityAPITest(TestCase):
             )
 
         self.assertEqual(response.status_code, 200)
-        self.assertQuerysetEqual(video.playlist.portable_to.all(), [ported_to_playlist])
+        self.assertQuerySetEqual(video.playlist.portable_to.all(), [ported_to_playlist])
 
     def test_has_portability_portable_to_new(self):
         """
@@ -310,7 +310,7 @@ class PlaylistPortabilityAPITest(TestCase):
         response = self._patch_video(video, {"portable_to": [str(new_playlist.id)]})
 
         self.assertEqual(response.status_code, 200)
-        self.assertQuerysetEqual(video.playlist.portable_to.all(), [new_playlist])
+        self.assertQuerySetEqual(video.playlist.portable_to.all(), [new_playlist])
 
     def test_has_portability_portable_to_unknown(self):
         """
@@ -332,7 +332,7 @@ class PlaylistPortabilityAPITest(TestCase):
             response.json(),
             {"portable_to": f"Some playlists don't exist: {unknown_id}."},
         )
-        self.assertQuerysetEqual(video.playlist.portable_to.all(), [ported_to_playlist])
+        self.assertQuerySetEqual(video.playlist.portable_to.all(), [ported_to_playlist])
 
     def test_has_portability_portable_to_unknown_and_ported(self):
         """
@@ -356,7 +356,7 @@ class PlaylistPortabilityAPITest(TestCase):
             response.json(),
             {"portable_to": f"Some playlists don't exist: {unknown_id}."},
         )
-        self.assertQuerysetEqual(video.playlist.portable_to.all(), [ported_to_playlist])
+        self.assertQuerySetEqual(video.playlist.portable_to.all(), [ported_to_playlist])
 
     def test_has_portability_portable_to_new_and_ported(self):
         """
@@ -375,7 +375,7 @@ class PlaylistPortabilityAPITest(TestCase):
         )
 
         self.assertEqual(response.status_code, 200)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             video.playlist.portable_to.all(),
             [new_playlist, ported_to_playlist],
             ordered=False,
@@ -404,7 +404,7 @@ class PlaylistPortabilityAPITest(TestCase):
             response.json(),
             {"portable_to": f"Some playlists don't exist: {unknown_id}."},
         )
-        self.assertQuerysetEqual(video.playlist.portable_to.all(), [ported_to_playlist])
+        self.assertQuerySetEqual(video.playlist.portable_to.all(), [ported_to_playlist])
 
     def test_has_portability_portable_to_unknown_ported_and_new(self):
         """
@@ -437,7 +437,7 @@ class PlaylistPortabilityAPITest(TestCase):
             response.json(),
             {"portable_to": f"Some playlists don't exist: {unknown_id}."},
         )
-        self.assertQuerysetEqual(video.playlist.portable_to.all(), [ported_to_playlist])
+        self.assertQuerySetEqual(video.playlist.portable_to.all(), [ported_to_playlist])
 
     def test_has_portability_portable_to_unknown_self_ported_and_new(self):
         """
@@ -470,4 +470,4 @@ class PlaylistPortabilityAPITest(TestCase):
         self.assertEqual(
             response.json(), {"portable_to": "Playlist is not portable to itself."}
         )
-        self.assertQuerysetEqual(video.playlist.portable_to.all(), [ported_to_playlist])
+        self.assertQuerySetEqual(video.playlist.portable_to.all(), [ported_to_playlist])

--- a/src/backend/marsha/deposit/tests/api/depositedfiles/test_initiate_upload.py
+++ b/src/backend/marsha/deposit/tests/api/depositedfiles/test_initiate_upload.py
@@ -177,7 +177,7 @@ class DepositedFileInitiateUploadAPITest(TestCase):
         )
         jwt_token = UserAccessTokenFactory(user=organization_access.user)
 
-        now = datetime(2018, 8, 8, tzinfo=timezone.utc)
+        now = datetime(2018, 8, 8, tzinfo=baseTimezone.utc)
         with mock.patch.object(timezone, "now", return_value=now), mock.patch(
             "datetime.datetime"
         ) as mock_dt:

--- a/src/backend/marsha/markdown/factories.py
+++ b/src/backend/marsha/markdown/factories.py
@@ -36,6 +36,7 @@ class MarkdownDocumentFactory(DjangoModelFactory):
 
     class Meta:  # noqa
         model = models.MarkdownDocument
+        skip_postgeneration_save = True
 
     lti_id = factory.Faker("uuid4")
     playlist = factory.SubFactory(PlaylistFactory)


### PR DESCRIPTION
## Purpose

In django 5.0, lot of code related to pytz timezone is removed. Naive datetime are not supported anymore because we will use the USE_TZ setting with the value True. Also, django.utils.timezone.utc is removed.

## Proposal

- [x] remove deprecation about timezone

