### PR TITLE
🐛(back) fix management command to rename deposited files and documents

### DIFF
--- a/src/backend/marsha/core/management/commands/rename_documents.py
+++ b/src/backend/marsha/core/management/commands/rename_documents.py
@@ -36,6 +36,7 @@ class Command(BaseCommand):
 
         value = value.replace("/", "_")
         value = value.replace("\\", "_")
+        value = value.replace(" ", "_")
         value = value.lstrip(".")
 
         return value
@@ -58,7 +59,7 @@ class Command(BaseCommand):
                 "Key": file_key_src,
             }
 
-            filename = self.validate_filename(document.filename)
+            filename = self.validate_filename(document.title + extension)
 
             # Override document filename with the validated S3-compatible filename
             if filename != document.filename:

--- a/src/backend/marsha/deposit/management/commands/rename_deposited_files.py
+++ b/src/backend/marsha/deposit/management/commands/rename_deposited_files.py
@@ -1,7 +1,6 @@
 """Rename deposited files in Scaleway S3 for serving them with the right name."""
 
 import logging
-from os.path import splitext
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
@@ -51,9 +50,7 @@ class Command(BaseCommand):
         for file in files:
             # Get the file stored on Scaleway S3 under `aws/`
             stamp = time_utils.to_timestamp(file.uploaded_on)
-            extension = ""
-            if "." in file.filename:
-                extension = splitext(file.filename)[1]
+            extension = "." + file.extension if file.extension else ""
 
             file_key_src = file.get_storage_key(
                 filename=f"{stamp}{extension}", base_dir=AWS_STORAGE_BASE_DIRECTORY

--- a/src/backend/marsha/deposit/tests/test_command_rename_deposited_files.py
+++ b/src/backend/marsha/deposit/tests/test_command_rename_deposited_files.py
@@ -1,7 +1,6 @@
 """Test the ``rename_deposited_files`` management command."""
 
 from datetime import datetime, timezone
-from os.path import splitext
 from unittest import mock
 
 from django.core.management import call_command
@@ -43,6 +42,7 @@ class RenameDepositedFilesTestCase(TestCase):
             for filename_src, _ in filenames:
                 file = DepositedFileFactory(
                     filename=filename_src,
+                    extension="pdf",
                     uploaded_on=now,
                     upload_state=READY,
                     storage_location=AWS_S3,
@@ -54,9 +54,7 @@ class RenameDepositedFilesTestCase(TestCase):
             # were created, so we must iterate over objects.all() in the same sequence
             for file in DepositedFile.objects.all():
                 stamp = time_utils.to_timestamp(file.uploaded_on)
-                extension = ""
-                if "." in file.filename:
-                    extension = splitext(file.filename)[1]
+                extension = "." + file.extension if file.extension else ""
 
                 file_key_src = (
                     f"aws/{file.file_depository.id}/depositedfile/"


### PR DESCRIPTION
## Proposal

After some tests on preprod:
- the management commands to rename documents was not working as the documents have blank filenames. Fixing the command by using the title to create
the filename instead.
- the management commands was not working as some deposited files have an extension in their filename, but not in their object storage key. Fixing the command by using the extension field instead of
computing the extension from the filename.
