### PR TITLE
🔧(docker) fix prosody table creation on startup

### DIFF
--- a/docker/files/docker-entrypoint-initdb.d/init_user_db.sh
+++ b/docker/files/docker-entrypoint-initdb.d/init_user_db.sh
@@ -6,3 +6,9 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-E
     CREATE DATABASE prosody;
     GRANT ALL PRIVILEGES ON DATABASE prosody TO prosody;
 EOSQL
+
+# Connect to the prosody database to grant all privileges on schema public
+# Required since PostgreSQL > 15
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "prosody" <<-EOSQL
+  GRANT ALL ON SCHEMA public TO prosody;
+EOSQL


### PR DESCRIPTION
## Purpose

When doing a `make bootstrap`, an error occurs:
```
Error in SQL transaction: /usr/lib/prosody/util/sql.lua:163: Error preparing statement handle: ERROR:  relation "prosody" does not exist
```

This issue has been present since the upgrade from PostgreSQL 13 to 16.

## Proposal

Starting with PostreSQL 15, the CREATE privilege on `public` schema is revoked from all users except the database owner.
Adding a connection to the Prosody database at container startup to manually grant all privileges on the `public` schema, ensuring Prosody can create its tables properly.

