### PR TITLE
🔧(terraform) add classroom resource in SCW bucket policy

### DIFF
--- a/src/aws/s3_scaleway.tf
+++ b/src/aws/s3_scaleway.tf
@@ -58,6 +58,7 @@ resource "scaleway_object_bucket_policy" "policy" {
           Principal = "*",
           Action = "s3:GetObject",
           Resource = [
+            "${scaleway_object_bucket.marsha_object_bucket.name}/classroom/*",
             "${scaleway_object_bucket.marsha_object_bucket.name}/vod/*",
             "${scaleway_object_bucket.marsha_object_bucket.name}/tmp/*"
           ]


### PR DESCRIPTION
Allow users to read the `classroom` resource in the S3 SCW bucket policy.

