### PR TITLE
♻️(front) remove cue filtering in TranscriptReader

### DIFF
--- a/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/Transcripts/TranscriptReader/index.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoWidgetProvider/widgets/Transcripts/TranscriptReader/index.tsx
@@ -30,14 +30,8 @@ export const TranscriptReader = ({ transcript }: TranscriptReaderProps) => {
     const parser = new WebVTT.Parser(window, WebVTT.StringDecoder());
 
     parser.oncue = (cue: VTTCue) => {
-      setCues((prevCues) => {
-        // Dont insert duplicate cues
-        return !prevCues.filter((e) => e.id === cue.id).length
-          ? [...prevCues, cue]
-          : prevCues;
-      });
+      setCues((prevCues) => [...prevCues, cue]);
     };
-
     parser.parse(data);
     parser.flush();
   }, [data]);


### PR DESCRIPTION
## Purpose

The library (pycaption) we are using to convert transcript in a celery task does not keep the cue indeice anymore so we can't filter cues by there id.


## Proposal

- [x] remove cue filtering in TranscriptReader
