### PR TITLE
♻️(back) compute hls url based on video resolutions available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Compute hls url based on video resolutions available
+
 ## [5.0.1] - 2024-07-04
 
 ### Fixed

--- a/renovate.json
+++ b/renovate.json
@@ -68,6 +68,16 @@
         "pytest"
       ],
       "allowedVersions": "<8.0.0"
+    },
+    {
+      "enabled": false,
+      "groupName": "ignored python dependencies",
+      "matchManagers": [
+        "setup-cfg"
+      ],
+      "matchPackageNames": [
+        "django-storages"
+      ]
     }
   ]
 }

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -44,7 +44,7 @@ install_requires =
     django-parler==2.3
     django-redis==5.4.0
     django-safedelete==1.4.0
-    django-storages==1.14.4
+    django-storages==1.14.3
     django-peertube-runner-connector==0.6.0
     django-waffle==4.1.0
     Django<5


### PR DESCRIPTION
## Purpose

the combine usage of peertube-runner and cloudfront can lead to situation where the master HLS url is cached for 24 hours without all the resolutions available. Once the first resolution is transcoded, the master HLS file is generated and available in Marsha. The websocket updates the video object and the file is in cache for 24 hours. We introduce a query parameter used to compute the resolutions hash. So every time the list of resolutions available is changing, this hash also change and a new cache is generated.

## Proposal

- [x] compute hls url based on video resolutions available

Fixes #2600 