### PR TITLE
🐛(front) enable join classroom button with local storage username

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Cleanup transcoding temp files
 
+### Fixed
+
+- Enable join classroom button if username is populated from local storage
+
 ## [5.2.0] - 2024-10-22
 
 ### Added

--- a/src/frontend/packages/lib_classroom/src/components/DashboardClassroomAskUsername/index.spec.tsx
+++ b/src/frontend/packages/lib_classroom/src/components/DashboardClassroomAskUsername/index.spec.tsx
@@ -66,23 +66,28 @@ describe('<DashboardClassroomAskUsername />', () => {
   });
 
   it('populates fullname input value with local storage', () => {
-    const userFullname = '';
-    const mockSetUserFullname = jest.fn();
     localStorage.setItem(LOCAL_STORAGE_KEYS.CLASSROOM_USERNAME, 'Joe');
 
-    render(
-      <DashboardClassroomAskUsername
-        userFullname={userFullname}
-        setUserFullname={mockSetUserFullname}
-        onJoin={onJoin}
-      />,
-    );
+    const Component = () => {
+      const [userFullname, setUserFullname] = React.useState('');
+      return (
+        <DashboardClassroomAskUsername
+          userFullname={userFullname}
+          setUserFullname={setUserFullname}
+          onJoin={onJoin}
+        />
+      );
+    };
+
+    render(<Component />);
 
     const userFullNameInput = screen.getByRole('textbox', {
       name: 'Enter your name',
     });
 
     expect(userFullNameInput).toHaveValue('Joe');
+    const joinButton = screen.getByRole('button', { name: 'Join' });
+    expect(joinButton).toBeEnabled();
   });
 
   describe('<DashboardClassroomAskUsernameStudent />', () => {

--- a/src/frontend/packages/lib_classroom/src/components/DashboardClassroomAskUsername/index.tsx
+++ b/src/frontend/packages/lib_classroom/src/components/DashboardClassroomAskUsername/index.tsx
@@ -7,7 +7,7 @@ import {
   ModalButton,
   Text,
 } from 'lib-components';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 
 const messages = defineMessages({
@@ -70,6 +70,15 @@ const DashboardClassroomAskUsernameWrapper = ({
     localStorage.setItem(LOCAL_STORAGE_KEYS.CLASSROOM_USERNAME, userFullname);
     onJoin();
   };
+
+  useEffect(() => {
+    // On mount, if the userFullname is not set, we update it with the value retrieved
+    // in the local storage if it exists.
+    if (!userFullname && defaultUserName) {
+      setUserFullname(defaultUserName);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <Box pad="large" gap="medium" className="DashboardClassroomAskUsername">


### PR DESCRIPTION
## Purpose

Currently, in the form to join a classroom, if the input is populated with the username stored into local storage, the join button remains disabled until the user changes the input value.
The user should be able to click immediately on the join button once a value populates the field.