### PR TITLE
🐛(tray) add cloudfront signing key in jobs

### DIFF
--- a/src/tray/templates/services/app/cronjob_pipeline.yml.j2
+++ b/src/tray/templates/services/app/cronjob_pipeline.yml.j2
@@ -52,6 +52,8 @@ items:
                       value: "marsha-{{ marsha_postgresql_host }}-{{ deployment_stamp }}"
                     - name: POSTGRES_PORT
                       value: "{{ marsha_postgresql_port }}"
+                    - name: DJANGO_CLOUDFRONT_PRIVATE_KEY_PATH
+                      value: "{{ marsha_cloudfront_private_key_path }}"                      
                   envFrom:
                     - secretRef:
                         name: "{{ marsha_secret_name }}"
@@ -61,6 +63,10 @@ items:
                   volumeMounts:
                     - name: marsha-configmap
                       mountPath: /app/src/backend/marsha/configs
+{% if marsha_should_sign_requests %}
+                    - mountPath: "{{ marsha_cloudfront_private_key_path | dirname }}"
+                      name: marsha-cloudfront-private-key-secret
+{% endif %}                      
               securityContext:
                 runAsUser: {{ container_uid }}
                 runAsGroup: {{ container_gid }}
@@ -69,6 +75,11 @@ items:
                   configMap:
                     defaultMode: 420
                     name: marsha-app-{{ deployment_stamp }}
+{% if marsha_should_sign_requests %}
+                - name: marsha-cloudfront-private-key-secret
+                  secret:
+                    secretName: "{{ marsha_cloudfront_private_key_secret_name }}"
+{% endif %}                    
               restartPolicy: Never
 {% endif %}
 {% endfor %}

--- a/src/tray/templates/services/app/job_db_migrate.yml.j2
+++ b/src/tray/templates/services/app/job_db_migrate.yml.j2
@@ -42,12 +42,31 @@ spec:
               value: "{{ marsha_postgresql_port }}"
             - name: DJANGO_ALLOWED_HOSTS
               value: "{{ marsha_hosts[0] }}"
+            - name: DJANGO_CLOUDFRONT_PRIVATE_KEY_PATH
+              value: "{{ marsha_cloudfront_private_key_path }}"
           envFrom:
             - secretRef:
                 name: "{{ marsha_secret_name }}"
           command: ["python", "manage.py", "migrate"]
           resources: {{ marsha_app_job_db_migrate_resources }}
+          volumeMounts:
+            - name: marsha-configmap
+              mountPath: /app/src/backend/marsha/configs
+{% if marsha_should_sign_requests %}
+            - mountPath: "{{ marsha_cloudfront_private_key_path | dirname }}"
+              name: marsha-cloudfront-private-key-secret
+{% endif %}
       restartPolicy: Never
       securityContext:
         runAsUser: {{ container_uid }}
         runAsGroup: {{ container_gid }}
+      volumes:
+        - name: marsha-configmap
+          configMap:
+            defaultMode: 420
+            name: marsha-app-{{ deployment_stamp }}
+{% if marsha_should_sign_requests %}
+        - name: marsha-cloudfront-private-key-secret
+          secret:
+            secretName: "{{ marsha_cloudfront_private_key_secret_name }}"
+{% endif %}


### PR DESCRIPTION
## Purpose

To execute jobs, the cloudfront signing key is now needed. This is because the module stores is entirely loaded in a management command.

## Proposal

- [x] add cloudfront signing key in jobs

