### PR TITLE
✨(front) enable form submission with enter key when entering a classroom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Add thumbnail celery task
 - Add shared live media celery task
 - Add timed text track celery task
+- Add form submission with enter key when entering a classroom
 
 ### Changed
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -23,10 +23,11 @@
 - [Théo Clement](https://github.com/Kitero) <theoclementtheo@gmail.com>
 - [Henri Baudesson](https://github.com/polyhb) <henri.baudesson@polyconseil.fr>
 - [Antoine Lebaud](https://github.com/lebaudantoine) <lebaud.antoine131@gmail.com>
+- [Claude Dioudonnat](https://github.com/claudusd) <claude.dioudonnat@fun-mooc.fr>
+- [Wilfried Baradat](https://github.com/wilbrdt) <wilfried.baradat@fun-mooc.fr>
 
 - [Renovate Bot](https://renovatebot.com) <bot@renovateapp.com>
 - [Renovate Bot](https://renovatebot.com) <29139614+renovate[bot]@users.noreply.github.com>
 - [Pyup Bot](https://pyup.io) <github-bot@pyup.io>
 - [Dependabot](https://github.com/dependabot/dependabot-core) <49699333+dependabot[bot]@users.noreply.github.com>
 - [Snyk](https://snyk.io/) <snyk-bot@snyk.io>
--[Claude Dioudonnat](https://github.com/claudusd) <claude.dioudonnat@fun-mooc.fr>

--- a/src/frontend/packages/lib_classroom/src/components/DashboardClassroomAskUsername/index.spec.tsx
+++ b/src/frontend/packages/lib_classroom/src/components/DashboardClassroomAskUsername/index.spec.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { render } from 'lib-tests';
 import React from 'react';
 
@@ -11,7 +12,7 @@ const onJoin = jest.fn();
 const onCancel = jest.fn();
 
 describe('<DashboardClassroomAskUsername />', () => {
-  it('displays the form with cancel button', () => {
+  it('displays the form with cancel button', async () => {
     const userFullname = 'Initial value';
     const mockSetUserFullname = jest.fn();
 
@@ -31,9 +32,12 @@ describe('<DashboardClassroomAskUsername />', () => {
     fireEvent.change(inputUsername, { target: { value: 'Joe' } });
     expect(mockSetUserFullname).toHaveBeenCalledWith('Joe');
 
+    await userEvent.type(inputUsername, '{enter}');
+    expect(onJoin).toHaveBeenCalledTimes(1);
+
     const joinButton = screen.getByRole('button', { name: /join/i });
     fireEvent.click(joinButton);
-    expect(onJoin).toHaveBeenCalled();
+    expect(onJoin).toHaveBeenCalledTimes(2);
 
     const cancelButton = screen.getByRole('button', { name: /cancel/i });
     fireEvent.click(cancelButton);

--- a/src/frontend/packages/lib_classroom/src/components/DashboardClassroomAskUsername/index.tsx
+++ b/src/frontend/packages/lib_classroom/src/components/DashboardClassroomAskUsername/index.tsx
@@ -45,25 +45,31 @@ interface DashboardClassroomAskUsernameProps {
 const DashboardClassroomAskUsernameWrapper = ({
   userFullname,
   setUserFullname,
+  onJoin,
   children,
 }: React.PropsWithChildren<
-  Pick<DashboardClassroomAskUsernameProps, 'userFullname' | 'setUserFullname'>
+  Pick<
+    DashboardClassroomAskUsernameProps,
+    'userFullname' | 'setUserFullname' | 'onJoin'
+  >
 >) => {
   const intl = useIntl();
 
   return (
     <Box pad="large" gap="medium" className="DashboardClassroomAskUsername">
-      <Input
-        aria-label={intl.formatMessage(messages.labelEnterYourName)}
-        label={intl.formatMessage(messages.labelEnterYourName)}
-        fullWidth
-        onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-          setUserFullname(event.currentTarget.value);
-        }}
-        value={userFullname}
-        text={intl.formatMessage(messages.infoInput)}
-      />
-      {children}
+      <form onSubmit={onJoin}>
+        <Input
+          aria-label={intl.formatMessage(messages.labelEnterYourName)}
+          label={intl.formatMessage(messages.labelEnterYourName)}
+          fullWidth
+          onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+            setUserFullname(event.currentTarget.value);
+          }}
+          value={userFullname}
+          text={intl.formatMessage(messages.infoInput)}
+        />
+        {children}
+      </form>
     </Box>
   );
 };
@@ -91,6 +97,7 @@ export const DashboardClassroomAskUsernameStudent = ({
     <DashboardClassroomAskUsernameWrapper
       setUserFullname={setUserFullname}
       userFullname={userFullname}
+      onJoin={onJoin}
     >
       <Box>
         {isRecordingEnabled && (
@@ -121,7 +128,6 @@ export const DashboardClassroomAskUsernameStudent = ({
         <Button
           fullWidth
           aria-label={intl.formatMessage(messages.join)}
-          onClick={onJoin}
           disabled={!isStudentConsentRecord || !userFullname}
         >
           {intl.formatMessage(messages.join)}
@@ -143,10 +149,10 @@ export const DashboardClassroomAskUsername = ({
     <DashboardClassroomAskUsernameWrapper
       setUserFullname={setUserFullname}
       userFullname={userFullname}
+      onJoin={onJoin}
     >
       <ModalButton
         onClickCancel={onCancel || undefined}
-        onClickSubmit={onJoin}
         disabled={!userFullname}
         labelCancel={intl.formatMessage(messages.cancel)}
         aria-label={intl.formatMessage(messages.join)}

--- a/src/frontend/packages/lib_components/src/common/Modal/ModalButton.tsx
+++ b/src/frontend/packages/lib_components/src/common/Modal/ModalButton.tsx
@@ -63,6 +63,7 @@ export const ModalButton = ({
           color="secondary"
           onClick={onClickCancel}
           style={{ flex: '1' }}
+          type="button"
           fullWidth
         >
           {labelCancel || intl.formatMessage(messages.ButtonCancelModal)}


### PR DESCRIPTION
## Purpose

When users join a classroom via an invite link, they are prompted to enter a username before joining.
Previously, this form could not be submitted using the Enter key.

## Proposal

Adding form submission when pressing the Enter key.

Closes #2583 

[Screencast from 23-05-2024 12:21:36.webm](https://github.com/openfun/marsha/assets/18288083/635ae799-e37c-4d6b-b2bd-520e5a39756b)