### PR TITLE
⚡️(back) redirect video url instead of streaming it on /transcript-source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Allow to configure transcoding resolutions
 - Upgrade to python 3.12
+- Redirect video url instead of streaming it on /transcript-source
 
 ## [5.3.1] - 2024-11-07
 


### PR DESCRIPTION
## Purpose

The transcript-source video api endpoint was streaming the video content. Instead of doing this we can return a permanent redirect response to the video url. Peertube runner is able to manage this redirection, it releases pressure on our servers and will directly use a CDN URL.


## Proposal

- [x] redirect video url instead of streaming it on /transcript-source

