### PR TITLE
⬆️(e2e) upgrade playwright docker image to v1.40.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -577,7 +577,7 @@ jobs:
 
   test-e2e:
     docker:
-      - image: mcr.microsoft.com/playwright:v1.33.0
+      - image: mcr.microsoft.com/playwright:v1.40.0-jammy
         auth:
           username: $DOCKER_HUB_USER
           password: $DOCKER_HUB_PASS
@@ -654,7 +654,9 @@ jobs:
       - run:
           name: Ensure << parameters.browser >> browser is installed
           working_directory: /home/circleci/marsha/src/backend
-          command: python3.11 -m playwright install "<< parameters.browser >>"
+          command: |
+            python3.11 -m playwright install-deps "<< parameters.browser >>"
+            python3.11 -m playwright install "<< parameters.browser >>"
       - run:
           name: Install dockerize
           command: |
@@ -679,16 +681,16 @@ jobs:
                 command: python3.11 -m playwright install chrome
       # webkit browser is kind of broken with jammy
       # see https://github.com/microsoft/playwright/issues/15764#issuecomment-1462787720
-      - when:
-          condition:
-            equal: [webkit, << parameters.browser_channel >>]
-          steps:
-            - run:
-                name: Remove broken gstreamer plugin scan
-                command: rm /usr/lib/x86_64-linux-gnu/gstreamer1.0/gstreamer-1.0/gst-plugin-scanner
-            - run:
-                name: Replace gstreamer plugin scan with a dummy
-                command: ln -s /usr/bin/true /usr/lib/x86_64-linux-gnu/gstreamer1.0/gstreamer-1.0/gst-plugin-scanner
+      # - when:
+      #     condition:
+      #       equal: [ webkit, << parameters.browser_channel >> ]
+      #     steps:
+      #       - run:
+      #           name: Remove broken gstreamer plugin scan
+      #           command: rm /usr/lib/x86_64-linux-gnu/gstreamer1.0/gstreamer-1.0/gst-plugin-scanner
+      #       - run:
+      #           name: Replace gstreamer plugin scan with a dummy
+      #           command: ln -s /usr/bin/true /usr/lib/x86_64-linux-gnu/gstreamer1.0/gstreamer-1.0/gst-plugin-scanner
       - run:
           name: Run e2e tests
           working_directory: /home/circleci/marsha/src/backend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,6 +70,7 @@ services:
     env_file:
       - env.d/db
       - env.d/${ENV_FILE:-development}
+      - env.d/db
     ports:
       - "8070:8000"
     volumes:

--- a/docker/images/e2e/Dockerfile
+++ b/docker/images/e2e/Dockerfile
@@ -7,12 +7,22 @@ COPY src/backend/setup.cfg /app/src/backend/
 
 WORKDIR /app/src/backend
 
-# Ensure pip is installed
+# Install python 3.11 and Ensure pip is installed
 # Install xmlsec1 dependencies required for xmlsec (for SAML)
 # Needs to be kept before the `pip install`
 RUN apt-get update && \
-    apt-get install -y \
-    python3-pip pkg-config libxml2-dev libxmlsec1-openssl libxmlsec1-dev && \
+    apt-get upgrade -y && \
+    apt install -y software-properties-common && \
+    add-apt-repository -y ppa:deadsnakes/ppa && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        python3.11 \
+        python3.11-dev \
+        build-essential \
+        pkg-config \
+        libxml2-dev \
+        libxmlsec1-openssl \
+        libxmlsec1-dev && \
+    curl -sS https://bootstrap.pypa.io/get-pip.py | python3.11 && \
     rm -rf /var/lib/apt/lists/*
 
 # Install development dependencies

--- a/docker/images/e2e/Dockerfile
+++ b/docker/images/e2e/Dockerfile
@@ -1,6 +1,6 @@
 FROM marsha:dev as marsha
 
-FROM mcr.microsoft.com/playwright:v1.33.0
+FROM mcr.microsoft.com/playwright:v1.40.0-jammy
 
 COPY --from=marsha /app /app
 COPY src/backend/setup.cfg /app/src/backend/


### PR DESCRIPTION
## Purpose

The docker image version of playwright does not match anymore the python playsright package. We have to upgrade it both in our image and in the CI.

## Proposal

- [x] upgrade playwright docker image to v1.40.0

