### PR TITLE
⬆️(back) upgrade django-peertube-runner-connector library

### DIFF
--- a/src/backend/marsha/core/tests/utils/test_transcode.py
+++ b/src/backend/marsha/core/tests/utils/test_transcode.py
@@ -1,7 +1,5 @@
 """Tests for the `core.utils.transcode` module."""
 
-from unittest import mock
-
 from django.test import TestCase
 
 from django_peertube_runner_connector.models import (
@@ -30,8 +28,8 @@ class TranscodeTestCase(TestCase):
 
         # Create a test transcoded video
         self.transcoded_video = TranscodedVideo.objects.create(
-            state=VideoState.TO_TRANSCODE,
-            directory=f"scw/{self.video.pk}/video/1698941501",
+            state=VideoState.PUBLISHED,
+            directory=f"vod/{self.video.pk}/video/1698941501",
         )
         self.video_playlist = VideoStreamingPlaylist.objects.create(
             video=self.transcoded_video
@@ -53,11 +51,8 @@ class TranscodeTestCase(TestCase):
         )
 
     def test_transcoding_ended_callback(self):
-        """The marsha video should correctly be updated and dispatched."""
-        with mock.patch(
-            "marsha.websocket.utils.channel_layers_utils.dispatch_video"
-        ) as mock_dispatch_video:
-            transcoding_ended_callback(self.transcoded_video)
+        """The marsha video should correctly be updated."""
+        transcoding_ended_callback(self.transcoded_video)
 
         self.video.refresh_from_db()
 
@@ -67,4 +62,19 @@ class TranscodeTestCase(TestCase):
 
         self.assertEqual(self.video.upload_state, defaults.READY)
         self.assertEqual(self.video.transcode_pipeline, defaults.PEERTUBE_PIPELINE)
-        mock_dispatch_video.assert_called_once_with(self.video, to_admin=True)
+
+    def test_transcoding_ended_callback_with_error(self):
+        """The marsha video should be set with state on error and nothing else should be done."""
+        self.transcoded_video.state = VideoState.TRANSCODING_FAILED
+
+        transcoding_ended_callback(self.transcoded_video)
+
+        self.video.refresh_from_db()
+
+        self.assertEqual(self.video.upload_state, defaults.ERROR)
+
+        self.assertEqual(self.video.uploaded_on, None)
+
+        self.assertEqual(self.video.resolutions, [])
+
+        self.assertEqual(self.video.transcode_pipeline, None)

--- a/src/backend/marsha/core/utils/transcode.py
+++ b/src/backend/marsha/core/utils/transcode.py
@@ -1,10 +1,9 @@
 """ Utils related to transcoding """
-from django_peertube_runner_connector.models import Video as TranscodedVideo
+from django_peertube_runner_connector.models import Video as TranscodedVideo, VideoState
 
-from marsha.core.defaults import PEERTUBE_PIPELINE, READY
+from marsha.core.defaults import ERROR, PEERTUBE_PIPELINE, READY
 from marsha.core.models.video import Video
 from marsha.core.utils.time_utils import to_datetime
-from marsha.websocket.utils import channel_layers_utils
 
 
 def transcoding_ended_callback(transcoded_video: TranscodedVideo):
@@ -18,19 +17,24 @@ def transcoding_ended_callback(transcoded_video: TranscodedVideo):
         The transcoded video (The video a django_peertube_runner_connector Video model).
 
     """
-    # Directory format: "scw/<video_id>/video/<stamp>"
+    # Directory format: "vod/<video_id>/video/<stamp>"
     directory = transcoded_video.directory.split("/")
     uploaded_on = directory[-1]
     video_id = directory[-3]
     video = Video.objects.get(pk=video_id)
 
-    video.uploaded_on = to_datetime(uploaded_on)
-    if transcoded_video.streamingPlaylist:
-        video.resolutions = [
-            x.resolution for x in transcoded_video.streamingPlaylist.videoFiles.all()
-        ]
-    video.upload_state = READY
-    video.transcode_pipeline = PEERTUBE_PIPELINE
-    video.save()
+    if transcoded_video.state == VideoState.TRANSCODING_FAILED:
+        video.update_upload_state(ERROR, None)
+        return
 
-    channel_layers_utils.dispatch_video(video, to_admin=True)
+    resolutions = [
+        x.resolution for x in transcoded_video.streamingPlaylist.videoFiles.all()
+    ]
+    video.transcode_pipeline = PEERTUBE_PIPELINE
+    video.save(update_fields=["transcode_pipeline"])
+
+    video.update_upload_state(
+        READY,
+        to_datetime(uploaded_on),
+        **{"resolutions": resolutions},
+    )

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -757,7 +757,7 @@ class Base(Configuration):
     TRANSCODING_RUNNER_MAX_FAILURE = 5
 
     # The callback path to a function that will be called when a video is published
-    TRANSCODING_VIDEO_IS_PUBLISHED_CALLBACK_PATH = (
+    TRANSCODING_ENDED_CALLBACK_PATH = (
         "marsha.core.utils.transcode.transcoding_ended_callback"
     )
 

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -45,7 +45,7 @@ install_requires =
     django-redis==5.4.0
     django-safedelete==1.3.3
     django-storages==1.14.2
-    django-peertube-runner-connector==0.3.1
+    django-peertube-runner-connector==0.4.0
     django-waffle==4.0.0
     django==4.2.7
     djangorestframework==3.14.0


### PR DESCRIPTION
## Purpose

With the new version of the library, we can now update the video state to "error" when the transcoding fails.

## Proposal

Update the settings name and the callback function to update the video state accordingly to the transcoding result
