### PR TITLE
♻️(tray) add variant name in container name

### DIFF
--- a/src/tray/templates/services/app/_deploy_base.yml.j2
+++ b/src/tray/templates/services/app/_deploy_base.yml.j2
@@ -47,7 +47,7 @@ spec:
         - name: "{{ image_pull_secret_name }}"
 {% endif %}
       containers:
-        - name: marsha
+        - name: "{{ dc_name }}"
           image: "{{ marsha_image_name }}:{{ marsha_image_tag }}"
 {% if service_variant=="celery" %}
           command: {{ marsha_celery_command }}


### PR DESCRIPTION
## Purpose

For all variants (app, xapi and celery), the container name is the name. It is not possible to do a filter on a specific container name. WEe change the container name using the variant name.

## Proposal

- [x] add variant name in container name

