### PR TITLE
♻️(lib_video) manage sharing error when one resource is already shared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- On live, can now share resource when one is already shared (#2512)
 - Remove persistency on token from invite link (#2505)
 - Replace grommet Cards / Footer/ Anchor / Tip / Nav (#2503)
 - Refacto widgets SharedLiveMedia (#2504)

--- a/src/frontend/packages/lib_video/src/api/useStartSharingMedia/index.ts
+++ b/src/frontend/packages/lib_video/src/api/useStartSharingMedia/index.ts
@@ -3,15 +3,10 @@ import {
   useMutation,
   useQueryClient,
 } from '@tanstack/react-query';
-import { SharedLiveMedia, actionOne } from 'lib-components';
+import { FetchResponseError, SharedLiveMedia, actionOne } from 'lib-components';
 
 type UseStartSharingData = { sharedlivemedia: string };
-type UseStartSharingError =
-  | { code: 'exception' }
-  | {
-      code: 'invalid';
-      errors: { [key in keyof UseStartSharingData]?: string[] }[];
-    };
+type UseStartSharingError = FetchResponseError<UseStartSharingData>;
 type UseStartSharingLiveMediaOptions = UseMutationOptions<
   SharedLiveMedia,
   UseStartSharingError,


### PR DESCRIPTION
## Purpose

Issue: #2511

When a user tried to share a resource when another one was already shared, the sharing was not started and an error was displayed.

## Proposal

We now stop the sharing of the first resource and start the sharing of the new one if we get the error 'Video is already sharing' from the backend.