### PR TITLE
🔊(backend) improve error handling of ffprobe error in transcode video task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Handle video not found  error when task to transcode video
+  by increasing retries in celery's task
+
+
 ## [5.12.4] - 2026-07-20
 
 ### Fixed
@@ -283,7 +289,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Meta description and meta title on the website from the API (#2516)
 - Retrieve BBB learning analytics and send them through API
-- Classroom attendance analytics (#2499) 
+- Classroom attendance analytics (#2499)
 - Add a language picker for the invite link on the website (#2504)
 
 ### Changed

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -28,6 +28,7 @@
 - [Jean-Baptiste Penrath](https://github.com/jbpenrath) <jb.penrath@gmail.com>
 - [Nicolas Can](https://github.com/ptitloup) <nicolas.can@fun-mooc.fr>
 - [Liam Le Strat](https://github.com/liamls) <liam.le-strat@fun-mooc.fr>
+- [Jonathan Reveille](https://github.com/jonathanreveille) <jon.rev93001@gmail.com>
 
 - [Renovate Bot](https://renovatebot.com) <bot@renovateapp.com>
 - [Renovate Bot](https://renovatebot.com) <29139614+renovate[bot]@users.noreply.github.com>

--- a/src/backend/marsha/core/defaults.py
+++ b/src/backend/marsha/core/defaults.py
@@ -74,10 +74,19 @@ LIVE_CHOICES = (
 # UPLOAD ERROR REASONS
 MAX_RESOLUTION_EXCEDEED = "max_resolution_excedeed"
 RECORDING_SOURCE_ERROR = "recording_source_error"
+PROBE_ERROR = "ffmpeg_probe_error"
 
 UPLOAD_ERROR_REASON_CHOICES = (
     (MAX_RESOLUTION_EXCEDEED, _("max_resolution_excedeed")),
     (RECORDING_SOURCE_ERROR, _("recording_source_error")),
+    (PROBE_ERROR, _("probe_error")),
+)
+
+# TRANSCODING ERROR REASONS
+TMP_SOURCE_FILE_MISSING = "tmp_source_file_missing"
+
+TRANSCODING_ERROR_REASONS = (
+    (TMP_SOURCE_FILE_MISSING, _("temporary source file missing")),
 )
 
 # LIVE TYPE

--- a/src/backend/marsha/core/tasks/video.py
+++ b/src/backend/marsha/core/tasks/video.py
@@ -4,6 +4,7 @@ import logging
 
 from django.conf import settings
 
+from celery.exceptions import MaxRetriesExceededError
 from django_peertube_runner_connector.transcode import transcode_video
 from django_peertube_runner_connector.transcript import transcript_video
 from django_peertube_runner_connector.utils.ffprobe import (
@@ -16,7 +17,9 @@ from marsha.celery_app import app
 from marsha.core.defaults import (
     ERROR,
     MAX_RESOLUTION_EXCEDEED,
+    PROBE_ERROR,
     READY,
+    TMP_SOURCE_FILE_MISSING,
     TMP_STORAGE_BASE_DIRECTORY,
 )
 from marsha.core.models.video import Video
@@ -31,8 +34,14 @@ class MaxResolutionError(Exception):
     """Raised when the resolution of a video is higher than the maximum enabled resolution."""
 
 
-@app.task
-def launch_video_transcoding(video_pk: str, stamp: str, domain: str):
+@app.task(
+    bind=True,
+    max_retries=5,
+    retry_backoff=True,
+    retry_backoff_max=60,
+    retry_jitter=True,
+)
+def launch_video_transcoding(self, video_pk: str, stamp: str, domain: str):
     """Transcodes a video using file_storage.
     Args:
         video_pk (UUID): The video to transcode.
@@ -41,8 +50,25 @@ def launch_video_transcoding(video_pk: str, stamp: str, domain: str):
         domain (str): The domain name used to construct the download URL for peerTube runners.
     """
     video = Video.objects.get(pk=video_pk)
+    source = video.get_storage_prefix(stamp, TMP_STORAGE_BASE_DIRECTORY)
+
+    if not file_storage.exists(source):
+        logger.info(
+            "Source file not yet available (attempt %s/%s): %s (video %s)",
+            self.request.retries,
+            self.max_retries,
+            source,
+            video_pk,
+        )
+        try:
+            raise self.retry()
+        except MaxRetriesExceededError:
+            logger.error("Source file never appeared: %s (video %s)", source, video_pk)
+            video.upload_error_reason = TMP_SOURCE_FILE_MISSING
+            video.update_upload_state(ERROR, None)
+            return
+
     try:
-        source = video.get_storage_prefix(stamp, TMP_STORAGE_BASE_DIRECTORY)
         probe = ffmpeg.probe(file_storage.url(source))
         dimensions_info = get_video_stream_dimensions_info(
             path=source, existing_probe=probe
@@ -70,6 +96,12 @@ def launch_video_transcoding(video_pk: str, stamp: str, domain: str):
         video.upload_error_reason = MAX_RESOLUTION_EXCEDEED
         video.update_upload_state(ERROR, None)
         logger.info(exception)
+    except ffmpeg.Error as exception:
+        stderr = exception.stderr.decode(errors="replace") if exception.stderr else ""
+        logger.exception("ffmpeg/ffprobe error for video %s: %s", video.id, stderr)
+        video.upload_error_reason = PROBE_ERROR
+        video.update_upload_state(ERROR, None)
+        capture_exception(exception)
     except Exception as exception:  # pylint: disable=broad-except+
         capture_exception(exception)
         video.update_upload_state(ERROR, None)

--- a/src/backend/marsha/core/tests/tasks/test_video.py
+++ b/src/backend/marsha/core/tests/tasks/test_video.py
@@ -5,13 +5,17 @@ from unittest import mock
 
 from django.test import TestCase
 
+from celery.exceptions import Retry
+
 from marsha.core.defaults import (
     ERROR,
     MAX_RESOLUTION_EXCEDEED,
     PEERTUBE_PIPELINE,
+    PROBE_ERROR,
     READY,
 )
 from marsha.core.factories import VideoFactory
+from marsha.core.storage.storage_class import file_storage
 from marsha.core.tasks.video import (
     compute_video_information,
     ffmpeg,
@@ -237,6 +241,30 @@ class TestVideoTask(TestCase):
     Test for video celery tasks
     """
 
+    def test_launch_video_transcode_source_not_found_retries(self):
+        """
+        If the source file doesn't exist yet, the task should retry
+        rather than failing immediately.
+        """
+        video = VideoFactory()
+        stamp = "1640995200"
+
+        with mock.patch.object(
+            file_storage, "exists"
+        ) as mock_file_storage_exists, mock.patch.object(
+            launch_video_transcoding, "retry"
+        ) as mock_retry:
+
+            mock_file_storage_exists.return_value = False
+            mock_retry.side_effect = Retry()  # simulate Celery's retry signal
+
+            with self.assertRaises(Retry):
+                launch_video_transcoding.run(
+                    str(video.pk), stamp, "http://127.0.0.1:8000"
+                )
+
+            mock_retry.assert_called_once()
+
     def test_launch_video_transcode(self):
         """
         Test the the launch_video_transcoding task. It should simply call
@@ -248,10 +276,13 @@ class TestVideoTask(TestCase):
             "marsha.core.tasks.video.transcode_video"
         ) as mock_transcode_video, mock.patch.object(
             ffmpeg, "probe"
-        ) as mock_ffmpeg_probe:
+        ) as mock_ffmpeg_probe, mock.patch.object(
+            file_storage, "exists"
+        ) as mock_file_storage_exists:
 
+            mock_file_storage_exists.return_value = True
             mock_ffmpeg_probe.return_value = FFMPEG_PROBE_VALID
-            launch_video_transcoding(str(video.pk), stamp, "http://127.0.0.1:8000")
+            launch_video_transcoding.run(str(video.pk), stamp, "http://127.0.0.1:8000")
             mock_transcode_video.assert_called_once_with(
                 file_path=f"tmp/{video.pk}/video/{stamp}",
                 destination=f"vod/{video.pk}/video/{stamp}",
@@ -274,10 +305,13 @@ class TestVideoTask(TestCase):
             "marsha.core.tasks.video.transcode_video"
         ) as mock_transcode_video, mock.patch.object(
             ffmpeg, "probe"
-        ) as mock_ffmpeg_probe:
+        ) as mock_ffmpeg_probe, mock.patch.object(
+            file_storage, "exists"
+        ) as mock_file_storage_exists:
 
+            mock_file_storage_exists.return_value = True
             mock_ffmpeg_probe.return_value = FFMPEG_PROBE_WITHOUT_VIDEO_STREAM
-            launch_video_transcoding(str(video.pk), stamp, "http://127.0.0.1:8000")
+            launch_video_transcoding.run(str(video.pk), stamp, "http://127.0.0.1:8000")
             mock_transcode_video.assert_called_once_with(
                 file_path=f"tmp/{video.pk}/video/{stamp}",
                 destination=f"vod/{video.pk}/video/{stamp}",
@@ -300,22 +334,51 @@ class TestVideoTask(TestCase):
             "marsha.core.tasks.video.transcode_video"
         ) as mock_transcode_video, mock.patch.object(
             ffmpeg, "probe"
-        ) as mock_ffmpeg_probe:
+        ) as mock_ffmpeg_probe, mock.patch.object(
+            file_storage, "exists"
+        ) as mock_file_storage_exists:
 
+            mock_file_storage_exists.return_value = True
             mock_ffmpeg_probe.return_value = FFMPEG_PROBE_VALID
-
             mock_transcode_video.side_effect = Exception("Test exception")
-            launch_video_transcoding(str(video.pk), stamp, "http://127.0.0.1:8000")
-            mock_transcode_video.assert_called_once_with(
-                file_path=f"tmp/{video.pk}/video/{stamp}",
-                destination=f"vod/{video.pk}/video/{stamp}",
-                base_name=stamp,
-                domain="http://127.0.0.1:8000",
-            )
-            video.refresh_from_db()
-            self.assertEqual(video.upload_state, ERROR)
 
-    def test_launch_video_transcode_fail_resolution_too_hight(self):
+            launch_video_transcoding.run(str(video.pk), stamp, "http://127.0.0.1:8000")
+
+        video.refresh_from_db()
+        self.assertEqual(video.upload_state, ERROR)
+
+    def test_launch_video_transcode_probe_error(self):
+        """
+        Test the launch_video_transcoding task. The ffmpeg.probe call should
+        raise an ffmpeg.Error and video state should be ERROR with PROBE_ERROR reason.
+        """
+        video = VideoFactory()
+        stamp = "1640995200"
+        with mock.patch(
+            "marsha.core.tasks.video.transcode_video"
+        ) as mock_transcode_video, mock.patch.object(
+            ffmpeg, "probe"
+        ) as mock_ffmpeg_probe, mock.patch.object(
+            file_storage, "exists"
+        ) as mock_file_storage_exists, mock.patch(
+            "marsha.core.tasks.video.capture_exception"
+        ) as mock_capture_exception:
+
+            mock_file_storage_exists.return_value = True
+            mock_ffmpeg_probe.side_effect = ffmpeg.Error(
+                "ffprobe", b"", b"stderr error message"
+            )
+
+            launch_video_transcoding.run(str(video.pk), stamp, "http://127.0.0.1:8000")
+
+            mock_transcode_video.assert_not_called()
+            mock_capture_exception.assert_called_once()
+
+        video.refresh_from_db()
+        self.assertEqual(video.upload_state, ERROR)
+        self.assertEqual(video.upload_error_reason, PROBE_ERROR)
+
+    def test_launch_video_transcode_fail_resolution_too_high(self):
         """
         Test the the launch_video_transcoding task. The transcode_video
         function should raise an exception and video state should be ERROR
@@ -327,16 +390,20 @@ class TestVideoTask(TestCase):
             "marsha.core.tasks.video.transcode_video"
         ) as mock_transcode_video, mock.patch.object(
             ffmpeg, "probe"
-        ) as mock_ffmpeg_probe:
+        ) as mock_ffmpeg_probe, mock.patch.object(
+            file_storage, "exists"
+        ) as mock_file_storage_exists:
 
+            mock_file_storage_exists.return_value = True
             mock_ffmpeg_probe.return_value = FFMPEG_PROBE_TOO_HIGH_RESOLUTION
 
-            mock_transcode_video.side_effect = Exception("Test exception")
-            launch_video_transcoding(str(video.pk), stamp, "http://127.0.0.1:8000")
+            launch_video_transcoding.run(str(video.pk), stamp, "http://127.0.0.1:8000")
+
             mock_transcode_video.assert_not_called()
-            video.refresh_from_db()
-            self.assertEqual(video.upload_state, ERROR)
-            self.assertEqual(video.upload_error_reason, MAX_RESOLUTION_EXCEDEED)
+
+        video.refresh_from_db()
+        self.assertEqual(video.upload_state, ERROR)
+        self.assertEqual(video.upload_error_reason, MAX_RESOLUTION_EXCEDEED)
 
     def test_launch_video_transcript(self):
         """
@@ -348,7 +415,7 @@ class TestVideoTask(TestCase):
         with mock.patch(
             "marsha.core.tasks.video.transcript_video"
         ) as mock_transcript_video:
-            launch_video_transcript(str(video.pk), stamp, "http://127.0.0.1:8000")
+            launch_video_transcript.run(str(video.pk), stamp, "http://127.0.0.1:8000")
             mock_transcript_video.assert_called_once_with(
                 destination=f"vod/{video.pk}/video/{stamp}",
                 domain="http://127.0.0.1:8000",
@@ -364,7 +431,7 @@ class TestVideoTask(TestCase):
         with mock.patch(
             "marsha.core.tasks.video.transcript_video"
         ) as mock_transcript_video:
-            launch_video_transcript(
+            launch_video_transcript.run(
                 str(video.pk), stamp, "http://127.0.0.1:8000", "video_url"
             )
             mock_transcript_video.assert_called_once_with(


### PR DESCRIPTION
## Purpose

In this PR, we want to increase the level of retry in video transcoding task when they fail because the code can't reach the video that is stored. It will allow the celery task to retry 5 times maximum before letting it go.


## Proposal

- [x] increase rety in task to video transcoding when the video is not yet found in file_storage
