### PR TITLE
🐛(lib-video) fix display issues with picture shared ressource in live

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Blocking error when shared document is deleted (#2504)
+- Improve render sharing picture in live (#2508)
 
 ## [4.7.0] - 2023-10-19
 

--- a/src/frontend/packages/lib_video/src/components/common/PictureInPictureLayer/PictureActionLayer/index.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/PictureInPictureLayer/PictureActionLayer/index.tsx
@@ -69,7 +69,7 @@ export const PictureActionLayer = ({
           a11yTitle={intl.formatMessage(messages.moreOptionTitle)}
           dropAlign={{ top: 'bottom' }}
           dropContent={
-            <Box background="black">
+            <Box background="black" align="center">
               {actions?.map((action, index) => (
                 <Box key={`pip_action_${index}`} margin="small">
                   {action}

--- a/src/frontend/packages/lib_video/src/components/common/PictureInPictureLayer/PictureInPictureElement/index.spec.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/PictureInPictureLayer/PictureInPictureElement/index.spec.tsx
@@ -29,9 +29,10 @@ describe('<PictureInPictureElement />', () => {
     const Compo = () => (
       <Button onClick={onButtonClick}>my button label</Button>
     );
+    const Action = () => <Button>some action</Button>;
 
     render(
-      <PictureInPictureElement isPicture>
+      <PictureInPictureElement isPicture pictureLayer={<Action />}>
         <Compo />
       </PictureInPictureElement>,
     );

--- a/src/frontend/packages/lib_video/src/components/common/PictureInPictureLayer/PictureInPictureElement/index.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/PictureInPictureLayer/PictureInPictureElement/index.tsx
@@ -37,11 +37,13 @@ const PictureInPictureElement = forwardRef<
       >
         {children}
 
-        <Box fill hidden={!isPicture}>
-          {pictureLayer}
+        {isPicture && pictureLayer && (
+          <Box fill>
+            {pictureLayer}
 
-          <ResizerCorner key="resize-corner" startResizing={startResizing} />
-        </Box>
+            <ResizerCorner key="resize-corner" startResizing={startResizing} />
+          </Box>
+        )}
       </Stack>
     </Box>
   );

--- a/src/frontend/packages/lib_video/src/components/common/PictureInPictureLayer/PictureInPictureSwitchAction/index.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/PictureInPictureLayer/PictureInPictureSwitchAction/index.tsx
@@ -1,5 +1,4 @@
-import { Button } from '@openfun/cunningham-react';
-import { Box, SwitchToDocumentSVG, SwitchToPlayerSVG } from 'lib-components';
+import { SwitchToDocumentSVG, SwitchToPlayerSVG } from 'lib-components';
 import React from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 
@@ -24,25 +23,34 @@ export const PictureInPictureSwitchAction = () => {
   const intl = useIntl();
   const [pipState, setPipState] = usePictureInPicture();
 
+  const style = {
+    maxHeight: '35px',
+    maxWidth: '35px',
+    width: '100%',
+    height: '100%',
+  };
+
+  if (pipState.reversed) {
+    return (
+      <SwitchToPlayerSVG
+        iconColor="white"
+        aria-label={intl.formatMessage(messages.documentActive)}
+        onClick={() => {
+          setPipState({ reversed: !pipState.reversed });
+        }}
+        style={style}
+      />
+    );
+  }
+
   return (
-    <Button
-      className="c__button-no-bg"
-      aria-label={intl.formatMessage(
-        pipState.reversed ? messages.documentActive : messages.playerActive,
-      )}
-      color="tertiary"
-      icon={
-        <Box margin="auto" height={{ max: '35px' }} width={{ max: '35px' }}>
-          {pipState.reversed ? (
-            <SwitchToPlayerSVG iconColor="white" height="100%" width="100%" />
-          ) : (
-            <SwitchToDocumentSVG iconColor="white" height="100%" width="100%" />
-          )}
-        </Box>
-      }
+    <SwitchToDocumentSVG
+      iconColor="white"
+      aria-label={intl.formatMessage(messages.playerActive)}
       onClick={() => {
         setPipState({ reversed: !pipState.reversed });
       }}
+      style={style}
     />
   );
 };

--- a/src/frontend/packages/lib_video/src/components/common/PictureInPictureLayer/index.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/PictureInPictureLayer/index.tsx
@@ -103,7 +103,7 @@ export const PictureInPictureLayer = ({
         isPicture={reversed}
         pictureLayer={
           <PictureActionLayer
-            actions={[pipSwitch, ...(pictureActions ?? [])]}
+            actions={[...[pipSwitch, ...(pictureActions ?? [])]]}
             pictureWidth={pictureWidth}
             startDragging={startDragging}
           />
@@ -121,7 +121,7 @@ export const PictureInPictureLayer = ({
           isPicture={!reversed}
           pictureLayer={
             <PictureActionLayer
-              actions={[pipSwitch, ...(pictureActions ?? [])]}
+              actions={[...[pipSwitch, ...(pictureActions ?? [])]]}
               pictureWidth={pictureWidth}
               startDragging={startDragging}
             />

--- a/src/frontend/packages/lib_video/src/components/common/TeacherVideoInfoBar/index.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/TeacherVideoInfoBar/index.tsx
@@ -13,7 +13,7 @@ export const TeacherVideoInfoBar = ({
   ...props
 }: TeacherVideoInfoBarProps) => {
   return (
-    <Box justify="center" flex="auto" {...props}>
+    <Box justify="center" flex="auto" gap="xsmall" {...props}>
       <VideoInfoBar isTeacher startDate={startDate} />
     </Box>
   );

--- a/src/frontend/packages/lib_video/src/components/common/VideoInfoBar/index.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoInfoBar/index.tsx
@@ -155,18 +155,19 @@ export const VideoInfoBar = ({ isTeacher, startDate }: VideoInfoBarProps) => {
           level={2}
           style={{ maxWidth: '100%' }}
           truncate
+          margin="none"
         >
           {title}
         </Heading>
       )}
       {numberOfStudents > 0 || localStartDate ? (
-        <Box>
+        <Box gap="xsmall">
           {numberOfStudents > 0 && (
             <Text
               type="p"
               color={colorsTokens['info-500']}
-              className={`mb-0 mr-b mb-t`}
               size="small"
+              margin={{ vertical: 'none', right: 'medium' }}
             >
               {intl.formatMessage(messages.nbViewers, {
                 numberOfStudents,
@@ -174,7 +175,7 @@ export const VideoInfoBar = ({ isTeacher, startDate }: VideoInfoBarProps) => {
             </Text>
           )}
           {localStartDate && (
-            <Text type="p" className={`mb-t`} size="small">
+            <Text type="p" size="small">
               {localStartDate}
             </Text>
           )}

--- a/src/frontend/packages/lib_video/src/components/live/Student/StudentLiveStarter/StudentLiveWrapper/StudentLiveInfoBar/index.tsx
+++ b/src/frontend/packages/lib_video/src/components/live/Student/StudentLiveStarter/StudentLiveWrapper/StudentLiveInfoBar/index.tsx
@@ -10,7 +10,7 @@ interface StudentLiveInfoBarProps {
 
 export const StudentLiveInfoBar = ({ startDate }: StudentLiveInfoBarProps) => {
   return (
-    <Box>
+    <Box gap="xsmall">
       <VideoInfoBar isTeacher={false} startDate={startDate} />
     </Box>
   );

--- a/src/frontend/packages/lib_video/src/components/live/Teacher/Wrapper/Controls/TeacherLiveRecordingActions/index.tsx
+++ b/src/frontend/packages/lib_video/src/components/live/Teacher/Wrapper/Controls/TeacherLiveRecordingActions/index.tsx
@@ -23,23 +23,7 @@ export const TeacherLiveRecordingActions = ({
     return <Fragment />;
   }
 
-  if (video.is_recording) {
-    return (
-      <Box
-        margin={{ horizontal: 'medium' }}
-        pad={{ horizontal: 'auto', vertical: 'small' }}
-      >
-        <StopRecording />
-      </Box>
-    );
-  } else {
-    return (
-      <Box
-        margin={{ horizontal: 'medium' }}
-        pad={{ horizontal: 'auto', vertical: 'small' }}
-      >
-        <StartRecording />
-      </Box>
-    );
-  }
+  return (
+    <Box>{video.is_recording ? <StopRecording /> : <StartRecording />}</Box>
+  );
 };

--- a/src/frontend/packages/lib_video/src/components/live/Teacher/Wrapper/Controls/index.tsx
+++ b/src/frontend/packages/lib_video/src/components/live/Teacher/Wrapper/Controls/index.tsx
@@ -19,7 +19,12 @@ export const Controls = ({
   return (
     <Fragment>
       {isLiveStarted && <TeacherLiveControlBar />}
-      <Box direction="row" justify="space-evenly" style={{ flexFlow: 'wrap' }}>
+      <Box
+        direction="row"
+        justify="space-evenly"
+        gap="xsmall"
+        style={{ flexFlow: 'wrap' }}
+      >
         <TeacherLiveRecordingActions isJitsiAdministrator={canStartLive} />
         <TeacherLiveLifecycleControls
           canStartStreaming={canShowStartButton}

--- a/src/frontend/packages/lib_video/src/components/live/common/JitsiControls/AudioControl/index.tsx
+++ b/src/frontend/packages/lib_video/src/components/live/common/JitsiControls/AudioControl/index.tsx
@@ -1,6 +1,5 @@
-import { Button } from '@openfun/cunningham-react';
 import { Nullable } from 'lib-common';
-import { Box, MicrophoneOffSVG, MicrophoneOnSVG } from 'lib-components';
+import { MicrophoneOffSVG, MicrophoneOnSVG } from 'lib-components';
 import React, { Fragment, useCallback, useEffect, useState } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 
@@ -55,22 +54,34 @@ export const AudioControl = () => {
     return <Fragment />;
   }
 
+  const style = {
+    maxHeight: '35px',
+    maxWidth: '35px',
+    width: '100%',
+    height: '100%',
+  };
+
+  if (isAudioOn) {
+    return (
+      <MicrophoneOnSVG
+        iconColor="white"
+        aria-label={intl.formatMessage(messages.enableTitle)}
+        style={style}
+        onClick={() => {
+          if (!jitsiApi) {
+            return;
+          }
+
+          jitsiApi.executeCommand('toggleAudio');
+        }}
+      />
+    );
+  }
+
   return (
-    <Button
-      className="c__button-no-bg"
-      aria-label={intl.formatMessage(
-        isAudioOn ? messages.enableTitle : messages.disableTitle,
-      )}
-      color="tertiary"
-      icon={
-        <Box margin="auto" height={{ max: '35px' }} width={{ max: '35px' }}>
-          {isAudioOn ? (
-            <MicrophoneOnSVG iconColor="white" height="100%" width="100%" />
-          ) : (
-            <MicrophoneOffSVG iconColor="white" height="100%" width="100%" />
-          )}
-        </Box>
-      }
+    <MicrophoneOffSVG
+      iconColor="white"
+      aria-label={intl.formatMessage(messages.disableTitle)}
       onClick={() => {
         if (!jitsiApi) {
           return;
@@ -78,6 +89,7 @@ export const AudioControl = () => {
 
         jitsiApi.executeCommand('toggleAudio');
       }}
+      style={style}
     />
   );
 };

--- a/src/frontend/packages/lib_video/src/components/live/common/JitsiControls/CameraControl/index.tsx
+++ b/src/frontend/packages/lib_video/src/components/live/common/JitsiControls/CameraControl/index.tsx
@@ -1,6 +1,5 @@
-import { Button } from '@openfun/cunningham-react';
 import { Nullable } from 'lib-common';
-import { Box, CameraOffSVG, CameraOnSVG } from 'lib-components';
+import { CameraOffSVG, CameraOnSVG } from 'lib-components';
 import React, { Fragment, useCallback, useEffect, useState } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 
@@ -55,22 +54,34 @@ export const CameraControl = () => {
     return <Fragment />;
   }
 
+  const style = {
+    maxHeight: '35px',
+    maxWidth: '35px',
+    width: '100%',
+    height: '100%',
+  };
+
+  if (isCameraOn) {
+    return (
+      <CameraOnSVG
+        iconColor="white"
+        aria-label={intl.formatMessage(messages.enableTitle)}
+        style={style}
+        onClick={() => {
+          if (!jitsiApi) {
+            return;
+          }
+
+          jitsiApi.executeCommand('toggleVideo');
+        }}
+      />
+    );
+  }
+
   return (
-    <Button
-      className="c__button-no-bg"
-      color="tertiary"
-      aria-label={intl.formatMessage(
-        isCameraOn ? messages.enableTitle : messages.disableTitle,
-      )}
-      icon={
-        <Box margin="auto" height={{ max: '35px' }} width={{ max: '35px' }}>
-          {isCameraOn ? (
-            <CameraOnSVG iconColor="white" height="100%" width="100%" />
-          ) : (
-            <CameraOffSVG iconColor="white" height="100%" width="100%" />
-          )}
-        </Box>
-      }
+    <CameraOffSVG
+      iconColor="white"
+      aria-label={intl.formatMessage(messages.disableTitle)}
       onClick={() => {
         if (!jitsiApi) {
           return;
@@ -78,6 +89,7 @@ export const CameraControl = () => {
 
         jitsiApi.executeCommand('toggleVideo');
       }}
+      style={style}
     />
   );
 };


### PR DESCRIPTION
## Purpose

 (live) glitch d'affichage du partage de documents en mode fenêtré sur navigateur.

https://trello.com/1/cards/654b8ab615e123d2213a9c9a/attachments/655347173d05e4332536b0e1/download/Partage_de_document_-_responsiveness.webm

https://trello.com/1/cards/654b8ab615e123d2213a9c9a/attachments/65534793bf00d478bfc1589f/download/Partage_de_document_-_responsiveness_02.webm

## Fixed

- [x] icons could sometime be duplicated between layers
- [x] positioning was not everytime correct, with a icon on the top left corner of the screen
- [x] icons too big
- [x] improve spacing in title box live

## Observation

The width of the vignette is limited here:
https://github.com/openfun/marsha/blob/d55f4d5e95c075291f2a27e775f8a65f363b7f36/src/frontend/packages/lib_video/src/conf/pictureInPicture.ts#L3

It could have been nice to increase to 0.8, but we get a responsive problem with the height, it asks a not so small refacto to be able to make it works correctly.
