### PR TITLE
🐛(back) force bbb user_id uniqueness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Upgrade to python 3.11
 - Upgrade channels and channels-redis to version 4
 
+### Fixed
+
+- force bbb user_id uniqueness in join url
+
 ## [4.5.0] - 2023-09-15
 
 ### Changed

--- a/src/backend/marsha/bbb/api.py
+++ b/src/backend/marsha/bbb/api.py
@@ -1,4 +1,6 @@
 """Declare API endpoints with Django RestFramework viewsets."""
+from uuid import uuid4
+
 from django.conf import settings
 from django.db.models import Q
 from django.http import Http404
@@ -339,8 +341,8 @@ class ClassroomViewSet(
                 roles = request.resource.roles
                 moderator = "administrator" in roles or "instructor" in roles
                 consumer_site_user_id = (
-                    f"{request.resource.consumer_site}_"
-                    f"{request.resource.user.get('id')}"
+                    f"{request.resource.consumer_site or request.resource.playlist_id}_"
+                    f"{request.resource.user.get('id', uuid4())}"
                 )
             else:
                 # Assume that the user is a moderator
@@ -349,6 +351,7 @@ class ClassroomViewSet(
 
                 # Use the user id as consumer_site_user_id
                 consumer_site_user_id = request.user.id
+
             response = join(
                 classroom=self.get_object(),
                 consumer_site_user_id=consumer_site_user_id,

--- a/src/backend/marsha/bbb/tests/test_utils_tokens.py
+++ b/src/backend/marsha/bbb/tests/test_utils_tokens.py
@@ -2,6 +2,7 @@
 from datetime import datetime, timedelta, timezone as baseTimezone
 import json
 from unittest import mock
+from uuid import UUID
 
 from django.test import TestCase, override_settings
 from django.utils import timezone
@@ -241,17 +242,20 @@ class CreateStableInviteJwtTestCase(TestCase):
         classroom = ClassroomFactory()
         jwt = create_classroom_stable_invite_jwt(classroom)
 
-        response = self.client.patch(
-            f"/api/classrooms/{classroom.id}/join/",
-            data=json.dumps({"fullname": "John Doe"}),
-            content_type="application/json",
-            HTTP_AUTHORIZATION=f"Bearer {jwt}",
-        )
+        with mock.patch("marsha.bbb.api.uuid4") as uuid_mock:
+            uuid_mock.return_value = UUID("0c0ff476-7495-444f-b452-713d5c9aa859")
+            response = self.client.patch(
+                f"/api/classrooms/{classroom.id}/join/",
+                data=json.dumps({"fullname": "John Doe"}),
+                content_type="application/json",
+                HTTP_AUTHORIZATION=f"Bearer {jwt}",
+            )
         self.assertEqual(response.status_code, 200)
         self.assertIn(
             "https://10.7.7.1/bigbluebutton/api/join?"
             f"fullName=John+Doe&meetingID={classroom.meeting_id}&"
-            "role=viewer&userID=None_None&redirect=true",
+            f"role=viewer&userID={classroom.playlist_id}_0c0ff476-7495-444f-b452-713d5c9aa859"
+            "&redirect=true",
             response.data.get("url"),
         )
 
@@ -295,16 +299,19 @@ class CreateStableInviteJwtTestCase(TestCase):
         classroom = ClassroomFactory()
         jwt = create_classroom_stable_invite_jwt(classroom, role=INSTRUCTOR)
 
-        response = self.client.patch(
-            f"/api/classrooms/{classroom.id}/join/",
-            data=json.dumps({"fullname": "John Doe"}),
-            content_type="application/json",
-            HTTP_AUTHORIZATION=f"Bearer {jwt}",
-        )
+        with mock.patch("marsha.bbb.api.uuid4") as uuid_mock:
+            uuid_mock.return_value = UUID("24bd554e-30f8-4a3a-9883-3c98f83982c9")
+            response = self.client.patch(
+                f"/api/classrooms/{classroom.id}/join/",
+                data=json.dumps({"fullname": "John Doe"}),
+                content_type="application/json",
+                HTTP_AUTHORIZATION=f"Bearer {jwt}",
+            )
         self.assertEqual(response.status_code, 200)
         self.assertIn(
             "https://10.7.7.1/bigbluebutton/api/join?"
             f"fullName=John+Doe&meetingID={classroom.meeting_id}&"
-            "role=moderator&userID=None_None&redirect=true",
+            f"role=moderator&userID={classroom.playlist_id}_24bd554e-30f8-4a3a-9883-3c98f83982c9"
+            "&redirect=true",
             response.data.get("url"),
         )


### PR DESCRIPTION
## Purpose

When a user is joining a classroom, created in the standalone site, from an invite link, the JWT token does not contains user id and the resource does not belong to a consumer site. In that case, the user_id parameters set in the join url will be the same for all user using an invite link. With BBB 2.6 it seems that it is not possible anymore to have multiple time the same user with the same user_id. Surprisingly user are ejected once 4 users with the same user_id have joined and they are ejected randomly.

## Proposal

- [x] force bbb user_id uniqueness

