### PR TITLE
🔧(tray) increase connection timeout for peertube runner requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Increase connection timeout on Nginx for peertube runner success request
+
 ## [5.5.3] - 2025-01-09
 
 ### Fixed

--- a/src/tray/templates/services/nginx/configs/marsha.conf.j2
+++ b/src/tray/templates/services/nginx/configs/marsha.conf.j2
@@ -105,6 +105,11 @@ server {
 
   location /api/v1/runners {
     client_max_body_size 4000m;
+
+    proxy_connect_timeout 300s;
+    proxy_send_timeout 300s;
+    proxy_read_timeout 300s;
+
     try_files $uri @proxy_to_marsha_app;
   }
 


### PR DESCRIPTION
## Purpose

Some requests to the `success` endpoint ends up returning a 504 Timeout, usually
for the bigger vod files.

## Proposal

The `success` endpoint loads the converted video file and manipulates it, which
could be taking some time.
Increasing the connection timeout on the Nginx conf to 300s so it does not
timeout for longer files.

