### PR TITLE
🔥(backend) revert default transcoding pipeline and remove Cloudfront URL signing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Increase connection timeout on Nginx for peertube runner success request
 - Allow disabling Cloudfront signed URLs
-- Use Peertube pipeline by default for BBB VOD transcoding
 
 ## [5.5.3] - 2025-01-09
 

--- a/src/aws/cloudfront.tf
+++ b/src/aws/cloudfront.tf
@@ -96,8 +96,6 @@ resource "aws_cloudfront_distribution" "marsha_cloudfront_distribution" {
     allowed_methods  = ["GET", "HEAD", "OPTIONS"]
     cached_methods   = ["GET", "HEAD", "OPTIONS"]
     target_origin_id = local.s3_destination_origin_id
-    trusted_signers  = []
-    trusted_key_groups = [aws_cloudfront_key_group.marsha_cloudfront_signer_key_group.id]
 
     forwarded_values {
       query_string = false
@@ -115,14 +113,11 @@ resource "aws_cloudfront_distribution" "marsha_cloudfront_distribution" {
     viewer_protocol_policy = "redirect-to-https"
   }
 
-  # Destination bucket: access to MP4 videos is restricted to signed urls/cookies
   ordered_cache_behavior {
     path_pattern     = "*/mp4/*"
     allowed_methods  = ["GET", "HEAD", "OPTIONS"]
     cached_methods   = ["GET", "HEAD", "OPTIONS"]
     target_origin_id = local.s3_destination_origin_id
-    trusted_signers  = []
-    trusted_key_groups = [aws_cloudfront_key_group.marsha_cloudfront_signer_key_group.id]
 
     forwarded_values {
       query_string = true
@@ -145,8 +140,6 @@ resource "aws_cloudfront_distribution" "marsha_cloudfront_distribution" {
     allowed_methods  = ["GET", "HEAD", "OPTIONS"]
     cached_methods   = ["GET", "HEAD", "OPTIONS"]
     target_origin_id = local.s3_destination_origin_id
-    trusted_signers  = []
-    trusted_key_groups = [aws_cloudfront_key_group.marsha_cloudfront_signer_key_group.id]
 
     forwarded_values {
       query_string = true
@@ -169,8 +162,6 @@ resource "aws_cloudfront_distribution" "marsha_cloudfront_distribution" {
     allowed_methods  = ["GET", "HEAD", "OPTIONS"]
     cached_methods   = ["GET", "HEAD", "OPTIONS"]
     target_origin_id = local.s3_destination_origin_id
-    trusted_signers  = []
-    trusted_key_groups = [aws_cloudfront_key_group.marsha_cloudfront_signer_key_group.id]
 
     forwarded_values {
       query_string = true
@@ -193,8 +184,6 @@ resource "aws_cloudfront_distribution" "marsha_cloudfront_distribution" {
     allowed_methods  = ["GET", "HEAD", "OPTIONS"]
     cached_methods   = ["GET", "HEAD", "OPTIONS"]
     target_origin_id = local.s3_destination_origin_id
-    trusted_signers  = []
-    trusted_key_groups = [aws_cloudfront_key_group.marsha_cloudfront_signer_key_group.id]
 
     forwarded_values {
       query_string = true
@@ -217,8 +206,6 @@ resource "aws_cloudfront_distribution" "marsha_cloudfront_distribution" {
     allowed_methods  = ["GET", "HEAD", "OPTIONS"]
     cached_methods   = ["GET", "HEAD", "OPTIONS"]
     target_origin_id = local.s3_destination_origin_id
-    trusted_signers  = []
-    trusted_key_groups = [aws_cloudfront_key_group.marsha_cloudfront_signer_key_group.id]
 
     forwarded_values {
       query_string = true
@@ -259,14 +246,11 @@ resource "aws_cloudfront_distribution" "marsha_cloudfront_distribution" {
     viewer_protocol_policy = "redirect-to-https"
   }
 
-  # Destination bucket: access to timed text tracks is restricted to signed urls/cookies
   ordered_cache_behavior {
     path_pattern     = "*/timedtext/*"
     allowed_methods  = ["GET", "HEAD", "OPTIONS"]
     cached_methods   = ["GET", "HEAD", "OPTIONS"]
     target_origin_id = local.s3_destination_origin_id
-    trusted_signers  = []
-    trusted_key_groups = [aws_cloudfront_key_group.marsha_cloudfront_signer_key_group.id]
 
     forwarded_values {
       query_string = true
@@ -383,8 +367,6 @@ resource "aws_cloudfront_distribution" "marsha_cloudfront_distribution" {
     allowed_methods  = ["GET", "HEAD", "OPTIONS"]
     cached_methods   = ["GET", "HEAD", "OPTIONS"]
     target_origin_id = local.scw_object_storage_origin_id
-    trusted_signers  = []
-    trusted_key_groups = [aws_cloudfront_key_group.marsha_cloudfront_signer_key_group.id]
 
     forwarded_values {
       query_string = false

--- a/src/backend/marsha/bbb/api.py
+++ b/src/backend/marsha/bbb/api.py
@@ -763,7 +763,7 @@ class ClassroomRecordingViewSet(
         classroom_recording.vod = Video.objects.create(
             title=request.data.get("title"),
             playlist=classroom_recording.classroom.playlist,
-            transcode_pipeline=defaults.PEERTUBE_PIPELINE,
+            transcode_pipeline=defaults.AWS_PIPELINE,
         )
         classroom_recording.save()
 

--- a/src/backend/marsha/bbb/tests/api/classroom/recordings/test_create_vod.py
+++ b/src/backend/marsha/bbb/tests/api/classroom/recordings/test_create_vod.py
@@ -163,12 +163,12 @@ class ClassroomRecordingCreateVodAPITest(TestCase):
             status=200,
         )
 
-        with (
-            mock.patch(
-                "marsha.bbb.api.invoke_lambda_convert"
-            ) as mock_invoke_lambda_convert,
-            mock.patch.object(timezone, "now", return_value=now),
-            self.assertNumQueries(9),
+        with mock.patch(
+            "marsha.bbb.api.invoke_lambda_convert"
+        ) as mock_invoke_lambda_convert, mock.patch.object(
+            timezone, "now", return_value=now
+        ), self.assertNumQueries(
+            9
         ):
             response = self.client.post(
                 f"/api/classrooms/{recording.classroom.id}/recordings/{recording.id}/create-vod/",
@@ -177,7 +177,7 @@ class ClassroomRecordingCreateVodAPITest(TestCase):
             )
 
         self.assertEqual(Video.objects.count(), 1)
-        self.assertEqual(Video.objects.first().transcode_pipeline, "peertube")
+        self.assertEqual(Video.objects.first().transcode_pipeline, "AWS")
         self.assertEqual(response.status_code, 201)
 
         recording.refresh_from_db()
@@ -225,10 +225,9 @@ class ClassroomRecordingCreateVodAPITest(TestCase):
 
         now = timezone.now()
 
-        with (
-            mock.patch.object(timezone, "now", return_value=now),
-            self.assertNumQueries(1),
-        ):
+        with mock.patch.object(
+            timezone, "now", return_value=now
+        ), self.assertNumQueries(1):
             response = self.client.post(
                 f"/api/classrooms/{recording.classroom.id}"
                 f"/recordings/{recording.classroom.id}/create-vod/",
@@ -332,7 +331,7 @@ class ClassroomRecordingCreateVodAPITest(TestCase):
 
         self.assertEqual(response.status_code, 201)
         self.assertEqual(Video.objects.count(), 1)
-        self.assertEqual(Video.objects.first().transcode_pipeline, "peertube")
+        self.assertEqual(Video.objects.first().transcode_pipeline, "AWS")
 
     @responses.activate
     def test_api_classroom_recording_create_vod_from_standalone_site_no_consumer_site(
@@ -411,7 +410,7 @@ class ClassroomRecordingCreateVodAPITest(TestCase):
 
         self.assertEqual(response.status_code, 201)
         self.assertEqual(Video.objects.count(), 1)
-        self.assertEqual(Video.objects.first().transcode_pipeline, "peertube")
+        self.assertEqual(Video.objects.first().transcode_pipeline, "AWS")
 
     def test_api_classroom_recording_create_vod_from_standalone_site_inactive_conversion(
         self,
@@ -511,7 +510,7 @@ class ClassroomRecordingCreateVodAPITest(TestCase):
 
         self.assertEqual(response.status_code, 201)
         self.assertEqual(Video.objects.count(), 1)
-        self.assertEqual(Video.objects.first().transcode_pipeline, "peertube")
+        self.assertEqual(Video.objects.first().transcode_pipeline, "AWS")
 
     @responses.activate
     def test_api_classroom_recording_create_vod_user_access_token_playlist_instructor(
@@ -585,7 +584,7 @@ class ClassroomRecordingCreateVodAPITest(TestCase):
 
         self.assertEqual(response.status_code, 201)
         self.assertEqual(Video.objects.count(), 1)
-        self.assertEqual(Video.objects.first().transcode_pipeline, "peertube")
+        self.assertEqual(Video.objects.first().transcode_pipeline, "AWS")
 
     def test_api_classroom_recording_create_vod_user_access_token_playlist_student(
         self,
@@ -667,12 +666,12 @@ class ClassroomRecordingCreateVodAPITest(TestCase):
 
         now = timezone.now()
 
-        with (
-            mock.patch(
-                "marsha.bbb.api.invoke_lambda_convert"
-            ) as mock_invoke_lambda_convert,
-            mock.patch.object(timezone, "now", return_value=now),
-            self.assertNumQueries(1),
+        with mock.patch(
+            "marsha.bbb.api.invoke_lambda_convert"
+        ) as mock_invoke_lambda_convert, mock.patch.object(
+            timezone, "now", return_value=now
+        ), self.assertNumQueries(
+            1
         ):
             response = self.client.post(
                 f"/api/classrooms/{recording.classroom.id}/recordings/{recording.id}/create-vod/",


### PR DESCRIPTION
## Purpose

- As the BBB VODs are fetched and processed by a Lambda, some deeper changes need
to be done to change the default transcoding pipeline from AWS to Peertube.
- As we are migrating from Cloudfront to Scaleway Edge Services, we cannot sign
URLs anymore.

## Proposal

- Reverting the changes so the default pipeline for VODs is AWS.
- Removing Cloudfront signing using Terraform (applied to staging, not to production yet)
