### PR TITLE
🐛(back) correctly set startime with filtering medialive logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Correctly set startime with filtering medialive logs
 - Remove non existing fields in PortabilityRequestAdmin
 - Correctly send xapi statement to a configured LRS
 

--- a/src/backend/marsha/core/management/commands/check_live_state.py
+++ b/src/backend/marsha/core/management/commands/check_live_state.py
@@ -67,7 +67,7 @@ class Command(BaseCommand):
             live_info = video.live_info
             logs = logs_client.filter_log_events(
                 logGroupName=live_info["cloudwatch"]["logGroupName"],
-                startTime=int(int(video.live_info.get("started_at")) * 1000),
+                startTime=int((int(video.live_info.get("started_at")) - 60) * 1000),
                 filterPattern=(
                     "{"
                     '($.detail-type = "MediaLive Channel Alert") && '

--- a/src/backend/marsha/core/tests/management_commands/test_check_live_state.py
+++ b/src/backend/marsha/core/tests/management_commands/test_check_live_state.py
@@ -53,7 +53,7 @@ class CheckLiveStateTest(TestCase):
                 "filter_log_events",
                 expected_params={
                     "logGroupName": "/aws/lambda/dev-test-marsha-medialive",
-                    "startTime": 1598313600000,
+                    "startTime": 1598313540000,
                     "filterPattern": (
                         "{"
                         '($.detail-type = "MediaLive Channel Alert") && '
@@ -151,7 +151,7 @@ class CheckLiveStateTest(TestCase):
                 "filter_log_events",
                 expected_params={
                     "logGroupName": "/aws/lambda/dev-test-marsha-medialive",
-                    "startTime": 1598313600000,
+                    "startTime": 1598313540000,
                     "filterPattern": (
                         "{"
                         '($.detail-type = "MediaLive Channel Alert") && '
@@ -236,7 +236,7 @@ class CheckLiveStateTest(TestCase):
                 "filter_log_events",
                 expected_params={
                     "logGroupName": "/aws/lambda/dev-test-marsha-medialive",
-                    "startTime": 1598313600000,
+                    "startTime": 1598313540000,
                     "filterPattern": (
                         "{"
                         '($.detail-type = "MediaLive Channel Alert") && '


### PR DESCRIPTION
## Purpose

Medialive has changed when the alerts are set for a medialive channels. Before alerts were set with a delay once the channel started, now they are set at the exact same time. So we have to adjust the startTime when filtering logs in the check_live_state command to be sure to have all the logs from the beginning. Otherwise some logs are missed and the command is failing.

## Proposal

- [x] correctly set startime with filtering medialive logs

Fix #2564 
