### PR TITLE
✨(back) transcode video celery task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Replace CRA by Vite (#2530)
 - Replace grommet Image and Grid component (#2518)
 - Optimized apps bundle (#2528)
+- Launch transcoding through a celery task
 
 ## [4.9.0] - 2023-12-04
 

--- a/src/backend/marsha/core/models/playlist.py
+++ b/src/backend/marsha/core/models/playlist.py
@@ -13,7 +13,7 @@ from safedelete.queryset import SafeDeleteQueryset
 
 from marsha.core.models.account import ADMINISTRATOR, INSTRUCTOR, ROLE_CHOICES
 from marsha.core.models.base import BaseModel
-from marsha.core.tasks.video import delete_s3_video
+from marsha.core.tasks.s3 import delete_s3_video
 
 
 logger = logging.getLogger(__name__)

--- a/src/backend/marsha/core/tasks/s3.py
+++ b/src/backend/marsha/core/tasks/s3.py
@@ -1,4 +1,4 @@
-"""Celery videos tasks for the core app."""
+"""Celery s3 tasks for the core app."""
 
 
 from marsha import settings

--- a/src/backend/marsha/core/tasks/video.py
+++ b/src/backend/marsha/core/tasks/video.py
@@ -1,0 +1,34 @@
+"""Celery videos tasks for the core app."""
+
+
+from django_peertube_runner_connector.transcode import transcode_video
+from sentry_sdk import capture_exception
+
+from marsha.celery_app import app
+from marsha.core.defaults import ERROR, TMP_VIDEOS_STORAGE_BASE_DIRECTORY
+from marsha.core.models.video import Video
+
+
+@app.task
+def launch_video_transcoding(video_pk: str, stamp: str, domain: str):
+    """Resize a thumbnail using video_storage.
+    Args:
+        video_pk (UUID): The video to transcode.
+        stamp (str): The stamp at which the thumbnail was uploaded
+        which will be used to find the key.
+    """
+    video = Video.objects.get(pk=video_pk)
+    try:
+        source = video.get_videos_storage_prefix(
+            stamp, TMP_VIDEOS_STORAGE_BASE_DIRECTORY
+        )
+        prefix_destination = video.get_videos_storage_prefix(stamp)
+        transcode_video(
+            file_path=source,
+            destination=prefix_destination,
+            base_name=stamp,
+            domain=domain,
+        )
+    except Exception as exception:  # pylint: disable=broad-except+
+        capture_exception(exception)
+        video.update_upload_state(ERROR, None)

--- a/src/backend/marsha/core/tests/api/video/test_upload_ended.py
+++ b/src/backend/marsha/core/tests/api/video/test_upload_ended.py
@@ -44,8 +44,8 @@ class VideoUploadEndedAPITest(TestCase):
         with mock.patch(
             "marsha.websocket.utils.channel_layers_utils.dispatch_video"
         ) as mock_dispatch_video, mock.patch(
-            "marsha.core.api.video.transcode_video"
-        ) as mock_transcode_video:
+            "marsha.core.api.video.launch_video_transcoding.delay"
+        ) as mock_launch_video_transcoding:
             response = self.client.post(
                 f"/api/videos/{video.id}/upload-ended/",
                 {
@@ -53,11 +53,8 @@ class VideoUploadEndedAPITest(TestCase):
                 },
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
-            mock_transcode_video.assert_called_once_with(
-                file_path=f"tmp/{video.pk}/video/4564565456",
-                destination=f"vod/{video.pk}/video/4564565456",
-                base_name="4564565456",
-                domain="http://testserver",
+            mock_launch_video_transcoding.assert_called_once_with(
+                video_pk=str(video.pk), stamp="4564565456", domain="http://testserver"
             )
             mock_dispatch_video.assert_called_once_with(video, to_admin=True)
 

--- a/src/backend/marsha/core/tests/tasks/test_s3.py
+++ b/src/backend/marsha/core/tests/tasks/test_s3.py
@@ -1,16 +1,16 @@
-"""Test for video celery tasks"""
+"""Test for s3 celery tasks"""
 # pylint: disable=protected-access
 from unittest import mock
 
 from django.test import TestCase
 
 from marsha.core.factories import VideoFactory
-from marsha.core.tasks.video import delete_s3_video
+from marsha.core.tasks.s3 import delete_s3_video
 
 
-class TestVideoTask(TestCase):
+class TestS3Task(TestCase):
     """
-    Test for video celery tasks
+    Test for s3 celery tasks
     """
 
     def test_delete_s3_video(self):
@@ -22,7 +22,7 @@ class TestVideoTask(TestCase):
         video = VideoFactory()
 
         with mock.patch(
-            "marsha.core.tasks.video.move_s3_directory"
+            "marsha.core.tasks.s3.move_s3_directory"
         ) as mock_move_s3_directory:
             delete_s3_video(str(video.pk))
             mock_move_s3_directory.assert_has_calls(

--- a/src/backend/marsha/core/tests/tasks/test_video.py
+++ b/src/backend/marsha/core/tests/tasks/test_video.py
@@ -1,0 +1,54 @@
+"""Test for video celery tasks"""
+# pylint: disable=protected-access
+from unittest import mock
+
+from django.test import TestCase
+
+from marsha.core.defaults import ERROR
+from marsha.core.factories import VideoFactory
+from marsha.core.tasks.video import launch_video_transcoding
+
+
+class TestVideoTask(TestCase):
+    """
+    Test for video celery tasks
+    """
+
+    def test_launch_video_transcode(self):
+        """
+        Test the the launch_video_transcoding task. It should simply call
+        the launch_video_transcoding function.
+        """
+        video = VideoFactory()
+        stamp = "1640995200"
+        with mock.patch(
+            "marsha.core.tasks.video.transcode_video"
+        ) as mock_transcode_video:
+            launch_video_transcoding(str(video.pk), stamp, "http://127.0.0.1:8000")
+            mock_transcode_video.assert_called_once_with(
+                file_path=f"tmp/{video.pk}/video/{stamp}",
+                destination=f"vod/{video.pk}/video/{stamp}",
+                base_name=stamp,
+                domain="http://127.0.0.1:8000",
+            )
+
+    def test_launch_video_transcode_fail(self):
+        """
+        Test the the launch_video_transcoding task. The transcode_video
+        function should raise an exception and video state should be ERROR.
+        """
+        video = VideoFactory()
+        stamp = "1640995200"
+        with mock.patch(
+            "marsha.core.tasks.video.transcode_video"
+        ) as mock_transcode_video:
+            mock_transcode_video.side_effect = Exception("Test exception")
+            launch_video_transcoding(str(video.pk), stamp, "http://127.0.0.1:8000")
+            mock_transcode_video.assert_called_once_with(
+                file_path=f"tmp/{video.pk}/video/{stamp}",
+                destination=f"vod/{video.pk}/video/{stamp}",
+                base_name=stamp,
+                domain="http://127.0.0.1:8000",
+            )
+            video.refresh_from_db()
+            self.assertEqual(video.upload_state, ERROR)


### PR DESCRIPTION
## Purpose

The upload-ended is taking too much time with S3 storage because it launch the transcoding process that is fetching uploaded video info, and create thumbnail 

## Proposal

Create a celery task that will launch the transcoding process

- [x] celery task

