### PR TITLE
🐛(front) allow to update persisted username on join classroom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow to change username if one is persisted on classroom join
+
 ## [5.0.3] - 2024-08-01
 
 ### Fixed

--- a/src/frontend/packages/lib_classroom/src/components/DashboardClassroom/index.tsx
+++ b/src/frontend/packages/lib_classroom/src/components/DashboardClassroom/index.tsx
@@ -1,4 +1,3 @@
-import { LOCAL_STORAGE_KEYS } from '@lib-components/settings';
 import {
   AnonymousUser,
   Box,
@@ -74,9 +73,7 @@ const DashboardClassroom = ({ classroomId }: DashboardClassroomProps) => {
   const [askUsername, setAskUsername] = useState(false);
   const [classroomJoined, setClassroomJoined] = useState(false);
   const [userFullname, setUserFullname] = useState(
-    (user && user !== AnonymousUser.ANONYMOUS && user.full_name) ||
-      localStorage.getItem(LOCAL_STORAGE_KEYS.CLASSROOM_USERNAME) ||
-      '',
+    (user && user !== AnonymousUser.ANONYMOUS && user.full_name) || '',
   );
 
   const {
@@ -139,7 +136,6 @@ const DashboardClassroom = ({ classroomId }: DashboardClassroomProps) => {
     if (userFullname) {
       askUserNameAction(false);
       joinClassroomMutation.mutate({ fullname: userFullname });
-      localStorage.setItem(LOCAL_STORAGE_KEYS.CLASSROOM_USERNAME, userFullname);
     } else {
       askUserNameAction(true);
     }

--- a/src/frontend/packages/lib_classroom/src/components/DashboardClassroomAskUsername/index.spec.tsx
+++ b/src/frontend/packages/lib_classroom/src/components/DashboardClassroomAskUsername/index.spec.tsx
@@ -1,3 +1,4 @@
+import { LOCAL_STORAGE_KEYS } from '@lib-components/settings';
 import { fireEvent, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render } from 'lib-tests';
@@ -12,6 +13,10 @@ const onJoin = jest.fn();
 const onCancel = jest.fn();
 
 describe('<DashboardClassroomAskUsername />', () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+
   it('displays the form with cancel button', async () => {
     const userFullname = 'Initial value';
     const mockSetUserFullname = jest.fn();
@@ -58,6 +63,26 @@ describe('<DashboardClassroomAskUsername />', () => {
     const cancelButton = screen.queryByText('Cancel');
     expect(cancelButton).toBeNull();
     expect(mockSetUserFullname).toHaveBeenCalledTimes(0);
+  });
+
+  it('populates fullname input value with local storage', () => {
+    const userFullname = '';
+    const mockSetUserFullname = jest.fn();
+    localStorage.setItem(LOCAL_STORAGE_KEYS.CLASSROOM_USERNAME, 'Joe');
+
+    render(
+      <DashboardClassroomAskUsername
+        userFullname={userFullname}
+        setUserFullname={mockSetUserFullname}
+        onJoin={onJoin}
+      />,
+    );
+
+    const userFullNameInput = screen.getByRole('textbox', {
+      name: 'Enter your name',
+    });
+
+    expect(userFullNameInput).toHaveValue('Joe');
   });
 
   describe('<DashboardClassroomAskUsernameStudent />', () => {

--- a/src/frontend/packages/lib_classroom/src/components/DashboardClassroomAskUsername/index.tsx
+++ b/src/frontend/packages/lib_classroom/src/components/DashboardClassroomAskUsername/index.tsx
@@ -1,6 +1,12 @@
 import { colorsTokens } from '@lib-common/cunningham';
 import { Button, Checkbox, Input } from '@openfun/cunningham-react';
-import { Box, Classroom, ModalButton, Text } from 'lib-components';
+import {
+  Box,
+  Classroom,
+  LOCAL_STORAGE_KEYS,
+  ModalButton,
+  Text,
+} from 'lib-components';
 import React, { useState } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 
@@ -54,10 +60,20 @@ const DashboardClassroomAskUsernameWrapper = ({
   >
 >) => {
   const intl = useIntl();
+  const defaultUserName =
+    userFullname ||
+    localStorage.getItem(LOCAL_STORAGE_KEYS.CLASSROOM_USERNAME) ||
+    '';
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    localStorage.setItem(LOCAL_STORAGE_KEYS.CLASSROOM_USERNAME, userFullname);
+    onJoin();
+  };
 
   return (
     <Box pad="large" gap="medium" className="DashboardClassroomAskUsername">
-      <form onSubmit={onJoin}>
+      <form onSubmit={handleSubmit}>
         <Input
           aria-label={intl.formatMessage(messages.labelEnterYourName)}
           label={intl.formatMessage(messages.labelEnterYourName)}
@@ -65,7 +81,7 @@ const DashboardClassroomAskUsernameWrapper = ({
           onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
             setUserFullname(event.currentTarget.value);
           }}
-          value={userFullname}
+          value={defaultUserName}
           text={intl.formatMessage(messages.infoInput)}
         />
         {children}

--- a/src/frontend/yarn.lock
+++ b/src/frontend/yarn.lock
@@ -5953,20 +5953,10 @@ camelize@^1.0.0:
   resolved "https://registry.yarnpkg.com/camelize/-/camelize-1.0.1.tgz#89b7e16884056331a35d6b5ad064332c91daa6c3"
   integrity sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==
 
-caniuse-lite@^1.0.30001541:
-  version "1.0.30001549"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001549.tgz#7d1a3dce7ea78c06ed72c32c2743ea364b3615aa"
-  integrity sha512-qRp48dPYSCYaP+KurZLhDYdVE+yEyht/3NlmcJgVQ2VMGt6JL36ndQ/7rgspdZsJuxDPFIo/OzBT2+GmIJ53BA==
-
-caniuse-lite@^1.0.30001565:
-  version "1.0.30001571"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001571.tgz#4182e93d696ff42930f4af7eba515ddeb57917ac"
-  integrity sha512-tYq/6MoXhdezDLFZuCO/TKboTzuQ/xR5cFdgXPfDtM7/kchBO3b4VWghE/OAi/DV7tTdhmLjZiZBZi1fA/GheQ==
-
-caniuse-lite@^1.0.30001580:
-  version "1.0.30001581"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001581.tgz#0dfd4db9e94edbdca67d57348ebc070dece279f4"
-  integrity sha512-whlTkwhqV2tUmP3oYhtNfaWGYHDdS3JYFQBKXxcUR9qqPWsRhFHhoISO2Xnl/g0xyKzht9mI1LZpiNWfMzHixQ==
+caniuse-lite@^1.0.30001541, caniuse-lite@^1.0.30001565, caniuse-lite@^1.0.30001580:
+  version "1.0.30001651"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001651.tgz"
+  integrity sha512-9Cf+Xv1jJNe1xPZLGuUXLNkE1BoDkqRqYyFJ9TDYSqhduqA4hu4oR9HluGoWYQC/aj8WHjsGVV+bwkh0+tegRg==
 
 ccount@^2.0.0:
   version "2.0.1"
@@ -12556,16 +12546,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -12647,14 +12628,7 @@ stringify-entities@^4.0.0:
     character-entities-html4 "^2.0.0"
     character-entities-legacy "^3.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -13742,16 +13716,7 @@ word-wrap@~1.2.3:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
## Purpose

Previously, in commit 29480e5, we persist fullname on join classroom in order to
 improve ux. But the current implementation has a drawback, indeed once a
 username is persisted, the user directly join the classroom and is not able
 anymore to update its fullname. In order to improve that, instead of joining
 immediately the room, we simply use the persisted value as default value for
 the full name form.