### PR TITLE
🐛(frontend) fix markdown rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Markdown save sent previously saved content
+
 ## [4.6.0] - 2023-10-02
 
 ### Added

--- a/src/frontend/packages/lib_markdown/src/components/MdxRenderer/index.spec.tsx
+++ b/src/frontend/packages/lib_markdown/src/components/MdxRenderer/index.spec.tsx
@@ -75,6 +75,7 @@ describe('<MdxRenderer />', () => {
     expect(
       container.getElementsByClassName('markdown-body')[0],
     ).toMatchSnapshot();
+    expect(onRenderedContentChange).toHaveBeenCalledWith('');
   });
 
   it('renders simple markdown', async () => {
@@ -101,6 +102,9 @@ describe('<MdxRenderer />', () => {
     expect(
       container.getElementsByClassName('markdown-body')[0],
     ).toMatchSnapshot();
+    expect(onRenderedContentChange).toHaveBeenCalledWith(
+      container.getElementsByClassName('markdown-body')[0].outerHTML,
+    );
   });
 
   it('renders very simple markdown with brace', async () => {
@@ -160,6 +164,9 @@ describe('<MdxRenderer />', () => {
     expect(
       container.getElementsByClassName('markdown-body')[0],
     ).toMatchSnapshot();
+    expect(onRenderedContentChange).toHaveBeenCalledWith(
+      container.getElementsByClassName('markdown-body')[0].outerHTML,
+    );
   });
 
   it('renders markdown with math to Mathjax', async () => {
@@ -194,6 +201,9 @@ describe('<MdxRenderer />', () => {
     expect(
       container.getElementsByClassName('markdown-body')[0],
     ).toMatchSnapshot();
+    expect(onRenderedContentChange).toHaveBeenCalledWith(
+      container.getElementsByClassName('markdown-body')[0].outerHTML,
+    );
   });
 
   it('renders markdown with MDX', async () => {
@@ -235,6 +245,9 @@ describe('<MdxRenderer />', () => {
     expect(
       container.getElementsByClassName('markdown-body')[0],
     ).toMatchSnapshot();
+    expect(onRenderedContentChange).toHaveBeenCalledWith(
+      container.getElementsByClassName('markdown-body')[0].outerHTML,
+    );
   });
 
   it('renders markdown with Mermaid content', async () => {
@@ -314,6 +327,9 @@ describe('<MdxRenderer />', () => {
     expect(
       container.getElementsByClassName('markdown-body')[0],
     ).toMatchSnapshot();
+    expect(onRenderedContentChange).toHaveBeenCalledWith(
+      container.getElementsByClassName('markdown-body')[0].outerHTML,
+    );
   });
 
   it('renders markdown without XSS', async () => {
@@ -346,6 +362,9 @@ describe('<MdxRenderer />', () => {
     expect(
       container.getElementsByClassName('markdown-body')[0],
     ).toMatchSnapshot();
+    expect(onRenderedContentChange).toHaveBeenCalledWith(
+      container.getElementsByClassName('markdown-body')[0].outerHTML,
+    );
 
     // Now renders with MDX
     rerender(
@@ -367,6 +386,9 @@ describe('<MdxRenderer />', () => {
     expect(
       container.getElementsByClassName('markdown-body')[0],
     ).toMatchSnapshot();
+    expect(onRenderedContentChange).toHaveBeenCalledWith(
+      container.getElementsByClassName('markdown-body')[0].outerHTML,
+    );
   });
 
   it('renders uploaded images', async () => {

--- a/src/frontend/packages/lib_markdown/src/components/MdxRenderer/index.tsx
+++ b/src/frontend/packages/lib_markdown/src/components/MdxRenderer/index.tsx
@@ -184,10 +184,10 @@ export const MdxRenderer = ({
 
             setLoading(false); // needs to be done before fetching content, of course.
 
-            // Fetch the whole rendered content including the markdown styled div
-            const bodies = document.querySelectorAll('div.markdown-body');
-            if (bodies.length && bodies[0].outerHTML) {
-              onRenderedContentChange(bodies[0].outerHTML);
+            if (sanitizedHtmlRenderedContent) {
+              // Wrap the generated HTML in a div.markdown-body
+              const renderedHTML = `<div class="markdown-body">${sanitizedHtmlRenderedContent}</div>`;
+              onRenderedContentChange(renderedHTML);
             }
           })
           .catch((reason) => {


### PR DESCRIPTION
## Purpose

Markdown save was broken, because of a gap between the real rendered content, and the one sent to the parent component callback.

## Proposal

Don't use the dom to retrieve generated content.
