### PR TITLE
⚗️(front) remove websocket connection in VOD student dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Split websocket and asgi apps in tray
+- Remove websocket connection in VOD student dashboard
 
 ### Fixed
 

--- a/src/frontend/packages/lib_video/src/components/vod/Student/Dashboard.tsx
+++ b/src/frontend/packages/lib_video/src/components/vod/Student/Dashboard.tsx
@@ -3,7 +3,6 @@ import { Box, Video, liveState, useTimedTextTrack } from 'lib-components';
 import React from 'react';
 
 import { VideoPlayer } from '@lib-video/components/common/VideoPlayer';
-import { VideoWebSocketInitializer } from '@lib-video/components/common/VideoWebSocketInitializer';
 import { VideoWidgetProvider } from '@lib-video/components/common/VideoWidgetProvider';
 import { MissingVideoUrlsException } from '@lib-video/errors';
 import { CurrentVideoProvider } from '@lib-video/hooks/useCurrentVideo';
@@ -31,28 +30,26 @@ export const Dashboard = ({
 
   return (
     <CurrentVideoProvider value={video}>
-      <VideoWebSocketInitializer url={socketUrl} videoId={video.id}>
-        <Box background={colorsTokens['primary-100']}>
-          <Box>
-            {video.live_state === liveState.ENDED ? (
-              <VideoFromLiveDashboard
-                video={video}
-                socketUrl={socketUrl}
-                playerType={playerType}
-                timedTextTracks={timedTextTracks}
-              />
-            ) : (
-              <VideoPlayer
-                video={video}
-                playerType={playerType}
-                timedTextTracks={timedTextTracks}
-              />
-            )}
-          </Box>
-
-          <VideoWidgetProvider isLive={false} isTeacher={false} />
+      <Box background={colorsTokens['primary-100']}>
+        <Box>
+          {video.live_state === liveState.ENDED ? (
+            <VideoFromLiveDashboard
+              video={video}
+              socketUrl={socketUrl}
+              playerType={playerType}
+              timedTextTracks={timedTextTracks}
+            />
+          ) : (
+            <VideoPlayer
+              video={video}
+              playerType={playerType}
+              timedTextTracks={timedTextTracks}
+            />
+          )}
         </Box>
-      </VideoWebSocketInitializer>
+
+        <VideoWidgetProvider isLive={false} isTeacher={false} />
+      </Box>
     </CurrentVideoProvider>
   );
 };


### PR DESCRIPTION
## Purpose

in the VOD student dashboard we are using the websocket to update the video view. Opening a websocket can consume lot of resources on the backend application for very few user experience improvement. We want to try to remove this connection to see if there is an impact on the backend load vs degrading a little bit the user experience.

## Proposal

- [x] remove websocket connection in VOD student dashboard

