### PR TITLE
🐛(back) use right settings module in s3 task

### DIFF
--- a/src/backend/marsha/core/tasks/s3.py
+++ b/src/backend/marsha/core/tasks/s3.py
@@ -1,6 +1,7 @@
 """Celery s3 tasks for the core app."""
 
-from marsha import settings
+from django.conf import settings
+
 from marsha.celery_app import app
 from marsha.core.defaults import (
     DELETED_VIDEOS_STORAGE_BASE_DIRECTORY,


### PR DESCRIPTION
## Purpose

In the s3 task module, the settings was imported from the marsha namesapce, it should be from django.conf

## Proposal

- [x] use right settings module in s3 task

