### PR TITLE
📌(back) pin lxml to version < 5

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -60,6 +60,16 @@
       "allowedVersions": "<5"
     },
     {
+      "groupName": "allowed lxml versions",
+      "matchManagers": [
+        "setup-cfg"
+      ],
+      "matchPackageNames": [
+        "lxml"
+      ],
+      "allowedVersions": "<5"
+    },
+    {
       "groupName": "allowed pytest versions",
       "matchManagers": [
         "setup-cfg"

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -54,6 +54,7 @@ install_requires =
     drf-spectacular==0.27.1
     gunicorn==21.2.0
     logging-ldp==0.0.7
+    lxml<5
     oauthlib==3.2.2
     Pillow==10.2.0
     psycopg[binary]==3.1.17


### PR DESCRIPTION
## Purpose

We are not able tu use lxml >= 5.0.0. We have a segfault when using it. The solution could be to install it without binaries but it is not possible to do it using the setup.cfg file.
We have to investigate if it will be possible if we switch to pyproject.

Linked issues :

https://github.com/SAML-Toolkits/python3-saml/issues/388 
https://github.com/SAML-Toolkits/python3-saml/issues/389

## Proposal

- [x] pin lxml to version < 5

