### PR TITLE
🐛(back) ignore XAPI statements from public view without consumer_site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Ignore XAPI statements from public view without consumer_site
+
 ## [5.3.0] - 2024-11-04
 
 ### Added


### PR DESCRIPTION
## Purpose

When a video or document is used in a public view and has been created on the website, we have no information at all about the consumer site to use. In that specifice case we want to ignore the XAPI statement.

## Proposal

- [x] ignore XAPI statements from public view without consumer_site

