### PR TITLE
🐛(backend) fix clean_aws_elemental_stack

### DIFF
--- a/src/backend/marsha/core/management/commands/clean_aws_elemental_stack.py
+++ b/src/backend/marsha/core/management/commands/clean_aws_elemental_stack.py
@@ -94,7 +94,8 @@ class Command(BaseCommand):
         live.upload_state = DELETED
         live.live_info.pop("medialive")
         live.live_info.pop("mediapackage")
-        live.live_info.pop("live_stopped_with_email")
+        if live.live_info.get("live_stopped_with_email"):
+            live.live_info.pop("live_stopped_with_email")
         live.save(
             update_fields=(
                 "live_state",


### PR DESCRIPTION


## Purpose

When an old live without live_stopped_with_email set in live_info is cleaned, a KeyError was raised.

## Proposal

Check for live_stopped_with_email presence in live_info before removing it.

