### PR TITLE
🔧(docker) fix FromAsCasing warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 # Marsha, a FUN LTI video provider
 
 # ---- base image to inherit from ----
-FROM python:3.11-slim-bookworm as base
+FROM python:3.11-slim-bookworm AS base
 
 # ---- back-end builder image ----
-FROM base as back-builder
+FROM base AS back-builder
 
 # We want the most up-to-date stable pip release
 RUN pip install --upgrade pip
@@ -29,7 +29,7 @@ RUN mkdir /install && \
     pip install --prefix=/install .
 
 # ---- front-end builder image ----
-FROM node:20 as front-builder
+FROM node:20 AS front-builder
 
 WORKDIR /app
 
@@ -58,7 +58,7 @@ RUN yarn compile-translations && \
     yarn workspace marsha run build --mode=production --output-path /app/marsha/static/js/build/lti_site/
 
 # ---- mails ----
-FROM node:20 as mail-builder
+FROM node:20 AS mail-builder
 RUN mkdir -p /app/backend/marsha/core/templates/core/mail/html/ && \
     mkdir -p /app/backend/marsha/core/templates/core/mail/text/ && \
     mkdir -p /app/mail
@@ -71,7 +71,7 @@ RUN yarn install --frozen-lockfile && \
     yarn build-mails
 
 # ---- static link collector ----
-FROM base as link-collector
+FROM base AS link-collector
 ARG MARSHA_STATIC_ROOT=/data/static
 
 # Install rdfind & libxmlsec1 (required to run django)

--- a/docker/images/webtorrent/Dockerfile
+++ b/docker/images/webtorrent/Dockerfile
@@ -1,6 +1,6 @@
-FROM node:20-bookworm-slim as base
+FROM node:20-bookworm-slim AS base
 
-FROM  base as builder
+FROM  base AS builder
 
 WORKDIR /app
 

--- a/src/aws/Dockerfile
+++ b/src/aws/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine as mediainfo
+FROM alpine AS mediainfo
 
 ARG MEDIAINFO_VERSION=20.09
 
@@ -6,7 +6,7 @@ ARG MEDIAINFO_VERSION=20.09
 RUN wget https://mediaarea.net/download/binary/mediainfo/20.09/MediaInfo_CLI_${MEDIAINFO_VERSION}_Lambda.zip && \
     unzip MediaInfo_CLI_${MEDIAINFO_VERSION}_Lambda.zip -d /tmp/mediainfo
 
-FROM amazon/aws-lambda-nodejs:18 as core
+FROM amazon/aws-lambda-nodejs:18 AS core
 ARG POPPLER_VERSION
 ARG POPPLER_DATA_VERSION
 ARG OPENJPEG_VERSION
@@ -125,7 +125,7 @@ RUN npm install -g yarn
 VOLUME /mnt/transcoded_video
 
 # Image used in developement with development dependencies
-FROM core as development
+FROM core AS development
 
 RUN cd lambda-complete && yarn install && cd .. && \
     cd lambda-configure && yarn install && cd .. && \
@@ -139,7 +139,7 @@ RUN cd lambda-complete && yarn install && cd .. && \
 CMD [ "index.handler" ]
 
 # Image used in production without development dependencies
-FROM core as production
+FROM core AS production
 
 RUN cd lambda-complete && yarn install --frozen-lockfile --production=true && cd .. && \
     cd lambda-configure && yarn install --frozen-lockfile --production=true && cd .. && \


### PR DESCRIPTION
## Purpose

Since a recent version of docker, we have a warning telling us that the FROM and As instruction are not using the same case. This commit fix it.

https://docs.docker.com/reference/build-checks/from-as-casing/

## Proposal

- [x] fix FromAsCasing warning

