### PR TITLE
⬆️(back) upgrade django-peertube-runner-connector to version 0.11

### DIFF
--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -45,7 +45,7 @@ install_requires =
     django-redis==5.4.0
     django-safedelete==1.4.0
     django-storages==1.14.3
-    django-peertube-runner-connector==0.10.0
+    django-peertube-runner-connector==0.11.0
     django-waffle==4.1.0
     Django<5
     djangorestframework==3.15.2


### PR DESCRIPTION
## Purpose

https://github.com/openfun/django-peertube-runner-connector/releases/tag/v0.11.0

## Proposal

- [x] upgrade django-peertube-runner-connector to version 0.11

