### PR TITLE
⬆️(back) upgrade to python 3.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,7 +223,7 @@ jobs:
   # Build backend development environment
   build-back:
     docker:
-      - image: cimg/python:3.11
+      - image: cimg/python:3.12
         auth:
           username: $DOCKER_HUB_USER
           password: $DOCKER_HUB_PASS
@@ -245,7 +245,7 @@ jobs:
   # Build backend translations
   build-back-i18n:
     docker:
-      - image: cimg/python:3.11
+      - image: cimg/python:3.12
         auth:
           username: $DOCKER_HUB_USER
           password: $DOCKER_HUB_PASS
@@ -296,7 +296,7 @@ jobs:
 
   lint-back:
     docker:
-      - image: cimg/python:3.11
+      - image: cimg/python:3.12
         auth:
           username: $DOCKER_HUB_USER
           password: $DOCKER_HUB_PASS
@@ -325,7 +325,7 @@ jobs:
 
   test-back:
     docker:
-      - image: cimg/python:3.11
+      - image: cimg/python:3.12
         auth:
           username: $DOCKER_HUB_USER
           password: $DOCKER_HUB_PASS
@@ -564,7 +564,7 @@ jobs:
 
   test-e2e:
     docker:
-      - image: mcr.microsoft.com/playwright:v1.47.0-noble
+      - image: cimg/python:3.12-node
         auth:
           username: $DOCKER_HUB_USER
           password: $DOCKER_HUB_PASS
@@ -622,50 +622,44 @@ jobs:
       - restore_cache:
           keys:
             - build-front-<< pipeline.parameters.cache-version >>-{{ checksum "frontend-last-commit.txt" }}
-      - run: # Can be removed when switching to mcr.microsoft.com/playwright:lunar
-          name: Install Python 3.11
-          command: apt update && apt upgrade -y && apt install -y software-properties-common && add-apt-repository -y ppa:deadsnakes/ppa && DEBIAN_FRONTEND=noninteractive apt install -y python3.11 python3.11-dev build-essential
-      - run: # Can be removed when switching to mcr.microsoft.com/playwright:lunar
-          name: Install pip for Python 3.11
-          command: curl -sS https://bootstrap.pypa.io/get-pip.py | python3.11
       - run:
           name: Install xmlsec1 requirements
-          command: apt-get update && apt-get install -y pkg-config libxml2-dev libxmlsec1-openssl libxmlsec1-dev
+          command: |
+            sudo apt update 
+            sudo apt install -y pkg-config libxml2-dev libxmlsec1-openssl libxmlsec1-dev
       - run:
           name: Install e2e dependencies
           working_directory: /home/circleci/marsha/src/backend
-          command: python3.11 -m pip install --user .[dev,e2e]
+          command: python3.12 -m pip install --user .[dev,e2e]
       - run:
           name: Copy iframe resizer
           command: yarn workspace marsha run copy-iframe-resizer
       - run:
+          name: install playwright
+          command: npx -y playwright@1.48.0 install --with-deps
+      - run:
           name: Ensure << parameters.browser >> browser is installed
           working_directory: /home/circleci/marsha/src/backend
           command: |
-            python3.11 -m playwright install-deps "<< parameters.browser >>"
-            python3.11 -m playwright install "<< parameters.browser >>"
-      - run:
-          name: Install dockerize
-          command: |
-            curl -LO https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-            && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-            && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+            python3.12 -m playwright install-deps "<< parameters.browser >>"
+            python3.12 -m playwright install "<< parameters.browser >>"
       - run:
           name: Copy e2e media files
           command: |
-            mkdir -p /data/media \
-            && cp -r /home/circleci/marsha/src/backend/marsha/e2e/media /data/media/e2e
+            sudo mkdir -p /data/media
+            sudo chmod -R 777 /data 
+            cp -r /home/circleci/marsha/src/backend/marsha/e2e/media /data/media/e2e
       - when:
           condition:
             equal: [chrome, << parameters.browser_channel >>]
           steps:
             - run:
                 name: Build apt cache
-                command: apt update
+                command: sudo apt update
             - run:
                 name: Install chrome
                 working_directory: ~/marsha/src/backend
-                command: python3.11 -m playwright install chrome
+                command: python3.12 -m playwright install chrome
       # webkit browser is kind of broken with jammy
       # see https://github.com/microsoft/playwright/issues/15764#issuecomment-1462787720
       # - when:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Allow to configure transcoding resolutions
+- Upgrade to python 3.12
 
 ## [5.3.1] - 2024-11-07
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Marsha, a FUN LTI video provider
 
 # ---- base image to inherit from ----
-FROM python:3.11-slim-bookworm AS base
+FROM python:3.12-slim-bookworm AS base
 
 # ---- back-end builder image ----
 FROM base AS back-builder

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.4"
-
 services:
   db:
     image: postgres:13

--- a/docker/images/e2e/Dockerfile
+++ b/docker/images/e2e/Dockerfile
@@ -1,34 +1,16 @@
-FROM marsha:dev as marsha
+FROM marsha:dev AS marsha
 
-FROM mcr.microsoft.com/playwright:v1.47.0-noble
+USER root:root
 
-COPY --from=marsha /app /app
-COPY src/backend/setup.cfg /app/src/backend/
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash && \
+    NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")" && \
+    [ -s "$NVM_DIR/nvm.sh" ] && \
+    \. "$NVM_DIR/nvm.sh" # This loads nvm && \
+    nvm install 20 --default && \
+    npx -y playwright@1.48.0 install --with-deps
 
-WORKDIR /app/src/backend
 
-# Install python 3.11 and Ensure pip is installed
-# Install xmlsec1 dependencies required for xmlsec (for SAML)
-# Needs to be kept before the `pip install`
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt install -y software-properties-common && \
-    add-apt-repository -y ppa:deadsnakes/ppa && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y \
-        python3.11 \
-        python3.11-dev \
-        build-essential \
-        pkg-config \
-        libxml2-dev \
-        libxmlsec1-openssl \
-        libxmlsec1-dev && \
-    curl -sS https://bootstrap.pypa.io/get-pip.py | python3.11 && \
-    rm -rf /var/lib/apt/lists/*
+RUN pip install .[e2e]
 
-# Install development dependencies
-# and forcibly remove the marsha package
-RUN pip install .[dev,e2e] && \
-    pip uninstall -y marsha
-
-RUN playwright install-deps chrome firefox webkit
-RUN playwright install chrome firefox webkit
+RUN playwright install-deps chrome firefox webkit && \
+    playwright install chrome firefox webkit


### PR DESCRIPTION
## Purpose

Python 3.13 has been released in october 2024, we want to upgrade to python 3.12 to keep max 1 version of difference. The e2e image has been revamped and is based on the marsha:dev image.

## Proposal

- [x] upgrade to python 3.12

