### PR TITLE
📌(backend) pin lxml dependency to 5.2.1

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -60,16 +60,6 @@
       "allowedVersions": "<5"
     },
     {
-      "groupName": "allowed lxml versions",
-      "matchManagers": [
-        "setup-cfg"
-      ],
-      "matchPackageNames": [
-        "lxml"
-      ],
-      "allowedVersions": "<5"
-    },
-    {
       "groupName": "allowed pytest versions",
       "matchManagers": [
         "setup-cfg"

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -54,7 +54,7 @@ install_requires =
     drf-spectacular==0.27.1
     gunicorn==21.2.0
     logging-ldp==0.0.7
-    lxml<5
+    lxml==5.2.1
     oauthlib==3.2.2
     Pillow==10.2.0
     psycopg[binary]==3.1.18


### PR DESCRIPTION
## Purpose

With the constraint on lxml<5, an error on the collectstatic occured about lxml
and xmlsec libxml2 versions mismatch.

## Proposal

Pin lxml to the latest release fix this error.

