### PR TITLE
♻️(tray) split websocket and asgi apps in tray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Add peertube transcript generation
 
+### Changed
+
+- Split websocket and asgi apps in tray
+
 ### Fixed
 
 - Allow to change username if one is persisted on classroom join

--- a/src/tray/templates/services/app/deploy_ws.yml.j2
+++ b/src/tray/templates/services/app/deploy_ws.yml.j2
@@ -1,0 +1,29 @@
+{% set service_variant = "ws" %}
+{% set marsha_replicas = marsha_ws_replicas %}
+{% set marsha_livenessprobe = {
+    "httpGet": {
+        "path": "/__heartbeat__",
+        "port": "django-port",
+        "httpHeaders": [{
+            "name": "Host",
+            "value": marsha_hosts[0],
+        }],
+    },
+    "initialDelaySeconds": 60,
+    "periodSeconds": 30 ,
+} %}
+{% set marsha_readynessprobe = {
+    "httpGet": {
+        "path": "/__lbheartbeat__",
+        "port": "django-port",
+        "httpHeaders": [{
+            "name": "Host",
+            "value": marsha_hosts[0],
+        }],
+    },
+    "initialDelaySeconds": 10,
+    "periodSeconds": 5,
+} %}
+{% set marsha_resources = marsha_ws_resources %}
+
+{% include "./_deploy_base.yml.j2" with context %}

--- a/src/tray/templates/services/app/svc_ws.yml.j2
+++ b/src/tray/templates/services/app/svc_ws.yml.j2
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: marsha
+    service: ws
+    version: "{{ marsha_image_tag }}"
+    deployment_stamp: "{{ deployment_stamp }}"
+  name: marsha-ws-{{ deployment_stamp }}  # name of the service should be host name in nginx
+  namespace: "{{ namespace_name }}"
+spec:
+  ports:
+  - name: {{ marsha_django_port }}-tcp
+    port: {{ marsha_django_port }}
+    protocol: TCP
+    targetPort: {{ marsha_django_port }}
+  selector:
+    app: marsha
+    deployment: "marsha-ws-{{ deployment_stamp }}"
+  type: ClusterIP

--- a/src/tray/templates/services/nginx/configs/marsha.conf.j2
+++ b/src/tray/templates/services/nginx/configs/marsha.conf.j2
@@ -4,6 +4,10 @@ upstream marsha-backend {
   server marsha-app-{{ deployment_stamp }}:{{ marsha_django_port }} fail_timeout=0;
 }
 
+upstream marsha-ws {
+  server marsha-ws-{{ deployment_stamp }}:{{ marsha_django_port }} fail_timeout=0;
+}
+
 upstream marsha-xapi {
   server marsha-xapi-{{ deployment_stamp }}:{{ marsha_django_port }} fail_timeout=0;
 }
@@ -62,7 +66,7 @@ server {
   }
 
   location /ws/ {
-    proxy_pass http://marsha-backend;
+    proxy_pass http://marsha-ws;
 
     proxy_http_version 1.1;
     proxy_set_header Connection "Upgrade";

--- a/src/tray/vars/all/main.yml
+++ b/src/tray/vars/all/main.yml
@@ -33,6 +33,7 @@ marsha_image_name: "fundocker/marsha"
 marsha_image_tag: "3.23.0"
 marsha_django_port: 8000
 marsha_app_replicas: 1
+marsha_ws_replicas: 1
 marsha_xapi_replicas: 1
 marsha_celery_replicas: 1
 marsha_django_configuration: "Development"
@@ -116,6 +117,14 @@ marsha_celery_readynessprobe:
 
 # -- resource 
 marsha_app_resources:
+  requests:
+    cpu: 0.3
+    memory: 500Mi
+  limits:
+    cpu: 0.8
+    memory: 1Gi
+
+marsha_ws_resources:
   requests:
     cpu: 0.3
     memory: 500Mi


### PR DESCRIPTION
## Purpose

We have detected a memory leak in the websocket application. An issue exists on the django channels github repo about this topic. We also detected that this memory leak can have side effect on the asgi application, the application can become slower leading to timeout. To remove this side effect we decided to create a deploy dedicated to the websocket application and nginx is reponsible to use the right backend based on the request path.

https://github.com/django/channels/issues/2094

## Proposal

- [x] split websocket and asgi apps in tray

