### PR TITLE
🐛(frontend) fix svg icons import on videoplayer control bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Restore download, transcription and shared media icons on the video player 
+
 ## [5.6.0] - 2025-03-06
 
 ### Added

--- a/src/frontend/packages/lib_video/src/components/common/VideoPlayer/index.tsx
+++ b/src/frontend/packages/lib_video/src/components/common/VideoPlayer/index.tsx
@@ -39,19 +39,19 @@ export const StyledBox = styled(Box)`
   }
 
   .vjs-icon-download {
-    background-image: url(${DownloadIcon});
+    background-image: url(\"${DownloadIcon}\");
     background-repeat: no-repeat;
     background-position: center;
   }
 
   .vjs-icon-transcript {
-    background-image: url(${TranscriptIcon});
+    background-image: url(\"${TranscriptIcon}\");
     background-repeat: no-repeat;
     background-position: center;
   }
 
   .vjs-icon-shared-media {
-    background-image: url(${SharedMediaIcon});
+    background-image: url(\"${SharedMediaIcon}\");
     background-repeat: no-repeat;
     background-position: center;
   }


### PR DESCRIPTION
## Purpose

Since the Vite upgrade from 5.4.9 to 6.0.1, the download, transcript and shared
media icons were missing from the video player control bar on the standalone
site.

## Proposal

Based on the Vite documentation (https://vite.dev/guide/assets), when inlining
SVGs through url(), the variable needs to be wrapped within double quotes.

