### PR TITLE
🛂(frontend) remove persistance student token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Remove persistency on token from invite link (#2505)
 - Replace grommet Cards / Footer/ Anchor / Tip / Nav (#2503)
 - Refacto widgets SharedLiveMedia (#2504)
 - Replace grommet Button (#2453)

--- a/src/frontend/apps/standalone_site/src/features/App/AppRoutes.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/App/AppRoutes.spec.tsx
@@ -1,7 +1,11 @@
 import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import fetchMock from 'fetch-mock';
-import { useCurrentUser, useJwt } from 'lib-components';
+import {
+  useCurrentUser,
+  useJwt,
+  localStore as useLocalJwt,
+} from 'lib-components';
 import { render } from 'lib-tests';
 
 import featureContentLoader from 'features/Contents/features/featureLoader';
@@ -126,6 +130,13 @@ describe('<AppRoutes />', () => {
     });
 
     test('render invite route', async () => {
+      useLocalJwt.setState({
+        setDecodedJwt: (jwt) =>
+          useLocalJwt.setState({
+            internalDecodedJwt: `${jwt!}-decoded` as any,
+          }),
+      });
+
       fetchMock.get('/api/classrooms/456789/token/?invite_token=123456', {
         access_token: 'fake-jwt',
       });
@@ -141,7 +152,11 @@ describe('<AppRoutes />', () => {
       ).not.toBeInTheDocument();
       expect(screen.getByText('My ClassRoomUpdate Page')).toBeInTheDocument();
       expect(screen.getByText('My Footer')).toBeInTheDocument();
-      expect(useJwt.getState().jwt).toEqual('fake-jwt');
+      expect(useLocalJwt.getState().jwt).toEqual('fake-jwt');
+      expect(useLocalJwt.getState().internalDecodedJwt).toEqual(
+        'fake-jwt-decoded',
+      );
+      expect(useJwt.getState().jwt).toBeUndefined();
     });
 
     test('render invite route error message', async () => {

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Update/ClassRoomUpdate.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Update/ClassRoomUpdate.tsx
@@ -9,6 +9,7 @@ import {
   isDecodedJwtWeb,
   useCurrentResourceContext,
   useJwt,
+  localStore as useLocalJwt,
   useResponsive,
 } from 'lib-components';
 import { useEffect, useMemo } from 'react';
@@ -69,9 +70,20 @@ const DashboardClassroomStyled = styled(Box)<DashboardClassroomStyledProps>`
 `;
 
 const ClassRoomUpdate = () => {
-  const { classroomId } = useParams();
+  const { classroomId, inviteId } = useParams();
 
-  const internalDecodedJwt = useJwt((state) => state.internalDecodedJwt);
+  const internalDecodedPersistingJwt = useJwt(
+    (state) => state.internalDecodedJwt,
+  );
+  const internalDecodedLocalJwt = useLocalJwt(
+    (state) => state.internalDecodedJwt,
+  );
+
+  // Invited users have a local jwt (working only for the current browser tab),
+  // otherwise it's a persisting jwt
+  const internalDecodedJwt = inviteId
+    ? internalDecodedLocalJwt
+    : internalDecodedPersistingJwt;
   const resourceContext: ResourceContext = useMemo(() => {
     let permissions = {
       can_access_dashboard: false,

--- a/src/frontend/packages/lib_components/src/common/Typo/index.tsx
+++ b/src/frontend/packages/lib_components/src/common/Typo/index.tsx
@@ -9,9 +9,11 @@ import {
 } from 'react';
 
 import {
+  Flex,
   Height,
   MarginPadding,
   Width,
+  stylesFlex,
   stylesHeight,
   stylesMargin,
   stylesPad,
@@ -42,8 +44,7 @@ export interface TypoPropsOnly {
   color?: CSSProperties['color'];
   display?: CSSProperties['display'];
   fill?: boolean | 'horizontal' | 'vertical' | 'full';
-  // eslint-disable-next-line @typescript-eslint/ban-types
-  flex?: boolean | 'grow' | 'shrink' | (string & {});
+  flex?: Flex;
   flow?: CSSProperties['flexFlow'];
   fontSize?: CSSProperties['fontSize'];
   height?: Height;
@@ -178,6 +179,13 @@ const TypoRef = forwardRef(
       bgClassname = ` ${background}`;
     }
 
+    if (flex) {
+      moreStyles = {
+        ...moreStyles,
+        ...stylesFlex(flex),
+      };
+    }
+
     return createElement(
       type,
       {
@@ -189,14 +197,6 @@ const TypoRef = forwardRef(
           background: bgClassname ? undefined : background,
           color: colorClassname ? undefined : color,
           display,
-          flex:
-            flex === 'grow'
-              ? '1 0 auto'
-              : flex === 'shrink'
-                ? '0 1 auto'
-                : flex === true
-                  ? '1 1 auto'
-                  : flex,
           flexBasis: basis,
           flexFlow: flow,
           fontSize,

--- a/src/frontend/packages/lib_components/src/common/Typo/styleBuilder.ts
+++ b/src/frontend/packages/lib_components/src/common/Typo/styleBuilder.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/ban-types */
 import { themeTokens } from 'lib-common';
 
 const {
@@ -14,7 +15,6 @@ const {
 } = themeTokens.spacings;
 
 type SpacingsKey = keyof typeof spacings;
-// eslint-disable-next-line @typescript-eslint/ban-types
 export type Spacings = SpacingsKey | (string & {});
 
 export const spacingValue = (value?: Spacings) =>
@@ -33,7 +33,6 @@ export type MarginPadding =
     };
 
 type SizesKey = keyof typeof sizes;
-// eslint-disable-next-line @typescript-eslint/ban-types
 export type Sizes = SizesKey | (string & {}) | (number & {});
 
 export const sizesValue = (value?: Sizes) =>
@@ -152,4 +151,31 @@ export const stylesHeight = (height: Height) => {
       height: sizesValue(height),
     };
   }
+};
+
+export type Flex = boolean | 'grow' | 'shrink' | (string & {});
+export const stylesFlex = (flex: Flex) => {
+  if (flex === 'grow') {
+    return {
+      flexGrow: 1,
+      flexShrink: 0,
+      flexBasis: 'auto',
+    };
+  } else if (flex === 'shrink') {
+    return {
+      flexGrow: 0,
+      flexShrink: 1,
+      flexBasis: 'auto',
+    };
+  } else if (flex === true) {
+    return {
+      flexGrow: 1,
+      flexShrink: 1,
+      flexBasis: 'auto',
+    };
+  }
+
+  return {
+    flex,
+  };
 };

--- a/src/frontend/packages/lib_components/src/hooks/stores/useJwt/index.ts
+++ b/src/frontend/packages/lib_components/src/hooks/stores/useJwt/index.ts
@@ -3,8 +3,8 @@ import { create } from 'zustand';
 import { DecodedJwt } from '../../../types/jwt';
 import { decodeJwt } from '../../../utils/decodeJwt';
 
-const JWT_KEY = 'JWT';
-const REFRESH_JWT_KEY = 'REFRESH_JWT';
+export const JWT_KEY = 'JWT';
+export const REFRESH_JWT_KEY = 'REFRESH_JWT';
 
 interface JwtStoreInterface {
   refreshJwtBlackListed?: string;
@@ -21,13 +21,15 @@ interface JwtStoreInterface {
   resetJwt: () => void;
 }
 
-const localStore = create<JwtStoreInterface>((set, get) => ({
+export const localStore = create<JwtStoreInterface>((set, get) => ({
   refreshJwtBlackListed: undefined,
   jwt: undefined,
   refreshJwt: undefined,
   internalDecodedJwt: undefined,
   getJwt: () => get().jwt,
-  setJwt: (jwt) => set((state) => ({ ...state, jwt })),
+  setJwt: (jwt) => {
+    set((state) => ({ ...state, jwt }));
+  },
   getRefreshJwt: () => get().refreshJwt,
   setRefreshJwt: (refreshJwt) => set((state) => ({ ...state, refreshJwt })),
   setRefreshJwtBlackListed: (refreshJwt) => {
@@ -37,8 +39,14 @@ const localStore = create<JwtStoreInterface>((set, get) => ({
     }));
   },
   setDecodedJwt: (jwt) => {
-    const decoded = decodeJwt(jwt);
-    set((state) => ({ ...state, internalDecodedJwt: decoded }));
+    if (jwt) {
+      const decoded = decodeJwt(jwt);
+      set((state) => ({ ...state, internalDecodedJwt: decoded }));
+    } else {
+      if (get().internalDecodedJwt) {
+        set((state) => ({ ...state, internalDecodedJwt: undefined }));
+      }
+    }
   },
   getDecodedJwt: () => {
     const currentValue = get().internalDecodedJwt;

--- a/src/frontend/packages/lib_components/src/utils/serviceWorker/serviceWorkerRefreshToken/useServiceWorkerRefreshToken/index.spec.tsx
+++ b/src/frontend/packages/lib_components/src/utils/serviceWorker/serviceWorkerRefreshToken/useServiceWorkerRefreshToken/index.spec.tsx
@@ -4,7 +4,7 @@ import { render } from 'lib-tests';
 import React, { Fragment } from 'react';
 
 import { useCurrentUser } from '@lib-components/hooks/stores/useCurrentUser';
-import { useJwt } from '@lib-components/hooks/stores/useJwt';
+import { JWT_KEY, useJwt } from '@lib-components/hooks/stores/useJwt';
 import { EServiceworkerAuthAction } from '@lib-components/types/serviceWorker';
 
 import { useServiceWorkerRefreshToken } from './index';
@@ -32,7 +32,7 @@ const TestComponent = () => {
 
 describe('<useServiceWorkerRefreshToken />', () => {
   beforeEach(() => {
-    localStorage.removeItem('jwt-storage');
+    localStorage.removeItem(JWT_KEY);
 
     useJwt.getState().resetJwt();
     fetchMock.restore();


### PR DESCRIPTION
## Purpose

Opening a classroom invite link switch our current token to
a student token, so when we go back to the browser instructor tab,
the resources cannot be access anymore, this is because of the
persistency of the student token. We remove this persistency,
the student token is now only valid for the current tab.

## Proposal

- [x] Remove the persistency when we are on the classroom invite link.

