### PR TITLE
Add monitoring and configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Handle BBB error when converting a video
+
+### Added
+
+- Allow tuning Celery worker concurrency via Matsuo
+
 ## [5.12.3] - 2026-04-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Allow tuning Celery worker concurrency via Matsuo
+- Allow tuning Celery worker max tasks/memory per child via Matsuo
 
 ## [5.12.3] - 2026-04-24
 

--- a/src/backend/marsha/bbb/api.py
+++ b/src/backend/marsha/bbb/api.py
@@ -18,6 +18,7 @@ from rest_framework.decorators import action
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.throttling import AnonRateThrottle
+from sentry_sdk import capture_exception
 
 from marsha.bbb import permissions, serializers
 from marsha.bbb.defaults import LTI_ROUTE
@@ -818,9 +819,14 @@ class ClassroomRecordingViewSet(
         else:
             domain = f"{request.scheme}://{request.get_host()}"
 
+        try:
+            record_url = get_recording_url(record_id=classroom_recording.record_id)
+        except ApiMeetingException as error:
+            capture_exception(error)
+
         process_chain = chain(
             copy_video_recording.si(
-                record_url=get_recording_url(record_id=classroom_recording.record_id),
+                record_url=record_url,
                 video_pk=classroom_recording.vod.pk,
                 stamp=stamp,
             ),

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -789,6 +789,9 @@ class Base(Configuration):
     CELERY_RESULT_BACKEND = values.Value("redis://redis:6379/0")
     CELERY_BROKER_TRANSPORT_OPTIONS = values.DictValue({})
     CELERY_DEFAULT_QUEUE = values.Value("celery")
+    # Celery defaults to os.cpu_count() child processes when unset, which ignores
+    # the CPU actually allocated to the pod.
+    CELERY_WORKER_CONCURRENCY = values.PositiveIntegerValue(None)
 
     # pylint: disable=invalid-name
     @property

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -792,6 +792,12 @@ class Base(Configuration):
     # Celery defaults to os.cpu_count() child processes when unset, which ignores
     # the CPU actually allocated to the pod.
     CELERY_WORKER_CONCURRENCY = values.PositiveIntegerValue(None)
+    # Recycle a worker child process after this many tasks, to mitigate memory
+    # growth from libraries that leak (e.g. native codecs used during transcoding).
+    CELERY_WORKER_MAX_TASKS_PER_CHILD = values.PositiveIntegerValue(None)
+    # Kill and replace a worker child process once it exceeds this RSS, in kilobytes
+    # (Celery's `worker_max_memory_per_child` unit). Unset by default, tune via Matsuo.
+    CELERY_WORKER_MAX_MEMORY_PER_CHILD = values.PositiveIntegerValue(None)
 
     # pylint: disable=invalid-name
     @property


### PR DESCRIPTION
When BigBlueButton couldn't find the recording, the error was never caught and reported. The created `Video` stayed in `PENDING` state forever and the "Convert to VOD" button stayed disabled forever with no feedback for the user. We now report this failure to Sentry.

We also now allow tuning Celery workers via environment variables (worker concurrency, max tasks/memory per child), so they can be sized to match the resources allocated in each environment (Matsuo).