### PR TITLE
🐛(back) force to end BBB meeting when creation fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Markdown save sent previously saved content
+- Force to end BBB meeting when creation fail
 
 ## [4.6.0] - 2023-10-02
 

--- a/src/frontend/packages/lib_classroom/src/components/DashboardClassroomForm/index.tsx
+++ b/src/frontend/packages/lib_classroom/src/components/DashboardClassroomForm/index.tsx
@@ -2,7 +2,7 @@ import { Box, Button, Tab, Tabs, ThemeContext } from 'grommet';
 import { normalizeColor } from 'grommet/utils';
 import { theme } from 'lib-common';
 import { Classroom } from 'lib-components';
-import React from 'react';
+import React, { useState } from 'react';
 import toast from 'react-hot-toast';
 import { defineMessages, useIntl } from 'react-intl';
 import styled from 'styled-components';
@@ -42,6 +42,7 @@ interface DashboardClassroomFormProps {
 
 const DashboardClassroomForm = ({ classroom }: DashboardClassroomFormProps) => {
   const intl = useIntl();
+  const [isCreating, setIsCreating] = useState(false);
   const extendedTheme = {
     tabs: {
       header: {
@@ -72,9 +73,11 @@ const DashboardClassroomForm = ({ classroom }: DashboardClassroomFormProps) => {
   const createClassroomMutation = useCreateClassroomAction(classroom.id, {
     onSuccess: (data) => {
       toast.success(data.message);
+      setIsCreating(false);
     },
     onError: () => {
       toast.error(intl.formatMessage(messages.createClassroomFail));
+      setIsCreating(false);
     },
   });
 
@@ -99,10 +102,11 @@ const DashboardClassroomForm = ({ classroom }: DashboardClassroomFormProps) => {
           <Button
             type="submit"
             label={intl.formatMessage(messages.startClassroomLabel)}
-            disabled={!classroom.title}
+            disabled={!classroom.title || isCreating}
             primary
             size="small"
             onClick={() => {
+              setIsCreating(true);
               createClassroomMutation.mutate(classroom);
             }}
           />


### PR DESCRIPTION
## Purpose

When a meeting is not correctly closed by BBB, it is not possible
to create it again. To fix this issue, we must try to force to end it
to be _maybe_ be able to create it again
See https://github.com/bigbluebutton/bigbluebutton/issues/18913


## Proposal

- [x] force to end BBB meeting when creation fail
- [x] disable classroom launch button when creating one

