### PR TITLE
🐛(back) fix import error preventing uploads in Marsha Document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix settings import in Marsha Document
+
 ## [5.9.0] - 2025-06-23
 
 ### Added

--- a/src/backend/marsha/core/api/file.py
+++ b/src/backend/marsha/core/api/file.py
@@ -1,12 +1,12 @@
 """Declare API endpoints for documents with Django RestFramework viewsets."""
 
+from django.conf import settings
 from django.utils import timezone
 
 from rest_framework import mixins, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
-from marsha import settings
 from marsha.core import defaults, permissions, serializers, storage
 from marsha.core.api.base import APIViewMixin, ObjectPkMixin
 from marsha.core.forms import DocumentForm


### PR DESCRIPTION
## Proposal

In the preprod environment, uploading files to Marsha Document was failing due to incorrect import of the settings module from `marsha` instead of `django.conf`.
It could be nice to have a linter rule for that but it would need adding a flake8 plugin.

