### PR TITLE
✨(backend) use peertube transcoding pipeline by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Increase connection timeout on Nginx for peertube runner success request
 - Allow disabling Cloudfront signed URLs
+- Use Peertube pipeline by default for BBB VOD transcoding
 
 ## [5.5.3] - 2025-01-09
 

--- a/src/backend/marsha/bbb/api.py
+++ b/src/backend/marsha/bbb/api.py
@@ -763,7 +763,7 @@ class ClassroomRecordingViewSet(
         classroom_recording.vod = Video.objects.create(
             title=request.data.get("title"),
             playlist=classroom_recording.classroom.playlist,
-            transcode_pipeline=defaults.AWS_PIPELINE,
+            transcode_pipeline=defaults.PEERTUBE_PIPELINE,
         )
         classroom_recording.save()
 

--- a/src/backend/marsha/bbb/tests/api/classroom/recordings/test_create_vod.py
+++ b/src/backend/marsha/bbb/tests/api/classroom/recordings/test_create_vod.py
@@ -163,12 +163,12 @@ class ClassroomRecordingCreateVodAPITest(TestCase):
             status=200,
         )
 
-        with mock.patch(
-            "marsha.bbb.api.invoke_lambda_convert"
-        ) as mock_invoke_lambda_convert, mock.patch.object(
-            timezone, "now", return_value=now
-        ), self.assertNumQueries(
-            9
+        with (
+            mock.patch(
+                "marsha.bbb.api.invoke_lambda_convert"
+            ) as mock_invoke_lambda_convert,
+            mock.patch.object(timezone, "now", return_value=now),
+            self.assertNumQueries(9),
         ):
             response = self.client.post(
                 f"/api/classrooms/{recording.classroom.id}/recordings/{recording.id}/create-vod/",
@@ -177,7 +177,7 @@ class ClassroomRecordingCreateVodAPITest(TestCase):
             )
 
         self.assertEqual(Video.objects.count(), 1)
-        self.assertEqual(Video.objects.first().transcode_pipeline, "AWS")
+        self.assertEqual(Video.objects.first().transcode_pipeline, "peertube")
         self.assertEqual(response.status_code, 201)
 
         recording.refresh_from_db()
@@ -225,9 +225,10 @@ class ClassroomRecordingCreateVodAPITest(TestCase):
 
         now = timezone.now()
 
-        with mock.patch.object(
-            timezone, "now", return_value=now
-        ), self.assertNumQueries(1):
+        with (
+            mock.patch.object(timezone, "now", return_value=now),
+            self.assertNumQueries(1),
+        ):
             response = self.client.post(
                 f"/api/classrooms/{recording.classroom.id}"
                 f"/recordings/{recording.classroom.id}/create-vod/",
@@ -331,7 +332,7 @@ class ClassroomRecordingCreateVodAPITest(TestCase):
 
         self.assertEqual(response.status_code, 201)
         self.assertEqual(Video.objects.count(), 1)
-        self.assertEqual(Video.objects.first().transcode_pipeline, "AWS")
+        self.assertEqual(Video.objects.first().transcode_pipeline, "peertube")
 
     @responses.activate
     def test_api_classroom_recording_create_vod_from_standalone_site_no_consumer_site(
@@ -410,7 +411,7 @@ class ClassroomRecordingCreateVodAPITest(TestCase):
 
         self.assertEqual(response.status_code, 201)
         self.assertEqual(Video.objects.count(), 1)
-        self.assertEqual(Video.objects.first().transcode_pipeline, "AWS")
+        self.assertEqual(Video.objects.first().transcode_pipeline, "peertube")
 
     def test_api_classroom_recording_create_vod_from_standalone_site_inactive_conversion(
         self,
@@ -510,7 +511,7 @@ class ClassroomRecordingCreateVodAPITest(TestCase):
 
         self.assertEqual(response.status_code, 201)
         self.assertEqual(Video.objects.count(), 1)
-        self.assertEqual(Video.objects.first().transcode_pipeline, "AWS")
+        self.assertEqual(Video.objects.first().transcode_pipeline, "peertube")
 
     @responses.activate
     def test_api_classroom_recording_create_vod_user_access_token_playlist_instructor(
@@ -584,7 +585,7 @@ class ClassroomRecordingCreateVodAPITest(TestCase):
 
         self.assertEqual(response.status_code, 201)
         self.assertEqual(Video.objects.count(), 1)
-        self.assertEqual(Video.objects.first().transcode_pipeline, "AWS")
+        self.assertEqual(Video.objects.first().transcode_pipeline, "peertube")
 
     def test_api_classroom_recording_create_vod_user_access_token_playlist_student(
         self,
@@ -666,12 +667,12 @@ class ClassroomRecordingCreateVodAPITest(TestCase):
 
         now = timezone.now()
 
-        with mock.patch(
-            "marsha.bbb.api.invoke_lambda_convert"
-        ) as mock_invoke_lambda_convert, mock.patch.object(
-            timezone, "now", return_value=now
-        ), self.assertNumQueries(
-            1
+        with (
+            mock.patch(
+                "marsha.bbb.api.invoke_lambda_convert"
+            ) as mock_invoke_lambda_convert,
+            mock.patch.object(timezone, "now", return_value=now),
+            self.assertNumQueries(1),
         ):
             response = self.client.post(
                 f"/api/classrooms/{recording.classroom.id}/recordings/{recording.id}/create-vod/",


### PR DESCRIPTION
## Purpose

The BigBlueButton VODs are still using the AWS transcoding pipeline by default.

## Proposal

Switching to use the Peertube transcoding pipeline.

