### PR TITLE
⬆️(backend) upgrade celery to 5.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Update Volta configuration with yarn fixed version
 - Update docker-compose for new versions
+- Upgrade Celery version from 5.5.2 to 5.6.3
 
 ## [5.12.2] - 2026-01-22
 

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -29,7 +29,7 @@ requires-python = >=3.9
 install_requires =
     Brotli==1.1.0
     boto3==1.38.5
-    celery==5.5.2
+    celery==5.6.3
     channels-redis==4.2.1
     channels[daphne]==4.2.2
     chardet==5.2.0


### PR DESCRIPTION
Upgrade celery this latest release have a memory leak fix in its and we want to handle this issue : from 5.5.2 to 5.6.3.

Changelog mentioning the memory leak issue : https://github.com/celery/celery/releases/tag/v5.6.0

