### PR TITLE
🐛(frontend) wrong store with invite link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix invite links on BBB (#2521)
+
 ## [4.8.0] - 2023-11-29
 
 ### Added

--- a/src/frontend/apps/standalone_site/src/features/App/AppRoutes.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/App/AppRoutes.spec.tsx
@@ -1,11 +1,7 @@
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import fetchMock from 'fetch-mock';
-import {
-  useCurrentUser,
-  useJwt,
-  localStore as useLocalJwt,
-} from 'lib-components';
+import { JWT_KEY, useCurrentUser, useJwt } from 'lib-components';
 import { render } from 'lib-tests';
 
 import featureContentLoader from 'features/Contents/features/featureLoader';
@@ -61,9 +57,7 @@ featureContentLoader([]);
 
 describe('<AppRoutes />', () => {
   beforeEach(() => {
-    useJwt.setState({
-      jwt: 'fake-jwt',
-    });
+    useJwt.getState().setJwt('fake-jwt');
 
     fetchMock.get('/api/pages/', {
       results: [
@@ -112,15 +106,15 @@ describe('<AppRoutes />', () => {
     });
 
     test('render invite route', async () => {
-      useLocalJwt.setState({
+      useJwt.setState({
         setDecodedJwt: (jwt) =>
-          useLocalJwt.setState({
+          useJwt.setState({
             internalDecodedJwt: `${jwt!}-decoded` as any,
           }),
       });
 
       fetchMock.get('/api/classrooms/456789/token/?invite_token=123456', {
-        access_token: 'fake-jwt',
+        access_token: 'fake-invite-jwt',
       });
 
       render(<AppRoutes />, {
@@ -134,11 +128,11 @@ describe('<AppRoutes />', () => {
       ).not.toBeInTheDocument();
       expect(screen.getByText('My ClassRoomUpdate Page')).toBeInTheDocument();
       expect(screen.getByText('My Footer')).toBeInTheDocument();
-      expect(useLocalJwt.getState().jwt).toEqual('fake-jwt');
-      expect(useLocalJwt.getState().internalDecodedJwt).toEqual(
-        'fake-jwt-decoded',
+      expect(useJwt.getState().jwt).toEqual('fake-invite-jwt');
+      expect(useJwt.getState().internalDecodedJwt).toEqual(
+        'fake-invite-jwt-decoded',
       );
-      expect(useJwt.getState().jwt).toBeUndefined();
+      expect(localStorage.getItem(JWT_KEY)).toEqual('fake-jwt');
     });
 
     test('render invite route error message', async () => {

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Update/ClassRoomUpdate.spec.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Update/ClassRoomUpdate.spec.tsx
@@ -1,10 +1,6 @@
 import { screen } from '@testing-library/react';
 import { ResponsiveContext } from 'grommet';
-import {
-  ltiPublicTokenMockFactory,
-  useJwt,
-  localStore as useLocalJwt,
-} from 'lib-components';
+import { ltiPublicTokenMockFactory, useJwt } from 'lib-components';
 import { render } from 'lib-tests';
 import { useParams } from 'react-router-dom';
 
@@ -57,7 +53,6 @@ describe('<ClassRoomUpdate />', () => {
 
   test('render', () => {
     useJwt.setState({
-      jwt: 'some token',
       internalDecodedJwt: ltiPublicTokenMockFactory(
         {},
         { can_access_dashboard: true, can_update: true },
@@ -133,8 +128,7 @@ describe('<ClassRoomUpdate />', () => {
       inviteId: '456789',
     });
 
-    useLocalJwt.setState({
-      jwt: 'some token',
+    useJwt.setState({
       internalDecodedJwt: ltiPublicTokenMockFactory(
         {},
         { can_access_dashboard: true, can_update: true },

--- a/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Update/ClassRoomUpdate.tsx
+++ b/src/frontend/apps/standalone_site/src/features/Contents/features/ClassRoom/components/Update/ClassRoomUpdate.tsx
@@ -9,7 +9,6 @@ import {
   isDecodedJwtWeb,
   useCurrentResourceContext,
   useJwt,
-  localStore as useLocalJwt,
   useResponsive,
 } from 'lib-components';
 import { useEffect, useMemo } from 'react';
@@ -70,20 +69,9 @@ const DashboardClassroomStyled = styled(Box)<DashboardClassroomStyledProps>`
 `;
 
 const ClassRoomUpdate = () => {
-  const { classroomId, inviteId } = useParams();
+  const { classroomId } = useParams();
 
-  const internalDecodedPersistingJwt = useJwt(
-    (state) => state.internalDecodedJwt,
-  );
-  const internalDecodedLocalJwt = useLocalJwt(
-    (state) => state.internalDecodedJwt,
-  );
-
-  // Invited users have a local jwt (working only for the current browser tab),
-  // otherwise it's a persisting jwt
-  const internalDecodedJwt = inviteId
-    ? internalDecodedLocalJwt
-    : internalDecodedPersistingJwt;
+  const internalDecodedJwt = useJwt((state) => state.internalDecodedJwt);
   const resourceContext: ResourceContext = useMemo(() => {
     let permissions = {
       can_access_dashboard: false,

--- a/src/frontend/packages/lib_components/src/hooks/stores/useJwt/index.spec.tsx
+++ b/src/frontend/packages/lib_components/src/hooks/stores/useJwt/index.spec.tsx
@@ -1,7 +1,7 @@
 import { act, render } from '@testing-library/react';
 import React, { useEffect } from 'react';
 
-import { persistentStore as useJwt } from '.';
+import { useJwt } from '.';
 
 const TestJwtComponent = ({
   renderFnc,
@@ -73,7 +73,8 @@ describe('useJwt', () => {
     expect(useJwt.getState().getJwt()).toEqual('another token');
   });
 
-  it('checks when another tab change jwt', () => {
+  it('checks when another tab change jwt if persistent store', () => {
+    useJwt.getState().setWithPersistancy(true);
     expect(useJwt.getState().getJwt()).toEqual(undefined);
 
     useJwt.getState().setJwt('some token');


### PR DESCRIPTION
## Purpose

The API calls were still using the persistent store instead of the local store when using the invite link. 

## Proposal

We removed these double stores logic and now only use 1 store that have a "withPersistency" option. 
The invite links set this option to false so that the store is not persistent.

