### PR TITLE
🐛(front) call upload-ended endpoint after deposited file upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix upload state of deposited files to Scaleway
+
 ## [5.8.1] - 2025-06-13
 
 ### Fixed

--- a/src/backend/marsha/core/storage/filesystem.py
+++ b/src/backend/marsha/core/storage/filesystem.py
@@ -110,7 +110,7 @@ def initiate_deposited_file_storage_upload(request, obj, filename, conditions):
         },
         "url": request.build_absolute_uri(
             reverse(
-                "local-deposited_file-upload",
+                "local-deposited-file-upload",
                 args=[obj.pk],
             )
         ),

--- a/src/frontend/apps/lti_site/apps/deposit/components/Dashboard/DashboardStudent/UploadFiles/index.spec.tsx
+++ b/src/frontend/apps/lti_site/apps/deposit/components/Dashboard/DashboardStudent/UploadFiles/index.spec.tsx
@@ -97,6 +97,7 @@ describe('<UploadFiles />', () => {
       depositedFile.id,
       file,
       depositedFile.file_depository_id,
+      expect.any(Function),
     );
   });
 

--- a/src/frontend/apps/lti_site/apps/deposit/components/Dashboard/DashboardStudent/UploadFiles/index.tsx
+++ b/src/frontend/apps/lti_site/apps/deposit/components/Dashboard/DashboardStudent/UploadFiles/index.tsx
@@ -10,6 +10,7 @@ import {
   FileDepositoryModelName as modelName,
   report,
   truncateFilename,
+  uploadEnded,
   useUploadManager,
 } from 'lib-components';
 import { DateTime } from 'luxon';
@@ -105,6 +106,14 @@ export const UploadFiles = () => {
         depositedFile.id,
         file,
         depositedFile.file_depository_id,
+        (presignedPost) => {
+          uploadEnded(
+            modelName.DepositedFiles,
+            depositedFile.id,
+            presignedPost.fields['key'],
+            depositedFile.file_depository_id,
+          );
+        },
       );
       refreshDepositedFiles();
     } catch (error) {


### PR DESCRIPTION
## Purpose

Deposited files were correctly uploaded to Scaleway S3, but the `upload-ended`
endpoint was not being called, causing deposited files to remain in a pending
state.

## Proposal

Adding the confirmation call after upload completion.
