### PR TITLE
🐛(backend) update peertube-runner to latest-whisper_ctranslate2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,7 @@ services:
     tty: true
 
   peertube-runner:
-    image: fundocker/peertube-runner:latest
+    image: fundocker/peertube-runner:latest-whisper_ctranslate2
     env_file:
       - env.d/peertube_runner
 


### PR DESCRIPTION


As we made a special tag for the peertube-runner image in which whisper_ctranslate2 is installed, we need to use it here.