### PR TITLE
♻️(back) allow all users created via shibboleth to have a playlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Allow all users created via shibboleth to have their own playlist
+
 ## [5.1.0] - 2024-10-09
 
 ### Added

--- a/src/backend/marsha/core/defaults.py
+++ b/src/backend/marsha/core/defaults.py
@@ -95,6 +95,7 @@ DOCUMENT = "document"
 RENATER_FER_SAML = "renater_fer_saml"
 VOD_CONVERT = "vod_convert"
 TRANSCRIPTION = "transcription"
+ALLOW_PLAYLIST_CREATION_FOR_ALL_ROLES = "allow_playlist_creation_for_all_roles"
 
 # LTI view states expected by the frontend LTI application
 APP_DATA_STATE_ERROR = "error"


### PR DESCRIPTION
## Purpose

When a user is created via shibbolet, we want to create a playlist for each of us and they will be administrator of this playlist.


## Proposal

- [x] Allow all users created via shibboleth to have a playlist

