### PR TITLE
⬆️(back) upgrade django_peertube_runner_connection to v0.9.0

### DIFF
--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -45,7 +45,7 @@ install_requires =
     django-redis==5.4.0
     django-safedelete==1.4.0
     django-storages==1.14.3
-    django-peertube-runner-connector==0.8.0
+    django-peertube-runner-connector==0.9.0
     django-waffle==4.1.0
     Django<5
     djangorestframework==3.15.2


### PR DESCRIPTION

## Purpose

Upgrade django_peertube_runner_connection to v0.9.0
https://github.com/openfun/django-peertube-runner-connector/releases/ tag/v0.9.0

