### PR TITLE
🩹(back) disable lti nonce and timestamp validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Disable lti nonce and timestamp validation
+
 ## [4.8.1] - 2023-11-29
 
 ### Fixed

--- a/src/backend/marsha/core/lti/validator.py
+++ b/src/backend/marsha/core/lti/validator.py
@@ -132,6 +132,9 @@ class LTIRequestValidator(RequestValidator):
             bool: True if the timestamp and nonce has not been used before
         """
 
+        if not settings.LTI_REPLAY_PROTECTION_ENABLED:
+            return True
+
         cache_timeout = settings.LTI_REPLAY_PROTECTION_CACHE_DURATION
         # Disallow usage of timestamp older than cache_timeout
         request_timestamp = int(timestamp)

--- a/src/backend/marsha/e2e/test_lti.py
+++ b/src/backend/marsha/e2e/test_lti.py
@@ -238,6 +238,7 @@ def mock_document_cloud_storage(mocker, live_server):
 
 @pytest.mark.django_db()
 @pytest.mark.usefixtures("mock_video_cloud_storage")
+@override_settings(LTI_REPLAY_PROTECTION_ENABLED=False)
 def test_lti_select_title_text(page: Page, live_server: LiveServer):
     """Test LTI select."""
     lti_consumer_parameters = {
@@ -309,8 +310,6 @@ def test_lti_select_title_text(page: Page, live_server: LiveServer):
     assert document_content_items in lti_select_iframe.content()
 
     # Select a video
-    # clear cache to allow the same nonce in the request
-    cache.clear()
     page.click('#lti_select input[type="submit"]')
     lti_select_iframe.click('button[role="tab"]:has-text("Videos")')
     # Use send text in the response to fill the activity text
@@ -340,8 +339,6 @@ def test_lti_select_title_text(page: Page, live_server: LiveServer):
     assert Video.objects.count() == 1
 
     # Select a new video
-    # clear cache to allow the same nonce in the request
-    cache.clear()
     page.click('#lti_select input[type="submit"]')
     lti_select_iframe.click('button[role="tab"]:has-text("Videos")')
     sent_title_and_text = (

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -396,6 +396,7 @@ class Base(Configuration):
     )
     LTI_CONFIG_CONTACT_EMAIL = values.Value()
     LTI_REPLAY_PROTECTION_CACHE_DURATION = values.PositiveIntegerValue(3600)  # 1 hour
+    LTI_REPLAY_PROTECTION_ENABLED = values.BooleanValue(True)
 
     # BBB
     BBB_ENABLED = values.BooleanValue(False)


### PR DESCRIPTION
## Purpose

In the LTIRequestValidator we check if the nonce has already been used but doing this we break the integration made in Richie. In a first step we allow to disable this verification by change the settings LTI_REPLAY_PROTECTION_ENABLED to False.

## Proposal

- [x] disable lti nonce and timestamp validation

