### PR TITLE
🐛(back) authorize ended live to initiate a transcription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Authorize ended live to initiate a transcription
+
 ## [5.4.0] - 2024-11-13
 
 ### Changed

--- a/src/backend/marsha/core/api/video.py
+++ b/src/backend/marsha/core/api/video.py
@@ -1215,7 +1215,7 @@ class VideoViewSet(
         """Initiate the transcript process for the video."""
         video = self.get_object()
 
-        if video.live_state is not None:
+        if video.live_state and video.live_state != defaults.ENDED:
             return Response(
                 {"detail": "Cannot initiate transcript on a live video"},
                 status=HTTPStatus.BAD_REQUEST,


### PR DESCRIPTION
## Purpose

When a live has been harvested and transform in VOD, then it is possible to initialize a transcription process.

## Proposal

- [x] authorize ended live to initiate a transcription

