### PR TITLE
Upgrade backend dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Add fields to video to store its size and duration
 - Display in admin video duration and size
 
+### Changed
+
+- Upgrade to django 5.0
+
 ### Fixed
 
 - Authorize ended live to initiate a transcription

--- a/renovate.json
+++ b/renovate.json
@@ -47,7 +47,7 @@
       "matchPackageNames": [
         "Django"
       ],
-      "allowedVersions": "<5"
+      "allowedVersions": "<5.1.0"
     },
     {
       "enabled": false,

--- a/renovate.json
+++ b/renovate.json
@@ -40,16 +40,6 @@
       "versioning": "semver"
     },
     {
-      "groupName": "allowed urllib3 versions",
-      "matchManagers": [
-        "setup-cfg"
-      ],
-      "matchPackageNames": [
-        "urllib3"
-      ],
-      "allowedVersions": "<2.1.0"
-    },
-    {
       "groupName": "allowed django versions",
       "matchManagers": [
         "setup-cfg"

--- a/renovate.json
+++ b/renovate.json
@@ -60,16 +60,6 @@
       "allowedVersions": "<5"
     },
     {
-      "groupName": "allowed pytest versions",
-      "matchManagers": [
-        "setup-cfg"
-      ],
-      "matchPackageNames": [
-        "pytest"
-      ],
-      "allowedVersions": "<8.0.0"
-    },
-    {
       "enabled": false,
       "groupName": "ignored python dependencies",
       "matchManagers": [

--- a/src/backend/marsha/account/tests/test_middleware.py
+++ b/src/backend/marsha/account/tests/test_middleware.py
@@ -1,5 +1,7 @@
 """Test SocialAuthExceptionMiddleware."""
 
+from importlib import reload
+import sys
 from unittest import mock
 
 from django.conf import settings
@@ -22,6 +24,12 @@ class TestMiddleware(TestCase):
             "account:social:complete", kwargs={"backend": "saml_fer"}
         )
         self.complete_url += "?RelayState=marsha-local-idp"
+
+        # Reload module social_core.backends.utils, it makes a global
+        # cache with already loaded backend defined in settings.AUTHENTICATION_BACKENDS.
+        # In this test we want to change it.
+        if "social_core.backends.utils" in sys.modules:
+            reload(sys.modules["social_core.backends.utils"])
 
     @override_settings()
     def test_exception(self):

--- a/src/backend/marsha/bbb/tests/api/classroom/test_retrieve.py
+++ b/src/backend/marsha/bbb/tests/api/classroom/test_retrieve.py
@@ -1,12 +1,11 @@
 """Tests for the classroom retrieve API."""
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import json
 import zoneinfo
 
 from django.core.cache import cache
 from django.test import TestCase, override_settings
-from django.utils import timezone
 
 import responses
 

--- a/src/backend/marsha/bbb/tests/bbb_utils/test_create.py
+++ b/src/backend/marsha/bbb/tests/bbb_utils/test_create.py
@@ -26,7 +26,7 @@ class ClassroomServiceTestCase(TestCase):
             title="Classroom 001",
             meeting_id="7a567d67-29d3-4547-96f3-035733a4dfaa",
         )
-        self.assertQuerysetEqual(classroom.sessions.all(), [])
+        self.assertQuerySetEqual(classroom.sessions.all(), [])
 
         responses.add(
             responses.GET,

--- a/src/backend/marsha/core/tests/management_commands/test_send_vod_convert_reminders.py
+++ b/src/backend/marsha/core/tests/management_commands/test_send_vod_convert_reminders.py
@@ -1,13 +1,13 @@
 """Test send_vod_convert_reminders command."""
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from io import StringIO
 from unittest import mock
 
 from django.core import mail
 from django.core.management import call_command
 from django.test import TestCase
-from django.utils import timezone
+from django.utils import timezone as django_timezone
 
 from marsha.core.defaults import HARVESTED, IDLE, JITSI, RUNNING, STOPPED
 from marsha.core.factories import VideoFactory
@@ -27,7 +27,7 @@ class SendVodConvertRemindersCommandTest(TestCase):
         """Test send_vod_convert_reminders command."""
         expiration_reminder_date = datetime(2022, 11, 1, 15, 00, tzinfo=timezone.utc)
 
-        start = timezone.now() - timedelta(minutes=20)
+        start = django_timezone.now() - timedelta(minutes=20)
         stop = start + timedelta(minutes=10)
 
         # first live not started yet, should not be reminded.

--- a/src/backend/marsha/core/tests/utils/test_send_emails.py
+++ b/src/backend/marsha/core/tests/utils/test_send_emails.py
@@ -1,9 +1,9 @@
 """Test the send_emails functions."""
 
+from datetime import datetime, timezone
+
 from django.core import mail
 from django.test import TestCase, override_settings
-from django.utils import timezone
-from django.utils.datetime_safe import datetime
 
 from marsha.core.factories import VideoFactory
 from marsha.core.utils.send_emails import (

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -67,7 +67,7 @@ install_requires =
     social-auth-app-django==5.4.2
     social-auth-core[saml]==4.5.4
     social-edu-federation==2.1.1
-    urllib3==2.0.7
+    urllib3==2.2.3
     uvicorn[standard]==0.32.1
     whitenoise==6.8.2
     xmpppy==0.7.1

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -106,14 +106,14 @@ dev =
     pytest-cov==6.0.0
     pytest-django==4.9.0
     pytest-mock==3.14.0
-    pytest<8.0.0
+    pytest==8.3.3
     responses==0.25.3
     signxml==4.0.3
     wheel==0.45.1
 
 e2e =
     playwright==1.49.0
-    pytest-playwright==0.5.2
+    pytest-playwright==0.6.2
 # mcr.microsoft.com/playwright:jammy requires tzdata
     tzdata==2024.2
 

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -47,7 +47,7 @@ install_requires =
     django-storages==1.14.3
     django-peertube-runner-connector==0.12.1
     django-waffle==4.2.0
-    Django<5
+    Django==5.0.9
     djangorestframework==3.15.2
     djangorestframework_simplejwt==5.3.1
     dockerflow==2024.4.2


### PR DESCRIPTION
## Purpose

Some backend dependencies were ignored by renovate. We can now upgrade part of them.
The upgrade to django 5.1 will be possible once postgresql 12 will be removed.

## Proposal

- [x] upgrade to pytest 8.3.3
- [x] upgrade to urllib3 2.2.3
- [x] upgrade to django 5.0.9
