### PR TITLE
🔧(tray) configure tray to handle connection with peertube runner

### DIFF
--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -45,7 +45,7 @@ install_requires =
     django-redis==5.4.0
     django-safedelete==1.3.3
     django-storages==1.14.2
-    django-peertube-runner-connector==0.5.0
+    django-peertube-runner-connector==0.6.0
     django-waffle==4.1.0
     Django<5
     djangorestframework==3.14.0

--- a/src/tray/templates/services/app/_deploy_base.yml.j2
+++ b/src/tray/templates/services/app/_deploy_base.yml.j2
@@ -72,9 +72,9 @@ spec:
             - name: POSTGRES_PORT
               value: "{{ marsha_postgresql_port }}"
             - name: DJANGO_ALLOWED_HOSTS
-              value: "{{ marsha_hosts | map('blue_green_hosts') | join(',') }}"
+              value: "{{ marsha_hosts | map('blue_green_hosts') | join(',') }},marsha-nginx-current"
             - name: DJANGO_CSRF_TRUSTED_ORIGINS
-              value: "{{ marsha_hosts | map('blue_green_hosts') | join(',') | split(',') | map('regex_replace', '^(.*)$', 'https://\\1') | join(',') }}"
+              value: "{{ marsha_hosts | map('blue_green_hosts') | join(',') | split(',') | map('regex_replace', '^(.*)$', 'https://\\1') | join(',') }},http://marsha-nginx-current"
             - name: DJANGO_CLOUDFRONT_PRIVATE_KEY_PATH
               value: "{{ marsha_cloudfront_private_key_path }}"
           envFrom:
@@ -82,7 +82,7 @@ spec:
                 name: "{{ marsha_secret_name }}"
             - configMapRef:
                 name: "marsha-app-dotenv-{{ deployment_stamp }}"
-          resources: {{ marsha_app_resources }}
+          resources: {{ marsha_resources }}
           volumeMounts:
             - name: marsha-configmap
               mountPath: /app/src/backend/marsha/configs

--- a/src/tray/templates/services/app/deploy_app.yml.j2
+++ b/src/tray/templates/services/app/deploy_app.yml.j2
@@ -24,5 +24,6 @@
     "initialDelaySeconds": 10,
     "periodSeconds": 5,
 } %}
+{% set marsha_resources = marsha_app_resources %}
 
 {% include "./_deploy_base.yml.j2" with context %}

--- a/src/tray/templates/services/app/deploy_celery.yml.j2
+++ b/src/tray/templates/services/app/deploy_celery.yml.j2
@@ -2,5 +2,6 @@
 {% set marsha_replicas = marsha_celery_replicas %}
 {% set marsha_livenessprobe = marsha_celery_livenessprobe %}
 {% set marsha_readynessprobe = marsha_celery_readynessprobe %}
+{% set marsha_resources = marsha_celery_resources %}
 
 {% include "./_deploy_base.yml.j2" with context %}

--- a/src/tray/templates/services/app/deploy_xapi.yml.j2
+++ b/src/tray/templates/services/app/deploy_xapi.yml.j2
@@ -25,5 +25,6 @@
     "periodSeconds": 5,
 } %}
 
+{% set marsha_resources = marsha_xapi_resources %}
 
 {% include "./_deploy_base.yml.j2" with context %}

--- a/src/tray/templates/services/nginx/configs/marsha.conf.j2
+++ b/src/tray/templates/services/nginx/configs/marsha.conf.j2
@@ -99,6 +99,11 @@ server {
     try_files $uri @proxy_to_marsha_xapi;
   }
 
+  location /api/v1/runners {
+    client_max_body_size 4000m;
+    try_files $uri @proxy_to_marsha_app;
+  }
+
 {% if marsha_nginx_admin_ip_whitelist | length > 0 %}
   location /admin {
     {#

--- a/src/tray/vars/all/main.yml
+++ b/src/tray/vars/all/main.yml
@@ -109,11 +109,27 @@ marsha_celery_readynessprobe:
 # -- resource 
 marsha_app_resources:
   requests:
-    cpu: 50m
+    cpu: 0.3
     memory: 500Mi
   limits:
-    cpu: 1
-    memory: 2.5Gi
+    cpu: 0.8
+    memory: 1Gi
+
+marsha_xapi_resources:
+  requests:
+    cpu: 0.3
+    memory: 500Mi
+  limits:
+    cpu: 0.8
+    memory: 700Mi
+
+marsha_celery_resources:
+  requests:
+    cpu: 0.3
+    memory: 500Mi
+  limits:
+    cpu: 0.8
+    memory: 700Mi
 
 marsha_app_job_db_migrate_resources:
   requests:


### PR DESCRIPTION
## Purpose

In order to manage connection with the peertube runner, we must have to configure the tray. First a new location is added in nginx to manage the socket connection. This connection is made between service directly without going out of the k8s cluster, so the service name must be added to the django allowed hosts.


## Proposal

- [x] configure tray to handle connection with peertube runner

