### PR TITLE
⬆️(backend) update psycopg to version 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Replace grommet Button (#2453)
+- Update psycopg to version 3
 
 ## [4.7.0] - 2023-10-19
 

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -53,7 +53,7 @@ install_requires =
     logging-ldp==0.0.7
     oauthlib==3.2.2
     django-parler==2.3
-    psycopg2-binary==2.9.9
+    psycopg[binary]==3.1.12
     PyLTI==0.7.0
     python-dateutil==2.8.2
     sentry-sdk==1.32.0


### PR DESCRIPTION


## Purpose

Django 4.2 supports psycopg 3, and will remove support for version 2 in the future.

Fix #2186 

## Proposal

No further modifications seems needed other than updating the dependency.
