### PR TITLE
⬆️(back) upgrade django-peertube-runner-connector to 0.5.0

### DIFF
--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -45,7 +45,7 @@ install_requires =
     django-redis==5.4.0
     django-safedelete==1.3.3
     django-storages==1.14.2
-    django-peertube-runner-connector==0.4.0
+    django-peertube-runner-connector==0.5.0
     django-waffle==4.0.0
     django==4.2.7
     djangorestframework==3.14.0


### PR DESCRIPTION
## Purpose

With the new version of the library, peertube runner is no more using the marsha app to download the video.

## Proposal

Update the django-peertube-runner-connector library to 0.5.0

- [x] update library

