### PR TITLE
🐛(backend) catch `ClientError` in `_get_items` to avoid crashing

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -28,6 +28,7 @@
 - [Jean-Baptiste Penrath](https://github.com/jbpenrath) <jb.penrath@gmail.com>
 - [Nicolas Can](https://github.com/ptitloup) <nicolas.can@fun-mooc.fr>
 - [Liam Le Strat](https://github.com/liamls) <liam.le-strat@fun-mooc.fr>
+- [Jonathan Reveille](https://github.com/jonathanreveille) <jon.rev93001@gmail.com>
 
 - [Renovate Bot](https://renovatebot.com) <bot@renovateapp.com>
 - [Renovate Bot](https://renovatebot.com) <29139614+renovate[bot]@users.noreply.github.com>

--- a/src/backend/marsha/core/tests/utils/medialive_utils/test_medialive_list_utils.py
+++ b/src/backend/marsha/core/tests/utils/medialive_utils/test_medialive_list_utils.py
@@ -1,5 +1,7 @@
 """Test medialive utils functions."""
 
+from unittest import mock
+
 from django.test import TestCase
 
 from botocore.stub import Stubber
@@ -10,13 +12,31 @@ from marsha.core.utils import medialive_utils
 # pylint: disable=too-many-lines
 
 
-# pylint: disable=too-many-lines
-
-
 class MediaLiveUtilsTestCase(TestCase):
     """Test medialive utils."""
 
     maxDiff = None
+
+    def test_list_mediapackage_channels_client_error(self):
+        """Should return an empty list and log a warning when AWS credentials are invalid."""
+        with Stubber(
+            medialive_utils.mediapackage_client
+        ) as mediapackage_client_stubber, mock.patch.object(
+            medialive_utils.logger, "warning"
+        ) as mock_logger_warning:
+
+            mediapackage_client_stubber.add_client_error(
+                "list_channels",
+                service_error_code="UnrecognizedClientException",
+                service_message="The security token included in the request is invalid.",
+                http_status_code=403,
+            )
+
+            channels = medialive_utils.list_mediapackage_channels()
+
+            mediapackage_client_stubber.assert_no_pending_responses()
+            self.assertEqual(channels, [])
+            mock_logger_warning.assert_called_once()
 
     def test_list_mediapackage_channels(self):
         """Should recursively get all mediapackage channels."""

--- a/src/backend/marsha/core/utils/medialive_utils/medialive_list_utils.py
+++ b/src/backend/marsha/core/utils/medialive_utils/medialive_list_utils.py
@@ -1,9 +1,16 @@
 """Utils to create MediaLive configuration."""
 
+import logging
+
+from botocore.exceptions import ClientError
+
 from marsha.core.utils.medialive_utils.medialive_client_utils import (
     medialive_client,
     mediapackage_client,
 )
+
+
+logger = logging.getLogger(__name__)
 
 
 def _get_items(  # nosec
@@ -39,7 +46,12 @@ def _get_items(  # nosec
     if next_token:
         params[next_token_key] = next_token
 
-    response = get_items(**params)
+    try:
+        response = get_items(**params)
+    except ClientError as e:
+        logger.warning("Failed to fetch items: %s, reason no more AWS credentials", e)
+        return []
+
     items = response.get(items_key)
     next_token = response.get(next_token_key)
 


### PR DESCRIPTION

## Purpose

We have portions of code still calls in staging AWS services that we don't use it anymore. Those portion of code still calls boto3 client that hits AWS. The django commands that triggers those portion of code will systematically fail and raise uncaught errors in our sentry. To exit in a proper way, we return an empty list when the credentials are not set.

## Proposal

- [x] avoid raising unhandled error in our sentry by catching better the exception when aws credentials are not set for django commands

Note : In the meantime, we have decided to stop cron jobs that would call AWS services.


