### PR TITLE
✨(back) display in admin video duration and size

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,10 @@ aliases:
       name: Login to DockerHub
       command: echo "$DOCKER_HUB_PASS" | docker login -u "$DOCKER_HUB_USER" --password-stdin
 
+  - &count_cpus
+    run:
+      name: Count the number of available cpu cores
+      command: echo "export NB_CPUS=$(cat /proc/cpuinfo | grep processor | wc -l)" >> $BASH_ENV
 # Configuration file anchors
 generate-version-file: &generate-version-file
   run:
@@ -308,6 +312,7 @@ jobs:
       - restore_cache:
           keys:
             - v4-back-dependencies-{{ .Revision }}
+      - *count_cpus
       - run:
           name: Lint code with isort
           command: ~/.local/bin/isort --check-only marsha
@@ -319,7 +324,7 @@ jobs:
           command: ~/.local/bin/flake8 marsha
       - run:
           name: Lint code with pylint
-          command: ~/.local/bin/pylint -j 4 --rcfile=pylintrc marsha
+          command: ~/.local/bin/pylint -j "${NB_CPUS}" --rcfile=pylintrc marsha
       - run:
           name: Lint code with bandit
           command: ~/.local/bin/bandit -c .bandit -qr marsha
@@ -532,24 +537,25 @@ jobs:
       - restore_cache:
           keys:
             - front-dependencies-<< pipeline.parameters.cache-version >>-{{ checksum "yarn.lock" }}
+      - *count_cpus
       - run:
           name: Run tests on libs-components
-          command: yarn workspace lib-components run test -w 3 --shard "$(($CIRCLE_NODE_INDEX + 1))/$CIRCLE_NODE_TOTAL"
+          command: yarn workspace lib-components run test -w "${NB_CPUS}" --shard "$(($CIRCLE_NODE_INDEX + 1))/$CIRCLE_NODE_TOTAL"
       - run:
           name: Run tests on lib-classroom
-          command: yarn workspace lib-classroom run test -w 3 --shard "$(($CIRCLE_NODE_INDEX + 1))/$CIRCLE_NODE_TOTAL"
+          command: yarn workspace lib-classroom run test -w "${NB_CPUS}" --shard "$(($CIRCLE_NODE_INDEX + 1))/$CIRCLE_NODE_TOTAL"
       - run:
           name: Run tests on lib-video
-          command: yarn workspace lib-video run test -w 3 --shard "$(($CIRCLE_NODE_INDEX + 1))/$CIRCLE_NODE_TOTAL"
+          command: yarn workspace lib-video run test -w "${NB_CPUS}" --shard "$(($CIRCLE_NODE_INDEX + 1))/$CIRCLE_NODE_TOTAL"
       - run:
           name: Run tests on lib-markdown
-          command: yarn workspace lib-markdown run test -w 3 --shard "$(($CIRCLE_NODE_INDEX + 1))/$CIRCLE_NODE_TOTAL"
+          command: yarn workspace lib-markdown run test -w "${NB_CPUS}" --shard "$(($CIRCLE_NODE_INDEX + 1))/$CIRCLE_NODE_TOTAL"
       - run:
           name: Run tests on lti site
-          command: yarn workspace marsha run test -w 3 --shard "$(($CIRCLE_NODE_INDEX + 1))/$CIRCLE_NODE_TOTAL"
+          command: yarn workspace marsha run test -w "${NB_CPUS}" --shard "$(($CIRCLE_NODE_INDEX + 1))/$CIRCLE_NODE_TOTAL"
       - run:
           name: Run tests on standalone site
-          command: yarn workspace standalone_site run test -w 3 --shard "$(($CIRCLE_NODE_INDEX + 1))/$CIRCLE_NODE_TOTAL"
+          command: yarn workspace standalone_site run test -w "${NB_CPUS}" --shard "$(($CIRCLE_NODE_INDEX + 1))/$CIRCLE_NODE_TOTAL"
       - store_artifacts:
           path: ~/marsha/src/frontend/apps/lti_site/__diff_output__
       - store_artifacts:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Reject transcoding job for video with too high resolution
 - Add fields to video to store its size and duration
+- Display in admin video duration and size
 
 ### Fixed
 

--- a/src/backend/marsha/core/tests/test_admin.py
+++ b/src/backend/marsha/core/tests/test_admin.py
@@ -4,7 +4,7 @@ from django.db import models
 from django.test import TestCase
 from django.urls import NoReverseMatch
 
-from marsha.core.admin import link_field
+from marsha.core.admin import display_human_duration, display_human_size, link_field
 from marsha.core.factories import (
     ConsumerSiteLTIPassportFactory,
     PlaylistLTIPassportFactory,
@@ -16,8 +16,8 @@ from marsha.core.models import BaseModel
 # pylint: disable=unused-argument
 
 
-class AdminLinkFieldTestCase(TestCase):
-    """Test the `link_field` helper works as expected."""
+class AdminTestCase(TestCase):
+    """Test all admin helpers."""
 
     def test_link_field_no_linked_object(self):
         """Assert `link_field` works properly when no instance is linked."""
@@ -64,3 +64,27 @@ class AdminLinkFieldTestCase(TestCase):
             link_field("linked_object")(instance_with_linked_object)
         reverse_exception = exc_context_mgr.exception
         self.assertIn("one_app_amodel_change", str(reverse_exception))
+
+    def test_display_human_duration(self):
+        """Assert `display_human_duration` works properly."""
+
+        self.assertEqual(display_human_duration(0), "0:00:00")
+        self.assertEqual(display_human_duration(1), "0:00:01")
+        self.assertEqual(display_human_duration(60), "0:01:00")
+        self.assertEqual(display_human_duration(61), "0:01:01")
+        self.assertEqual(display_human_duration(3600), "1:00:00")
+        self.assertEqual(display_human_duration(3661), "1:01:01")
+        self.assertEqual(display_human_duration(7500), "2:05:00")
+        self.assertEqual(display_human_duration(None), "-")
+
+    def test_display_human_size(self):
+        """Assert `display_human_size` works properly."""
+
+        self.assertEqual(display_human_size(0), "0.00 B")
+        self.assertEqual(display_human_size(1), "1.00 B")
+        self.assertEqual(display_human_size(1024), "1.00 KB")
+        self.assertEqual(display_human_size(1024**2), "1.00 MB")
+        self.assertEqual(display_human_size(1024**3), "1.00 GB")
+        self.assertEqual(display_human_size(1024**4), "1.00 TB")
+        self.assertEqual(display_human_size(1024**5), "1.00 PB")
+        self.assertEqual(display_human_size(None), "-")


### PR DESCRIPTION
## Purpose

In the admin, we want to display for an organization, consumer site and
    playlist the addition of videos size and duration.

## Proposal

- [x] display in admin video duration and size
- [x] count available cpu cores in circleci