### PR TITLE
Finalize peertube usage

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,11 +49,6 @@ services:
     tty: true
 
   celery:
-    build:
-      context: .
-      dockerfile: ./docker/images/dev/Dockerfile
-      args:
-        DOCKER_USER: ${DOCKER_USER:-1000}
     image: marsha:dev
     env_file:
       - env.d/db

--- a/src/aws/cloudfront.tf
+++ b/src/aws/cloudfront.tf
@@ -70,62 +70,13 @@ resource "aws_cloudfront_distribution" "marsha_cloudfront_distribution" {
   wait_for_deployment = false
 
   ordered_cache_behavior {
-    path_pattern     = "vod/*/video/*"
-    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
-    cached_methods   = ["GET", "HEAD", "OPTIONS"]
-    target_origin_id = local.scw_object_storage_origin_id
-
-    forwarded_values {
-      query_string = true
-      query_string_cache_keys = ["response-content-disposition"]
-      headers = ["Access-Control-Request-Headers", "Access-Control-Request-Method", "Origin"]
-
-      cookies {
-        forward = "none"
-      }
-    }
-
-    min_ttl                = 0
-    default_ttl            = 3600
-    max_ttl                = 86400
-    compress               = true
-    viewer_protocol_policy = "redirect-to-https"
-  }
-
-  ordered_cache_behavior {
     path_pattern     = "vod/*"
     allowed_methods  = ["GET", "HEAD", "OPTIONS"]
     cached_methods   = ["GET", "HEAD", "OPTIONS"]
     target_origin_id = local.scw_object_storage_origin_id
-    trusted_signers  = []
-    trusted_key_groups = [aws_cloudfront_key_group.marsha_cloudfront_signer_key_group.id]
 
     forwarded_values {
       query_string = true
-      headers = ["Access-Control-Request-Headers", "Access-Control-Request-Method", "Origin"]
-
-      cookies {
-        forward = "none"
-      }
-    }
-
-    min_ttl                = 0
-    default_ttl            = 3600
-    max_ttl                = 86400
-    compress               = true
-    viewer_protocol_policy = "redirect-to-https"
-  }
-
-   ordered_cache_behavior {
-    path_pattern     = "tmp/*"
-    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
-    cached_methods   = ["GET", "HEAD", "OPTIONS"]
-    target_origin_id = local.scw_object_storage_origin_id
-    trusted_signers  = []
-    trusted_key_groups = [aws_cloudfront_key_group.marsha_cloudfront_signer_key_group.id]
-
-    forwarded_values {
-      query_string = false
       headers = ["Access-Control-Request-Headers", "Access-Control-Request-Method", "Origin"]
 
       cookies {
@@ -213,7 +164,7 @@ resource "aws_cloudfront_distribution" "marsha_cloudfront_distribution" {
     viewer_protocol_policy = "redirect-to-https"
   }
 
-    ordered_cache_behavior {
+  ordered_cache_behavior {
     path_pattern     = "*/markdown-image/*"
     allowed_methods  = ["GET", "HEAD", "OPTIONS"]
     cached_methods   = ["GET", "HEAD", "OPTIONS"]
@@ -414,6 +365,30 @@ resource "aws_cloudfront_distribution" "marsha_cloudfront_distribution" {
         "Origin",
         "Accept-Encoding"
       ]
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+    compress               = true
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  ordered_cache_behavior {
+    path_pattern     = "tmp/*"
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = local.scw_object_storage_origin_id
+    trusted_signers  = []
+    trusted_key_groups = [aws_cloudfront_key_group.marsha_cloudfront_signer_key_group.id]
+
+    forwarded_values {
+      query_string = false
+      headers = ["Access-Control-Request-Headers", "Access-Control-Request-Method", "Origin"]
 
       cookies {
         forward = "none"

--- a/src/backend/marsha/core/storage/s3.py
+++ b/src/backend/marsha/core/storage/s3.py
@@ -30,6 +30,8 @@ class S3VideoStorage(S3Storage):
 
     bucket_name = settings.VIDEOS_STORAGE_S3_BUCKET_NAME
 
+    object_parameters = settings.VIDEOS_STORAGE_S3_OBJECT_PARAMETERS
+
     custom_domain = settings.CLOUDFRONT_DOMAIN
     url_protocol = "https:"
 

--- a/src/backend/marsha/core/tasks/video.py
+++ b/src/backend/marsha/core/tasks/video.py
@@ -1,11 +1,16 @@
 """Celery videos tasks for the core app."""
 
+import logging
+
 from django_peertube_runner_connector.transcode import transcode_video
 from sentry_sdk import capture_exception
 
 from marsha.celery_app import app
 from marsha.core.defaults import ERROR, TMP_VIDEOS_STORAGE_BASE_DIRECTORY
 from marsha.core.models.video import Video
+
+
+logger = logging.getLogger(__name__)
 
 
 @app.task
@@ -31,3 +36,4 @@ def launch_video_transcoding(video_pk: str, stamp: str, domain: str):
     except Exception as exception:  # pylint: disable=broad-except+
         capture_exception(exception)
         video.update_upload_state(ERROR, None)
+        logger.exception(exception)

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -777,6 +777,7 @@ class Base(Configuration):
     CELERY_BROKER_URL = values.Value("redis://redis:6379/0")
     CELERY_RESULT_BACKEND = values.Value("redis://redis:6379/0")
     CELERY_BROKER_TRANSPORT_OPTIONS = values.DictValue({})
+    CELERY_DEFAULT_QUEUE = values.Value("celery")
 
     # pylint: disable=invalid-name
     @property
@@ -1005,6 +1006,11 @@ class Development(Base):
             },
             "loggers": {
                 "marsha": {
+                    "handlers": ["console"],
+                    "level": "DEBUG",
+                    "propagate": True,
+                },
+                "celery": {
                     "handlers": ["console"],
                     "level": "DEBUG",
                     "propagate": True,

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -379,6 +379,9 @@ class Base(Configuration):
     VIDEOS_STORAGE_S3_ENDPOINT_URL = values.Value("https://s3.fr-par.scw.cloud")
     VIDEOS_STORAGE_S3_REGION_NAME = values.Value("fr-par")
     VIDEOS_STORAGE_S3_BUCKET_NAME = values.Value()
+    VIDEOS_STORAGE_S3_OBJECT_PARAMETERS = values.DictValue(
+        {"ContentDisposition": "attachment"}
+    )
 
     # LTI Config
     LTI_CONFIG_TITLE = values.Value("Marsha")

--- a/src/tray/templates/services/app/_deploy_base.yml.j2
+++ b/src/tray/templates/services/app/_deploy_base.yml.j2
@@ -77,6 +77,8 @@ spec:
               value: "{{ marsha_hosts | map('blue_green_hosts') | join(',') | split(',') | map('regex_replace', '^(.*)$', 'https://\\1') | join(',') }},http://marsha-nginx-current"
             - name: DJANGO_CLOUDFRONT_PRIVATE_KEY_PATH
               value: "{{ marsha_cloudfront_private_key_path }}"
+            - name: DJANGO_CELERY_DEFAULT_QUEUE
+              value: "default-queue-{{ deployment_stamp }}"
           envFrom:
             - secretRef:
                 name: "{{ marsha_secret_name }}"

--- a/src/tray/vars/all/main.yml
+++ b/src/tray/vars/all/main.yml
@@ -50,6 +50,8 @@ marsha_celery_command:
   - worker
   - -l
   - INFO
+  - -n
+  - marsha@%h
 
 # -- marsha webtorrent
 
@@ -95,13 +97,19 @@ marsha_pvc_static_name: "marsha-pvc-static"
 
 marsha_celery_livenessprobe:
   exec:
-    command: ["python", "manage.py", "check"]
+    command: 
+      - /bin/bash
+      - -c
+      - "celery -A marsha.celery_app inspect ping -d marsha@$HOSTNAME"
   initialDelaySeconds: 60
   periodSeconds: 30
   timeoutSeconds: 5
 marsha_celery_readynessprobe:
   exec:
-    command: ["python", "manage.py", "check"]
+    command:
+      - /bin/bash
+      - -c
+      - "celery -A marsha.celery_app inspect ping -d marsha@$HOSTNAME"
   initialDelaySeconds: 15
   periodSeconds: 10
   timeoutSeconds: 5


### PR DESCRIPTION
## Purpose
The workflow to use peertube runner was not working fine, mostly due to how cloudfront was configured. Because we now have only one mp4 fragmented file for each resolution we can't protect them anymore otherwise the player can't play them.
Other commits fine tuned celery usage,

## Proposal

- [x] allow to choose the url to signed with the S3VideoStorage
- [x] configure cloudfront path for scaleway storage
- [x] configure celery to be blue/green compatible
- [x] add logger in celery tasks
- [x] force content disposition when a file is saved using `S3VideoStorage`

