### PR TITLE
✨(front) persist username on classroom join

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Add shared live media celery task
 - Add timed text track celery task
 - Add form submission with enter key when entering a classroom
+- Persist username used on classroom join
 
 ### Changed
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -25,6 +25,7 @@
 - [Antoine Lebaud](https://github.com/lebaudantoine) <lebaud.antoine131@gmail.com>
 - [Claude Dioudonnat](https://github.com/claudusd) <claude.dioudonnat@fun-mooc.fr>
 - [Wilfried Baradat](https://github.com/wilbrdt) <wilfried.baradat@fun-mooc.fr>
+- [Jean-Baptiste Penrath](https://github.com/jbpenrath) <jb.penrath@gmail.com>
 
 - [Renovate Bot](https://renovatebot.com) <bot@renovateapp.com>
 - [Renovate Bot](https://renovatebot.com) <29139614+renovate[bot]@users.noreply.github.com>

--- a/src/frontend/packages/lib_classroom/src/components/DashboardClassroom/index.spec.tsx
+++ b/src/frontend/packages/lib_classroom/src/components/DashboardClassroom/index.spec.tsx
@@ -3,6 +3,8 @@ import { fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import fetchMock from 'fetch-mock';
 import {
+  AnonymousUser,
+  LOCAL_STORAGE_KEYS,
   useCurrentResourceContext,
   useCurrentUser,
   useJwt,
@@ -47,6 +49,7 @@ describe('<DashboardClassroom />', () => {
   afterEach(() => {
     jest.clearAllMocks();
     fetchMock.restore();
+    localStorage.clear();
   });
 
   it('shows student dashboard', async () => {
@@ -179,8 +182,14 @@ describe('<DashboardClassroom />', () => {
     render(<DashboardClassroom classroomId="1" />);
     classroomDeferred.resolve(classroom);
     fireEvent.click(await screen.findByText('Click here to access classroom'));
+    expect(
+      localStorage.getItem(LOCAL_STORAGE_KEYS.CLASSROOM_USERNAME),
+    ).toBeNull();
     await screen.findByText('Please enter your name to join the classroom');
     expect(screen.queryByText('Cancel')).not.toBeInTheDocument();
+    expect(
+      localStorage.getItem(LOCAL_STORAGE_KEYS.CLASSROOM_USERNAME),
+    ).toBeNull();
 
     const inputUsername = screen.getByRole('textbox');
     fireEvent.change(inputUsername, { target: { value: 'Joe' } });
@@ -195,6 +204,9 @@ describe('<DashboardClassroom />', () => {
     fetchMock.patch('/api/classrooms/1/join/', deferredPatch.promise);
     fireEvent.click(screen.getByText('Join'));
     deferredPatch.resolve({ url: 'server.bbb/classroom/url' });
+    expect(localStorage.getItem(LOCAL_STORAGE_KEYS.CLASSROOM_USERNAME)).toBe(
+      'Joe',
+    );
     await waitFor(() => {
       expect(window.open).toHaveBeenCalledTimes(1);
     });
@@ -247,6 +259,60 @@ describe('<DashboardClassroom />', () => {
       method: 'PATCH',
       body: JSON.stringify({
         fullname: token.user?.user_fullname,
+      }),
+    });
+    expect(window.open).toHaveBeenCalledTimes(1);
+    expect(window.open).toHaveBeenCalledWith(
+      'server.bbb/classroom/url',
+      '_blank',
+    );
+    const urlMessage = screen.queryByText(
+      'please click bbb url to join classroom',
+    );
+    expect(urlMessage).not.toBeInTheDocument();
+
+    // multiple joining must be avoided
+    await userEvent.click(screen.getByText('Join classroom'));
+    expect(window.open).toHaveBeenCalledTimes(2);
+  });
+
+  it('uses local storage fullname when joining a classroom', async () => {
+    const token = ltiInstructorTokenMockFactory();
+    localStorage.setItem('classroom_username', 'John Doe');
+    useCurrentUser.setState({ currentUser: AnonymousUser.ANONYMOUS });
+    mockedUseCurrentResource.mockReturnValue([token] as any);
+    window.open = jest.fn(() => window);
+
+    const classroom = classroomMockFactory({ id: '1', started: true });
+    const classroomDeferred = new Deferred();
+    fetchMock.get('/api/classrooms/1/', classroomDeferred.promise);
+    fetchMock.get('/api/classrooms/1/classroomdocuments/?limit=999', {
+      count: 0,
+      next: null,
+      previous: null,
+      results: [],
+    });
+
+    const deferredPatch = new Deferred();
+    fetchMock.patch('/api/classrooms/1/join/', deferredPatch.promise);
+
+    render(<DashboardClassroom classroomId="1" />);
+    classroomDeferred.resolve(classroom);
+    await userEvent.click(await screen.findByText('Join classroom'));
+    deferredPatch.resolve({ url: 'server.bbb/classroom/url' });
+
+    await waitFor(() =>
+      expect(fetchMock.calls()[1][0]).toEqual('/api/classrooms/1/join/'),
+    );
+    expect(fetchMock.calls()[1][1]).toEqual({
+      headers: {
+        Authorization: 'Bearer token',
+        'Content-Type': 'application/json',
+        'Accept-Language': 'en',
+      },
+      method: 'PATCH',
+      body: JSON.stringify({
+        fullname: 'John Doe',
       }),
     });
     expect(window.open).toHaveBeenCalledTimes(1);

--- a/src/frontend/packages/lib_classroom/src/components/DashboardClassroom/index.tsx
+++ b/src/frontend/packages/lib_classroom/src/components/DashboardClassroom/index.tsx
@@ -1,3 +1,4 @@
+import { LOCAL_STORAGE_KEYS } from '@lib-components/settings';
 import {
   AnonymousUser,
   Box,
@@ -73,7 +74,9 @@ const DashboardClassroom = ({ classroomId }: DashboardClassroomProps) => {
   const [askUsername, setAskUsername] = useState(false);
   const [classroomJoined, setClassroomJoined] = useState(false);
   const [userFullname, setUserFullname] = useState(
-    (user && user !== AnonymousUser.ANONYMOUS && user.full_name) || '',
+    (user && user !== AnonymousUser.ANONYMOUS && user.full_name) ||
+      localStorage.getItem(LOCAL_STORAGE_KEYS.CLASSROOM_USERNAME) ||
+      '',
   );
 
   const {
@@ -136,6 +139,7 @@ const DashboardClassroom = ({ classroomId }: DashboardClassroomProps) => {
     if (userFullname) {
       askUserNameAction(false);
       joinClassroomMutation.mutate({ fullname: userFullname });
+      localStorage.setItem(LOCAL_STORAGE_KEYS.CLASSROOM_USERNAME, userFullname);
     } else {
       askUserNameAction(true);
     }

--- a/src/frontend/packages/lib_components/src/settings.ts
+++ b/src/frontend/packages/lib_components/src/settings.ts
@@ -2,6 +2,10 @@ export const API_ENDPOINT = '/api';
 export const WS_ENPOINT = '/ws';
 export const XAPI_ENDPOINT = '/xapi';
 
+export enum LOCAL_STORAGE_KEYS {
+  CLASSROOM_USERNAME = 'classroom_username',
+}
+
 export const API_LIST_DEFAULT_PARAMS = {
   limit: 20,
   offset: 0,


### PR DESCRIPTION
## Purpose

Currently, each time an anonymous user wants to join a classroom, it has to provide a user name. It orders to improve UX, we decide to store username provided in local storage when user join the classroom. In this way, next time it wants to join, the input will be prefilled.

