### PR TITLE
🔧(tray) fix ineffective timeout settings for peertube runner requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix timeout increase on Nginx for peertube runner success request
+
 ## [5.7.0] - 2025-04-08
 
 ### Added

--- a/src/tray/templates/services/nginx/configs/marsha.conf.j2
+++ b/src/tray/templates/services/nginx/configs/marsha.conf.j2
@@ -41,6 +41,9 @@ server {
   location @proxy_to_marsha_app {
     proxy_set_header Host $http_host;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_connect_timeout 300s;
+    proxy_send_timeout 300s;
+    proxy_read_timeout 300s;
 
     proxy_redirect off;
     proxy_pass http://marsha-backend;
@@ -105,10 +108,6 @@ server {
 
   location /api/v1/runners {
     client_max_body_size 4000m;
-
-    proxy_connect_timeout 300s;
-    proxy_send_timeout 300s;
-    proxy_read_timeout 300s;
 
     try_files $uri @proxy_to_marsha_app;
   }


### PR DESCRIPTION
## Purpose

Previous increases to connection timeouts had no effect due to the requests being proxied through `proxy_to_marsha_app`, which overrides those settings. 
This fix moves the timeout configuration directly into the `proxy_to_marsha_app` location block to ensure they are properly applied. 

_Note: This is a temporary, hacky workaround to avoid 504 Gateway Timeouts when the PeerTube runner POSTs to /success. A proper fix is still needed._
