### PR TITLE
🐛(back) remove non existing fields in PortabilityRequestAdmin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Optimized apps bundle (#2528)
 - Launch transcoding through a celery task
 
+### Fixed
+
+- Remove non existing fields in PortabilityRequestAdmin
+
 ## [4.9.0] - 2023-12-04
 
 ### Added

--- a/src/backend/marsha/core/admin.py
+++ b/src/backend/marsha/core/admin.py
@@ -497,8 +497,6 @@ class PortabilityRequestAdmin(admin.ModelAdmin):
 
     fields = (
         "for_playlist",
-        "for_resource_id",
-        "for_resource_model",
         "from_playlist",
         "from_lti_consumer_site",
         "from_lti_user_id",


### PR DESCRIPTION
## Purpose

In the PortabilityRequestAdmin fields for_resource_id and for_resource_model were still present but not existing anymore in the model.

## Proposal

- [x] remove non existing fields in PortabilityRequestAdmin

