### PR TITLE
⬆️(back) upgrade channels and channels-redis to version 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Replace grommet Heading (#2410)
 - Upgrade to python 3.11
+- Upgrade channels and channels-redis to version 4
 
 ## [4.5.0] - 2023-09-15
 

--- a/renovate.json
+++ b/renovate.json
@@ -37,17 +37,6 @@
       ]
     },
     {
-      "groupName": "allowed django channels version",
-      "matchManagers": [
-        "setup-cfg"
-      ],
-      "matchPackageNames": [
-        "channels",
-        "channels-redis"
-      ],
-      "allowedVersions": "<4"
-    },
-    {
       "groupName": "allowed urllib3 versions",
       "matchManagers": [
         "setup-cfg"

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -870,7 +870,9 @@ class Development(Base):
     P2P_WEB_TORRENT_TRACKER_URLS = values.ListValue(["ws://localhost:8080"])
 
     # Development tools
-    INSTALLED_APPS = Base.INSTALLED_APPS + ["marsha.development.apps.DevelopmentConfig"]
+    INSTALLED_APPS = (
+        ["daphne"] + Base.INSTALLED_APPS + ["marsha.development.apps.DevelopmentConfig"]
+    )
 
     # Mail
     EMAIL_HOST = values.Value("mailcatcher")

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -29,8 +29,8 @@ requires-python = >=3.9
 install_requires =
     Brotli==1.1.0
     boto3==1.28.49
-    channels<4
-    channels-redis<4
+    channels[daphne]==4.0.0
+    channels-redis==4.1.0
     chardet==5.2.0
     coreapi==2.3.3
     cryptography==41.0.3


### PR DESCRIPTION
## Purpose

Channels and channels-redis were blocked in version 3 because version 4 was not compatible with recent version of python and django. Now we are using django 4.2 and python 3.11 we can upgrade them. Upgrading them fixes an issue linked to internal usage of asyncio.

## Proposal

- [x] upgrade channels and channels-redis to version 4

