### PR TITLE
♻️ (backend) update add renater FER authentication xml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Update renater xml metadata configuration
+
 ## [5.12.4] - 2026-07-20
 
 ### Fixed
@@ -283,7 +287,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Meta description and meta title on the website from the API (#2516)
 - Retrieve BBB learning analytics and send them through API
-- Classroom attendance analytics (#2499) 
+- Classroom attendance analytics (#2499)
 - Add a language picker for the invite link on the website (#2504)
 
 ### Changed

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -28,6 +28,8 @@
 - [Jean-Baptiste Penrath](https://github.com/jbpenrath) <jb.penrath@gmail.com>
 - [Nicolas Can](https://github.com/ptitloup) <nicolas.can@fun-mooc.fr>
 - [Liam Le Strat](https://github.com/liamls) <liam.le-strat@fun-mooc.fr>
+- [Jonathan Réveillé](https://github.com/jonathanreveille) <jon.rev93001@gmail.com>
+
 
 - [Renovate Bot](https://renovatebot.com) <bot@renovateapp.com>
 - [Renovate Bot](https://renovatebot.com) <29139614+renovate[bot]@users.noreply.github.com>

--- a/src/backend/marsha/settings.py
+++ b/src/backend/marsha/settings.py
@@ -727,7 +727,7 @@ class Base(Configuration):
 
     # Custom parameter to define the Renater Federation Metadata
     SOCIAL_AUTH_SAML_FER_FEDERATION_SAML_METADATA_URL = values.Value(
-        "https://metadata.federation.renater.fr/renater/main/main-idps-renater-metadata.xml"
+        "https://pub.federation.renater.fr/metadata/fer/idps.xml"
     )
 
     SOCIAL_AUTH_SAML_FER_PIPELINE = MARSHA_DEFAULT_AUTH_PIPELINE


### PR DESCRIPTION


## Purpose

Renater dropped the usage of the metadata xml that was deprecated on the 3rd of September. We will now use the newest one.

## Proposal

- [x] Update `SOCIAL_AUTH_SAML_FER_FEDERATION_SAML_METADATA_URL`
