### PR TITLE
🐛(xAPI) use domain from lti jwt token when no consumer site used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Enable join classroom button if username is populated from local storage
+- Use domain from lti jwt token when no consumer site used
 
 ## [5.2.0] - 2024-10-22
 

--- a/src/backend/marsha/core/tests/api/xapi/video/test_from_lti.py
+++ b/src/backend/marsha/core/tests/api/xapi/video/test_from_lti.py
@@ -1,0 +1,190 @@
+"""Tests for the video xAPI statement sent from LTI."""
+
+import io
+import json
+import logging
+
+from django.core.cache import cache
+from django.test import TestCase
+
+from logging_ldp.formatters import LDPGELFFormatter
+
+from marsha.core.factories import (
+    ConsumerSiteFactory,
+    OrganizationFactory,
+    PlaylistFactory,
+    VideoFactory,
+)
+from marsha.core.simple_jwt.factories import StudentLtiTokenFactory
+
+
+class XAPIVideoFromLTITest(TestCase):
+    """Tests for the video xAPI statement sent from LTI."""
+
+    maxDiff = None
+
+    def setUp(self):
+        self.logger = logging.getLogger("xapi.lti.example.com")
+        self.logger.setLevel(logging.INFO)
+        self.log_stream = io.StringIO()
+
+        handler = logging.StreamHandler(self.log_stream)
+        handler.setFormatter(LDPGELFFormatter(token="foo", null_character=False))
+        self.logger.addHandler(handler)
+
+        # Clear cache
+        cache.clear()
+
+        super().setUp()
+
+    def test_send_xapi_statement_from_lti_request(self):
+        """
+        A video xAPI statement should be sent when the video has been created in a LTI context.
+        """
+        video = VideoFactory(
+            id="7b18195e-e183-4bbf-b8ef-5145ef64ae19",
+            title="Video 000",
+            playlist__consumer_site__domain="lti.example.com",
+        )
+        jwt_token = StudentLtiTokenFactory(
+            playlist=video.playlist,
+            context_id="cf253c93-3738-496b-8c8f-1e8a1b09a6b1",
+        )
+
+        data = {
+            "verb": {
+                "id": "http://adlnet.gov/expapi/verbs/initialized",
+                "display": {"en-US": "initialized"},
+            },
+            "context": {
+                "extensions": {"https://w3id.org/xapi/video/extensions/volume": 1}
+            },
+        }
+
+        response = self.client.post(
+            f"/xapi/video/{video.id}/",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+            data=json.dumps(data),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        log = json.loads(self.log_stream.getvalue())
+        self.assertIn("short_message", log)
+        message = json.loads(log["short_message"])
+        self.assertEqual(
+            message.get("verb"),
+            {
+                "id": "http://adlnet.gov/expapi/verbs/initialized",
+                "display": {"en-US": "initialized"},
+            },
+        )
+        self.assertEqual(
+            message.get("context"),
+            {
+                "extensions": {"https://w3id.org/xapi/video/extensions/volume": 1},
+                "contextActivities": {
+                    "category": [{"id": "https://w3id.org/xapi/video"}],
+                    "parent": [
+                        {
+                            "id": "cf253c93-3738-496b-8c8f-1e8a1b09a6b1",
+                            "objectType": "Activity",
+                            "definition": {
+                                "type": "http://adlnet.gov/expapi/activities/course"
+                            },
+                        }
+                    ],
+                },
+            },
+        )
+        self.assertEqual(
+            message.get("object"),
+            {
+                "definition": {
+                    "type": "https://w3id.org/xapi/video/activity-type/video",
+                    "name": {"en-US": "Video 000"},
+                },
+                "id": "uuid://7b18195e-e183-4bbf-b8ef-5145ef64ae19",
+                "objectType": "Activity",
+            },
+        )
+
+    def test_send_xapi_statement_from_lti_request_video_no_consumer_site(self):
+        """
+        A video xAPI statement should be sent when the video has not been created in a LTI context.
+        """
+        organization = OrganizationFactory()
+        playlist = PlaylistFactory(
+            organization=organization, consumer_site=None, lti_id=None
+        )
+        consumer_site = ConsumerSiteFactory(domain="lti.example.com")
+        video = VideoFactory(
+            id="7b18195e-e183-4bbf-b8ef-5145ef64ae19",
+            title="Video 000",
+            playlist=playlist,
+        )
+        jwt_token = StudentLtiTokenFactory(
+            playlist=video.playlist,
+            context_id="cf253c93-3738-496b-8c8f-1e8a1b09a6b1",
+            consumer_site=str(consumer_site.id),
+        )
+        self.assertIsNotNone(video.playlist.organization)
+        self.assertIsNone(video.playlist.consumer_site)
+
+        data = {
+            "verb": {
+                "id": "http://adlnet.gov/expapi/verbs/initialized",
+                "display": {"en-US": "initialized"},
+            },
+            "context": {
+                "extensions": {"https://w3id.org/xapi/video/extensions/volume": 1}
+            },
+        }
+
+        response = self.client.post(
+            f"/xapi/video/{video.id}/",
+            HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+            data=json.dumps(data),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        log = json.loads(self.log_stream.getvalue())
+        self.assertIn("short_message", log)
+        message = json.loads(log["short_message"])
+        self.assertEqual(
+            message.get("verb"),
+            {
+                "id": "http://adlnet.gov/expapi/verbs/initialized",
+                "display": {"en-US": "initialized"},
+            },
+        )
+        self.assertEqual(
+            message.get("context"),
+            {
+                "extensions": {"https://w3id.org/xapi/video/extensions/volume": 1},
+                "contextActivities": {
+                    "category": [{"id": "https://w3id.org/xapi/video"}],
+                    "parent": [
+                        {
+                            "id": "cf253c93-3738-496b-8c8f-1e8a1b09a6b1",
+                            "objectType": "Activity",
+                            "definition": {
+                                "type": "http://adlnet.gov/expapi/activities/course"
+                            },
+                        }
+                    ],
+                },
+            },
+        )
+        self.assertEqual(
+            message.get("object"),
+            {
+                "definition": {
+                    "type": "https://w3id.org/xapi/video/activity-type/video",
+                    "name": {"en-US": "Video 000"},
+                },
+                "id": "uuid://7b18195e-e183-4bbf-b8ef-5145ef64ae19",
+                "objectType": "Activity",
+            },
+        )

--- a/src/backend/marsha/core/tests/test_xapi.py
+++ b/src/backend/marsha/core/tests/test_xapi.py
@@ -59,7 +59,12 @@ class XAPIVideoStatementTest(TestCase):
         }
 
         xapi_statement = XAPIVideoStatement()
-        statement = xapi_statement.from_lti(video, base_statement, jwt_token)
+        statement = xapi_statement.from_lti(
+            video,
+            base_statement,
+            jwt_token,
+            video.playlist.consumer_site.domain,
+        )
 
         self.assertIsNotNone(statement["timestamp"])
         self.assertEqual(
@@ -147,7 +152,12 @@ class XAPIVideoStatementTest(TestCase):
         }
 
         xapi_statement = XAPIVideoStatement()
-        statement = xapi_statement.from_lti(video, base_statement, jwt_token)
+        statement = xapi_statement.from_lti(
+            video,
+            base_statement,
+            jwt_token,
+            video.playlist.consumer_site.domain,
+        )
 
         self.assertIsNotNone(statement["timestamp"])
         self.assertEqual(
@@ -236,7 +246,12 @@ class XAPIVideoStatementTest(TestCase):
         }
 
         xapi_statement = XAPIVideoStatement()
-        statement = xapi_statement.from_lti(video, base_statement, jwt_token)
+        statement = xapi_statement.from_lti(
+            video,
+            base_statement,
+            jwt_token,
+            video.playlist.consumer_site.domain,
+        )
 
         self.assertIsNotNone(statement["timestamp"])
         self.assertEqual(
@@ -326,7 +341,12 @@ class XAPIVideoStatementTest(TestCase):
         }
 
         xapi_statement = XAPIVideoStatement()
-        statement = xapi_statement.from_lti(video, base_statement, jwt_token)
+        statement = xapi_statement.from_lti(
+            video,
+            base_statement,
+            jwt_token,
+            video.playlist.consumer_site.domain,
+        )
 
         self.assertIsNotNone(statement["timestamp"])
         self.assertEqual(
@@ -413,7 +433,12 @@ class XAPIVideoStatementTest(TestCase):
         }
 
         xapi_statement = XAPIVideoStatement()
-        statement = xapi_statement.from_lti(video, base_statement, jwt_token)
+        statement = xapi_statement.from_lti(
+            video,
+            base_statement,
+            jwt_token,
+            video.playlist.consumer_site.domain,
+        )
 
         self.assertIsNotNone(statement["timestamp"])
         self.assertEqual(
@@ -487,7 +512,94 @@ class XAPIDocumentStatementTest(TestCase):
         }
 
         xapi_statement = XAPIDocumentStatement()
-        statement = xapi_statement.from_lti(document, base_statement, jwt_token)
+        statement = xapi_statement.from_lti(
+            document,
+            base_statement,
+            jwt_token,
+            document.playlist.consumer_site.domain,
+        )
+
+        self.assertIsNotNone(statement["timestamp"])
+        self.assertEqual(
+            statement["actor"],
+            {
+                "objectType": "Agent",
+                "account": {
+                    "name": "b2584aa405540758db2a6278521b6478",
+                    "homePage": "http://example.com",
+                },
+            },
+        )
+        self.assertEqual(
+            statement["object"],
+            {
+                "definition": {
+                    "type": "http://id.tincanapi.com/activitytype/document",
+                    "name": {"en-US": "test document xapi"},
+                },
+                "id": "uuid://68333c45-4b8c-4018-a195-5d5e1706b838",
+                "objectType": "Activity",
+            },
+        )
+        self.assertEqual(
+            statement["context"],
+            {
+                "extensions": {
+                    "https://w3id.org/xapi/video/extensions/session-id": "a6151456-18b7-"
+                    "43b4-8452-2037fed588df"
+                },
+                "contextActivities": {
+                    "category": [{"id": "https://w3id.org/xapi/lms"}],
+                    "parent": [
+                        {
+                            "id": "course-v1:ufr+mathematics+0001",
+                            "objectType": "Activity",
+                            "definition": {
+                                "type": "http://adlnet.gov/expapi/activities/course"
+                            },
+                        }
+                    ],
+                },
+            },
+        )
+        self.assertEqual(statement["verb"], base_statement["verb"])
+        self.assertEqual(statement["id"], base_statement["id"])
+
+    @override_settings(LANGUAGE_CODE="en-us")
+    def test_xapi_statement_enrich_statement_no_domain(self):
+        """XAPI statement sent by the front application should be enriched."""
+        document = DocumentFactory(
+            id="68333c45-4b8c-4018-a195-5d5e1706b838",
+            playlist__consumer_site__domain="example.com",
+            title="test document xapi",
+        )
+
+        jwt_token = LTIPlaylistAccessTokenFactory(
+            session_id="326c0689-48c1-493e-8d2d-9fb0c289de7f",
+            context_id="course-v1:ufr+mathematics+0001",
+            user__id="b2584aa405540758db2a6278521b6478",
+        )
+
+        base_statement = {
+            "context": {
+                "extensions": {
+                    "https://w3id.org/xapi/video/extensions/session-id": "a6151456-18b7-"
+                    "43b4-8452-2037fed588df"
+                }
+            },
+            "verb": {
+                "display": {"en-US": "downloaded"},
+                "id": "http://id.tincanapi.com/verb/downloaded",
+            },
+            "id": "17dfcd44-b3e0-403d-ab96-e3ef7da616d4",
+        }
+
+        xapi_statement = XAPIDocumentStatement()
+        statement = xapi_statement.from_lti(
+            document,
+            base_statement,
+            jwt_token,
+        )
 
         self.assertIsNotNone(statement["timestamp"])
         self.assertEqual(
@@ -565,7 +677,12 @@ class XAPIDocumentStatementTest(TestCase):
         }
 
         xapi_statement = XAPIDocumentStatement()
-        statement = xapi_statement.from_lti(document, base_statement, jwt_token)
+        statement = xapi_statement.from_lti(
+            document,
+            base_statement,
+            jwt_token,
+            document.playlist.consumer_site.domain,
+        )
 
         self.assertIsNotNone(statement["timestamp"])
         self.assertEqual(
@@ -634,7 +751,12 @@ class XAPIDocumentStatementTest(TestCase):
         }
 
         xapi_statement = XAPIDocumentStatement()
-        statement = xapi_statement.from_lti(document, base_statement, jwt_token)
+        statement = xapi_statement.from_lti(
+            document,
+            base_statement,
+            jwt_token,
+            document.playlist.consumer_site.domain,
+        )
 
         self.assertIsNotNone(statement["timestamp"])
         self.assertEqual(
@@ -730,7 +852,80 @@ class XAPITest(TestCase):
         }
 
         xapi_statement = XAPIVideoStatement()
-        statement = xapi_statement.from_lti(video, base_statement, jwt_token)
+        statement = xapi_statement.from_lti(
+            video,
+            base_statement,
+            jwt_token,
+            video.playlist.consumer_site.domain,
+        )
+
+        responses.add(
+            responses.POST,
+            "https://lrs.example.com",
+            match=[
+                responses.matchers.json_params_matcher(statement),
+                responses.matchers.header_matcher(
+                    {
+                        "Authorization": "Basic auth_token",
+                        "Content-Type": "application/json",
+                        "X-Experience-API-Version": "1.0.3",
+                    }
+                ),
+            ],
+            status=204,
+        )
+
+        xapi.send(statement)
+
+    @responses.activate(assert_all_requests_are_fired=True)
+    def test_xapi_enrich_and_send_statement_no_domain(self):
+        """XAPI statement sent by the front application should be enriched.
+
+        Before sending a statement, the xapi module is responsible for enriching it.
+        """
+        xapi = XAPI("https://lrs.example.com", "Basic auth_token")
+
+        video = VideoFactory(
+            id="68333c45-4b8c-4018-a195-5d5e1706b838",
+            playlist__consumer_site__domain="example.com",
+            title="test video xapi",
+        )
+
+        jwt_token = LTIPlaylistAccessTokenFactory(
+            session_id="326c0689-48c1-493e-8d2d-9fb0c289de7f",
+            context_id="course-v1:ufr+mathematics+0001",
+            user__id="b2584aa405540758db2a6278521b6478",
+        )
+
+        base_statement = {
+            "context": {
+                "extensions": {
+                    "https://w3id.org/xapi/video/extensions/session-id": "a6151456-18b7-"
+                    "43b4-8452-2037fed588df"
+                }
+            },
+            "result": {
+                "extensions": {
+                    "https://w3id.org/xapi/video/extensions/time-from": 0,
+                    "https://w3id.org/xapi/video/extensions/time-to": 0,
+                    "https://w3id.org/xapi/video/extensions/length": 104.304,
+                    "https://w3id.org/xapi/video/extensions/progress": 0,
+                    "https://w3id.org/xapi/video/extensions/played-segments": "0",
+                }
+            },
+            "verb": {
+                "display": {"en-US": "seeked"},
+                "id": "https://w3id.org/xapi/video/verbs/seeked",
+            },
+            "id": "17dfcd44-b3e0-403d-ab96-e3ef7da616d4",
+        }
+
+        xapi_statement = XAPIVideoStatement()
+        statement = xapi_statement.from_lti(
+            video,
+            base_statement,
+            jwt_token,
+        )
 
         responses.add(
             responses.POST,

--- a/src/backend/marsha/core/xapi.py
+++ b/src/backend/marsha/core/xapi.py
@@ -33,11 +33,6 @@ class XAPIStatementMixin:
             else jwt_token.payload["session_id"]
         )
 
-    @staticmethod
-    def get_homepage(resource):
-        """Return the domain associated to the playlist consumer site."""
-        return resource.playlist.consumer_site.domain
-
     def get_locale(self):
         """Return the locale formatted with a - instead of _"""
 
@@ -140,13 +135,19 @@ class XAPIDocumentStatement(XAPIStatementMixin):
             document, statement, homepage=current_site.domain, user=user
         )
 
-    def from_lti(self, document, statement, jwt_token):
+    def from_lti(
+        self,
+        document,
+        statement,
+        jwt_token,
+        domain=None,
+    ):
         """Compute a valid xapi download activity statement."""
 
         statement = self._build_statement(
             document,
             statement,
-            homepage=self.get_homepage(document),
+            homepage=domain or document.playlist.consumer_site.domain,
             user_id=self.get_user_id(jwt_token),
         )
 
@@ -251,7 +252,7 @@ class XAPIVideoStatement(XAPIStatementMixin):
             video, statement, homepage=current_site.domain, user=user
         )
 
-    def from_lti(self, video, statement, jwt_token):
+    def from_lti(self, video, statement, jwt_token, domain=None):
         """Compute a valid xapi statement in an LTI context.
 
         Parameters
@@ -281,10 +282,11 @@ class XAPIVideoStatement(XAPIStatementMixin):
             A jwt token containing the context used to enrich the xapi statement
 
         """
+
         statement = self._build_statement(
             video,
             statement,
-            homepage=self.get_homepage(video),
+            homepage=domain or video.playlist.consumer_site.domain,
             user_id=self.get_user_id(jwt_token),
         )
 


### PR DESCRIPTION
## Purpose

When a xAPI request is made from a LTI context but the video was created on the website, there is no consumer_site attached to the playlist. We are using the domain from the consumer_site when the xAPI request is made in a LTI context. To fix this issue, in the xAPI endpoint is testing if there is a consumer site and if not the one from the LTI passport is used.
## Proposal

Description...

- [x] use domain from lti jwt token when no consumer site used

